### PR TITLE
chore: run full frontend and backend CI on main

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -27,7 +27,28 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Detect backend changes
+        id: backend-changes
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git diff --name-only "$BASE_SHA...$HEAD_SHA" > /tmp/backend-changed-files.txt
+          if grep -Eq '^(\.github/workflows/backend-tests\.yml$|src/api/)' /tmp/backend-changed-files.txt; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Python
+        if: steps.backend-changes.outputs.run == 'true'
         uses: actions/setup-python@v6
         with:
           # testmon invalidates its database when the Python patch version
@@ -39,6 +60,7 @@ jobs:
             src/api/requirements-ci.txt
 
       - name: Resolve testmon cache lineage
+        if: steps.backend-changes.outputs.run == 'true'
         id: testmon-cache
         shell: bash
         env:
@@ -58,6 +80,7 @@ jobs:
           echo "previous-sha=$previous_sha" >> "$GITHUB_OUTPUT"
 
       - name: Restore testmon cache
+        if: steps.backend-changes.outputs.run == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -74,15 +97,17 @@ jobs:
             testmon-${{ runner.os }}-py${{ env.BACKEND_PYTHON_VERSION }}-
 
       - name: Install dependencies
+        if: steps.backend-changes.outputs.run == 'true'
         working-directory: src/api
         run: python -m pip install -r requirements-ci.txt
 
       - name: Run contract tests
+        if: steps.backend-changes.outputs.run == 'true'
         working-directory: src/api
         run: python -m pytest tests/contract -v --tb=short
 
       - name: Select test targets (PR only)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.backend-changes.outputs.run == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -241,13 +266,18 @@ jobs:
                   summary.write(f"- Targets: `{targets_list}`\n")
           PY
 
+      - name: Skip backend tests (unrelated pull request)
+        if: github.event_name == 'pull_request' && steps.backend-changes.outputs.run != 'true'
+        run: |
+          echo "Skipping backend setup and tests because this pull request has no backend changes."
+
       - name: Skip backend tests (PR control-plane only)
-        if: github.event_name == 'pull_request' && env.SKIP_BACKEND_TESTS == '1'
+        if: github.event_name == 'pull_request' && steps.backend-changes.outputs.run == 'true' && env.SKIP_BACKEND_TESTS == '1'
         run: |
           echo "Skipping backend tests because the PR only changed backend control-plane or tooling files."
 
       - name: Run tests (PR incremental)
-        if: github.event_name == 'pull_request' && env.SKIP_BACKEND_TESTS != '1'
+        if: github.event_name == 'pull_request' && steps.backend-changes.outputs.run == 'true' && env.SKIP_BACKEND_TESTS != '1'
         working-directory: src/api
         run: |
           python -m pytest --testmon $TEST_TARGETS

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -2,15 +2,11 @@ name: Backend Tests
 
 on:
   pull_request:
-    paths:
-      - "src/api/**"
-      - ".github/workflows/backend-tests.yml"
+    branches:
+      - main
   push:
     branches:
       - main
-    paths:
-      - "src/api/**"
-      - ".github/workflows/backend-tests.yml"
   workflow_dispatch:
 
 permissions:
@@ -36,48 +32,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          # testmon invalidates its database when the Python patch version
-          # changes, so keep the complete interpreter version stable.
           python-version: ${{ env.BACKEND_PYTHON_VERSION }}
           cache: pip
           cache-dependency-path: |
             src/api/requirements.txt
             src/api/requirements-ci.txt
-
-      - name: Resolve testmon cache lineage
-        id: testmon-cache
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            current_sha="$PR_HEAD_SHA"
-          else
-            current_sha="$GITHUB_SHA"
-          fi
-          previous_sha="$(git rev-parse "${current_sha}^" 2>/dev/null || true)"
-          if [[ -z "$previous_sha" ]]; then
-            previous_sha="$current_sha"
-          fi
-          echo "current-sha=$current_sha" >> "$GITHUB_OUTPUT"
-          echo "previous-sha=$previous_sha" >> "$GITHUB_OUTPUT"
-
-      - name: Restore testmon cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            src/api/.testmondata
-            src/api/.pytest_cache
-          # A unique exact key lets each successful commit publish updated state.
-          # Prefer the exact parent commit before broader branch/main fallbacks.
-          key: testmon-${{ runner.os }}-py${{ env.BACKEND_PYTHON_VERSION }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt', 'src/api/requirements-ci.txt') }}-${{ steps.testmon-cache.outputs.current-sha }}
-          restore-keys: |
-            testmon-${{ runner.os }}-py${{ env.BACKEND_PYTHON_VERSION }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt', 'src/api/requirements-ci.txt') }}-${{ steps.testmon-cache.outputs.previous-sha }}
-            testmon-${{ runner.os }}-py${{ env.BACKEND_PYTHON_VERSION }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt', 'src/api/requirements-ci.txt') }}-
-            testmon-${{ runner.os }}-py${{ env.BACKEND_PYTHON_VERSION }}-main-main-${{ hashFiles('src/api/requirements.txt', 'src/api/requirements-ci.txt') }}-
-            testmon-${{ runner.os }}-py${{ env.BACKEND_PYTHON_VERSION }}-main-
-            testmon-${{ runner.os }}-py${{ env.BACKEND_PYTHON_VERSION }}-
 
       - name: Install dependencies
         working-directory: src/api
@@ -87,181 +46,15 @@ jobs:
         working-directory: src/api
         run: python -m pytest tests/contract -v --tb=short
 
-      - name: Select test targets (PR only)
+      - name: Run full backend test suite (pull request)
         if: github.event_name == 'pull_request'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          python - <<'PY'
-          from __future__ import annotations
-
-          import os
-          import pathlib
-          import subprocess
-
-          base_sha = os.environ.get("BASE_SHA")
-          head_sha = os.environ.get("HEAD_SHA")
-          if not base_sha or not head_sha:
-              raise SystemExit("Missing BASE_SHA or HEAD_SHA")
-
-          changed = subprocess.check_output(
-              ["git", "diff", "--name-only", base_sha, head_sha],
-              text=True,
-          ).splitlines()
-
-          targets: set[str] = set()
-          full_run = False
-          skip_run = False
-          api_root = pathlib.Path("src/api")
-
-          def normalize(path: str) -> str:
-              prefix = "src/api/"
-              return path[len(prefix):] if path.startswith(prefix) else path
-
-          def is_test_module(path: str) -> bool:
-              name = pathlib.PurePath(path).name
-              if not name.endswith(".py"):
-                  return False
-              return name.startswith("test_") or name.endswith("_test.py")
-
-          def has_test_module(directory: pathlib.Path) -> bool:
-              return any(
-                  is_test_module(str(child))
-                  for child in directory.rglob("*.py")
-              )
-
-          def enclosing_test_dir(path: str) -> str:
-              directory = pathlib.PurePath(path).parent
-              while True:
-                  if has_test_module(api_root / directory):
-                      return str(directory)
-                  if directory == pathlib.PurePath("tests") or not directory.parts:
-                      return "tests"
-                  directory = directory.parent
-
-          def module_name(path: str) -> str:
-              parts = list(pathlib.PurePath(path).with_suffix("").parts)
-              if parts[-1] == "__init__":
-                  parts.pop()
-              return ".".join(parts)
-
-          def imported_outside(path: str, package: str) -> bool:
-              # Test packages import each other's helpers by dotted path, so a
-              # helper used from another package needs the whole suite.
-              needle = module_name(path)
-              if not needle:
-                  return True
-              inside = f"{package}/"
-              for module in (api_root / "tests").rglob("*.py"):
-                  relative = module.relative_to(api_root).as_posix()
-                  if relative.startswith(inside):
-                      continue
-                  if not is_test_module(relative) and module.name != "conftest.py":
-                      continue
-                  if needle in module.read_text(encoding="utf-8"):
-                      return True
-              return False
-
-          def add_target(path: str) -> None:
-              global full_run
-              candidate = normalize(path)
-              if not (api_root / candidate).exists():
-                  return
-              if (api_root / candidate).is_file() and not is_test_module(candidate):
-                  # Helpers, fixtures and conftest files hold no tests of their
-                  # own, so run the nearest enclosing package that does instead
-                  # of collecting nothing and failing with pytest exit code 5.
-                  package = enclosing_test_dir(candidate)
-                  if candidate.endswith(".py") and imported_outside(candidate, package):
-                      full_run = True
-                      return
-                  candidate = package
-              targets.add(candidate)
-
-          def is_control_plane_backend_path(path: str) -> bool:
-              if path in {
-                  "src/api/AGENTS.md",
-                  "src/api/CLAUDE.md",
-                  "src/api/SKILL.md",
-                  ".github/workflows/backend-tests.yml",
-              }:
-                  return True
-              return path.startswith("src/api/scripts/")
-
-          for path in changed:
-              if path in {
-                  "src/api/requirements.txt",
-              }:
-                  full_run = True
-                  break
-              if not path.startswith("src/api/"):
-                  if path == ".github/workflows/backend-tests.yml":
-                      continue
-                  continue
-              if is_control_plane_backend_path(path):
-                  continue
-              if path.startswith("src/api/migrations/"):
-                  full_run = True
-                  break
-              if path.startswith("src/api/tests/"):
-                  add_target(path)
-                  continue
-              if path.startswith("src/api/flaskr/service/"):
-                  parts = path.split("/")
-                  if len(parts) > 4:
-                      module = parts[4]
-                      test_dir = pathlib.Path("tests/service") / module
-                      if (api_root / test_dir).exists():
-                          targets.add(str(test_dir))
-                      else:
-                          full_run = True
-                          break
-                  else:
-                      full_run = True
-                      break
-                  continue
-              # Fallback to full run for non-service changes under src/api.
-              full_run = True
-              break
-
-          if full_run:
-              targets = {"tests"}
-          elif not targets:
-              skip_run = True
-
-          targets_list = " ".join(sorted(targets))
-          if skip_run:
-              print("Selected targets: <skipped>")
-          else:
-              print(f"Selected targets: {targets_list}")
-          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
-              env_file.write(f"SKIP_BACKEND_TESTS={'1' if skip_run else '0'}\n")
-              env_file.write(f"TEST_TARGETS={targets_list}\n")
-          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
-              summary.write("### Backend test targets (PR)\n")
-              if skip_run:
-                  summary.write("- Targets: `skipped`\n")
-                  summary.write("- Reason: control-plane or tooling-only backend changes.\n")
-              else:
-                  summary.write(f"- Targets: `{targets_list}`\n")
-          PY
-
-      - name: Skip backend tests (PR control-plane only)
-        if: github.event_name == 'pull_request' && env.SKIP_BACKEND_TESTS == '1'
-        run: |
-          echo "Skipping backend tests because the PR only changed backend control-plane or tooling files."
-
-      - name: Run tests (PR incremental)
-        if: github.event_name == 'pull_request' && env.SKIP_BACKEND_TESTS != '1'
         working-directory: src/api
-        run: |
-          python -m pytest --testmon $TEST_TARGETS
+        run: python -m pytest
 
       - name: Run tests with coverage (main/full)
         if: github.event_name != 'pull_request'
         working-directory: src/api
         run: |
-          python -m coverage run -m pytest --testmon-noselect
+          python -m coverage run -m pytest
           python -m coverage report -m
           python -m coverage report -m >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -32,11 +32,48 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
+          # testmon invalidates its database when the Python patch version
+          # changes, so keep the complete interpreter version stable.
           python-version: ${{ env.BACKEND_PYTHON_VERSION }}
           cache: pip
           cache-dependency-path: |
             src/api/requirements.txt
             src/api/requirements-ci.txt
+
+      - name: Resolve testmon cache lineage
+        id: testmon-cache
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            current_sha="$PR_HEAD_SHA"
+          else
+            current_sha="$GITHUB_SHA"
+          fi
+          previous_sha="$(git rev-parse "${current_sha}^" 2>/dev/null || true)"
+          if [[ -z "$previous_sha" ]]; then
+            previous_sha="$current_sha"
+          fi
+          echo "current-sha=$current_sha" >> "$GITHUB_OUTPUT"
+          echo "previous-sha=$previous_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Restore testmon cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            src/api/.testmondata
+            src/api/.pytest_cache
+          # A unique exact key lets each successful commit publish updated state.
+          # Prefer the exact parent commit before broader branch/main fallbacks.
+          key: testmon-${{ runner.os }}-py${{ env.BACKEND_PYTHON_VERSION }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt', 'src/api/requirements-ci.txt') }}-${{ steps.testmon-cache.outputs.current-sha }}
+          restore-keys: |
+            testmon-${{ runner.os }}-py${{ env.BACKEND_PYTHON_VERSION }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt', 'src/api/requirements-ci.txt') }}-${{ steps.testmon-cache.outputs.previous-sha }}
+            testmon-${{ runner.os }}-py${{ env.BACKEND_PYTHON_VERSION }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.head_ref) || format('main-{0}', github.ref_name) }}-${{ hashFiles('src/api/requirements.txt', 'src/api/requirements-ci.txt') }}-
+            testmon-${{ runner.os }}-py${{ env.BACKEND_PYTHON_VERSION }}-main-main-${{ hashFiles('src/api/requirements.txt', 'src/api/requirements-ci.txt') }}-
+            testmon-${{ runner.os }}-py${{ env.BACKEND_PYTHON_VERSION }}-main-
+            testmon-${{ runner.os }}-py${{ env.BACKEND_PYTHON_VERSION }}-
 
       - name: Install dependencies
         working-directory: src/api
@@ -46,15 +83,181 @@ jobs:
         working-directory: src/api
         run: python -m pytest tests/contract -v --tb=short
 
-      - name: Run full backend test suite (pull request)
+      - name: Select test targets (PR only)
         if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python - <<'PY'
+          from __future__ import annotations
+
+          import os
+          import pathlib
+          import subprocess
+
+          base_sha = os.environ.get("BASE_SHA")
+          head_sha = os.environ.get("HEAD_SHA")
+          if not base_sha or not head_sha:
+              raise SystemExit("Missing BASE_SHA or HEAD_SHA")
+
+          changed = subprocess.check_output(
+              ["git", "diff", "--name-only", base_sha, head_sha],
+              text=True,
+          ).splitlines()
+
+          targets: set[str] = set()
+          full_run = False
+          skip_run = False
+          api_root = pathlib.Path("src/api")
+
+          def normalize(path: str) -> str:
+              prefix = "src/api/"
+              return path[len(prefix):] if path.startswith(prefix) else path
+
+          def is_test_module(path: str) -> bool:
+              name = pathlib.PurePath(path).name
+              if not name.endswith(".py"):
+                  return False
+              return name.startswith("test_") or name.endswith("_test.py")
+
+          def has_test_module(directory: pathlib.Path) -> bool:
+              return any(
+                  is_test_module(str(child))
+                  for child in directory.rglob("*.py")
+              )
+
+          def enclosing_test_dir(path: str) -> str:
+              directory = pathlib.PurePath(path).parent
+              while True:
+                  if has_test_module(api_root / directory):
+                      return str(directory)
+                  if directory == pathlib.PurePath("tests") or not directory.parts:
+                      return "tests"
+                  directory = directory.parent
+
+          def module_name(path: str) -> str:
+              parts = list(pathlib.PurePath(path).with_suffix("").parts)
+              if parts[-1] == "__init__":
+                  parts.pop()
+              return ".".join(parts)
+
+          def imported_outside(path: str, package: str) -> bool:
+              # Test packages import each other's helpers by dotted path, so a
+              # helper used from another package needs the whole suite.
+              needle = module_name(path)
+              if not needle:
+                  return True
+              inside = f"{package}/"
+              for module in (api_root / "tests").rglob("*.py"):
+                  relative = module.relative_to(api_root).as_posix()
+                  if relative.startswith(inside):
+                      continue
+                  if not is_test_module(relative) and module.name != "conftest.py":
+                      continue
+                  if needle in module.read_text(encoding="utf-8"):
+                      return True
+              return False
+
+          def add_target(path: str) -> None:
+              global full_run
+              candidate = normalize(path)
+              if not (api_root / candidate).exists():
+                  return
+              if (api_root / candidate).is_file() and not is_test_module(candidate):
+                  # Helpers, fixtures and conftest files hold no tests of their
+                  # own, so run the nearest enclosing package that does instead
+                  # of collecting nothing and failing with pytest exit code 5.
+                  package = enclosing_test_dir(candidate)
+                  if candidate.endswith(".py") and imported_outside(candidate, package):
+                      full_run = True
+                      return
+                  candidate = package
+              targets.add(candidate)
+
+          def is_control_plane_backend_path(path: str) -> bool:
+              if path in {
+                  "src/api/AGENTS.md",
+                  "src/api/CLAUDE.md",
+                  "src/api/SKILL.md",
+                  ".github/workflows/backend-tests.yml",
+              }:
+                  return True
+              return path.startswith("src/api/scripts/")
+
+          for path in changed:
+              if path in {
+                  "src/api/requirements.txt",
+              }:
+                  full_run = True
+                  break
+              if not path.startswith("src/api/"):
+                  if path == ".github/workflows/backend-tests.yml":
+                      continue
+                  continue
+              if is_control_plane_backend_path(path):
+                  continue
+              if path.startswith("src/api/migrations/"):
+                  full_run = True
+                  break
+              if path.startswith("src/api/tests/"):
+                  add_target(path)
+                  continue
+              if path.startswith("src/api/flaskr/service/"):
+                  parts = path.split("/")
+                  if len(parts) > 4:
+                      module = parts[4]
+                      test_dir = pathlib.Path("tests/service") / module
+                      if (api_root / test_dir).exists():
+                          targets.add(str(test_dir))
+                      else:
+                          full_run = True
+                          break
+                  else:
+                      full_run = True
+                      break
+                  continue
+              # Fallback to full run for non-service changes under src/api.
+              full_run = True
+              break
+
+          if full_run:
+              targets = {"tests"}
+          elif not targets:
+              skip_run = True
+
+          targets_list = " ".join(sorted(targets))
+          if skip_run:
+              print("Selected targets: <skipped>")
+          else:
+              print(f"Selected targets: {targets_list}")
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+              env_file.write(f"SKIP_BACKEND_TESTS={'1' if skip_run else '0'}\n")
+              env_file.write(f"TEST_TARGETS={targets_list}\n")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("### Backend test targets (PR)\n")
+              if skip_run:
+                  summary.write("- Targets: `skipped`\n")
+                  summary.write("- Reason: control-plane or tooling-only backend changes.\n")
+              else:
+                  summary.write(f"- Targets: `{targets_list}`\n")
+          PY
+
+      - name: Skip backend tests (PR control-plane only)
+        if: github.event_name == 'pull_request' && env.SKIP_BACKEND_TESTS == '1'
+        run: |
+          echo "Skipping backend tests because the PR only changed backend control-plane or tooling files."
+
+      - name: Run tests (PR incremental)
+        if: github.event_name == 'pull_request' && env.SKIP_BACKEND_TESTS != '1'
         working-directory: src/api
-        run: python -m pytest
+        run: |
+          python -m pytest --testmon $TEST_TARGETS
 
       - name: Run tests with coverage (main/full)
         if: github.event_name != 'pull_request'
         working-directory: src/api
         run: |
-          python -m coverage run -m pytest
+          python -m coverage run -m pytest --testmon-noselect
           python -m coverage report -m
           python -m coverage report -m >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -2,8 +2,6 @@ name: Backend Tests
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -27,7 +27,28 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Detect frontend changes
+        id: frontend-changes
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git diff --name-only "$BASE_SHA...$HEAD_SHA" > /tmp/frontend-changed-files.txt
+          if grep -Eq '^(\.github/workflows/frontend-tests\.yml$|src/cook-web/|src/i18n/)' /tmp/frontend-changed-files.txt; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Node.js
+        if: steps.frontend-changes.outputs.run == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "22.16.0"
@@ -35,9 +56,15 @@ jobs:
           cache-dependency-path: src/cook-web/package-lock.json
 
       - name: Install frontend dependencies
+        if: steps.frontend-changes.outputs.run == 'true'
         working-directory: src/cook-web
         run: npm ci
 
       - name: Run frontend tests
+        if: steps.frontend-changes.outputs.run == 'true'
         working-directory: src/cook-web
         run: npm run test:ci
+
+      - name: Skip frontend tests
+        if: steps.frontend-changes.outputs.run != 'true'
+        run: echo "Skipping frontend tests because this pull request has no frontend or shared i18n changes."

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -2,13 +2,11 @@ name: Frontend Tests
 
 on:
   pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/frontend-tests.yml"
-      - "src/cook-web/**"
-      - "src/i18n/**"
   workflow_dispatch:
 
 permissions:
@@ -29,28 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect frontend changes
-        id: frontend-changes
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          if [[ "$EVENT_NAME" != "pull_request" ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git diff --name-only "$BASE_SHA...$HEAD_SHA" > /tmp/frontend-changed-files.txt
-          if grep -Eq '^(\.github/workflows/frontend-tests\.yml$|src/cook-web/|src/i18n/)' /tmp/frontend-changed-files.txt; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Set up Node.js
-        if: steps.frontend-changes.outputs.run == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "22.16.0"
@@ -58,15 +35,9 @@ jobs:
           cache-dependency-path: src/cook-web/package-lock.json
 
       - name: Install frontend dependencies
-        if: steps.frontend-changes.outputs.run == 'true'
         working-directory: src/cook-web
         run: npm ci
 
       - name: Run frontend tests
-        if: steps.frontend-changes.outputs.run == 'true'
         working-directory: src/cook-web
         run: npm run test:ci
-
-      - name: Skip frontend tests
-        if: steps.frontend-changes.outputs.run != 'true'
-        run: echo "Skipping frontend tests because this pull request has no frontend or shared i18n changes."

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -2,8 +2,6 @@ name: Frontend Tests
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

- run Frontend Tests and Backend Tests after every push to main, regardless of changed paths
- preserve frontend change detection and backend testmon selection for pull requests on any base branch
- make Backend Tests trigger on every pull request so its required status is always reported
- skip Python setup, dependency installation, contract tests, and pytest for pull requests with no backend changes

## GitHub ruleset

- added `Run backend tests` to the active main ruleset's required status checks

## Verification

- frontend full suite: 162 suites, 1295 tests passed locally
- corrected PR behavior preserves selective frontend/backend execution
- `check-yaml .github/workflows/backend-tests.yml .github/workflows/frontend-tests.yml`
- `python3 scripts/check_repo_harness.py`
- `python3 scripts/check_architecture_boundaries.py`
- `lefthook run pre-commit`
- latest GitHub Actions run passed Backend Tests, Frontend Tests, autofix, static checks, and CodeQL