### PR TITLE
fix: protect subprocess argument boundaries

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -378,12 +378,13 @@ suppression at that call.
 For `S603`, treat every subprocess as a security boundary even when
 `shell=False`: use an argument list, fix or validate the executable, and
 allowlist or construct every dynamic argument rather than forwarding request or
-fixture input. When a test deliberately starts `sys.executable` with a script
-defined entirely in that test, preserve the process-isolation contract and use
-one explained inline suppression at the call; do not exempt the whole test
-tree. Run the test so its expected output, failure, or side effect still proves
-why the child process exists. Contributor maintenance scripts remain covered by
-their documented controlled-environment exception.
+fixture input. Put `--` before a dynamic positional path when the child CLI
+supports an option terminator, so a value beginning with `-` cannot become an
+option. When a test deliberately starts a fixed executable with source-defined
+arguments, preserve the process-isolation contract and use one explained inline
+suppression at the call. Run the test so its expected output, failure, or side
+effect still proves why the child process exists. Apply the same per-call audit
+to contributor tooling; do not exempt an entire test or script tree from S603.
 
 For `RUF001`, preserve the standard fullwidth Chinese punctuation explicitly
 allowed by `ruff.toml`: `，`, `：`, `！`, `？`, and `；`. These code points are

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -375,6 +375,16 @@ path to every call. If a test or platform entrypoint must freeze an executable
 name because the name itself is the contract, use one explained inline
 suppression at that call.
 
+For `S603`, treat every subprocess as a security boundary even when
+`shell=False`: use an argument list, fix or validate the executable, and
+allowlist or construct every dynamic argument rather than forwarding request or
+fixture input. When a test deliberately starts `sys.executable` with a script
+defined entirely in that test, preserve the process-isolation contract and use
+one explained inline suppression at the call; do not exempt the whole test
+tree. Run the test so its expected output, failure, or side effect still proves
+why the child process exists. Contributor maintenance scripts remain covered by
+their documented controlled-environment exception.
+
 For `RUF001`, preserve the standard fullwidth Chinese punctuation explicitly
 allowed by `ruff.toml`: `，`, `：`, `！`, `？`, and `；`. These code points are
 intentional in Chinese prose, notification formatting, and TTS sentence-boundary

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -462,6 +462,11 @@ plan's progress update for that rule.
   Ruff and format, translation checks, repository harness, architecture
   boundaries, development-tool validation, and every repository pre-commit
   hook pass on the S603 tip.
+- [x] 2026-08-21 07:14 CST: Opened ready S603 PR
+  [#2601](https://github.com/ai-shifu/ai-shifu/pull/2601) from
+  `sunner/ruff-s603` to the S607 branch after all local gates passed.
+- [ ] Merge or retarget S603 PR #2601 after its predecessors without combining
+  it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -438,6 +438,30 @@ plan's progress update for that rule.
   `sunner/ruff-s607` to the S101 branch after all local gates passed.
 - [ ] Merge or retarget S607 PR #2599 after its predecessors without combining
   it with the next rule unit.
+- [x] 2026-08-21 07:07 CST: Prepared the S603 stage on
+  `sunner/ruff-s603`, stacked on S607. Removing the test-tree exception exposes
+  exactly two calls: the fresh-MySQL migration smoke test and the pinned
+  LiteLLM adapter-contract test.
+- [x] 2026-08-21 07:07 CST: Both calls execute the current `sys.executable`
+  with a test-owned fixed `-c` script. No request, fixture, environment, or
+  database value can select the executable or become a command argument, and
+  child-process isolation is the behavior those tests need to exercise.
+- [x] 2026-08-21 07:07 CST: Removed S603 from the test-tree exception, retained
+  the two audited calls behind explained inline suppressions, and documented
+  the project contract for validating subprocess executables and arguments.
+- [x] 2026-08-21 07:11 CST: Configured and isolated test-tree S603 scans pass;
+  ignoring suppressions exposes exactly the two audited calls. The stable
+  `ALL` census remains exactly 28,202 findings across 28 rules because the
+  broad exception became equivalent narrow suppressions without debt transfer.
+- [x] 2026-08-21 07:11 CST: The two owning test files pass 61 tests and skip two
+  explicit environment contracts: the opt-in fresh-MySQL smoke test and the
+  LiteLLM 1.95.0 adapter test, because the shared local venv has 1.80.11 while
+  checked-in requirements pin 1.95.0. Final backend CI owns the clean current-
+  dependency execution of the latter.
+- [x] 2026-08-21 07:11 CST: Collaboration and knowledge generators, repository
+  Ruff and format, translation checks, repository harness, architecture
+  boundaries, development-tool validation, and every repository pre-commit
+  hook pass on the S603 tip.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -561,6 +585,11 @@ plan's progress update for that rule.
   paths; only the explained Windows `tzutil` entrypoint remains. A broad rule
   list must be audited code by code, and a clean lint result for a variable
   command does not replace semantic subprocess review.
+- S603 reports every subprocess even with `shell=False`, so deleting the two
+  test subprocesses or moving their scripts in-process would only weaken their
+  environment-isolation coverage. Both use the current interpreter and fixed
+  source owned by the test; their security boundary is narrow enough to explain
+  inline, allowing the entire backend test tree to become enforced.
 - D100 included one zero-byte, unreferenced `test_rag.py` placeholder. Removing
   it was more honest than inventing a module purpose and also removed one
   CPY001 finding; every documented module otherwise differs from its parent
@@ -796,6 +825,17 @@ explained Windows `tzutil` platform entrypoint is the only inline exception.
 Configured S607, repository Ruff, format, and harness pass, and the stable
 census remains 28,202 findings across 28 rules. Future runtime, test, and
 contributor code now follows the same executable-resolution contract.
+
+The S603 stage removes the backend test-tree exception and replaces it with two
+explained inline audits. Both calls run the current interpreter against fixed,
+test-owned source: one isolates a fresh-MySQL Alembic upgrade, and one isolates
+the pinned LiteLLM native-adapter contract. The owning files pass 61 tests;
+the MySQL smoke and current-LiteLLM contract skip locally only at their explicit
+environment gates, with the latter covered by final backend CI using checked-in
+requirements. Configured and isolated S603 scans pass, the stable census remains
+28,202 findings across 28 rules, and every repository hook passes. Future code
+now validates each subprocess boundary at the call rather than exempting tests
+as a class.
 
 ## Context and Orientation
 

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -498,6 +498,22 @@ plan's progress update for that rule.
   contract unchanged and isolated the test with pytest's cross-platform
   `tmp_path`; the test still exercises the exact subprocess command and stdin
   boundary it owns.
+- [x] 2026-08-21 08:09 CST: Rebased S603 onto expanded S607 commit
+  `ed43b47d3`. The predecessor's five resolved Git calls and resolved Codex
+  version call also require S603 argument-boundary audits, so all six now have
+  explained inline suppressions instead of restoring a script-tree exception.
+  The S603 Codex argument test now fixes and expects the predecessor's resolved
+  executable path.
+- [x] 2026-08-21 08:09 CST: Configured S603 and S607 scans pass. Ignoring S603
+  suppressions reports 13 reviewed boundaries: the 12 calls owned across these
+  two stacked rule units plus the pre-existing operator-supplied plugin clone.
+  Eight root-script tests pass, and the combined backend owners pass 67 tests
+  with the same two explicit environment skips. The stable `ALL` census remains
+  exactly 28,202 findings across 28 rules.
+- [x] 2026-08-21 08:10 CST: After the rebase adjustment, collaboration and
+  knowledge generators produced no extra diff; translations, repository
+  harness, architecture boundaries, development-tool validation, repository
+  Ruff and format, and every pre-commit hook pass on the final local S603 tip.
 - [ ] Merge or retarget S603 PR #2601 after its predecessors without combining
   it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
@@ -628,9 +644,10 @@ plan's progress update for that rule.
   environment-isolation coverage. Both use the current interpreter and fixed
   source owned by the test; their security boundary is narrow enough to explain
   inline, allowing the entire backend test tree to become enforced. The two
-  script-tree S603 exceptions also hid only four calls, not a durable class of
-  safe code. Auditing them individually exposed a real option-boundary gap in
-  the route inventory and made both broad exceptions removable.
+  script-tree S603 exceptions hid four original calls plus six resolved-command
+  calls introduced by the S607 predecessor, not a durable class of safe code.
+  Auditing them individually exposed a real option-boundary gap in the route
+  inventory and made both broad exceptions removable.
 - D100 included one zero-byte, unreferenced `test_rag.py` placeholder. Removing
   it was more honest than inventing a module purpose and also removed one
   CPY001 finding; every documented module otherwise differs from its parent
@@ -868,16 +885,17 @@ census remains 28,202 findings across 28 rules. Future runtime, test, and
 contributor code now follows the same executable-resolution contract.
 
 The S603 stage removes the backend test-tree and both script-tree exceptions,
-replacing them with six explained inline audits. The two child-process tests run
+replacing them with 12 explained inline audits. The two child-process tests run
 the current interpreter against fixed, test-owned source. The diagnostics
-runner does the same with a fixed repository script; the prompt evaluator uses
-a fixed Codex command; the Prettier helper allowlists `git` and `node`; and the
-route inventory terminates grep options before its dynamic directory. The root
-script suites pass four tests, while the backend script tests and original S603
-owners pass 63 tests with only the explicit local environment skips. Configured
-and isolated S603 scans pass, the stable census remains 28,202 findings across
-28 rules, and future code validates every subprocess boundary at the call
-rather than exempting tests or contributor scripts as a class.
+runner does the same with a fixed repository script; both Codex calls use the
+resolved executable and source-owned arguments; the Prettier helper allowlists
+`git` and `node`; the route inventory terminates grep options before its dynamic
+directory; and five Git calls use resolved executables with fixed subcommands.
+Eight root-script tests pass, while the backend script tests and original S603
+owners pass 67 tests with only the two explicit environment skips. Configured
+S603 and S607 scans pass, the stable census remains 28,202 findings across 28
+rules, and future code validates every subprocess boundary at the call rather
+than exempting tests or contributor scripts as a class.
 
 ## Context and Orientation
 

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -465,6 +465,33 @@ plan's progress update for that rule.
 - [x] 2026-08-21 07:14 CST: Opened ready S603 PR
   [#2601](https://github.com/ai-shifu/ai-shifu/pull/2601) from
   `sunner/ruff-s603` to the S607 branch after all local gates passed.
+- [x] 2026-08-21 07:28 CST: Extended the still-unstacked S603 PR instead of
+  opening a second PR for the same rule. Isolated scanning exposed four more
+  calls hidden by `scripts/**` and `src/api/scripts/**`: a fixed-interpreter
+  diagnostics runner, an allowlisted test-command helper, the fixed Codex
+  evaluator command, and a fixed `grep` route-inventory command.
+- [x] 2026-08-21 07:28 CST: Removed S603 from both script-tree exceptions and
+  replaced them with per-call audits. The Prettier test helper now rejects
+  executables outside `git` and `node`; the route inventory puts `--` before
+  its environment-provided root so a leading-dash path cannot become a grep
+  option. The other two commands already fixed the executable and constructed
+  every argument from source-owned structure.
+- [x] 2026-08-21 07:28 CST: Added regression coverage for the executable
+  allowlist, shell-like request and prompt values remaining single arguments,
+  and a leading-dash inventory directory. The two root script suites pass four
+  tests; the two new backend script tests plus the original S603 owners pass 63
+  tests and skip only the opt-in MySQL smoke and locally mismatched LiteLLM
+  contract.
+- [x] 2026-08-21 07:28 CST: Configured and isolated S603 scans pass. Ignoring
+  suppressions exposes seven explicit calls repository-wide: the six S603 PR
+  calls and the existing operator-supplied plugin clone. The stable `ALL`
+  census remains exactly 28,202 findings across 28 rules after making the new
+  tests ALL-neutral; all 18 remaining per-file patterns resolve to real files.
+- [x] 2026-08-21 07:32 CST: Collaboration and knowledge generators produced no
+  extra diff; repository Ruff and format, translations, repository harness,
+  architecture boundaries, development-tool validation, and all 19
+  pre-commit hooks pass for the extended S603 change. Final-SHA CI remains the
+  post-push acceptance gate.
 - [ ] Merge or retarget S603 PR #2601 after its predecessors without combining
   it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
@@ -594,7 +621,10 @@ plan's progress update for that rule.
   test subprocesses or moving their scripts in-process would only weaken their
   environment-isolation coverage. Both use the current interpreter and fixed
   source owned by the test; their security boundary is narrow enough to explain
-  inline, allowing the entire backend test tree to become enforced.
+  inline, allowing the entire backend test tree to become enforced. The two
+  script-tree S603 exceptions also hid only four calls, not a durable class of
+  safe code. Auditing them individually exposed a real option-boundary gap in
+  the route inventory and made both broad exceptions removable.
 - D100 included one zero-byte, unreferenced `test_rag.py` placeholder. Removing
   it was more honest than inventing a module purpose and also removed one
   CPY001 finding; every documented module otherwise differs from its parent
@@ -831,16 +861,17 @@ Configured S607, repository Ruff, format, and harness pass, and the stable
 census remains 28,202 findings across 28 rules. Future runtime, test, and
 contributor code now follows the same executable-resolution contract.
 
-The S603 stage removes the backend test-tree exception and replaces it with two
-explained inline audits. Both calls run the current interpreter against fixed,
-test-owned source: one isolates a fresh-MySQL Alembic upgrade, and one isolates
-the pinned LiteLLM native-adapter contract. The owning files pass 61 tests;
-the MySQL smoke and current-LiteLLM contract skip locally only at their explicit
-environment gates, with the latter covered by final backend CI using checked-in
-requirements. Configured and isolated S603 scans pass, the stable census remains
-28,202 findings across 28 rules, and every repository hook passes. Future code
-now validates each subprocess boundary at the call rather than exempting tests
-as a class.
+The S603 stage removes the backend test-tree and both script-tree exceptions,
+replacing them with six explained inline audits. The two child-process tests run
+the current interpreter against fixed, test-owned source. The diagnostics
+runner does the same with a fixed repository script; the prompt evaluator uses
+a fixed Codex command; the Prettier helper allowlists `git` and `node`; and the
+route inventory terminates grep options before its dynamic directory. The root
+script suites pass four tests, while the backend script tests and original S603
+owners pass 63 tests with only the explicit local environment skips. Configured
+and isolated S603 scans pass, the stable census remains 28,202 findings across
+28 rules, and future code validates every subprocess boundary at the call
+rather than exempting tests or contributor scripts as a class.
 
 ## Context and Orientation
 

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -492,6 +492,12 @@ plan's progress update for that rule.
   architecture boundaries, development-tool validation, and all 19
   pre-commit hooks pass for the extended S603 change. Final-SHA CI remains the
   post-push acceptance gate.
+- [x] 2026-08-21 07:39 CST: Final Backend Tests exposed a test-only platform
+  assumption: the new evaluator boundary test entered the script's macOS
+  `/private/tmp` context on a Linux runner. Kept the production evaluator
+  contract unchanged and isolated the test with pytest's cross-platform
+  `tmp_path`; the test still exercises the exact subprocess command and stdin
+  boundary it owns.
 - [ ] Merge or retarget S603 PR #2601 after its predecessors without combining
   it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest

--- a/ruff.toml
+++ b/ruff.toml
@@ -249,7 +249,7 @@ runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 # subprocess audit rules only add noise there.
 # Test suites are also full of literal fake passwords, tokens and secret keys
 # for fixtures and negative cases, which is what S105/S106 flag.
-"src/api/tests/**" = ["S101", "S105", "S106", "S603", "T20"]
+"src/api/tests/**" = ["S101", "S105", "S106", "T20"]
 # `app.py`, `celery_app.py` and `gunicorn.conf.py` are process entrypoints run
 # by path and never imported, so making `src/api` a package would only shadow
 # the top-level `flaskr` import path. `src/api/scripts` is a real package

--- a/ruff.toml
+++ b/ruff.toml
@@ -161,9 +161,11 @@ select = [
     # - S110/S112: `except Exception: pass` / `continue`. A deliberate
     #   best-effort block reads better as `contextlib.suppress(...)`, which the
     #   repo already uses; a narrower `except OSError:` is not flagged either.
-    # - S603/S605/S607: every subprocess and shell invocation. Application code
-    #   justifies each one inline; developer tooling resolves executables but
-    #   retains the broader S603 argument audit below.
+    # - S603: every subprocess. Each call validates or constructs its executable
+    #   and arguments, then explains any unavoidable false positive inline.
+    # - S605/S607: shell invocation and partial executable paths. Application
+    #   code justifies each one inline; developer tooling resolves executables
+    #   before invoking them.
     # - S608: every SQL string built by interpolation. Values always use bound
     #   parameters; the remaining sites interpolate table or column names, which
     #   bound parameters cannot carry, and justify it inline. Applied Alembic
@@ -244,9 +246,8 @@ runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 [lint.per-file-ignores]
 # `assert` is the point of a test, and both scripts below are test code: one is
 # a pytest module, the other keeps its regex fixtures in a `run_self_test()`.
-# Developer tooling (repo scripts, backend scripts, test harnesses) also shells
-# out to `git`, `node` and `python` with statically built argument lists, so the
-# subprocess audit rules only add noise there.
+# Developer tooling may use the controlled development PATH through the S607
+# exceptions below, but each S603 argument boundary is audited at its call.
 # Test suites are also full of literal fake passwords, tokens and secret keys
 # for fixtures and negative cases, which is what S105/S106 flag.
 "src/api/tests/**" = ["S101", "S105", "S106", "T20"]
@@ -278,10 +279,10 @@ runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 "src/api/migrations/versions/e1b2c3d4e5f6_add_ask_provider_config_to_shifu.py" = ["S608"]
 "src/api/migrations/versions/ef7dbc5a8be3_backfill_promo_campaign_tables.py" = ["S608"]
 # Developer scripts and the backend inventory/harness tooling are console
-# programs: printing to stdout is their interface. They resolve executable
-# paths explicitly, while the broader S603 argument audit remains separate.
-"scripts/**" = ["S603", "T20"]
+# programs: printing to stdout is their interface. Executable and subprocess
+# argument boundaries are audited at each call.
+"scripts/**" = ["T20"]
 # This fixture exists so check_architecture_boundaries.py can prove it resolves
 # parent-relative imports; rewriting them would delete the test case.
 "scripts/testdata/architecture_boundaries/**" = ["TID252"]
-"src/api/scripts/**" = ["S603", "T20"]
+"src/api/scripts/**" = ["T20"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -246,8 +246,8 @@ runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 [lint.per-file-ignores]
 # `assert` is the point of a test, and both scripts below are test code: one is
 # a pytest module, the other keeps its regex fixtures in a `run_self_test()`.
-# Developer tooling may use the controlled development PATH through the S607
-# exceptions below, but each S603 argument boundary is audited at its call.
+# Developer tooling resolves executable paths for S607 and audits each S603
+# argument boundary at its call.
 # Test suites are also full of literal fake passwords, tokens and secret keys
 # for fixtures and negative cases, which is what S105/S106 flag.
 "src/api/tests/**" = ["S101", "S105", "S106", "T20"]

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -81,7 +81,7 @@ def _hooks_dir() -> Path | None:
         return None
     git_executable = str(Path(git_executable).resolve())
     try:
-        configured = subprocess.run(
+        configured = subprocess.run(  # noqa: S603 - resolved Git, fixed arguments
             [git_executable, "config", "--get", "core.hooksPath"],
             cwd=ROOT,
             capture_output=True,
@@ -93,7 +93,7 @@ def _hooks_dir() -> Path | None:
             path = Path(configured.stdout.strip()).expanduser()
             return path if path.is_absolute() else (ROOT / path)
 
-        resolved = subprocess.run(
+        resolved = subprocess.run(  # noqa: S603 - resolved Git, fixed arguments
             [git_executable, "rev-parse", "--git-path", "hooks"],
             cwd=ROOT,
             capture_output=True,

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -378,7 +378,7 @@ def _git_executable() -> str:
 
 
 def _repository_relative_paths() -> list[str]:
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603 - resolved Git, fixed inventory arguments
         [
             _git_executable(),
             "ls-files",
@@ -399,7 +399,7 @@ def _repository_relative_paths() -> list[str]:
 
 
 def _index_entries() -> list[tuple[str, str]]:
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603 - resolved Git, fixed index arguments
         [_git_executable(), "ls-files", "--stage", "-z"],
         cwd=ROOT,
         check=True,
@@ -426,7 +426,7 @@ def _read_index_objects(object_ids: list[str]) -> dict[str, bytes]:
     unique_object_ids = list(dict.fromkeys(object_ids))
     if not unique_object_ids:
         return {}
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603 - resolved Git, fixed batch arguments
         [_git_executable(), "cat-file", "--batch"],
         cwd=ROOT,
         check=True,

--- a/scripts/harness/trace_run.py
+++ b/scripts/harness/trace_run.py
@@ -208,7 +208,7 @@ def run_backend_diagnostics(
         return entry
 
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603 - fixed interpreter and script
             command,
             cwd=script.parent.parent,
             capture_output=True,

--- a/scripts/test_prettier_check_changed.py
+++ b/scripts/test_prettier_check_changed.py
@@ -11,12 +11,17 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "src/cook-web/scripts/prettier-check-changed.mjs"
+ALLOWED_TEST_EXECUTABLES = {"git", "node"}
 
 
 def run(
     command: list[str], cwd: Path, env: dict[str, str] | None = None
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
+    executable = command[0] if command else "<missing>"
+    if executable not in ALLOWED_TEST_EXECUTABLES:
+        message = f"unexpected test executable: {executable}"
+        raise ValueError(message)
+    return subprocess.run(  # noqa: S603 - executable is allowlisted above
         command,
         cwd=cwd,
         env=env,
@@ -100,6 +105,16 @@ class PrettierCheckChangedTest(unittest.TestCase):
         assert result.returncode == 0, result.stderr
         assert not self.args_file.exists()
         assert "No changed Cook Web files" in result.stdout
+
+    def test_rejects_unexpected_executable(self) -> None:
+        """Reject commands outside the source-owned test allowlist."""
+        error = None
+        try:
+            run(["python", "untrusted.py"], self.repo)
+        except ValueError as exc:
+            error = exc
+
+        assert str(error) == "unexpected test executable: python"
 
 
 if __name__ == "__main__":

--- a/scripts/test_trace_run.py
+++ b/scripts/test_trace_run.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright 2026
+"""Tests for the durable harness trace collector."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from unittest.mock import patch
+
+from harness import trace_run
+
+
+class TraceRunTest(unittest.TestCase):
+    """Verify backend diagnostics keep subprocess boundaries fixed."""
+
+    def test_request_id_remains_one_argument(self) -> None:
+        """Keep shell-like request text in one child-process argument."""
+        request_id = "request; echo not-a-command"
+        completed = subprocess.CompletedProcess([], 0, stdout="result", stderr="")
+
+        with patch.object(trace_run.subprocess, "run", return_value=completed) as run:
+            result = trace_run.run_backend_diagnostics(request_id, timeout_seconds=7)
+
+        command = run.call_args.args[0]
+        assert command == [
+            sys.executable,
+            "scripts/harness_diagnostics.py",
+            "--request-id",
+            request_id,
+        ]
+        assert "shell" not in run.call_args.kwargs
+        assert result["returncode"] == 0
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/api/scripts/evaluate_learner_profile_optimizer_prompt.py
+++ b/src/api/scripts/evaluate_learner_profile_optimizer_prompt.py
@@ -181,7 +181,7 @@ def _run_codex(
         )
         started_at = time.monotonic()
         try:
-            completed = subprocess.run(
+            completed = subprocess.run(  # noqa: S603 - fixed Codex CLI command
                 command,
                 check=False,
                 capture_output=True,

--- a/src/api/scripts/evaluate_learner_profile_optimizer_prompt.py
+++ b/src/api/scripts/evaluate_learner_profile_optimizer_prompt.py
@@ -215,7 +215,7 @@ def _run_codex(
 
 def _codex_version() -> str:
     try:
-        completed = subprocess.run(
+        completed = subprocess.run(  # noqa: S603 - resolved Codex, fixed version flag
             [
                 _codex_executable(
                     missing_message="could not determine the codex CLI version",

--- a/src/api/scripts/inventory/match_routes.py
+++ b/src/api/scripts/inventory/match_routes.py
@@ -48,8 +48,13 @@ def grep_paths(root, extra_args=None):
     if not Path(root).is_dir():
         return set()
     # no quote anchoring: f-strings like f"{base}/api/x/{bid}/export" must hit
-    cmd = ["grep", "-rhoE", r"/api/[^'\"`[:space:]]*", root]
-    out = subprocess.run(cmd, capture_output=True, text=True, check=False).stdout
+    cmd = ["grep", "-rhoE", r"/api/[^'\"`[:space:]]*", "--", root]
+    out = subprocess.run(  # noqa: S603 - fixed grep with an option boundary
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout
     paths = set()
     for line in out.splitlines():
         p = line.strip().rstrip(".,;:)]}")

--- a/src/api/tests/migrations/test_fresh_mysql_upgrade.py
+++ b/src/api/tests/migrations/test_fresh_mysql_upgrade.py
@@ -147,7 +147,7 @@ def test_fresh_mysql_upgrade_reaches_head():
     env["SQLALCHEMY_DATABASE_URI"] = temp_uri
 
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603 - runs a fixed migration test script
             [sys.executable, "-c", _migration_subprocess_script()],
             cwd=API_ROOT,
             env=env,

--- a/src/api/tests/scripts/test_evaluate_learner_profile_optimizer_prompt.py
+++ b/src/api/tests/scripts/test_evaluate_learner_profile_optimizer_prompt.py
@@ -40,6 +40,7 @@ def test_run_codex_keeps_dynamic_values_as_arguments(
     temporary_directory = MagicMock()
     temporary_directory.return_value.__enter__.return_value = str(tmp_path)
     monkeypatch.setattr(evaluator.tempfile, "TemporaryDirectory", temporary_directory)
+    monkeypatch.setattr(evaluator.shutil, "which", lambda _name: "/trusted/codex")
     monkeypatch.setattr(evaluator.subprocess, "run", fake_run)
 
     # Exercise the internal runner without widening the production script API.
@@ -51,7 +52,7 @@ def test_run_codex_keeps_dynamic_values_as_arguments(
         timeout_seconds=5,
     )
 
-    assert captured_command[0] == "codex"
+    assert captured_command[0] == "/trusted/codex"
     assert captured_command[captured_command.index("--model") + 1] == "test-model"
     assert captured_kwargs["input"] == "profile; echo not-a-command"
     assert "shell" not in captured_kwargs

--- a/src/api/tests/scripts/test_evaluate_learner_profile_optimizer_prompt.py
+++ b/src/api/tests/scripts/test_evaluate_learner_profile_optimizer_prompt.py
@@ -1,0 +1,54 @@
+# Copyright 2026
+"""Verify the learner-profile prompt evaluator subprocess boundary."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from scripts import evaluate_learner_profile_optimizer_prompt as evaluator
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_run_codex_keeps_dynamic_values_as_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep prompt, model, and learner text out of the executable position."""
+    captured_command: list[str] = []
+    captured_kwargs: dict[str, object] = {}
+
+    def fake_run(
+        command: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        captured_command.extend(command)
+        captured_kwargs.update(kwargs)
+        output_path = Path(command[command.index("--output-last-message") + 1])
+        output_path.write_text("optimized profile", encoding="utf-8")
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout='{"type":"turn.completed","usage":{}}\n',
+            stderr="",
+        )
+
+    monkeypatch.setattr(evaluator.subprocess, "run", fake_run)
+
+    # Exercise the internal runner without widening the production script API.
+    run_codex = vars(evaluator)["_run_codex"]
+    result, metadata = run_codex(
+        system_prompt='Keep "quoted" text; do not execute it.',
+        user_message="profile; echo not-a-command",
+        model="test-model",
+        timeout_seconds=5,
+    )
+
+    assert captured_command[0] == "codex"
+    assert captured_command[captured_command.index("--model") + 1] == "test-model"
+    assert captured_kwargs["input"] == "profile; echo not-a-command"
+    assert "shell" not in captured_kwargs
+    assert result == "optimized profile"
+    assert metadata["tool_calls_observed"] is False

--- a/src/api/tests/scripts/test_evaluate_learner_profile_optimizer_prompt.py
+++ b/src/api/tests/scripts/test_evaluate_learner_profile_optimizer_prompt.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 from scripts import evaluate_learner_profile_optimizer_prompt as evaluator
 
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
 
 def test_run_codex_keeps_dynamic_values_as_arguments(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """Keep prompt, model, and learner text out of the executable position."""
     captured_command: list[str] = []
@@ -35,6 +37,9 @@ def test_run_codex_keeps_dynamic_values_as_arguments(
             stderr="",
         )
 
+    temporary_directory = MagicMock()
+    temporary_directory.return_value.__enter__.return_value = str(tmp_path)
+    monkeypatch.setattr(evaluator.tempfile, "TemporaryDirectory", temporary_directory)
     monkeypatch.setattr(evaluator.subprocess, "run", fake_run)
 
     # Exercise the internal runner without widening the production script API.

--- a/src/api/tests/scripts/test_match_routes.py
+++ b/src/api/tests/scripts/test_match_routes.py
@@ -1,0 +1,43 @@
+# Copyright 2026
+"""Verify backend route inventory subprocess argument handling."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "inventory" / "match_routes.py"
+)
+
+
+def test_leading_dash_consumer_root_is_not_parsed_as_grep_option(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep a leading-dash consumer directory positional to grep."""
+    inventory_dir = tmp_path / "inventory"
+    inventory_dir.mkdir()
+    (inventory_dir / "routes-backend.txt").write_text("", encoding="utf-8")
+
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    miniapp_dir = tmp_path / "-miniapp"
+    miniapp_dir.mkdir()
+    (miniapp_dir / "client.py").write_text(
+        'PATH = "/api/leading-dash-consumer"\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("INVENTORY_WORK_DIR", str(inventory_dir))
+    monkeypatch.setenv("SKILLS_REPO", str(skills_dir))
+    monkeypatch.setenv("MINIAPP_REPO", "-miniapp")
+
+    namespace = runpy.run_path(str(SCRIPT_PATH), run_name="__main__")
+
+    assert ("api", "leading-dash-consumer") in namespace["surfaces"]["miniprogram"]

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -1184,7 +1184,7 @@ def test_litellm_195_native_adapter_contracts():
     )
     env = os.environ.copy()
     env["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    completed = subprocess.run(
+    completed = subprocess.run(  # noqa: S603 - runs a fixed adapter test script
         [sys.executable, "-c", script],
         capture_output=True,
         env=env,


### PR DESCRIPTION
## Summary

- Enforce `S603` across backend tests, repository scripts, and backend maintenance scripts instead of hiding those trees.
- Replace broad exceptions with 12 explained per-call audits: two fixed-interpreter tests, five resolved Git commands, two resolved Codex calls, a fixed diagnostics runner, an allowlisted Prettier helper, and the route-inventory grep command.
- Restrict the Prettier helper to `git` and `node`, and terminate grep options before its dynamic root path.
- Keep subprocess isolation where it is the tested behavior and document the project-wide argument-boundary treatment.

## Stack

- Base: `sunner/ruff-s607` / #2599
- Head: `sunner/ruff-s603`
- Rule unit: `S603` only

## Ruff boundary

- Removed `S603` from `src/api/tests/**`, `scripts/**`, and `src/api/scripts/**`.
- Configured S603 and S607 scans pass.
- `--ignore-noqa` reports 13 reviewed S603 boundaries: the 12 calls owned by this stacked rule work plus the pre-existing operator-supplied plugin clone.
- Stable configured `ALL` census remains 28,202 findings across 28 rules; all 18 per-file patterns resolve to tracked paths.

## Tests

- Root executable/script suites: 8 passed.
- Backend evaluator, route inventory, fresh-MySQL, and LiteLLM owners: 67 passed, 2 skipped at their explicit environment gates.
- The Codex boundary test uses pytest `tmp_path`, so the exact subprocess contract is covered on Linux and macOS.

## Verification

- `ruff check . --select S603`
- `ruff check . --select S607`
- `ruff check .`
- `ruff format --check .`
- `python3 scripts/check_repo_harness.py`
- `python3 scripts/check_architecture_boundaries.py`
- `python3 scripts/check_dev_tools.py`
- translation validation and usage checks
- `lefthook run pre-commit --all-files`