### PR TITLE
refactor: replace unsafe module-global state without breaking plugins

### DIFF
--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -79,9 +79,15 @@ plan's progress update for that rule.
   repository pre-commit hooks passed.
 - [ ] Merge or retarget UP046 PR #2577 after its predecessors without combining
   it with the next rule unit.
-- [ ] Remove the PLW0603 global ignore by classifying and testing all 25 module-
-  state mutations, then refactoring safe cases and retaining only intrinsic
-  narrow exceptions.
+- [x] 2026-08-20 23:16 CST: Opened ready PLW0603 PR
+  [#2579](https://github.com/ai-shifu/ai-shifu/pull/2579) from
+  `sunner/ruff-plw0603` to the UP046 branch. All 25 findings across 13
+  state-writing sites were replaced with stable extensions, typed state
+  owners, or explicit accessors; no PLW0603 suppression remains. The full
+  backend suite passes 3,008 tests with 17 skips, and all repository
+  pre-commit hooks pass.
+- [ ] Merge or retarget PLW0603 PR #2579 after its predecessors without
+  combining it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -110,6 +116,10 @@ plan's progress update for that rule.
   `/api/user/send_sms_code` Flasgger YAML docstring. Rewriting it as a NumPy
   docstring section would corrupt the API specification, so the correct end
   state is global enforcement plus a narrow, explained suppression.
+- PLW0603's full-suite verification exposed a pre-existing test class that
+  permanently replaced `dao.init_redis` during collection. Fixture-scoped
+  injection now owns that test double, so collecting an unrelated test can no
+  longer alter the production DAO module for the rest of the process.
 - FIX002 and TD003 report the same two TODOs. One is a real password-login
   rate-limit feature and one is a compatibility-removal checkpoint. Renaming
   them to evade lint would hide work, and implementing either is larger than a
@@ -186,6 +196,14 @@ Python 3.12-only syntax. UP046 is clean under the configured Python 3.11 target;
 an explicit Python 3.12 audit records the `PageWindow` and `HistoryItem` class
 migrations. The billing suite passes 673 tests with 10 skips, the focused shifu
 history test passes, and the full repository gates pass.
+
+The PLW0603 stage removes the global ignore and every Python `global` statement
+without adding inline or per-file exceptions. Stable Flask extensions keep
+imported identities intact; replaceable process state now has explicit owners
+for app, config, Redis, plugins, Celery, Langfuse, analytics, Ping++, and TTS;
+verification codes read the current app instead of cross-app caches. Focused
+lifecycle suites and the full backend suite pass 3,008 tests with 17 skips, and
+the repository-wide pre-commit gate passes.
 
 ## Context and Orientation
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -106,7 +106,7 @@ select = [
     # --- Pylint subsets ---------------------------------------------------
     "PLE",     # pylint errors (yield/return in __init__, invalid dunders, ...)
     "PLC",     # pylint conventions (PLC0415 ignored below)
-    "PLW",     # pylint warnings (PLW0603 ignored below)
+    "PLW",     # pylint warnings
     # PLR is partial: the complexity/magic-value members have thousands of
     # violations, so only the mechanical ones are listed.
     "PLR01",   # comparison with itself / of two constants
@@ -236,7 +236,6 @@ ignore = [
     "DTZ001",  # naive datetime() -- naive UTC is the house convention
     "G004",    # f-string logging -- house style, and rewriting it is churn
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)
-    "PLW0603", # global statement -- used by module-level singletons/caches
     # INP001 is enforced; see per-file-ignores for the entrypoints, Alembic
     # revisions and boundary-check fixtures that are loaded by path rather
     # than imported.

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -8,7 +9,10 @@ from flasgger import Swagger
 from flask import Flask
 from flask_cors import CORS
 from flask_migrate import Migrate
-from flaskr.framework.plugin.plugin_manager import enable_plugin_manager
+from flaskr.framework.plugin.plugin_manager import (
+    enable_plugin_manager,
+    get_plugin_manager,
+)
 
 # set timezone to UTC
 # fix windows platform
@@ -27,19 +31,26 @@ else:
     # Flask app (and the registry-backed config instance) exists.
     os.environ["TZ"] = timezone
     time.tzset()
-app = None
+
+
+@dataclass(slots=True)
+class _ApplicationState:
+    app: Flask | None = None
+
+
+_application_state = _ApplicationState()
+app: Flask | None = None
 
 
 def create_app() -> Flask:
-    global app
-    if app:
-        return app
+    if _application_state.app is not None:
+        return _application_state.app
     import pymysql
 
     pymysql.install_as_MySQLdb()
-    app = Flask(__name__, instance_relative_config=True)
+    flask_app = Flask(__name__, instance_relative_config=True)
     CORS(
-        app,
+        flask_app,
         resources={
             r"/api/*": {
                 "origins": [
@@ -55,65 +66,71 @@ def create_app() -> Flask:
     from flaskr.common import Config, init_log
     from flaskr.common.observability import init_observability
 
-    app.config = Config(app.config, app)
+    flask_app.config = Config(flask_app.config, flask_app)
 
     # init observability before request logging so trace ids are available in logs
-    init_observability(app)
+    init_observability(flask_app)
     # init log
-    init_log(app)
-    app = enable_plugin_manager(app)
-    app.logger.info("ai-shifu-api mode: %s", app.config.get("MODE", "api"))
+    init_log(flask_app)
+    flask_app = enable_plugin_manager(flask_app)
+    flask_app.logger.info("ai-shifu-api mode: %s", flask_app.config.get("MODE", "api"))
     # init database
     from flaskr import dao
 
-    dao.init_db(app)
+    dao.init_db(flask_app)
 
     # init i18n
     from flaskr.i18n import load_translations
 
-    load_translations(app)
+    load_translations(flask_app)
 
     # init redis
-    dao.init_redis(app)
+    dao.init_redis(flask_app)
 
     from flaskr.service.user.auth import register_builtin_providers
 
     register_builtin_providers()
 
     # Init LLM
-    with app.app_context():
+    with flask_app.app_context():
         from flaskr.api import llm  # noqa: F401
     # init langfuse
     from flaskr import api
 
-    api.init_langfuse(app)
+    api.init_langfuse(flask_app)
     # load plugins
     from flaskr.framework.plugin.load_plugin import load_plugins_from_dir
-    from flaskr.framework.plugin.plugin_manager import plugin_manager
 
-    load_plugins_from_dir(app, str(Path("flaskr") / "service"))
+    plugin_manager = get_plugin_manager()
+    if plugin_manager is None:
+        raise RuntimeError("Plugin manager is not enabled")
+
+    load_plugins_from_dir(flask_app, str(Path("flaskr") / "service"))
     try:
-        load_plugins_from_dir(app, str(Path("flaskr") / "plugins"), plugin_manager)
+        load_plugins_from_dir(
+            flask_app, str(Path("flaskr") / "plugins"), plugin_manager
+        )
     except Exception as e:
-        app.logger.warning(f"load plugins error: {e}")
+        flask_app.logger.warning(f"load plugins error: {e}")
 
-    Migrate(app, dao.db)
+    Migrate(flask_app, dao.db)
     # register route
     from flaskr.route import register_route
 
-    app = register_route(app)
+    flask_app = register_route(flask_app)
     # init swagger
-    if app.config.get("SWAGGER_ENABLED", False):
+    if flask_app.config.get("SWAGGER_ENABLED", False):
         from flaskr.common import swagger_config
 
-        app.logger.info("swagger init ...")
-        Swagger(app, config=swagger_config, merge=True)
+        flask_app.logger.info("swagger init ...")
+        Swagger(flask_app, config=swagger_config, merge=True)
 
     # enable hot reload
-    if app.config.get("ENV") == "development":
+    if flask_app.config.get("ENV") == "development":
         plugin_manager.enable_hot_reload()
 
-    return app
+    _application_state.app = flask_app
+    return flask_app
 
 
 if __name__ == "__main__":

--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import uuid
+from dataclasses import dataclass, field
 from typing import Any
 
 from flask import Flask, request
@@ -62,11 +63,16 @@ class MockClient:
         return method
 
 
-langfuse_client = MockClient()
+@dataclass(slots=True)
+class _LangfuseState:
+    client: Any = field(default_factory=MockClient)
+
+
+_langfuse_state = _LangfuseState()
 
 
 def get_langfuse_client():
-    return langfuse_client
+    return _langfuse_state.client
 
 
 def get_request_id() -> str:
@@ -134,7 +140,6 @@ PRELOAD_MASTER_ENV = "AI_SHIFU_PRELOAD_MASTER"
 
 
 def init_langfuse(app: Flask):
-    global langfuse_client
     if os.environ.get(PRELOAD_MASTER_ENV):
         # Running inside the gunicorn preload master. Creating a real client
         # here starts the Langfuse/OTel BatchProcessor worker thread in the
@@ -145,7 +150,7 @@ def init_langfuse(app: Flask):
         # unrelated in-flight DB exchanges. post_fork clears the flag and
         # calls init_langfuse again to build the real client per worker.
         app.logger.info("Deferring Langfuse init out of the preload master")
-        langfuse_client = MockClient()
+        _langfuse_state.client = MockClient()
         return
     app.logger.info("Initializing Langfuse client")
     if (
@@ -153,14 +158,14 @@ def init_langfuse(app: Flask):
         and app.config.get("LANGFUSE_SECRET_KEY")
         and app.config.get("LANGFUSE_HOST")
     ):
-        langfuse_client = Langfuse(
+        _langfuse_state.client = Langfuse(
             public_key=app.config["LANGFUSE_PUBLIC_KEY"],
             secret_key=app.config["LANGFUSE_SECRET_KEY"],
             host=app.config["LANGFUSE_HOST"],
         )
     else:
         app.logger.warning("Langfuse configuration not found, using MockLangfuse")
-        langfuse_client = MockClient()
+        _langfuse_state.client = MockClient()
 
 
 def _has_langfuse_value(value: Any) -> bool:

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -64,10 +64,11 @@ class CacheUnavailableError(RuntimeError):
 class _DynamicRedisCacheProvider:
     def _client(self):
         try:
-            from flaskr.dao import redis_client
+            from flaskr.dao import get_redis_client
         except Exception as exc:  # pragma: no cover - defensive
             raise CacheUnavailableError("Redis client import failed") from exc
 
+        redis_client = get_redis_client()
         if redis_client is None:
             raise CacheUnavailableError("Redis is not configured")
         return redis_client

--- a/src/api/flaskr/common/celery_app.py
+++ b/src/api/flaskr/common/celery_app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import os
+from dataclasses import dataclass
 from typing import Any
 
 from celery import Celery, Task
@@ -22,7 +23,13 @@ _DEFAULT_BILLING_CREDIT_EXPIRING_CRON = "0 * * * *"
 _DEFAULT_BILLING_DAILY_USAGE_METRICS_CRON = "15 1 * * *"
 _DEFAULT_BILLING_DAILY_LEDGER_SUMMARY_CRON = "30 1 * * *"
 
-__CELERY_APP__: Celery | None = None
+
+@dataclass(slots=True)
+class _CeleryState:
+    app: Celery | None = None
+
+
+_celery_state = _CeleryState()
 
 
 def dispose_inherited_db_pools(flask_app: Flask) -> None:
@@ -86,10 +93,9 @@ def create_celery_app(flask_app: Flask | None = None) -> Celery:
 
 def get_celery_app(flask_app: Flask | None = None) -> Celery:
     """Return a cached Celery app or create one on demand."""
-    global __CELERY_APP__
-    if __CELERY_APP__ is None or flask_app is not None:
-        __CELERY_APP__ = create_celery_app(flask_app=flask_app)
-    return __CELERY_APP__
+    if _celery_state.app is None or flask_app is not None:
+        _celery_state.app = create_celery_app(flask_app=flask_app)
+    return _celery_state.app
 
 
 def _build_celery_config(flask_app: Flask) -> dict[str, Any]:

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -2089,25 +2091,24 @@ class EnhancedConfig:
         return "\n".join(lines)
 
 
-# Global instance
-__INSTANCE__ = None
 __ENHANCED_CONFIG__ = EnhancedConfig(ENV_VARS)
 
 
 class Config(FlaskConfig):
     """Flask configuration wrapper with enhanced environment variable support."""
 
+    _instance: Config | None = None
+
     def __init__(
         self, parent: FlaskConfig, app: Flask, defaults: dict | None = None
     ) -> None:
-        global __INSTANCE__
         self.parent = parent
         self.app = app
         self.enhanced = __ENHANCED_CONFIG__
         # Reset shared cache per initialization to avoid cross-app contamination
         self.enhanced._cache.clear()
         self.enhanced._validated = False
-        __INSTANCE__ = self
+        Config._instance = self
         # Validate environment on initialization
         try:
             self.enhanced.validate_environment(allow_conversion_errors=True)
@@ -2249,7 +2250,7 @@ def get_config(key: str, default: Any = None) -> Any:
         Configuration value or default
 
     """
-    if __INSTANCE__ is None:
+    if Config._instance is None:
         # Before initialization, try to get from environment directly
         # This is needed for module-level calls like timezone setup
         if key in ENV_VARS:
@@ -2260,7 +2261,7 @@ def get_config(key: str, default: Any = None) -> Any:
             return value
         # For unknown keys, check environment directly
         return os.environ.get(key, default)
-    return __INSTANCE__.get(key, default)
+    return Config._instance.get(key, default)
 
 
 def has_explicit_env_override(key: str) -> bool:

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -84,6 +84,13 @@ def set_redis_client(client: Redis | None) -> None:
     _redis_state.client = client
 
 
+def __getattr__(name: str) -> Redis | None:
+    """Expose the owned Redis client to plugins using the legacy import name."""
+    if name == "redis_client":
+        return get_redis_client()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 def _socket_has_unread_data(dbapi_connection, timeout: float = 0) -> bool:
     """Return True when the DBAPI connection's socket has readable bytes.
 

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -32,10 +32,6 @@ from sqlalchemy.orm.exc import FlushError
 
 logger = logging.getLogger(__name__)
 
-# create a global db object
-db = None
-redis_client = None
-
 # Session scope tokens must never repeat. Flask-SQLAlchemy's stock scope
 # function keys the scoped-session registry on id(app_ctx) - a CPython memory
 # address that is recycled as soon as a context is garbage collected. With
@@ -61,6 +57,31 @@ def _unique_app_ctx_scope() -> int:
         token = next(_app_ctx_scope_counter)
         ctx.__dict__["_dao_session_scope_token"] = token
     return token
+
+
+# Flask extensions are stable module objects; initialization binds them to an app
+# without rebinding every model's imported ``db`` reference.
+db = SQLAlchemy(session_options={"scopefunc": _unique_app_ctx_scope})
+
+
+class _RedisState:
+    """Own the optional process-local Redis client."""
+
+    def __init__(self) -> None:
+        self.client: Redis | None = None
+
+
+_redis_state = _RedisState()
+
+
+def get_redis_client() -> Redis | None:
+    """Return the configured Redis client, if Redis is enabled."""
+    return _redis_state.client
+
+
+def set_redis_client(client: Redis | None) -> None:
+    """Replace the Redis client through its single lifecycle owner."""
+    _redis_state.client = client
 
 
 def _socket_has_unread_data(dbapi_connection, timeout: float = 0) -> bool:
@@ -522,7 +543,6 @@ def retry_on_deadlock(max_attempts: int = 3, backoff_seconds: float = 0.1):
 
 
 def init_db(app: Flask):
-    global db
     if app.debug:
         logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
 
@@ -583,8 +603,6 @@ def init_db(app: Flask):
 
     app.config["SQLALCHEMY_ENGINE_OPTIONS"] = existing_options
 
-    if db is None:
-        db = SQLAlchemy(session_options={"scopefunc": _unique_app_ctx_scope})
     db.init_app(app)
 
     # Global last-resort guard: any interrupted path not covered by an
@@ -642,8 +660,6 @@ def init_db(app: Flask):
 
 
 def init_redis(app: Flask):
-    global redis_client
-
     host = app.config.get("REDIS_HOST")
     port = app.config.get("REDIS_PORT")
 
@@ -651,7 +667,7 @@ def init_redis(app: Flask):
         app.logger.warning(
             "Redis not configured: REDIS_HOST or REDIS_PORT is None - running without Redis"
         )
-        redis_client = None
+        set_redis_client(None)
         return
 
     app.logger.info(
@@ -665,18 +681,22 @@ def init_redis(app: Flask):
         app.config.get("REDIS_PASSWORD") is not None
         and app.config["REDIS_PASSWORD"] != ""
     ):
-        redis_client = Redis(
-            host=host,
-            port=port,
-            db=app.config["REDIS_DB"],
-            password=app.config["REDIS_PASSWORD"],
-            username=app.config.get("REDIS_USER", None),
+        set_redis_client(
+            Redis(
+                host=host,
+                port=port,
+                db=app.config["REDIS_DB"],
+                password=app.config["REDIS_PASSWORD"],
+                username=app.config.get("REDIS_USER", None),
+            )
         )
     else:
-        redis_client = Redis(
-            host=host,
-            port=port,
-            db=app.config["REDIS_DB"],
+        set_redis_client(
+            Redis(
+                host=host,
+                port=port,
+                db=app.config["REDIS_DB"],
+            )
         )
     app.logger.info("init redis done")
 
@@ -684,6 +704,10 @@ def init_redis(app: Flask):
 def run_with_redis(app, key, timeout: int, func, args):
     with app.app_context():
         app.logger.info(f"run_with_redis start {key}")
+        redis_client = get_redis_client()
+        if redis_client is None:
+            app.logger.info(f"run_with_redis skipped without Redis {key}")
+            return None
         lock = redis_client.lock(key, timeout=timeout, blocking_timeout=timeout)
         if lock.acquire(blocking=False):
             app.logger.info(f"run_with_redis get lock {key}")

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -8,10 +8,14 @@ from alembic.config import Config
 from flask import Flask
 from flask.cli import with_appcontext
 
-from .plugin_manager import plugin_manager
+from .plugin_manager import get_plugin_manager
 
 
 def enable_plugins(app: Flask):
+    plugin_manager = get_plugin_manager()
+    if plugin_manager is None:
+        raise RuntimeError("Plugin manager is not enabled")
+
     @app.cli.group()
     def plugin():
         """Plugin management commands."""

--- a/src/api/flaskr/framework/plugin/hot_reload.py
+++ b/src/api/flaskr/framework/plugin/hot_reload.py
@@ -60,7 +60,14 @@ class PluginHotReloader:
         try:
             import sys
 
-            from .plugin_manager import plugin_manager
+            from .plugin_manager import get_plugin_manager
+
+            plugin_manager = get_plugin_manager()
+            if plugin_manager is None:
+                self.app.logger.warning(
+                    "Plugin unload skipped because the plugin manager is not enabled"
+                )
+                return
 
             # Convert path to module name
             module_name = plugin_path.replace("/", ".").replace(".py", "")

--- a/src/api/flaskr/framework/plugin/plugin_manager.py
+++ b/src/api/flaskr/framework/plugin/plugin_manager.py
@@ -4,8 +4,6 @@ from flask import Flask
 
 from .hot_reload import PluginHotReloader
 
-plugin_manager = None
-
 
 class PluginManager:
     def __init__(self, app: Flask) -> None:
@@ -83,25 +81,48 @@ class PluginManager:
         return None
 
 
+class _PluginManagerState:
+    """Own the replaceable manager without rebinding module state."""
+
+    def __init__(self) -> None:
+        self.manager: PluginManager | None = None
+
+
+_plugin_manager_state = _PluginManagerState()
+
+
+def get_plugin_manager() -> PluginManager | None:
+    """Return the process-local plugin manager, if it has been enabled."""
+    return _plugin_manager_state.manager
+
+
+def set_plugin_manager(manager: PluginManager | None) -> None:
+    """Set the process-local plugin manager through its single owner."""
+    _plugin_manager_state.manager = manager
+
+
 def enable_plugin_manager(app: Flask):
     app.logger.info("enable_plugin_manager")
-    global plugin_manager
-    plugin_manager = PluginManager(app)
+    set_plugin_manager(PluginManager(app))
     return app
 
 
 def disable_plugin_manager(app: Flask):
     app.logger.info("disable_plugin_manager")
-    if plugin_manager:
-        plugin_manager.disable_hot_reload()
-        plugin_manager.is_enabled = False
+    manager = get_plugin_manager()
+    if manager:
+        manager.disable_hot_reload()
+        manager.is_enabled = False
     return app
 
 
 # extensible decorator
 def extension(target_func_name):
     def decorator(func):
-        plugin_manager.register_extension(target_func_name, func)
+        manager = get_plugin_manager()
+        if manager is None:
+            raise RuntimeError("Plugin manager is not enabled")
+        manager.register_extension(target_func_name, func)
         return func
 
     return decorator
@@ -109,7 +130,10 @@ def extension(target_func_name):
 
 def extensible_generic_register(func_name):
     def decorator(func):
-        plugin_manager.register_extensible_generic(func_name, func)
+        manager = get_plugin_manager()
+        if manager is None:
+            raise RuntimeError("Plugin manager is not enabled")
+        manager.register_extensible_generic(func_name, func)
         return func
 
     return decorator
@@ -120,7 +144,10 @@ def extensible(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         result = func(*args, **kwargs)
-        return plugin_manager.execute_extensions(func.__name__, result, *args, **kwargs)
+        manager = get_plugin_manager()
+        if manager is None:
+            return result
+        return manager.execute_extensions(func.__name__, result, *args, **kwargs)
 
     return wrapper
 
@@ -140,10 +167,11 @@ def extensible_generic(func):
         result = func(*args, **kwargs)
         if result:
             yield from result
-        if func.__name__ in plugin_manager.extensible_generic_functions:
-            result = plugin_manager.execute_extensible_generic(
-                func.__name__, *args, **kwargs
-            )
+        manager = get_plugin_manager()
+        if manager is None:
+            return
+        if func.__name__ in manager.extensible_generic_functions:
+            result = manager.execute_extensible_generic(func.__name__, *args, **kwargs)
             if result:
                 yield from result
 

--- a/src/api/flaskr/service/billing/admin_ops_state.py
+++ b/src/api/flaskr/service/billing/admin_ops_state.py
@@ -51,9 +51,9 @@ def update_admin_billing_config_status(
 @contextmanager
 def _admin_ops_lock(key: str) -> Iterator[None]:
     try:
-        from flaskr import dao
+        from flaskr.dao import get_redis_client
 
-        redis = getattr(dao, "redis_client", None)
+        redis = get_redis_client()
         lock = (
             None
             if redis is None

--- a/src/api/flaskr/service/creator_analytics/engine.py
+++ b/src/api/flaskr/service/creator_analytics/engine.py
@@ -13,6 +13,7 @@ plain ``{"columns": [...], "rows": [...]}`` dict suitable for the HTTP layer.
 from __future__ import annotations
 
 import threading
+from dataclasses import dataclass, field
 from typing import Any
 
 from flask import Flask
@@ -21,10 +22,16 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine, Result
 from sqlalchemy.sql import Select
 
-_FALLBACK_WARNED = False
-_lock = threading.Lock()
-_engine: Engine | None = None
-_engine_uri: str | None = None
+
+@dataclass(slots=True)
+class _AnalyticsEngineState:
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    engine: Engine | None = None
+    uri: str | None = None
+    fallback_warned: bool = False
+
+
+_engine_state = _AnalyticsEngineState()
 
 
 def get_analytics_engine(app: Flask) -> Engine:
@@ -34,30 +41,35 @@ def get_analytics_engine(app: Flask) -> Engine:
     cached for the process lifetime. When the URI is empty the primary
     Flask-SQLAlchemy engine is reused and a one-shot warning is emitted.
     """
-    global _engine, _engine_uri, _FALLBACK_WARNED
-
     uri = (app.config.get("ANALYTICS_DATABASE_URI") or "").strip()
 
     if not uri:
-        if not _FALLBACK_WARNED:
-            app.logger.warning(
-                "creator-analytics is falling back to the primary database; "
-                "set ANALYTICS_DATABASE_URI to a read-only replica in production."
-            )
-            _FALLBACK_WARNED = True
+        with _engine_state.lock:
+            if not _engine_state.fallback_warned:
+                app.logger.warning(
+                    "creator-analytics is falling back to the primary database; "
+                    "set ANALYTICS_DATABASE_URI to a read-only replica in production."
+                )
+                _engine_state.fallback_warned = True
         return db.engine
 
-    with _lock:
-        if _engine is None or _engine_uri != uri:
+    with _engine_state.lock:
+        if _engine_state.engine is None or _engine_state.uri != uri:
             pool_size = _coerce_int(app, "ANALYTICS_DATABASE_POOL_SIZE", 5)
-            _engine = create_engine(
+            previous_engine = _engine_state.engine
+            _engine_state.engine = create_engine(
                 uri,
                 pool_size=pool_size,
                 pool_pre_ping=True,
                 future=True,
             )
-            _engine_uri = uri
-        return _engine
+            _engine_state.uri = uri
+            if previous_engine is not None:
+                previous_engine.dispose()
+        engine = _engine_state.engine
+        if engine is None:  # pragma: no cover - guarded by the branch above
+            raise RuntimeError("Analytics engine initialization failed")
+        return engine
 
 
 def run_query(app: Flask, stmt: Select) -> dict[str, Any]:
@@ -72,13 +84,12 @@ def run_query(app: Flask, stmt: Select) -> dict[str, Any]:
 
 def reset_for_tests() -> None:
     """Clear the cached engine — used by the test suite between cases."""
-    global _engine, _engine_uri, _FALLBACK_WARNED
-    with _lock:
-        if _engine is not None:
-            _engine.dispose()
-        _engine = None
-        _engine_uri = None
-        _FALLBACK_WARNED = False
+    with _engine_state.lock:
+        if _engine_state.engine is not None:
+            _engine_state.engine.dispose()
+        _engine_state.engine = None
+        _engine_state.uri = None
+        _engine_state.fallback_warned = False
 
 
 def _coerce_int(app: Flask, key: str, default: int) -> int:

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -1086,8 +1086,9 @@ def _tts_synth_sem_acquire(app: Flask, user_bid: str, outline_bid: str) -> str:
     if max_count <= 0 or not user_bid or not outline_bid:
         return _TTS_SLOT_BYPASS
     try:
-        from flaskr.dao import redis_client
+        from flaskr.dao import get_redis_client
 
+        redis_client = get_redis_client()
         if redis_client is None:
             return _TTS_SLOT_BYPASS  # fail open when Redis is unavailable
         result = redis_client.eval(
@@ -1113,8 +1114,9 @@ def _tts_synth_sem_release(app: Flask, user_bid: str, outline_bid: str) -> None:
     if _get_max_parallel_tts_synth_count(app) <= 0 or not user_bid or not outline_bid:
         return
     try:
-        from flaskr.dao import redis_client
+        from flaskr.dao import get_redis_client
 
+        redis_client = get_redis_client()
         if redis_client is None:
             return
         redis_client.eval(

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -196,8 +196,9 @@ def _get_ask_sem_key(app: Flask, user_bid: str, outline_bid: str) -> str:
 def _ask_sem_acquire(app: Flask, user_bid: str, outline_bid: str) -> bool:
     """Try to acquire an ask semaphore slot. Returns True if slot acquired."""
     try:
-        from flaskr.dao import redis_client
+        from flaskr.dao import get_redis_client
 
+        redis_client = get_redis_client()
         if redis_client is None:
             return True  # fail open when Redis is unavailable
         result = redis_client.eval(
@@ -221,8 +222,9 @@ def _ask_sem_acquire(app: Flask, user_bid: str, outline_bid: str) -> bool:
 def _ask_sem_release(app: Flask, user_bid: str, outline_bid: str) -> None:
     """Release an ask semaphore slot."""
     try:
-        from flaskr.dao import redis_client
+        from flaskr.dao import get_redis_client
 
+        redis_client = get_redis_client()
         if redis_client is None:
             return
         redis_client.eval(

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -4,6 +4,7 @@ import base64
 import json
 import re
 import threading
+from dataclasses import dataclass, field
 from functools import wraps
 from pathlib import Path
 from typing import Any
@@ -22,9 +23,17 @@ from .base import (
     SubscriptionUpdateResult,
 )
 
-_PINGPP_CLIENT: Any | None = None
-_PINGPP_IMPORT_ERROR: Exception | None = None
 _PINGPP_CONFIG_LOCK = threading.RLock()
+
+
+@dataclass(slots=True)
+class _PingppClientState:
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    client: Any | None = None
+    import_error: Exception | None = None
+
+
+_pingpp_client_state = _PingppClientState()
 
 
 def _serialized_pingpp_config(func):
@@ -37,20 +46,20 @@ def _serialized_pingpp_config(func):
 
 
 def _get_pingpp_client() -> Any:
-    global _PINGPP_CLIENT, _PINGPP_IMPORT_ERROR
-    if _PINGPP_CLIENT is not None:
-        return _PINGPP_CLIENT
-    if _PINGPP_IMPORT_ERROR is not None:
-        raise _PINGPP_IMPORT_ERROR
-    try:
-        import pingpp  # type: ignore[import-untyped]
+    with _pingpp_client_state.lock:
+        if _pingpp_client_state.client is not None:
+            return _pingpp_client_state.client
+        if _pingpp_client_state.import_error is not None:
+            raise _pingpp_client_state.import_error
+        try:
+            import pingpp  # type: ignore[import-untyped]
 
-        _PINGPP_CLIENT = pingpp
-    except Exception as exc:  # pragma: no cover
-        _PINGPP_IMPORT_ERROR = exc
-        raise
-    else:
-        return pingpp
+            _pingpp_client_state.client = pingpp
+        except Exception as exc:  # pragma: no cover
+            _pingpp_client_state.import_error = exc
+            raise
+        else:
+            return pingpp
 
 
 class PingxxProvider(PaymentProvider):

--- a/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
+++ b/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
@@ -64,9 +64,9 @@ def _admission_key(app: Flask, *, user_id: str) -> str:
 
 
 def _redis_client():
-    from flaskr.dao import redis_client
+    from flaskr.dao import get_redis_client
 
-    return redis_client
+    return get_redis_client()
 
 
 def _acquire_redis_admission(*, key: str, token: str) -> _AdmissionLease | None:

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -160,8 +160,9 @@ def _acquire_local_slot(
 
 
 def _get_redis_client():
-    from flaskr.dao import redis_client
+    from flaskr.dao import get_redis_client
 
+    redis_client = get_redis_client()
     if redis_client is None:
         raise RuntimeError("Redis is not configured")
     return redis_client

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -73,30 +73,40 @@ from flaskr.util.uuid import generate_id
 
 logger = AppLoggerProxy(logging.getLogger(__name__))
 
-# Global thread pool for TTS synthesis, created lazily per process. A
+
+# Process-local thread pool for TTS synthesis, created lazily. A
 # module-level instance would be created during the gunicorn master's
 # preload import and inherited by every forked worker; its gevent-patched
 # internals then carry wakeup links bound to the parent's hub, which can
 # crash in AbstractLinkable._notify_links and silently interrupt unrelated
 # greenlets (observed as DB protocol desync). The pid guard hands each
 # process its own executor.
-_tts_executor: ThreadPoolExecutor | None = None
-_tts_executor_pid: int | None = None
+@dataclass(slots=True)
+class _TTSExecutorState:
+    executor: ThreadPoolExecutor | None = None
+    pid: int | None = None
+
+
+_tts_executor_state = _TTSExecutorState()
 
 
 def _get_tts_executor() -> ThreadPoolExecutor:
-    global _tts_executor, _tts_executor_pid
     current_pid = os.getpid()
     # Rebuild only when there is no executor or the recorded pid is STALE.
     # An executor with no recorded pid was injected directly (tests patch
-    # `_tts_executor` with a mock) and must be honored as-is; production
-    # code always records the pid alongside the instance it creates.
-    if _tts_executor is None or (
-        _tts_executor_pid is not None and _tts_executor_pid != current_pid
+    # `_tts_executor_state.executor` with a mock) and must be honored as-is;
+    # production code always records the pid alongside the instance it creates.
+    if _tts_executor_state.executor is None or (
+        _tts_executor_state.pid is not None and _tts_executor_state.pid != current_pid
     ):
-        _tts_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="tts_")
-        _tts_executor_pid = current_pid
-    return _tts_executor
+        _tts_executor_state.executor = ThreadPoolExecutor(
+            max_workers=4, thread_name_prefix="tts_"
+        )
+        _tts_executor_state.pid = current_pid
+    executor = _tts_executor_state.executor
+    if executor is None:  # pragma: no cover - guarded by the branch above
+        raise RuntimeError("TTS executor initialization failed")
+    return executor
 
 
 _EMPTY_AUDIO_ERROR_MESSAGE = "No audio data received"

--- a/src/api/flaskr/service/user/email_flow.py
+++ b/src/api/flaskr/service/user/email_flow.py
@@ -32,13 +32,6 @@ from flaskr.service.user.repository import (
 from flaskr.service.user.utils import generate_token
 from flaskr.util.datetime import now_utc
 
-FIX_CHECK_CODE = None
-
-
-def configure_fix_check_code(value: str | None) -> None:
-    global FIX_CHECK_CODE
-    FIX_CHECK_CODE = value
-
 
 def _is_within_seconds(value: datetime.datetime, *, seconds: int) -> bool:
     if value is None:
@@ -95,14 +88,13 @@ def verify_email_code(
         update_user_profile_with_lable,
     )
 
-    if FIX_CHECK_CODE is None:
-        configure_fix_check_code(app.config.get("UNIVERSAL_VERIFICATION_CODE"))
+    fixed_check_code = app.config.get("UNIVERSAL_VERIFICATION_CODE")
 
     email_key = (email or "").strip()
     code_key = (
         get_redis_derived_prefix("REDIS_KEY_PREFIX_MAIL_CODE", app=app) + email_key
     )
-    if code != FIX_CHECK_CODE:
+    if code != fixed_check_code:
         cached = redis.get(code_key)
         if cached is not None:
             cached_str = (

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -45,13 +45,7 @@ from flaskr.service.user.utils import (
 from flaskr.util.datetime import now_utc
 from sqlalchemy import text
 
-FIX_CHECK_CODE = None
 BOOTSTRAP_LOCK_NAME = "user_first_verified_bootstrap"
-
-
-def configure_fix_check_code(value: str | None) -> None:
-    global FIX_CHECK_CODE
-    FIX_CHECK_CODE = value
 
 
 def _acquire_bootstrap_lock(app: Flask, timeout_seconds: int = 5) -> bool | None:
@@ -279,8 +273,7 @@ def verify_phone_code(
         update_user_profile_with_lable,
     )
 
-    if FIX_CHECK_CODE is None:
-        configure_fix_check_code(app.config.get("UNIVERSAL_VERIFICATION_CODE"))
+    fixed_check_code = app.config.get("UNIVERSAL_VERIFICATION_CODE")
 
     raw_phone = (phone or "").strip()
     normalized_phone = normalize_phone_identifier(raw_phone)
@@ -291,7 +284,7 @@ def verify_phone_code(
         lookup_phones.append(raw_phone)
     phone_code_prefix = get_redis_derived_prefix("REDIS_KEY_PREFIX_PHONE_CODE", app=app)
     code_keys = [phone_code_prefix + lookup_phone for lookup_phone in lookup_phones]
-    if code != FIX_CHECK_CODE:
+    if code != fixed_check_code:
         cached = None
         cached_phone = normalized_phone
         for code_key, lookup_phone in zip(code_keys, lookup_phones, strict=False):

--- a/src/api/flaskr/service/user/post_auth.py
+++ b/src/api/flaskr/service/user/post_auth.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from flask import Flask
-from flaskr.framework.plugin import plugin_manager as plugin_manager_module
+from flaskr.framework.plugin.plugin_manager import get_plugin_manager
 
 
 @dataclass(slots=True, frozen=True)
@@ -25,7 +25,7 @@ class PostAuthContext:
 
 def run_post_auth_extensions(app: Flask, context: PostAuthContext) -> PostAuthContext:
     """Execute registered post-auth handlers without blocking login success."""
-    manager = plugin_manager_module.plugin_manager
+    manager = get_plugin_manager()
     if manager is None:
         return context
 

--- a/src/api/scripts/check_mdflow_listen_adapter.py
+++ b/src/api/scripts/check_mdflow_listen_adapter.py
@@ -35,13 +35,9 @@ os.environ.setdefault("SKIP_APP_AUTOCREATE", "1")
 os.environ.setdefault("SKIP_DB_MIGRATIONS_FOR_TESTS", "1")
 
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
 from flaskr import dao
 from sqlalchemy.dialects.mysql import BIGINT, LONGTEXT
 from sqlalchemy.ext.compiler import compiles
-
-if dao.db is None:
-    dao.db = SQLAlchemy()
 
 
 @compiles(LONGTEXT, "sqlite")

--- a/src/api/scripts/check_sse_segmentation.py
+++ b/src/api/scripts/check_sse_segmentation.py
@@ -29,12 +29,6 @@ os.environ.setdefault("SKIP_LOAD_DOTENV", "1")
 os.environ.setdefault("SKIP_APP_AUTOCREATE", "1")
 os.environ.setdefault("SKIP_DB_MIGRATIONS_FOR_TESTS", "1")
 
-from flask_sqlalchemy import SQLAlchemy
-from flaskr import dao
-
-if dao.db is None:
-    dao.db = SQLAlchemy()
-
 from flaskr.service.tts import streaming_tts as streaming_tts_module
 from flaskr.service.tts.pipeline import split_av_speakable_segments
 

--- a/src/api/tests/common/test_celery_app.py
+++ b/src/api/tests/common/test_celery_app.py
@@ -325,7 +325,7 @@ def test_get_celery_app_loads_flask_app_from_app_factory(
         "app",
         types.SimpleNamespace(create_app=lambda: fake_flask_app),
     )
-    monkeypatch.setattr(celery_app_module, "__CELERY_APP__", None)
+    monkeypatch.setattr(celery_app_module._celery_state, "app", None)
 
     celery_app = celery_app_module.get_celery_app()
 

--- a/src/api/tests/common/test_config.py
+++ b/src/api/tests/common/test_config.py
@@ -79,12 +79,12 @@ class TestConfigInitialization:
         # Clear global instance
         import flaskr.common.config as config_module
 
-        config_module.__INSTANCE__ = None
+        config_module.Config._instance = None
 
         config = Config(parent_config, app)
 
         # Check global instance is set
-        assert config == config_module.__INSTANCE__
+        assert config == config_module.Config._instance
 
 
 class TestConfigGetItem:
@@ -417,8 +417,8 @@ class TestGetConfigFunction:
         # Clear global instance
         import flaskr.common.config as config_module
 
-        original_instance = config_module.__INSTANCE__
-        config_module.__INSTANCE__ = None
+        original_instance = config_module.Config._instance
+        config_module.Config._instance = None
 
         try:
             # Test with a known ENV_VAR key - should get from environment or default
@@ -441,7 +441,7 @@ class TestGetConfigFunction:
             assert value == ""  # Default value from ENV_VARS
         finally:
             # Restore original instance
-            config_module.__INSTANCE__ = original_instance
+            config_module.Config._instance = original_instance
 
 
 class TestConfigIntegrationWithFlask:

--- a/src/api/tests/common/test_config_integration.py
+++ b/src/api/tests/common/test_config_integration.py
@@ -304,7 +304,7 @@ class TestMultiEnvironmentSupport:
         # Clear instance for new environment
         import flaskr.common.config as config_module
 
-        config_module.__INSTANCE__ = None
+        config_module.Config._instance = None
 
         # Switch to production environment
         for key, value in PRODUCTION_ENV_CONFIG.items():
@@ -369,8 +369,8 @@ class TestBackwardCompatibility:
         # Clear global instance to test uninitialized state
         import flaskr.common.config as config_module
 
-        original_instance = config_module.__INSTANCE__
-        config_module.__INSTANCE__ = None
+        original_instance = config_module.Config._instance
+        config_module.Config._instance = None
 
         try:
             # Test with a known ENV_VAR key - should get from environment or default
@@ -392,7 +392,7 @@ class TestBackwardCompatibility:
             value = get_config("REDIS_HOST")
             assert value == ""  # Default value from ENV_VARS
         finally:
-            config_module.__INSTANCE__ = original_instance
+            config_module.Config._instance = original_instance
 
     def test_required_means_no_default(self):
         """Test that required=True prevents having defaults."""

--- a/src/api/tests/common/test_module_state_owners.py
+++ b/src/api/tests/common/test_module_state_owners.py
@@ -48,6 +48,16 @@ def test_redis_initialization_updates_the_owned_client(monkeypatch):
     }
 
 
+def test_legacy_redis_client_import_reads_the_owned_client():
+    sentinel = object()
+    dao.set_redis_client(sentinel)
+
+    from flaskr.dao import redis_client as legacy_redis_client
+
+    assert legacy_redis_client is sentinel
+    assert "redis_client" not in vars(dao)
+
+
 def test_plugin_manager_registry_replaces_one_owned_instance(monkeypatch):
     first_app = Flask("first-plugin-manager")
     second_app = Flask("second-plugin-manager")

--- a/src/api/tests/common/test_module_state_owners.py
+++ b/src/api/tests/common/test_module_state_owners.py
@@ -1,0 +1,65 @@
+from flask import Flask
+from flaskr import dao
+from flaskr.framework.plugin import plugin_manager as plugin_manager_module
+
+
+def test_database_extension_keeps_one_shared_identity():
+    app = Flask("stable-database-extension")
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    shared_db = dao.db
+
+    dao.init_db(app)
+
+    assert dao.db is shared_db
+    assert app.extensions["sqlalchemy"] is shared_db
+
+
+def test_redis_initialization_updates_the_owned_client(monkeypatch):
+    app = Flask("owned-redis-client")
+    app.config.update(
+        REDIS_HOST="redis.internal",
+        REDIS_PORT=6380,
+        REDIS_DB=4,
+        REDIS_PASSWORD="secret",
+        REDIS_USER="worker",
+    )
+    sentinel = object()
+    captured: dict[str, object] = {}
+
+    def fake_redis(**kwargs):
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(dao, "Redis", fake_redis)
+    dao.set_redis_client(None)
+
+    dao.init_redis(app)
+
+    assert dao.get_redis_client() is sentinel
+    assert captured == {
+        "host": "redis.internal",
+        "port": 6380,
+        "db": 4,
+        "password": "secret",
+        "username": "worker",
+    }
+
+
+def test_plugin_manager_registry_replaces_one_owned_instance(monkeypatch):
+    first_app = Flask("first-plugin-manager")
+    second_app = Flask("second-plugin-manager")
+    monkeypatch.setattr(plugin_manager_module._plugin_manager_state, "manager", None)
+
+    plugin_manager_module.enable_plugin_manager(first_app)
+    first_manager = plugin_manager_module.get_plugin_manager()
+    plugin_manager_module.enable_plugin_manager(second_app)
+    second_manager = plugin_manager_module.get_plugin_manager()
+
+    assert first_manager is not None
+    assert second_manager is not None
+    assert first_manager is not second_manager
+    assert first_manager.app is first_app
+    assert second_manager.app is second_app

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -237,6 +237,7 @@ def isolate_env_for_non_app_tests(request):
     # reflects per-test env changes.
     from flaskr.common import config as config_module
 
+    original_config_instance = config_module.Config._instance
     with contextlib.suppress(Exception):
         config_module.__ENHANCED_CONFIG__._cache.clear()
     with contextlib.suppress(Exception):
@@ -254,3 +255,4 @@ def isolate_env_for_non_app_tests(request):
     with contextlib.suppress(Exception):
         if config_module.Config._instance is not None:
             config_module.Config._instance.enhanced._cache.clear()
+    config_module.Config._instance = original_config_instance

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -38,9 +38,8 @@ if not _test_db_uri:
     _test_db_path = _test_db_dir / "test.db"
     _test_db_uri = f"sqlite:///{_test_db_path}"
 
-from flask_sqlalchemy import SQLAlchemy
 from flaskr import dao
-from flaskr.framework.plugin import plugin_manager as plugin_manager_module
+from flaskr.framework.plugin.plugin_manager import set_plugin_manager
 from sqlalchemy.dialects.mysql import BIGINT, LONGTEXT
 from sqlalchemy.ext.compiler import compiles
 
@@ -64,7 +63,7 @@ class _TestPluginManager:
         return None
 
 
-plugin_manager_module.plugin_manager = _TestPluginManager()
+set_plugin_manager(_TestPluginManager())
 
 
 @compiles(LONGTEXT, "sqlite")
@@ -76,9 +75,6 @@ def _compile_longtext_sqlite(_type, _compiler, **_kw):
 def _compile_bigint_sqlite(_type, _compiler, **_kw):
     return "INTEGER"
 
-
-if dao.db is None:
-    dao.db = SQLAlchemy()
 
 import contextlib
 
@@ -179,7 +175,7 @@ def mock_redis_client(monkeypatch, request):
     # test_funcs.py uses its own `@patch` decorators for fine-grained Redis control.
     if "service/config/test_funcs.py" in request.node.nodeid:
         return fake_redis
-    monkeypatch.setattr(dao, "redis_client", fake_redis, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", fake_redis)
 
     module_paths = [
         "flaskr.service.user.phone_flow",
@@ -244,8 +240,8 @@ def isolate_env_for_non_app_tests(request):
     with contextlib.suppress(Exception):
         config_module.__ENHANCED_CONFIG__._cache.clear()
     with contextlib.suppress(Exception):
-        if config_module.__INSTANCE__ is not None:
-            config_module.__INSTANCE__.enhanced._cache.clear()
+        if config_module.Config._instance is not None:
+            config_module.Config._instance.enhanced._cache.clear()
     yield
     for key, value in original.items():
         if value is None:
@@ -256,5 +252,5 @@ def isolate_env_for_non_app_tests(request):
     with contextlib.suppress(Exception):
         config_module.__ENHANCED_CONFIG__._cache.clear()
     with contextlib.suppress(Exception):
-        if config_module.__INSTANCE__ is not None:
-            config_module.__INSTANCE__.enhanced._cache.clear()
+        if config_module.Config._instance is not None:
+            config_module.Config._instance.enhanced._cache.clear()

--- a/src/api/tests/service/billing/test_admin_ops_state.py
+++ b/src/api/tests/service/billing/test_admin_ops_state.py
@@ -43,7 +43,7 @@ def _patch_config_store(monkeypatch):
 def test_admin_billing_ops_state_updates_under_redis_lock(app, monkeypatch):
     redis = _TrackingRedis()
     store = _patch_config_store(monkeypatch)
-    monkeypatch.setattr(dao, "redis_client", redis, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", redis)
 
     admin_ops_state.update_admin_billing_config_status(
         app,

--- a/src/api/tests/service/creator_analytics/test_query.py
+++ b/src/api/tests/service/creator_analytics/test_query.py
@@ -682,6 +682,44 @@ def test_fallback_engine_uses_primary_db_with_warning(
         assert engine is db.engine
 
 
+def test_dedicated_engine_replacement_disposes_previous_owner(app, monkeypatch):
+    class _FakeEngine:
+        def __init__(self, uri: str) -> None:
+            self.uri = uri
+            self.disposed = False
+
+        def dispose(self) -> None:
+            self.disposed = True
+
+    created: list[_FakeEngine] = []
+
+    def fake_create_engine(uri, **_kwargs):
+        engine = _FakeEngine(uri)
+        created.append(engine)
+        return engine
+
+    monkeypatch.setattr(analytics_engine, "create_engine", fake_create_engine)
+    monkeypatch.setitem(
+        app.config, "ANALYTICS_DATABASE_URI", "sqlite:///analytics-one.db"
+    )
+
+    first = analytics_engine.get_analytics_engine(app)
+    same = analytics_engine.get_analytics_engine(app)
+    monkeypatch.setitem(
+        app.config, "ANALYTICS_DATABASE_URI", "sqlite:///analytics-two.db"
+    )
+    second = analytics_engine.get_analytics_engine(app)
+
+    assert first is same
+    assert second is not first
+    assert first.disposed is True
+    assert second.disposed is False
+    assert [engine.uri for engine in created] == [
+        "sqlite:///analytics-one.db",
+        "sqlite:///analytics-two.db",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # bill_daily_usage_metrics — credit-cost queries (v3)
 # ---------------------------------------------------------------------------

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -9,7 +9,6 @@ import unittest
 from unittest.mock import MagicMock, call, patch
 
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
 
 
 def _install_litellm_stub() -> None:
@@ -82,25 +81,10 @@ def _install_openai_responses_stub() -> None:
 _install_litellm_stub()
 _install_openai_responses_stub()
 
-# Ensure minimal SQLAlchemy bindings exist so model classes can be defined.
-from flaskr import dao
-
-if dao.db is None:
-    _test_app = Flask("test-context-v2")
-    _test_app.config.update(
-        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
-        SQLALCHEMY_TRACK_MODIFICATIONS=False,
-    )
-    _db = SQLAlchemy()
-    _db.init_app(_test_app)
-    dao.db = _db
-
-if not hasattr(dao, "redis_client"):
-    dao.redis_client = None
-
 import itertools
 
 import pytest
+from flaskr import dao
 from flaskr.service.learn import context_v2 as context_v2_module
 from flaskr.service.learn.const import CONTEXT_INTERACTION_NEXT
 from flaskr.service.learn.context_v2 import (

--- a/src/api/tests/service/learn/test_context_v2_tts_runtime_voice.py
+++ b/src/api/tests/service/learn/test_context_v2_tts_runtime_voice.py
@@ -1,21 +1,6 @@
 from types import SimpleNamespace
 
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
-from flaskr import dao
-
-if dao.db is None:
-    _test_app = Flask("test-context-v2-tts-runtime-voice-bootstrap")
-    _test_app.config.update(
-        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
-        SQLALCHEMY_TRACK_MODIFICATIONS=False,
-    )
-    _db = SQLAlchemy()
-    _db.init_app(_test_app)
-    dao.db = _db
-
-if not hasattr(dao, "redis_client"):
-    dao.redis_client = None
 
 
 def test_context_v2_tts_processor_uses_runtime_minimax_voice_fallback(monkeypatch):

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -3,21 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
 from flaskr import dao
-
-if dao.db is None:
-    _test_app = Flask("test-generated-block-tts-av-mode")
-    _test_app.config.update(
-        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
-        SQLALCHEMY_TRACK_MODIFICATIONS=False,
-    )
-    _db = SQLAlchemy()
-    _db.init_app(_test_app)
-    dao.db = _db
-
-if not hasattr(dao, "redis_client"):
-    dao.redis_client = None
 
 
 @dataclass

--- a/src/api/tests/service/learn/test_learn_funcs.py
+++ b/src/api/tests/service/learn/test_learn_funcs.py
@@ -4,7 +4,6 @@ import unittest
 import unittest.mock
 
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
 
 # Provide a lightweight Redis stub if the dependency is missing in the test env.
 try:
@@ -19,21 +18,6 @@ except ImportError:  # pragma: no cover - optional dependency
     sys.modules["redis"] = redis_stub
 
 from flaskr import dao
-
-# Ensure SQLAlchemy is available for model declarations.
-if dao.db is None:
-    _test_app = Flask("test-learn-funcs")
-    _test_app.config.update(
-        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
-        SQLALCHEMY_TRACK_MODIFICATIONS=False,
-    )
-    _db = SQLAlchemy()
-    _db.init_app(_test_app)
-    dao.db = _db
-
-if not hasattr(dao, "redis_client"):
-    dao.redis_client = None
-
 from flaskr.service.learn.const import LEARN_STATUS_IN_PROGRESS
 from flaskr.service.learn.context_v2 import (
     BlockType as MarkdownFlowBlockType,

--- a/src/api/tests/service/learn/test_learn_record.py
+++ b/src/api/tests/service/learn/test_learn_record.py
@@ -2,23 +2,7 @@ import types
 import unittest
 
 from flask import Flask, request
-from flask_sqlalchemy import SQLAlchemy
 from flaskr import dao
-
-if dao.db is None:
-    _test_app = Flask("test-learn-record")
-    _test_app.config.update(
-        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
-        SQLALCHEMY_BINDS={
-            "ai_shifu_saas": "sqlite:///:memory:",
-            "ai_shifu_admin": "sqlite:///:memory:",
-        },
-        SQLALCHEMY_TRACK_MODIFICATIONS=False,
-    )
-    _db = SQLAlchemy()
-    _db.init_app(_test_app)
-    dao.db = _db
-
 from flaskr.i18n import _
 from flaskr.service.learn.const import CONTEXT_INTERACTION_NEXT
 from flaskr.service.learn.learn_dtos import BlockType

--- a/src/api/tests/service/learn/test_listen_element_history_subtitles.py
+++ b/src/api/tests/service/learn/test_listen_element_history_subtitles.py
@@ -1,19 +1,5 @@
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
 from flaskr import dao
-
-if dao.db is None:
-    _test_app = Flask("test-listen-element-history-subtitles")
-    _test_app.config.update(
-        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
-        SQLALCHEMY_TRACK_MODIFICATIONS=False,
-    )
-    _db = SQLAlchemy()
-    _db.init_app(_test_app)
-    dao.db = _db
-
-if not hasattr(dao, "redis_client"):
-    dao.redis_client = None
 
 
 class TestListenElementHistorySubtitles:

--- a/src/api/tests/service/learn/test_listen_elements_legacy_record.py
+++ b/src/api/tests/service/learn/test_listen_elements_legacy_record.py
@@ -1,19 +1,5 @@
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
 from flaskr import dao
-
-if dao.db is None:
-    _test_app = Flask("test-listen-elements-legacy-record")
-    _test_app.config.update(
-        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
-        SQLALCHEMY_TRACK_MODIFICATIONS=False,
-    )
-    _db = SQLAlchemy()
-    _db.init_app(_test_app)
-    dao.db = _db
-
-if not hasattr(dao, "redis_client"):
-    dao.redis_client = None
 
 
 class TestBuildListenElementsFromLegacyRecord:

--- a/src/api/tests/service/learn/test_tts_synth_concurrency.py
+++ b/src/api/tests/service/learn/test_tts_synth_concurrency.py
@@ -1,3 +1,4 @@
+from flaskr import dao
 from flaskr.service.learn import learn_funcs
 from flaskr.service.learn.learn_funcs import (
     _TTS_SLOT_ACQUIRED,
@@ -44,7 +45,7 @@ class ExplodingRedis:
 
 def test_tts_synth_semaphore_caps_at_limit_and_releases(app, monkeypatch):
     fake = FakeRedis()
-    monkeypatch.setattr("flaskr.dao.redis_client", fake, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", fake)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 2
 
     assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o1") == _TTS_SLOT_ACQUIRED
@@ -61,7 +62,7 @@ def test_tts_synth_semaphore_caps_at_limit_and_releases(app, monkeypatch):
 
 
 def test_tts_synth_semaphore_bypasses_without_redis(app, monkeypatch):
-    monkeypatch.setattr("flaskr.dao.redis_client", None, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", None)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
 
     # Redis unavailable -> bypass (never blocks synthesis, no cap enforced)
@@ -71,7 +72,7 @@ def test_tts_synth_semaphore_bypasses_without_redis(app, monkeypatch):
 
 def test_tts_synth_semaphore_bypasses_on_redis_error(app, monkeypatch):
     boom = ExplodingRedis()
-    monkeypatch.setattr("flaskr.dao.redis_client", boom, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", boom)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
 
     assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") == _TTS_SLOT_BYPASS
@@ -80,7 +81,7 @@ def test_tts_synth_semaphore_bypasses_on_redis_error(app, monkeypatch):
 
 def test_tts_synth_semaphore_disabled_when_zero(app, monkeypatch):
     fake = FakeRedis()
-    monkeypatch.setattr("flaskr.dao.redis_client", fake, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", fake)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 0
 
     assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") == _TTS_SLOT_BYPASS
@@ -90,7 +91,7 @@ def test_tts_synth_semaphore_disabled_when_zero(app, monkeypatch):
 
 def test_tts_synth_semaphore_ignores_incomplete_key(app, monkeypatch):
     fake = FakeRedis()
-    monkeypatch.setattr("flaskr.dao.redis_client", fake, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", fake)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
 
     # Missing user/outline -> bypass, no counter created
@@ -101,7 +102,7 @@ def test_tts_synth_semaphore_ignores_incomplete_key(app, monkeypatch):
 
 def test_yield_tts_synthesis_sheds_request_when_full(app, monkeypatch):
     fake = FakeRedis()
-    monkeypatch.setattr("flaskr.dao.redis_client", fake, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", fake)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
 
     body_calls = {"n": 0}
@@ -132,7 +133,7 @@ def test_yield_tts_synthesis_sheds_request_when_full(app, monkeypatch):
 
 def test_yield_tts_synthesis_runs_and_releases_slot(app, monkeypatch):
     fake = FakeRedis()
-    monkeypatch.setattr("flaskr.dao.redis_client", fake, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", fake)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
 
     def _body():
@@ -161,7 +162,7 @@ def test_yield_tts_synthesis_bypass_does_not_release(app, monkeypatch):
     # release, otherwise it would decrement a slot that was never reserved and
     # could steal another request's slot.
     boom = ExplodingRedis()
-    monkeypatch.setattr("flaskr.dao.redis_client", boom, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", boom)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
 
     def _body():

--- a/src/api/tests/service/order/test_pingxx_client_state.py
+++ b/src/api/tests/service/order/test_pingxx_client_state.py
@@ -1,0 +1,17 @@
+import sys
+from types import SimpleNamespace
+
+from flaskr.service.order.payment_providers import pingxx
+
+
+def test_pingxx_client_import_is_cached_by_its_state_owner(monkeypatch):
+    sentinel = SimpleNamespace()
+    monkeypatch.setattr(pingxx._pingpp_client_state, "client", None)
+    monkeypatch.setattr(pingxx._pingpp_client_state, "import_error", None)
+    monkeypatch.setitem(sys.modules, "pingpp", sentinel)
+
+    first = pingxx._get_pingpp_client()
+    second = pingxx._get_pingpp_client()
+
+    assert first is sentinel
+    assert second is sentinel

--- a/src/api/tests/service/profile/test_profile_routes.py
+++ b/src/api/tests/service/profile/test_profile_routes.py
@@ -1,27 +1,28 @@
-import os
 from types import SimpleNamespace
 
 import flaskr.service.config.funcs as config_funcs
 import pytest
-from flaskr import dao
 
 _dummy_lock = SimpleNamespace(
     acquire=lambda *args, **kwargs: False, release=lambda *args, **kwargs: None
 )
 
 
-@pytest.mark.usefixtures("app")
-class TestProfileRoutes:
-    # Avoid real Redis in app init
-    os.environ["REDIS_HOST"] = ""
-    os.environ["REDIS_PORT"] = ""
-    dao.init_redis = lambda _app: None  # type: ignore[assignment]
-    config_funcs.redis = SimpleNamespace(
-        get=lambda _key: None,
-        set=lambda *args, **kwargs: None,
-        lock=lambda *args, **kwargs: _dummy_lock,
+@pytest.fixture(autouse=True)
+def _stub_profile_config_cache(monkeypatch):
+    monkeypatch.setattr(
+        config_funcs,
+        "redis",
+        SimpleNamespace(
+            get=lambda _key: None,
+            set=lambda *args, **kwargs: None,
+            lock=lambda *args, **kwargs: _dummy_lock,
+        ),
     )
 
+
+@pytest.mark.usefixtures("app")
+class TestProfileRoutes:
     def _mock_request_user(self, monkeypatch):
         dummy_user = SimpleNamespace(user_id="test-user", language="en-US")
         monkeypatch.setattr(

--- a/src/api/tests/service/shifu/test_course_copy.py
+++ b/src/api/tests/service/shifu/test_course_copy.py
@@ -218,8 +218,8 @@ def _clear_config_caches() -> None:
     with contextlib.suppress(AttributeError, KeyError, TypeError):
         config_module.__ENHANCED_CONFIG__._cache.clear()
     try:
-        if config_module.__INSTANCE__ is not None:
-            config_module.__INSTANCE__.enhanced._cache.clear()
+        if config_module.Config._instance is not None:
+            config_module.Config._instance.enhanced._cache.clear()
     except (AttributeError, KeyError, TypeError):
         pass
 

--- a/src/api/tests/service/shifu/test_permissions.py
+++ b/src/api/tests/service/shifu/test_permissions.py
@@ -62,8 +62,8 @@ def _clear_config_caches() -> None:
     with contextlib.suppress(Exception):
         config_module.__ENHANCED_CONFIG__._cache.clear()
     with contextlib.suppress(Exception):
-        if config_module.__INSTANCE__ is not None:
-            config_module.__INSTANCE__.enhanced._cache.clear()
+        if config_module.Config._instance is not None:
+            config_module.Config._instance.enhanced._cache.clear()
 
 
 def _allow_email_login(monkeypatch) -> None:

--- a/src/api/tests/service/shifu/test_transfer_creator.py
+++ b/src/api/tests/service/shifu/test_transfer_creator.py
@@ -130,8 +130,8 @@ def _clear_config_caches() -> None:
     with contextlib.suppress(Exception):
         config_module.__ENHANCED_CONFIG__._cache.clear()
     with contextlib.suppress(Exception):
-        if config_module.__INSTANCE__ is not None:
-            config_module.__INSTANCE__.enhanced._cache.clear()
+        if config_module.Config._instance is not None:
+            config_module.Config._instance.enhanced._cache.clear()
 
 
 def _ensure_trial_billing_enabled(app, monkeypatch) -> None:

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -39,7 +39,7 @@ def create_test_processor(mock_app, **kwargs):
 class TestFinalizeSegmentation:
     """Tests for finalize segmentation improvements."""
 
-    @patch("flaskr.service.tts.streaming_tts._tts_executor")
+    @patch("flaskr.service.tts.streaming_tts._tts_executor_state.executor")
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_process_chunk_submits_only_after_sentence_boundary(
         self, mock_is_configured, mock_executor, mock_app
@@ -70,7 +70,7 @@ class TestFinalizeSegmentation:
         list(processor.process_chunk("!"))
         assert submitted_texts == ["Hello without ending still no ending!"]
 
-    @patch("flaskr.service.tts.streaming_tts._tts_executor")
+    @patch("flaskr.service.tts.streaming_tts._tts_executor_state.executor")
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_submit_remaining_text_in_segments_splits_at_sentence_boundaries(
         self, mock_is_configured, mock_executor, mock_app
@@ -113,7 +113,7 @@ class TestFinalizeSegmentation:
         for _i, text in enumerate(submitted_texts[:-1]):
             assert text.rstrip().endswith((".", "!", "?", "。", "！", "？"))
 
-    @patch("flaskr.service.tts.streaming_tts._tts_executor")
+    @patch("flaskr.service.tts.streaming_tts._tts_executor_state.executor")
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_submit_remaining_text_does_not_split_by_char_count_without_sentence(
         self, mock_is_configured, mock_executor, mock_app
@@ -148,7 +148,7 @@ class TestFinalizeSegmentation:
 
         assert submitted_texts == [remaining_text]
 
-    @patch("flaskr.service.tts.streaming_tts._tts_executor")
+    @patch("flaskr.service.tts.streaming_tts._tts_executor_state.executor")
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_submit_remaining_text_handles_short_text(
         self, mock_is_configured, mock_executor, mock_app
@@ -182,7 +182,7 @@ class TestFinalizeSegmentation:
         assert len(submitted_texts) == 1
         assert submitted_texts[0] == "Hi"
 
-    @patch("flaskr.service.tts.streaming_tts._tts_executor")
+    @patch("flaskr.service.tts.streaming_tts._tts_executor_state.executor")
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_submit_remaining_text_handles_empty_string(
         self, mock_is_configured, mock_executor, mock_app
@@ -198,7 +198,7 @@ class TestFinalizeSegmentation:
         # Should not submit anything
         assert mock_executor.submit.call_count == 0
 
-    @patch("flaskr.service.tts.streaming_tts._tts_executor")
+    @patch("flaskr.service.tts.streaming_tts._tts_executor_state.executor")
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_submit_remaining_text_handles_whitespace_only(
         self, mock_is_configured, mock_executor, mock_app
@@ -214,7 +214,7 @@ class TestFinalizeSegmentation:
         # Should not submit anything
         assert mock_executor.submit.call_count == 0
 
-    @patch("flaskr.service.tts.streaming_tts._tts_executor")
+    @patch("flaskr.service.tts.streaming_tts._tts_executor_state.executor")
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_submit_remaining_text_logs_segment_info(
         self, mock_is_configured, mock_executor, mock_app, caplog
@@ -632,7 +632,7 @@ class TestStreamingSynthesisRetries:
 class TestOffsetDriftRegression:
     """Regression tests for offset drift when markdown becomes complete across chunks."""
 
-    @patch("flaskr.service.tts.streaming_tts._tts_executor")
+    @patch("flaskr.service.tts.streaming_tts._tts_executor_state.executor")
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_bold_spanning_chunks_no_text_loss(
         self, mock_is_configured, mock_executor, mock_app
@@ -678,7 +678,7 @@ class TestOffsetDriftRegression:
             f"Text 'Third' was lost. Submitted: {submitted_texts}"
         )
 
-    @patch("flaskr.service.tts.streaming_tts._tts_executor")
+    @patch("flaskr.service.tts.streaming_tts._tts_executor_state.executor")
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_link_spanning_chunks_no_text_loss(
         self, mock_is_configured, mock_executor, mock_app
@@ -766,7 +766,7 @@ class TestFinalizeDelayManagement:
             (500, 1000),
         ]
 
-    @patch("flaskr.service.tts.streaming_tts._tts_executor")
+    @patch("flaskr.service.tts.streaming_tts._tts_executor_state.executor")
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     @patch("flaskr.service.tts.streaming_tts.time.sleep")
     def test_yield_ready_segments_adds_delay_between_segments(

--- a/src/api/tests/service/tts/test_streaming_tts_subtitles.py
+++ b/src/api/tests/service/tts/test_streaming_tts_subtitles.py
@@ -1,19 +1,5 @@
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
 from flaskr import dao
-
-if dao.db is None:
-    _test_app = Flask("test-streaming-tts-subtitles")
-    _test_app.config.update(
-        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
-        SQLALCHEMY_TRACK_MODIFICATIONS=False,
-    )
-    _db = SQLAlchemy()
-    _db.init_app(_test_app)
-    dao.db = _db
-
-if not hasattr(dao, "redis_client"):
-    dao.redis_client = None
 
 
 class TestStreamingTtsSubtitles:

--- a/src/api/tests/service/tts/test_tts_executor_fork_isolation.py
+++ b/src/api/tests/service/tts/test_tts_executor_fork_isolation.py
@@ -31,8 +31,8 @@ def test_module_does_not_create_an_executor_at_import_time():
 
 
 def test_executor_is_cached_within_one_process(monkeypatch):
-    monkeypatch.setattr(streaming_tts, "_tts_executor", None)
-    monkeypatch.setattr(streaming_tts, "_tts_executor_pid", None)
+    monkeypatch.setattr(streaming_tts._tts_executor_state, "executor", None)
+    monkeypatch.setattr(streaming_tts._tts_executor_state, "pid", None)
 
     first = streaming_tts._get_tts_executor()
     second = streaming_tts._get_tts_executor()
@@ -42,25 +42,27 @@ def test_executor_is_cached_within_one_process(monkeypatch):
 
 
 def test_directly_injected_executor_is_honored(monkeypatch):
-    # Existing tests patch `_tts_executor` with a mock and leave the pid
+    # Existing tests patch the registry executor with a mock and leave the pid
     # unset; the accessor must return the injection instead of clobbering
     # it with a real executor.
     sentinel = object()
-    monkeypatch.setattr(streaming_tts, "_tts_executor", sentinel)
-    monkeypatch.setattr(streaming_tts, "_tts_executor_pid", None)
+    monkeypatch.setattr(streaming_tts._tts_executor_state, "executor", sentinel)
+    monkeypatch.setattr(streaming_tts._tts_executor_state, "pid", None)
 
     assert streaming_tts._get_tts_executor() is sentinel
 
 
 def test_executor_is_rebuilt_after_fork(monkeypatch):
-    monkeypatch.setattr(streaming_tts, "_tts_executor", None)
-    monkeypatch.setattr(streaming_tts, "_tts_executor_pid", None)
+    monkeypatch.setattr(streaming_tts._tts_executor_state, "executor", None)
+    monkeypatch.setattr(streaming_tts._tts_executor_state, "pid", None)
 
     parent_executor = streaming_tts._get_tts_executor()
 
     # Simulate the child process: same module state, different pid.
     monkeypatch.setattr(
-        streaming_tts.os, "getpid", lambda: streaming_tts._tts_executor_pid + 1
+        streaming_tts.os,
+        "getpid",
+        lambda: streaming_tts._tts_executor_state.pid + 1,
     )
     child_executor = streaming_tts._get_tts_executor()
 

--- a/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from flaskr import dao
 from flaskr.service.common.models import AppError
 from flaskr.service.profile import learner_profile_optimizer_admission as admission
 
@@ -59,7 +60,7 @@ def _assert_admission_denied(app, *, user_id: str) -> None:
 
 def test_admission_allows_only_one_in_flight_request_per_user(app, monkeypatch):
     fake_redis = FakeRedis()
-    monkeypatch.setattr("flaskr.dao.redis_client", fake_redis, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", fake_redis)
 
     with admission.learner_profile_optimization_admission(
         app,
@@ -78,7 +79,7 @@ def test_admission_allows_only_one_in_flight_request_per_user(app, monkeypatch):
 
 def test_admission_does_not_group_different_users(app, monkeypatch):
     fake_redis = FakeRedis()
-    monkeypatch.setattr("flaskr.dao.redis_client", fake_redis, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", fake_redis)
 
     with (
         admission.learner_profile_optimization_admission(app, user_id="user-one"),
@@ -89,7 +90,7 @@ def test_admission_does_not_group_different_users(app, monkeypatch):
 
 def test_admission_releases_slot_after_request_error(app, monkeypatch):
     fake_redis = FakeRedis()
-    monkeypatch.setattr("flaskr.dao.redis_client", fake_redis, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", fake_redis)
 
     with (
         pytest.raises(RuntimeError, match="provider failed"),
@@ -109,7 +110,7 @@ def test_admission_releases_slot_after_request_error(app, monkeypatch):
 
 def test_expired_lease_release_cannot_remove_replacement_redis_slot(app, monkeypatch):
     fake_redis = FakeRedis()
-    monkeypatch.setattr("flaskr.dao.redis_client", fake_redis, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", fake_redis)
 
     first = admission._acquire_admission(app, user_id="ttl-race-user")
     fake_redis.expire_in_flight()
@@ -125,7 +126,7 @@ def test_configured_redis_failure_denies_request_without_logging_identity(
     app, monkeypatch, caplog
 ):
     sentinel_identity = "SENSITIVE_ADMISSION_IDENTITY"
-    monkeypatch.setattr("flaskr.dao.redis_client", ExplodingRedis(), raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", ExplodingRedis())
 
     app.logger.addHandler(caplog.handler)
     try:
@@ -138,7 +139,7 @@ def test_configured_redis_failure_denies_request_without_logging_identity(
 
 
 def test_missing_redis_uses_process_local_user_slot(app, monkeypatch):
-    monkeypatch.setattr("flaskr.dao.redis_client", None, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", None)
 
     with admission.learner_profile_optimization_admission(
         app,

--- a/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
+++ b/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
@@ -693,7 +693,7 @@ def test_phone_sign_in_merges_profile_without_course_id(app, monkeypatch, caplog
 
     caplog.set_level(logging.INFO)
     monkeypatch.setattr(phone_flow, "redis", _FakeRedis())
-    monkeypatch.setattr(phone_flow, "FIX_CHECK_CODE", "9999")
+    app.config["UNIVERSAL_VERIFICATION_CODE"] = "9999"
     monkeypatch.setattr(phone_flow, "init_first_course", lambda *_args: False)
     monkeypatch.setattr(
         phone_flow,
@@ -741,7 +741,7 @@ def test_email_sign_in_transfers_cleared_state_without_course_id(app, monkeypatc
     from flaskr.service.user import email_flow
 
     monkeypatch.setattr(email_flow, "redis", _FakeRedis())
-    monkeypatch.setattr(email_flow, "FIX_CHECK_CODE", "9999")
+    app.config["UNIVERSAL_VERIFICATION_CODE"] = "9999"
     monkeypatch.setattr(email_flow, "init_first_course", lambda *_args: False)
     with app.app_context():
         email = f"{uuid.uuid4().hex[:12]}@example.com"
@@ -776,7 +776,7 @@ def test_legacy_profile_migration_preserves_target_nickname(
 
     flow = phone_flow if sign_in_method == "phone" else email_flow
     monkeypatch.setattr(flow, "redis", _FakeRedis())
-    monkeypatch.setattr(flow, "FIX_CHECK_CODE", "9999")
+    app.config["UNIVERSAL_VERIFICATION_CODE"] = "9999"
     monkeypatch.setattr(flow, "init_first_course", lambda *_args: False)
     monkeypatch.setattr(flow, "migrate_user_study_record", lambda *_args: None)
     monkeypatch.setattr(
@@ -839,7 +839,7 @@ def test_legacy_profile_migration_transfers_guest_nickname_when_target_has_none(
 
     flow = phone_flow if sign_in_method == "phone" else email_flow
     monkeypatch.setattr(flow, "redis", _FakeRedis())
-    monkeypatch.setattr(flow, "FIX_CHECK_CODE", "9999")
+    app.config["UNIVERSAL_VERIFICATION_CODE"] = "9999"
     monkeypatch.setattr(flow, "init_first_course", lambda *_args: False)
     monkeypatch.setattr(flow, "migrate_user_study_record", lambda *_args: None)
     monkeypatch.setattr(

--- a/src/api/tests/service/user/test_trial_credit_bootstrap.py
+++ b/src/api/tests/service/user/test_trial_credit_bootstrap.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 import pytest
 from flask import Flask
 from flaskr import dao
-from flaskr.framework.plugin import plugin_manager as plugin_manager_module
+from flaskr.framework.plugin.plugin_manager import get_plugin_manager
 from flaskr.service.billing.consts import (
     BILLING_ORDER_STATUS_PAID,
     BILLING_SUBSCRIPTION_STATUS_ACTIVE,
@@ -102,7 +102,7 @@ def user_trial_client(monkeypatch, tmp_path):
     monkeypatch.setattr(phone_flow, "redis", fake_redis, raising=False)
     monkeypatch.setattr(email_flow, "redis", fake_redis, raising=False)
     monkeypatch.setattr(user_utils, "redis", fake_redis, raising=False)
-    monkeypatch.setattr(dao, "redis_client", fake_redis, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", fake_redis)
     token_store._cache = fake_redis
 
     with app.app_context():
@@ -368,7 +368,9 @@ def test_post_auth_extension_failures_do_not_block_trial_bootstrap(
     def _failing_post_auth_handler(_context, *, app):
         raise RuntimeError("boom")
 
-    handlers = plugin_manager_module.plugin_manager.extension_functions.setdefault(
+    plugin_manager = get_plugin_manager()
+    assert plugin_manager is not None
+    handlers = plugin_manager.extension_functions.setdefault(
         "run_post_auth_extensions",
         [],
     )

--- a/src/api/tests/service/user/test_user_identify.py
+++ b/src/api/tests/service/user/test_user_identify.py
@@ -52,7 +52,6 @@ def _reset_shifu_tables() -> None:
 
 def test_phone_flow_marks_temp_phone_claim_as_created_new_user(tmp_path, monkeypatch):
     from flask import Flask
-    from flask_sqlalchemy import SQLAlchemy
     from flaskr import dao
     from flaskr.service.user import phone_flow
     from flaskr.service.user.consts import (
@@ -79,8 +78,6 @@ def test_phone_flow_marks_temp_phone_claim_as_created_new_user(tmp_path, monkeyp
         ADMIN_LOGIN_GRANT_CREATOR_WITH_DEMO=False,
     )
 
-    if dao.db is None:
-        dao.db = SQLAlchemy()
     dao.db.init_app(app)
 
     fake_redis = _FakeRedis()

--- a/src/api/tests/test_app.py
+++ b/src/api/tests/test_app.py
@@ -1,6 +1,4 @@
-import pytest
+def test_create_app_reuses_the_owned_application(app):
+    from app import create_app
 
-
-@pytest.fixture
-def test_client(app):
-    print("test_client")
+    assert create_app() is app

--- a/src/api/tests/test_langfuse_preload_deferral.py
+++ b/src/api/tests/test_langfuse_preload_deferral.py
@@ -24,10 +24,12 @@ def _configure(app, monkeypatch):
     app.config["LANGFUSE_PUBLIC_KEY"] = "pk"
     app.config["LANGFUSE_SECRET_KEY"] = "sk"
     app.config["LANGFUSE_HOST"] = "https://langfuse.example"
-    # init_langfuse rebinds the module-global client; snapshot the current
+    # init_langfuse replaces the registry-owned client; snapshot the current
     # value so monkeypatch restores it and later tests keep the real mock.
     monkeypatch.setattr(
-        langfuse_module, "langfuse_client", langfuse_module.langfuse_client
+        langfuse_module._langfuse_state,
+        "client",
+        langfuse_module.get_langfuse_client(),
     )
 
 
@@ -40,7 +42,7 @@ def test_preload_master_defers_real_client(app, monkeypatch):
     init_langfuse(app)
 
     assert _RecordingLangfuse.instances == []
-    assert isinstance(langfuse_module.langfuse_client, MockClient)
+    assert isinstance(langfuse_module.get_langfuse_client(), MockClient)
 
 
 def test_worker_builds_real_client_after_flag_cleared(app, monkeypatch):

--- a/src/api/tests/test_redislock.py
+++ b/src/api/tests/test_redislock.py
@@ -4,10 +4,18 @@ def test_run_with_redis_executes_once(app, monkeypatch):
     from tests.common.fixtures.fake_redis import FakeRedis
 
     fake_redis = FakeRedis()
-    monkeypatch.setattr(dao, "redis_client", fake_redis, raising=False)
+    monkeypatch.setattr(dao._redis_state, "client", fake_redis)
 
     def add_one(value):
         return value + 1
 
     result = dao.run_with_redis(app, "lock-key", 10, add_one, [1])
     assert result == 2
+
+
+def test_run_with_redis_skips_when_client_is_unconfigured(app, monkeypatch):
+    from flaskr import dao
+
+    monkeypatch.setattr(dao._redis_state, "client", None)
+
+    assert dao.run_with_redis(app, "lock-key", 10, lambda: "unused", []) is None


### PR DESCRIPTION
## Summary

- restore the safe module-state ownership refactor from #2579 after its rollback in #2603
- preserve and restore the active `Config` owner around non-app backend tests
- expose the owned Redis client through the legacy `flaskr.dao.redis_client` import contract
- prevent temporary `MagicMock` configuration wrappers from leaking into later API golden tests

## Root causes

The stable config owner introduced by #2579 retained temporary wrappers created by unit tests, so `onboarding_status` later read a mocked guide-course bid.

The same refactor removed the `flaskr.dao.redis_client` module attribute while the deployed SaaS plugin still imports that name lazily. This caused `ImportError` when creator customization loaded the plugin during `/api/user/require_tmp`.

## Compatibility

The legacy `redis_client` name is now resolved dynamically from the owned Redis state. Existing plugins keep working without restoring module-level rebinding; new code continues to use `get_redis_client()`.

## Verification

- reproduced the original config-state golden failure before the fix
- session app -> config tests -> onboarding golden sequence: 28 passed
- legacy Redis import and billing customization tests: 18 passed, 10 skipped
- full backend suite: 3009 passed, 17 skipped
- pre-commit checks passed, including architecture boundaries, translations, Ruff check, and Ruff format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when switching application, analytics, Redis, plugin, and third-party service configurations.
  * Prevented stale cached resources from being reused and ensured replaced analytics resources are properly released.
  * Redis-dependent operations now safely bypass processing when Redis is unavailable.
  * Verification codes now reflect the current application configuration.

* **Refactor**
  * Improved management of shared application services and state for more predictable initialization and testing.

* **Tests**
  * Added coverage for resource replacement, state ownership, caching, and unavailable Redis behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->