### PR TITLE
chore: annotate public return contracts

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -562,6 +562,23 @@ are runtime data, search for `__doc__` and inspection consumers, prove
 executable AST equality after removing only the new function docstrings, and
 run focused Swagger and CLI regressions when those surfaces are touched.
 
+For `ANN201`, annotate every public production and test function or method with
+its observable return contract. Use `None` for procedures and behavior tests,
+`Never` for paths that cannot return, concrete DTO, model, Flask, or collection
+types for values, and `Iterator[T]` / `AsyncIterator[T]` for generator
+functions and yielding fixtures. Decorator factories should expose the precise
+callable shape they accept and return. Use `object` only at a genuinely
+heterogeneous SDK, ORM, or decorator boundary; do not add `Any` merely to
+silence `ANN201`, because that transfers the same uncertainty to `ANN401`.
+Keep annotation-only imports behind `TYPE_CHECKING` when postponed annotations
+make that safe, but first inspect framework overrides, protocol declarations,
+decorators, and consumers of runtime `__annotations__`. Ruff's unsafe fix is a
+starting point rather than proof: review every inferred non-`None` contract and
+every manual boundary, then verify executable AST equality without the added
+annotations and type-import scaffolding. Applied Alembic revisions are
+immutable and keep their conventional unannotated `upgrade` / `downgrade`
+hooks; new and otherwise mutable public functions must be annotated.
+
 For `FIX002`, do not make an unresolved task invisible by renaming `TODO`,
 adding `noqa`, or turning the same promise into an untracked prose comment.
 Complete the work when it is part of the current change. When it genuinely

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -756,6 +756,33 @@ plan's progress update for that rule.
   repository knowledge, then passed the repository harness, architecture
   boundary ratchet, pinned Ruff 0.16.3 developer-tool check, and every
   repository pre-commit hook across all files.
+- [x] 2026-08-21 15:00 CST: Ready D103 PR #2614 passed every GitHub check,
+  including the 3,032-test backend job and runtime harness. Selected ANN201 as
+  the next additive contract rule after deferring early-return and stable-
+  signature candidates whose mechanical fixes would reduce readability or
+  compatibility.
+- [x] 2026-08-21 15:34 CST: Enabled ANN201 across every mutable public
+  callable. Ruff inferred 1,927 return contracts after excluding applied
+  migrations, and 257 manually reviewed boundaries received concrete DTO,
+  model, collection, Flask, iterator, callable, or deliberately heterogeneous
+  `object` contracts. No new return annotation uses `Any`.
+- [x] 2026-08-21 15:34 CST: Retained one exact migration-history exception for
+  102 conventional `upgrade` / `downgrade` hooks and made no change under
+  `src/api/migrations/versions/`. A semantic audit found exactly 2,184 added
+  return annotations and 133 annotation-only import aliases across 331 Python
+  files, with identical executable ASTs after removing that type scaffolding.
+  Configured ANN201 and repository Ruff pass.
+- [x] 2026-08-21 15:34 CST: The stable census falls from 22,963 to 20,845:
+  configured ANN201 falls from 2,286 findings to zero, while formatter-owned
+  COM812 rises by 165 and E501 by three because concrete return types expand
+  signatures. The isolated census falls from 36,993 to 34,977 and exposes
+  exactly the 102 immutable migration hooks; no enforced rule gains debt.
+- [x] 2026-08-21 15:40 CST: The complete backend suite passes 3,032 tests with
+  17 skips and 733 existing warnings. Regenerated collaboration mirrors and
+  repository knowledge, then passed translation validation, the repository
+  harness, architecture boundary ratchet, configured Ruff and format, pinned
+  Ruff 0.16.3 development-tool validation, and every repository pre-commit
+  hook across all files.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -976,6 +1003,15 @@ plan's progress update for that rule.
   ignored options. A fixture parameter can own setup even when the test body
   never reads it. Do not trade an argument finding for a broken keyword call,
   renamed pytest fixture, or broad suppression.
+- 2026-08-21: ANN201 is an additive public contract, but Ruff's unsafe fix is
+  not sufficient evidence. Review inferred non-`None` results and every manual
+  boundary, prefer concrete observable types, use `object` only for truly
+  heterogeneous integration contracts, and never introduce `Any` just to move
+  the finding to ANN401. Yielding pytest fixtures use `Iterator[T]`; behavior
+  tests return `None`. Applied migration hooks remain an exact immutable-history
+  exception. Prove the final edit preserves executable ASTs after removing
+  annotations and type-only import scaffolding, then run the complete backend
+  suite to catch runtime annotation and import consumers.
 
 ## Outcomes & Retrospective
 
@@ -1258,6 +1294,20 @@ touched Swagger YAML docstrings remain unchanged. The stable census falls by
 exactly the 2,108 intentional D103 findings. Translation and representative CLI
 contracts, 11 focused Swagger and legacy-record tests, the full 3,032-test
 backend suite, and every repository pre-commit hook pass.
+
+The ANN201 stage adds observable return contracts to all 2,184 mutable public
+production, tool, and test callables across 331 Python files. Concrete return,
+generator, fixture, and decorator types are preferred; deliberately dynamic
+SDK, ORM, and decorator boundaries use `object`, and no new `Any` return is
+introduced. The only exception is the exact applied-migration tree, which
+retains 102 immutable conventional hooks without editing migration history. A
+semantic audit strips the new return annotations and 133 type-only import
+aliases and matches every executable AST to the D103 parent. Configured ANN201
+falls from 2,286 findings to zero, the stable census falls to 20,845, and the
+isolated census falls to 34,977 with exactly the 102 documented hooks exposed.
+The complete backend suite passes 3,032 tests with 17 skips, and all repository
+harness, architecture, Ruff, format, development-tool, and pre-commit gates
+pass.
 
 ## Context and Orientation
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,7 +15,7 @@
 #   below, so the rationale survives the next Ruff upgrade.
 #
 # Deliberately not selected:
-# - ANN (except ANN002/ANN003/ANN204/ANN205/ANN206, see `select`) / SLF001 /
+# - ANN (except ANN002/ANN003/ANN201/ANN204/ANN205/ANN206, see `select`) / SLF001 /
 #   PLC0415 / PLR2004
 #   (and D1xx, see the ignore block): thousands of violations each; enforcing
 #   them is a codebase-wide project, not a lint config change.
@@ -190,6 +190,7 @@ select = [
     # readable at a glance.
     "ANN002",  # missing type for *args
     "ANN003",  # missing type for **kwargs
+    "ANN201",  # missing return type on a public function or method
     "ANN204",  # missing return type on a special method
     "ANN205",  # missing return type on a staticmethod
     "ANN206",  # missing return type on a classmethod
@@ -268,6 +269,9 @@ runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 # would break `alembic` revision discovery. Applied migration history is also
 # immutable, so its standard `upgrade` / `downgrade` hooks retain D103.
 "src/api/migrations/**" = ["D103", "INP001"]
+# Applied revision hooks are immutable public functions. New revisions inherit
+# Alembic's `upgrade` / `downgrade` contract instead of rewriting history.
+"src/api/migrations/versions/**" = ["ANN201"]
 # This applied no-op revision keeps a legacy `NOTE:` section in its module
 # docstring. Migration history is immutable, so D405 is scoped to this file.
 "src/api/migrations/versions/a4d68cce5ce6_add_demo_shifu.py" = ["D405"]

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -72,7 +72,7 @@ def flatten_translation(data, namespace: str) -> dict[str, str]:
     return _flatten(data, namespace)
 
 
-def validate_locale_files(locale_dirs: Iterable[Path]):
+def validate_locale_files(locale_dirs: Iterable[Path]) -> None:
     """Validate key parity and ICU placeholders across every locale."""
     files_per_locale: dict[str, dict[str, Path]] = {}
     flattened_per_locale: dict[str, dict[str, dict[str, str]]] = {}

--- a/scripts/generate_languages.py
+++ b/scripts/generate_languages.py
@@ -26,7 +26,7 @@ def collect_json_files(dir_path: Path) -> list[Path]:
     return files
 
 
-def read_json(path: Path):
+def read_json(path: Path) -> object:
     """Read JSON."""
     return json.loads(path.read_text(encoding="utf-8"))
 

--- a/scripts/testdata/architecture_boundaries/relative_violating/backend/flaskr/service/order/route.py
+++ b/scripts/testdata/architecture_boundaries/relative_violating/backend/flaskr/service/order/route.py
@@ -1,5 +1,5 @@
 """Exercise a parent-relative cross-service import violation."""
 
 
-def register_order_handler():
+def register_order_handler() -> None:
     return None

--- a/scripts/testdata/architecture_boundaries/relative_violating/backend/flaskr/service/profile/funcs.py
+++ b/scripts/testdata/architecture_boundaries/relative_violating/backend/flaskr/service/profile/funcs.py
@@ -1,5 +1,5 @@
 """Exercise a parent-relative cross-service import violation."""
 
 
-def save_user_profiles():
+def save_user_profiles() -> None:
     return None

--- a/scripts/testdata/architecture_boundaries/relative_violating/backend/flaskr/service/user/relative_helper.py
+++ b/scripts/testdata/architecture_boundaries/relative_violating/backend/flaskr/service/user/relative_helper.py
@@ -5,5 +5,5 @@ from ..order.route import register_order_handler
 from ..profile import funcs
 
 
-def helper():
+def helper() -> tuple[object, object, object]:
     return register_order_handler, funcs, optional_token_validation

--- a/scripts/testdata/architecture_boundaries/violating/backend/flaskr/service/user/helper.py
+++ b/scripts/testdata/architecture_boundaries/violating/backend/flaskr/service/user/helper.py
@@ -5,5 +5,5 @@ from flaskr.service.learn.funcs import get_lesson_preview
 from flaskr.service.learn.routes import register_learn_handler
 
 
-def load_helpers():
+def load_helpers() -> tuple[object, object, object]:
     return register_user_handler, get_lesson_preview, register_learn_handler

--- a/scripts/update_i18n.py
+++ b/scripts/update_i18n.py
@@ -25,7 +25,7 @@ BACKEND_DIR = ROOT / "src" / "api"
 COOK_WEB_DIR = ROOT / "src" / "cook-web"
 
 
-def load_json(path: Path):
+def load_json(path: Path) -> object:
     """Load JSON."""
     return json.loads(path.read_text(encoding="utf-8"))
 

--- a/src/api/flaskr/api/check/ilivedata.py
+++ b/src/api/flaskr/api/check/ilivedata.py
@@ -128,7 +128,9 @@ def ilivedata_check(
     )
 
 
-def send(querystring, signature, time_stamp, pid, timeout=DEFAULT_TIMEOUT_SECONDS):
+def send(
+    querystring, signature, time_stamp, pid, timeout=DEFAULT_TIMEOUT_SECONDS
+) -> dict[str, object]:
     """Send the content-safety request to the configured provider."""
     headers = {
         "X-AppId": pid,

--- a/src/api/flaskr/api/check/yidun.py
+++ b/src/api/flaskr/api/check/yidun.py
@@ -63,7 +63,7 @@ CHECK_RESULT_MAP = {
 }
 
 
-def gen_signature(params=None):
+def gen_signature(params=None) -> str:
     """Generate signature for yidun check."""
     buff = ""
     for k in sorted(params.keys()):

--- a/src/api/flaskr/api/doc/feishu.py
+++ b/src/api/flaskr/api/doc/feishu.py
@@ -11,7 +11,7 @@ from flaskr.service.config import get_config
 # ref: https://open.feishu.cn/document/server-docs/docs/docs-overview
 
 
-def send_notify(app: Flask, title, msgs):
+def send_notify(app: Flask, title, msgs) -> object | None:
     """Send a document-platform notification to Feishu."""
     url = get_config("FEISHU_NOTIFY_URL", None)
     if not url:

--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -78,7 +78,7 @@ class _LangfuseState:
 _langfuse_state = _LangfuseState()
 
 
-def get_langfuse_client():
+def get_langfuse_client() -> object:
     """Return langfuse client."""
     return _langfuse_state.client
 
@@ -152,7 +152,7 @@ def build_langfuse_observation_link(
 PRELOAD_MASTER_ENV = "AI_SHIFU_PRELOAD_MASTER"
 
 
-def init_langfuse(app: Flask):
+def init_langfuse(app: Flask) -> None:
     """Initialize langfuse."""
     if os.environ.get(PRELOAD_MASTER_ENV):
         # Running inside the gunicorn preload master. Creating a real client
@@ -396,7 +396,7 @@ def create_trace_with_root_span(
     client: Any,
     trace_payload: dict[str, Any],
     root_span_payload: dict[str, Any],
-):
+) -> tuple[LangfuseTraceHandle, LangfuseObservationHandle]:
     """Create trace with root span."""
     trace_payload = compact_langfuse_payload(trace_payload)
     root_payload = _map_observation_kwargs(root_span_payload, _OBSERVATION_KEYS)
@@ -418,7 +418,7 @@ def update_langfuse_trace(
     trace: Any,
     payload: dict[str, Any] | None = None,
     **kwargs: object,
-):
+) -> object:
     """Update langfuse trace."""
     update_payload = compact_langfuse_payload(payload or kwargs)
     if update_payload:
@@ -430,7 +430,7 @@ def update_langfuse_observation(
     observation: Any,
     payload: dict[str, Any] | None = None,
     **kwargs: object,
-):
+) -> object:
     """Update langfuse observation."""
     update_payload = compact_langfuse_payload(payload or kwargs)
     if update_payload:
@@ -444,7 +444,7 @@ def finalize_langfuse_trace(
     root_span: Any | None,
     trace_payload: dict[str, Any] | None = None,
     root_span_payload: dict[str, Any] | None = None,
-):
+) -> object:
     # Update trace attributes before ending the root span: in SDK v3 trace
     # attributes are written through the (still open) root span.
     """Finalize langfuse trace."""

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -984,7 +984,11 @@ class LLMStreamResponse:
         self.usage = LLMStreamaUsage(**usage) if usage else None
 
 
-def get_litellm_params_and_model(model: str):
+def get_litellm_params_and_model(
+    model: str,
+) -> tuple[
+    dict[str, str] | None, str, Callable[[str, float], dict[str, object]] | None
+]:
     """Return litellm params and model."""
     requested_model = model
     provider_key, invoke_model = _resolve_provider_for_model(model)

--- a/src/api/flaskr/api/tts/tencent_provider.py
+++ b/src/api/flaskr/api/tts/tencent_provider.py
@@ -16,7 +16,7 @@ import logging
 import time
 import unicodedata
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import requests
 
@@ -41,6 +41,9 @@ from flaskr.service.tts.audio_utils import (
     try_get_audio_duration_ms,
 )
 from flaskr.service.tts.subtitle_utils import normalize_subtitle_cues
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 logger = AppLoggerProxy(logging.getLogger(__name__))
 
@@ -1231,7 +1234,7 @@ class TencentTTSProvider(BaseTTSProvider):
         voice_settings: VoiceSettings | None = None,
         audio_settings: AudioSettings | None = None,
         model: str | None = None,
-    ):
+    ) -> Iterator[TencentSSEStreamChunk]:
         """Stream synthesized speech from this provider."""
         if not self.is_configured():
             error_message = "Tencent TTS is not configured"

--- a/src/api/flaskr/api/wechat.py
+++ b/src/api/flaskr/api/wechat.py
@@ -6,7 +6,7 @@ from flask import Flask
 from flaskr.service.config import get_config
 
 
-def get_wechat_access_token(app: Flask, code: str):
+def get_wechat_access_token(app: Flask, code: str) -> dict[str, object] | None:
     """Return wechat access token."""
     app.logger.info("get_wechat_access_token")
     app_id = app.config.get("WECHAT_APP_ID") or get_config("WECHAT_APP_ID", "")

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -20,7 +20,7 @@ from .unified_migration_task import MigrationConfig, UnifiedMigrationTask
 from .update_shifu_demo import update_demo_shifu
 
 
-def setup_migration_logging():
+def setup_migration_logging() -> None:
     """Set up logging for migration commands."""
     logging.basicConfig(
         level=logging.INFO,
@@ -32,7 +32,7 @@ def setup_migration_logging():
     )
 
 
-def enable_commands(app: Flask):
+def enable_commands(app: Flask) -> None:
     """Register the application's command-line commands."""
 
     @app.cli.group()

--- a/src/api/flaskr/command/import_user.py
+++ b/src/api/flaskr/command/import_user.py
@@ -17,7 +17,7 @@ from flaskr.service.user.repository import (
 
 def import_user(
     app: Flask, mobile, course_id, discount_code="web", user_nick_name=None
-):
+) -> None:
     """Import user and enable course."""
     app.logger.info("import_user: %s, %s", mobile, course_id)
     with app.app_context():

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -1058,13 +1058,13 @@ class UnifiedMigrationTask:
 
         return "\n".join(report)
 
-    def close(self):
+    def close(self) -> None:
         """Close database connections."""
         if self.engine:
             self.engine.dispose()
 
 
-async def main():
+async def main() -> None:
     """Run the unified migration task."""
     import argparse
 

--- a/src/api/flaskr/command/update_shifu_demo.py
+++ b/src/api/flaskr/command/update_shifu_demo.py
@@ -127,7 +127,7 @@ def _ensure_creator_permissions(app: Flask, shifu_bid: str):
         db.session.commit()
 
 
-def update_demo_shifu(app: Flask):
+def update_demo_shifu(app: Flask) -> None:
     """Update demo shifu for both Chinese and English versions."""
     if get_env_config("SKIP_DEMO_SHIFU_IMPORT"):
         app.logger.info("Skip demo shifu import due to SKIP_DEMO_SHIFU_IMPORT")

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -12,7 +12,9 @@ from typing import Any, Protocol, runtime_checkable
 class CacheLock(Protocol):
     """Define the locking operations required by cache providers."""
 
-    def acquire(self, blocking: bool = True, blocking_timeout: int | None = None):
+    def acquire(
+        self, blocking: bool = True, blocking_timeout: int | None = None
+    ) -> bool:
         """Acquire this cache lock."""
         raise NotImplementedError
 
@@ -25,11 +27,13 @@ class CacheLock(Protocol):
 class CacheProvider(Protocol):
     """Define the cache operations used by application services."""
 
-    def get(self, key: str):
+    def get(self, key: str) -> bytes | None:
         """Return the stored value for a key."""
         raise NotImplementedError
 
-    def getex(self, key: str, ex: int | None = None, px: int | None = None):
+    def getex(
+        self, key: str, ex: int | None = None, px: int | None = None
+    ) -> bytes | None:
         """Return a cached value and update its expiration."""
         raise NotImplementedError
 
@@ -43,11 +47,11 @@ class CacheProvider(Protocol):
         xx: bool = False,
         *args: object,
         **kwargs: object,
-    ):
+    ) -> bool:
         """Store a value under a cache key."""
         raise NotImplementedError
 
-    def setex(self, key: str, time_in_seconds: int, value: Any):
+    def setex(self, key: str, time_in_seconds: int, value: Any) -> bool:
         """Store a cached value with an expiration."""
         raise NotImplementedError
 
@@ -55,7 +59,7 @@ class CacheProvider(Protocol):
         """Delete values for the supplied keys."""
         raise NotImplementedError
 
-    def incr(self, key: str, amount: int = 1):
+    def incr(self, key: str, amount: int = 1) -> int:
         """Increment the integer stored under a cache key."""
         raise NotImplementedError
 
@@ -68,7 +72,7 @@ class CacheProvider(Protocol):
         key: str,
         timeout: int | None = None,
         blocking_timeout: int | None = None,
-    ):
+    ) -> CacheLock:
         """Create a distributed lock for the supplied key."""
         raise NotImplementedError
 
@@ -195,14 +199,16 @@ class InMemoryCacheProvider:
         if entry.expires_at <= self._now():
             self._store.pop(key, None)
 
-    def get(self, key: str):
+    def get(self, key: str) -> bytes | None:
         """Return the stored value for a key."""
         with self._mu:
             self._purge_if_expired(key)
             entry = self._store.get(key)
             return entry.value if entry is not None else None
 
-    def getex(self, key: str, ex: int | None = None, px: int | None = None):
+    def getex(
+        self, key: str, ex: int | None = None, px: int | None = None
+    ) -> bytes | None:
         """Return a cached value and update its expiration."""
         with self._mu:
             self._purge_if_expired(key)
@@ -225,7 +231,7 @@ class InMemoryCacheProvider:
         xx: bool = False,
         *args: object,
         **kwargs: object,
-    ):
+    ) -> bool:
         """Store a value under a cache key."""
         _ = kwargs
         with self._mu:
@@ -246,7 +252,7 @@ class InMemoryCacheProvider:
             )
             return True
 
-    def setex(self, key: str, time_in_seconds: int, value: Any):
+    def setex(self, key: str, time_in_seconds: int, value: Any) -> bool:
         """Store a cached value with an expiration."""
         return self.set(key, value, ex=time_in_seconds)
 
@@ -261,7 +267,7 @@ class InMemoryCacheProvider:
                     self._store.pop(key, None)
         return deleted
 
-    def incr(self, key: str, amount: int = 1):
+    def incr(self, key: str, amount: int = 1) -> int:
         """Increment the integer stored under a cache key."""
         with self._mu:
             self._purge_if_expired(key)
@@ -291,7 +297,7 @@ class InMemoryCacheProvider:
         key: str,
         timeout: int | None = None,
         blocking_timeout: int | None = None,
-    ):
+    ) -> CacheLock:
         """Create a distributed lock for the supplied key."""
         _ = (timeout, blocking_timeout)
         with self._mu:
@@ -321,11 +327,13 @@ class FallbackCacheProvider:
             # Redis connectivity errors should not break core flows.
             return fallback_fn(*args, **kwargs)
 
-    def get(self, key: str):
+    def get(self, key: str) -> bytes | None:
         """Return the stored value for a key."""
         return self._call("get", key)
 
-    def getex(self, key: str, ex: int | None = None, px: int | None = None):
+    def getex(
+        self, key: str, ex: int | None = None, px: int | None = None
+    ) -> bytes | None:
         """Return a cached value and update its expiration."""
         return self._call("getex", key, ex=ex, px=px)
 
@@ -339,7 +347,7 @@ class FallbackCacheProvider:
         xx: bool = False,
         *args: object,
         **kwargs: object,
-    ):
+    ) -> bool:
         """Store a value under a cache key."""
         return self._call(
             "set",
@@ -353,7 +361,7 @@ class FallbackCacheProvider:
             **kwargs,
         )
 
-    def setex(self, key: str, time_in_seconds: int, value: Any):
+    def setex(self, key: str, time_in_seconds: int, value: Any) -> bool:
         """Store a cached value with an expiration."""
         return self._call("setex", key, time_in_seconds, value)
 
@@ -361,7 +369,7 @@ class FallbackCacheProvider:
         """Delete values for the supplied keys."""
         return int(self._call("delete", *keys))
 
-    def incr(self, key: str, amount: int = 1):
+    def incr(self, key: str, amount: int = 1) -> int:
         """Increment the integer stored under a cache key."""
         return self._call("incr", key, amount)
 
@@ -374,7 +382,7 @@ class FallbackCacheProvider:
         key: str,
         timeout: int | None = None,
         blocking_timeout: int | None = None,
-    ):
+    ) -> CacheLock:
         """Create a distributed lock for the supplied key."""
         return self._call(
             "lock", key, timeout=timeout, blocking_timeout=blocking_timeout

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -44,7 +44,7 @@ class AppLoggerProxy:
 class RequestFormatter(logging.Formatter):
     """Format request-aware application log records."""
 
-    def formatTime(self, record, datefmt=None):  # noqa: N802 - logging.Formatter hook name
+    def formatTime(self, record, datefmt=None) -> str:  # noqa: N802 - logging.Formatter hook name
         # create time zone info
         """Format a log timestamp in the application timezone."""
         bj_time = pytz.timezone("Asia/Shanghai")
@@ -59,7 +59,7 @@ class RequestFormatter(logging.Formatter):
                 s = ct.isoformat()
         return s
 
-    def format(self, record):
+    def format(self, record) -> str:
         """Format a log record with request context."""
         try:
             request_id = getattr(thread_local, "request_id", "No_Request_ID")
@@ -124,7 +124,7 @@ class FeishuLogHandler(logging.Handler):
         except Exception:
             logging.getLogger(__name__).warning(message, exc, exc_info=True)
 
-    def emit(self, record):
+    def emit(self, record) -> None:
         """Deliver a formatted error record to Feishu."""
         if getattr(self._delivering, "active", False):
             return

--- a/src/api/flaskr/common/swagger.py
+++ b/src/api/flaskr/common/swagger.py
@@ -48,7 +48,7 @@ def sanitize_swagger_docstring(text: str) -> str:
     return BR_SANITIZER(stripped)
 
 
-def parse_comments(cls):
+def parse_comments(cls) -> dict[str, str]:
     """Extract field descriptions from a DTO's source comments."""
     source = inspect.getsource(cls)
     tree = ast.parse(source)
@@ -83,7 +83,7 @@ def parse_comments(cls):
     return comments
 
 
-def get_field_schema(typ, description: str = ""):
+def get_field_schema(typ, description: str = "") -> dict[str, object]:
     """Build the Swagger schema for an annotated DTO field."""
     field_schema = {}
     origin = typing.get_origin(typ)
@@ -137,7 +137,7 @@ def get_field_schema(typ, description: str = ""):
     return field_schema
 
 
-def register_schema_to_swagger(cls):
+def register_schema_to_swagger(cls) -> type[object] | dict[str, object]:
     """Register schema to swagger."""
     if swagger_config["components"]["schemas"].get(cls.__name__, None):
         return swagger_config["components"]["schemas"].get(cls.__name__)

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -11,6 +11,7 @@ import select as select_module
 import sys
 import time
 import traceback
+from collections.abc import Callable
 from pathlib import Path
 
 import sqlparse
@@ -495,7 +496,9 @@ def _rollback_quietly() -> bool:
         return True
 
 
-def retry_on_deadlock(max_attempts: int = 3, backoff_seconds: float = 0.1):
+def retry_on_deadlock(
+    max_attempts: int = 3, backoff_seconds: float = 0.1
+) -> Callable[..., object]:
     """Retry a transactional function when MySQL reports a deadlock (1213) or a lock wait timeout (1205).
 
     The failed transaction is rolled back on every caught error so the session is left
@@ -544,7 +547,7 @@ def retry_on_deadlock(max_attempts: int = 3, backoff_seconds: float = 0.1):
     return decorator
 
 
-def init_db(app: Flask):
+def init_db(app: Flask) -> None:
     """Initialize database."""
     if app.debug:
         logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
@@ -663,7 +666,7 @@ def init_db(app: Flask):
             setup_sql_logging()
 
 
-def init_redis(app: Flask):
+def init_redis(app: Flask) -> None:
     """Initialize Redis."""
     host = app.config.get("REDIS_HOST")
     port = app.config.get("REDIS_PORT")
@@ -706,7 +709,7 @@ def init_redis(app: Flask):
     app.logger.info("init redis done")
 
 
-def run_with_redis(app, key, timeout: int, func, args):
+def run_with_redis(app, key, timeout: int, func, args) -> object | None:
     """Run with Redis."""
     with app.app_context():
         app.logger.info("run_with_redis start %s", key)

--- a/src/api/flaskr/dao/uow.py
+++ b/src/api/flaskr/dao/uow.py
@@ -34,14 +34,18 @@ from __future__ import annotations
 
 import contextvars
 import logging
-from contextlib import contextmanager, nullcontext
+from contextlib import AbstractContextManager, contextmanager, nullcontext
+from typing import TYPE_CHECKING
 
 from flask import has_app_context
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 logger = logging.getLogger(__name__)
 
 
-def app_context_scope(app):
+def app_context_scope(app) -> AbstractContextManager[object]:
     """Reuse the caller's app context (and DB session) when one is active.
 
     Flask-SQLAlchemy 3.1 scopes the session to the innermost app context, so
@@ -90,7 +94,7 @@ def _run_post_commit(callbacks: list) -> None:
 
 
 @contextmanager
-def unit_of_work():
+def unit_of_work() -> Iterator[None]:
     """Commit on clean exit of the outermost block; roll back on exception.
 
     Nested blocks join the outer transaction (no commit, no rollback): an

--- a/src/api/flaskr/framework/plugin/base.py
+++ b/src/api/flaskr/framework/plugin/base.py
@@ -11,7 +11,7 @@ class BasePlugin:
         self.name = self.__class__.__name__
         self.migration_dir = None  # plugin migration dir
 
-    def on_load(self):
+    def on_load(self) -> None:
         """Run plugin initialization after loading."""
         if self.migration_dir:
             self._run_migrations()
@@ -29,8 +29,8 @@ class BasePlugin:
 
         command.upgrade(alembic_cfg, "head")
 
-    def on_unload(self):
+    def on_unload(self) -> None:
         """Handle the plugin being unloaded."""
 
-    def on_reload(self):
+    def on_reload(self) -> None:
         """Handle the plugin being reloaded."""

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -13,7 +13,7 @@ from flask.cli import with_appcontext
 from .plugin_manager import get_plugin_manager
 
 
-def enable_plugins(app: Flask):
+def enable_plugins(app: Flask) -> None:
     """Enable plugins."""
     plugin_manager = get_plugin_manager()
     if plugin_manager is None:

--- a/src/api/flaskr/framework/plugin/hot_reload.py
+++ b/src/api/flaskr/framework/plugin/hot_reload.py
@@ -18,19 +18,19 @@ class PluginHotReloader:
         self.watched_files = {}
         self.observer = Observer()
 
-    def start(self):
+    def start(self) -> None:
         """1111111."""
         event_handler = PluginFileHandler(self)
         self.observer.schedule(event_handler, self.plugin_dir, recursive=True)
         self.observer.start()
         self.app.logger.info("Plugin hot reload started")
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop watching for hot reloads."""
         self.observer.stop()
         self.observer.join()
 
-    def reload_plugin(self, plugin_path: str):
+    def reload_plugin(self, plugin_path: str) -> None:
         """Reload a single plugin."""
         try:
             # 1. unload plugin
@@ -135,7 +135,7 @@ class PluginFileHandler(FileSystemEventHandler):
         self.last_reload_time = {}  # Track last reload time per file
         self.min_reload_interval = 1.0  # Minimum seconds between reloads
 
-    def on_modified(self, event):
+    def on_modified(self, event) -> None:
         """Reload the plugin affected by a file change."""
         if event.is_directory:
             return

--- a/src/api/flaskr/framework/plugin/inject.py
+++ b/src/api/flaskr/framework/plugin/inject.py
@@ -1,10 +1,11 @@
 """Inject plugin dependencies into application components."""
 
+from collections.abc import Callable
 from functools import wraps
 
 
 # inject app to function and set inject flag
-def inject(func):
+def inject(func) -> Callable[..., object]:
     """Inject a plugin callback at the requested extension point."""
 
     @wraps(func)

--- a/src/api/flaskr/framework/plugin/load_plugin.py
+++ b/src/api/flaskr/framework/plugin/load_plugin.py
@@ -20,7 +20,7 @@ SRC_DIR = "src"
 
 def load_plugins_from_dir(
     app: Flask, plugins_dir: str, plugin_manager: PluginManager = None
-):
+) -> list[object]:
     """Load plugins from dir."""
     plugins = []
     app.logger.info("load modules from: %s", plugins_dir)

--- a/src/api/flaskr/framework/plugin/plugin_manager.py
+++ b/src/api/flaskr/framework/plugin/plugin_manager.py
@@ -1,5 +1,6 @@
 """Coordinate Flask plugin registration and lifecycle."""
 
+from collections.abc import Callable, Iterator
 from functools import wraps
 
 from flask import Flask
@@ -20,7 +21,7 @@ class PluginManager:
         self.plugins = {}
         self.is_enabled = True
 
-    def enable_hot_reload(self):
+    def enable_hot_reload(self) -> None:
         """Enable the hot reload."""
         if not self.is_enabled:
             return
@@ -28,18 +29,18 @@ class PluginManager:
             self.hot_reloader = PluginHotReloader(self.app)
             self.hot_reloader.start()
 
-    def disable_hot_reload(self):
+    def disable_hot_reload(self) -> None:
         """Disable the hot reload."""
         if self.hot_reloader:
             self.hot_reloader.stop()
             self.hot_reloader = None
 
-    def clear_extension(self, target_func_name):
+    def clear_extension(self, target_func_name) -> None:
         """Clear all registered functions for the specified extension point."""
         if target_func_name in self.extension_functions:
             del self.extension_functions[target_func_name]
 
-    def register_extension(self, target_func_name, func):
+    def register_extension(self, target_func_name, func) -> None:
         """Register an extension callback for a target function."""
         self.app.logger.info(
             "register_extension: %s -> %s", target_func_name, func.__name__
@@ -51,7 +52,9 @@ class PluginManager:
             self.extension_functions[target_func_name] = []
         self.extension_functions[target_func_name].append(func)
 
-    def execute_extensions(self, func_name, result, *args: object, **kwargs: object):
+    def execute_extensions(
+        self, func_name, result, *args: object, **kwargs: object
+    ) -> object:
         """Execute callbacks registered for a target function."""
         self.app.logger.info("execute_extensions: %s", func_name)
         if not self.is_enabled:
@@ -61,7 +64,7 @@ class PluginManager:
                 result = func(result, *args, **kwargs)
         return result
 
-    def register_extensible_generic(self, func_name, func):
+    def register_extensible_generic(self, func_name, func) -> None:
         """Register a generic extensible function."""
         self.app.logger.info(
             "register_extensible_generic: %s -> %s", func_name, func.__name__
@@ -79,7 +82,7 @@ class PluginManager:
         result,
         *args: object,
         **kwargs: object,
-    ):
+    ) -> Iterator[object]:
         """Execute a generic extensible function and its callbacks."""
         self.app.logger.info("execute_extensible_generic: %s", func_name)
         if not self.is_enabled:
@@ -116,14 +119,14 @@ def set_plugin_manager(manager: PluginManager | None) -> None:
     _plugin_manager_state.manager = manager
 
 
-def enable_plugin_manager(app: Flask):
+def enable_plugin_manager(app: Flask) -> Flask:
     """Enable plugin manager."""
     app.logger.info("enable_plugin_manager")
     set_plugin_manager(PluginManager(app))
     return app
 
 
-def disable_plugin_manager(app: Flask):
+def disable_plugin_manager(app: Flask) -> Flask:
     """Disable plugin manager."""
     app.logger.info("disable_plugin_manager")
     manager = get_plugin_manager()
@@ -134,7 +137,7 @@ def disable_plugin_manager(app: Flask):
 
 
 # extensible decorator
-def extension(target_func_name):
+def extension(target_func_name) -> Callable[..., object]:
     """Decorate a function with registered extension callbacks."""
 
     def decorator(func):
@@ -148,7 +151,7 @@ def extension(target_func_name):
     return decorator
 
 
-def extensible_generic_register(func_name):
+def extensible_generic_register(func_name) -> Callable[..., object]:
     """Register a generic extension point."""
 
     def decorator(func):
@@ -163,7 +166,7 @@ def extensible_generic_register(func_name):
 
 
 # extensible decorator
-def extensible(func):
+def extensible(func) -> Callable[..., object]:
     """Decorate a function as an extension point."""
 
     @wraps(func)
@@ -178,7 +181,7 @@ def extensible(func):
 
 
 # extensible_generic decorator
-def extensible_generic(func):
+def extensible_generic(func) -> Callable[..., object]:
     """Decorate a generic function as an extension point."""
     try:
         from flask import current_app, has_app_context

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -247,7 +247,7 @@ def _load_python_translations(app: Flask, translations_dir: Path):
                                     )
 
 
-def load_translations(app: Flask, translations_dir=None):
+def load_translations(app: Flask, translations_dir=None) -> None:
     """Load translations."""
     if translations_dir:
         base_path = Path(translations_dir)
@@ -268,7 +268,7 @@ def load_translations(app: Flask, translations_dir=None):
     _load_python_translations(app, Path(__file__).resolve().parent)
 
 
-def translate_for_language(text: str, language: str | None = None):
+def translate_for_language(text: str, language: str | None = None) -> str:
     """Translate for language."""
     language = language or getattr(_thread_local, "language", "en-US")
     translations = _translations.get(language) or {}
@@ -290,18 +290,18 @@ def get_current_language():
     return getattr(_thread_local, "language", "en-US")
 
 
-def set_language(language):
+def set_language(language) -> None:
     """Set language."""
     _thread_local.language = language
 
 
-def clear_language():
+def clear_language() -> None:
     """Clear language."""
     if hasattr(_thread_local, "language"):
         delattr(_thread_local, "language")
 
 
-def get_i18n_list():
+def get_i18n_list() -> list[str]:
     """Return i18n list."""
     return list(_translations.keys())
 

--- a/src/api/flaskr/route/__init__.py
+++ b/src/api/flaskr/route/__init__.py
@@ -1,7 +1,9 @@
 """Route package entrypoints."""
 
+from flask import Flask
 
-def register_route(app):
+
+def register_route(app) -> Flask:
     """Register every API route group on the Flask application."""
     from flaskr.service.referral.routes import register_referral_routes
 

--- a/src/api/flaskr/route/callback.py
+++ b/src/api/flaskr/route/callback.py
@@ -23,7 +23,7 @@ from flaskr.service.order.raw_snapshots import native_snapshot_model
 from .common import bypass_token_validation
 
 
-def register_callback_handler(app: Flask, path_prefix: str):
+def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
     """Register the callback routes on the Flask application."""
 
     @app.route("/api/order/webhooks/<provider_name>/<callback_token>", methods=["POST"])

--- a/src/api/flaskr/route/common.py
+++ b/src/api/flaskr/route/common.py
@@ -4,6 +4,7 @@ import datetime
 import decimal
 import json
 import traceback
+from collections.abc import Callable
 from functools import wraps
 
 from flask import Flask, jsonify, request
@@ -60,7 +61,7 @@ def _extract_request_language() -> str | None:
 
 
 # Decorator that exempts a route from token validation
-def bypass_token_validation(func):
+def bypass_token_validation(func) -> Callable[..., object]:
     """Mark a route as exempt from token validation."""
     by_pass_login_func.append(func.__name__)
 
@@ -108,7 +109,7 @@ def register_common_handler(app: Flask) -> Flask:
     return app
 
 
-def fmt(o):
+def fmt(o) -> object:
     """Serialize a value for the shared API response envelope."""
     if isinstance(o, datetime.datetime):
         # Single serialization choke point for datetimes returned by APIs.
@@ -125,7 +126,7 @@ def fmt(o):
     return o.__json__()
 
 
-def make_common_response(data):
+def make_common_response(data) -> str:
     """Build common response."""
     if data is None:
         data = {}

--- a/src/api/flaskr/route/open_api.py
+++ b/src/api/flaskr/route/open_api.py
@@ -1,6 +1,7 @@
 """Open API routes for external partner course order management."""
 
 import hmac
+from collections.abc import Callable
 from functools import wraps
 
 from flask import Flask, request
@@ -15,7 +16,7 @@ from flaskr.service.order.open_api import (
 from flaskr.service.user.models import UserInfo
 
 
-def require_api_key(f):
+def require_api_key(f) -> Callable[..., object]:
     """Authenticate Open API requests via X-User-Uid + X-Api-Key headers."""
 
     @wraps(f)

--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -42,7 +42,7 @@ from flaskr.service.shifu.utils import get_shifu_creator_bid
 from flaskr.util.datetime import parse_naive_utc
 
 
-def register_order_handler(app: Flask, path_prefix: str):
+def register_order_handler(app: Flask, path_prefix: str) -> Flask:
     """Register the order routes on the Flask application."""
 
     def _require_creator():

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -1,6 +1,7 @@
 """Expose user HTTP routes."""
 
 import contextlib
+from collections.abc import Callable
 from functools import wraps
 
 from flask import Flask, current_app, make_response, request
@@ -195,7 +196,7 @@ def _extract_referral_post_auth_fields(payload: dict) -> dict[str, str]:
     )
 
 
-def optional_token_validation(f):
+def optional_token_validation(f) -> Callable[..., object]:
     """Allow a route to accept an optional authentication token."""
 
     @wraps(f)

--- a/src/api/flaskr/service/billing/api.py
+++ b/src/api/flaskr/service/billing/api.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from flaskr.service.billing import primitives as billing_primitives
 from flaskr.service.billing.admission import CreatorUsageAdmission, admit_creator_usage
 from flaskr.service.billing.charges import (
@@ -59,6 +61,9 @@ from flaskr.service.billing.referral_reward_grants import (
     load_referral_reward_summary,
 )
 
+if TYPE_CHECKING:
+    from decimal import Decimal
+
 
 def is_billing_enabled(*, default: bool = False) -> bool:
     """Return whether billing enabled."""
@@ -68,17 +73,17 @@ def is_billing_enabled(*, default: bool = False) -> bool:
         return billing_primitives.is_billing_enabled()
 
 
-def quantize_credit_amount(value, *, precision: int | None = None):
+def quantize_credit_amount(value, *, precision: int | None = None) -> Decimal:
     """Quantize credit amount."""
     return billing_primitives.quantize_credit_amount(value, precision=precision)
 
 
-def credit_decimal_to_number(value, *, precision: int | None = None):
+def credit_decimal_to_number(value, *, precision: int | None = None) -> int | float:
     """Convert a credit Decimal to an API-safe number."""
     return billing_primitives.credit_decimal_to_number(value, precision=precision)
 
 
-def to_decimal(value):
+def to_decimal(value) -> Decimal:
     """Convert a value to the billing Decimal representation."""
     return billing_primitives.to_decimal(value)
 

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -70,7 +70,7 @@ try:  # pragma: no cover - exercised indirectly when Celery is installed
     from celery import shared_task
 except ImportError:  # pragma: no cover - local fallback for non-Celery test envs
 
-    def shared_task(*args: object, **kwargs: object):
+    def shared_task(*args: object, **kwargs: object) -> Callable[..., object]:
         """Register a Celery task with the configured application context."""
         _ = (args, kwargs)
 

--- a/src/api/flaskr/service/check_risk/funcs.py
+++ b/src/api/flaskr/service/check_risk/funcs.py
@@ -20,7 +20,7 @@ def add_risk_control_result(
     check_resp,
     is_pass,
     check_strategy,
-):
+) -> int:
     """Add risk control result."""
     with app.app_context():
         risk_control_result = RiskControlResult(

--- a/src/api/flaskr/service/common/dicts.py
+++ b/src/api/flaskr/service/common/dicts.py
@@ -32,7 +32,7 @@ class Dict:
         return {"name": self.name, "display": self.display, "items": self.items}
 
 
-def register_dict(name, desp, items: dict):
+def register_dict(name, desp, items: dict) -> None:
     """Register dict."""
     if name in DICTS:
         return

--- a/src/api/flaskr/service/common/models.py
+++ b/src/api/flaskr/service/common/models.py
@@ -3,6 +3,7 @@
 
 import json
 from pathlib import Path
+from typing import Never
 
 from flaskr.i18n import _
 from flaskr.util.deprecation import deprecated_alias_getattr
@@ -57,12 +58,12 @@ def _load_error_codes() -> dict[str, int]:
 ERROR_CODE = _load_error_codes()
 
 
-def register_error(error_name, error_code):
+def register_error(error_name, error_code) -> None:
     """Register error."""
     ERROR_CODE[error_name] = error_code
 
 
-def raise_param_error(param_message):
+def raise_param_error(param_message) -> Never:
     """Raise a localized invalid-parameter application error."""
     raise AppError(
         _("server.common.paramsError").format(param_message=param_message),
@@ -70,7 +71,7 @@ def raise_param_error(param_message):
     )
 
 
-def raise_error(error_name):
+def raise_error(error_name) -> Never:
     """Raise a localized application error for the supplied key."""
     raise AppError(
         _(error_name),
@@ -78,7 +79,7 @@ def raise_error(error_name):
     )
 
 
-def raise_error_with_args(error_name, **kwargs: object):
+def raise_error_with_args(error_name, **kwargs: object) -> Never:
     """Raise error with args."""
     raise AppError(
         _(error_name).format(**kwargs),

--- a/src/api/flaskr/service/common/stripe_client.py
+++ b/src/api/flaskr/service/common/stripe_client.py
@@ -14,7 +14,7 @@ class StripeClientConfigError(RuntimeError):
     """Raised when Stripe SDK or credentials are unavailable."""
 
 
-def ensure_stripe_client(app: Flask):
+def ensure_stripe_client(app: Flask) -> object:
     """Ensure stripe client."""
     try:
         import stripe  # type: ignore[import-untyped]

--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import random
 import threading
+from collections.abc import Iterator
 from contextlib import contextmanager
 
 from cryptography.fernet import Fernet
@@ -28,7 +29,7 @@ _config_override_local = threading.local()
 
 
 @contextmanager
-def config_overrides(values: dict[str, object]):
+def config_overrides(values: dict[str, object]) -> Iterator[None]:
     """Return config overrides."""
     previous = getattr(_config_override_local, "values", None)
     merged = dict(previous) if previous is not None else {}

--- a/src/api/flaskr/service/feedback/funs.py
+++ b/src/api/flaskr/service/feedback/funs.py
@@ -8,7 +8,7 @@ from flaskr.service.user.repository import load_user_aggregate
 from .models import FeedBack
 
 
-def submit_feedback(app: Flask, user_id: str, feedback: str, mail: str):
+def submit_feedback(app: Flask, user_id: str, feedback: str, mail: str) -> int:
     """Submit feedback."""
     with app.app_context():
         feedback_item = FeedBack(user_id=user_id, feedback=feedback)

--- a/src/api/flaskr/service/learn/check_text.py
+++ b/src/api/flaskr/service/learn/check_text.py
@@ -1,5 +1,7 @@
 """Moderate learner text with the configured LLM guardrail."""
 
+from collections.abc import Iterator
+
 from flask import Flask
 from flaskr.api.check import (
     CHECK_RESULT_PASS,
@@ -39,7 +41,7 @@ def check_text_with_llm_response(
     usage_context: UsageContext,
     chapter_title: str = "",
     scene: str = "lesson_runtime",
-):
+) -> Iterator[str | None]:
     """Check text with LLM response."""
     res = check_text(app, log_script.generated_block_bid, user_input, user_info.user_id)
     span.event(

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -6,7 +6,7 @@ import inspect
 import json
 import queue
 import threading
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable, Generator, Iterable, Iterator
 from dataclasses import dataclass, replace
 from decimal import Decimal
 from enum import Enum
@@ -451,11 +451,11 @@ class MdflowContextV2:
             )
             self._mdflow = self._mdflow.set_output_language(resolved_output_language)
 
-    def get_block(self, block_index: int):
+    def get_block(self, block_index: int) -> object:
         """Return a MarkdownFlow block by identifier."""
         return self._mdflow.get_block(block_index)
 
-    def get_all_blocks(self):
+    def get_all_blocks(self) -> list[object]:
         """Return all MarkdownFlow blocks in encounter order."""
         return self._mdflow.get_all_blocks()
 
@@ -467,7 +467,7 @@ class MdflowContextV2:
         context: list[dict[str, str]] | None = None,
         variables: dict | None = None,
         user_input: dict[str, list[str]] | None = None,
-    ):
+    ) -> object:
         """Process the current MarkdownFlow content."""
         return self._mdflow.process(
             block_index=block_index,
@@ -2194,7 +2194,7 @@ class RunScriptContextV2:
             return False
         return bool(str(input_value).strip())
 
-    def set_input(self, user_input: str | dict, input_type: str):
+    def set_input(self, user_input: str | dict, input_type: str) -> None:
         """Set user input.
 
         Args:
@@ -3687,7 +3687,7 @@ class RunScriptContextV2:
         reload_generated_block_bid: str,
         *,
         reload_element_bid: str | None = None,
-    ):
+    ) -> Iterator[object]:
         """Reload run state from persisted progress."""
         with app.app_context():
             anchor_element = None

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -6,6 +6,7 @@ import logging
 import queue
 import time
 import uuid
+from collections.abc import Iterator
 from dataclasses import replace
 from datetime import UTC, datetime
 
@@ -1572,7 +1573,7 @@ def stream_generated_block_audio(
     user_bid: str,
     preview_mode: bool,
     listen: bool = False,
-):
+) -> Iterator[RunMarkdownFlowDTO]:
     """Stream generated block audio."""
     with app.app_context():
         generated_block = LearnGeneratedBlock.query.filter(
@@ -1963,7 +1964,7 @@ def stream_preview_tts_audio(
     user_bid: str,
     text: str,
     preview_mode: bool,
-):
+) -> Iterator[RunMarkdownFlowDTO]:
     """Stream preview TTS audio."""
     with app.app_context():
         provider, tts_model, voice_settings, audio_settings = (

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -533,7 +533,7 @@ def run_script_inner(
     yield from _run()
 
 
-def fmt(o):
+def fmt(o) -> object:
     """Serialize a value for the shared API response envelope."""
     if isinstance(o, datetime):
         return to_utc_iso(o)

--- a/src/api/flaskr/service/llm/route.py
+++ b/src/api/flaskr/service/llm/route.py
@@ -7,7 +7,7 @@ from flaskr.route.common import make_common_response
 
 
 @inject
-def register_llm_routes(app: Flask, path_prefix="/api/llm"):
+def register_llm_routes(app: Flask, path_prefix="/api/llm") -> Flask:
     """Register LLM routes."""
     app.logger.info("register llm routes %s", path_prefix)
 

--- a/src/api/flaskr/service/order/coupon_funcs.py
+++ b/src/api/flaskr/service/order/coupon_funcs.py
@@ -7,7 +7,11 @@ from flask import Flask
 from flaskr.api.doc.feishu import send_notify
 from flaskr.dao import db
 from flaskr.service.common import raise_error
-from flaskr.service.order.funs import query_buy_record, success_buy_record
+from flaskr.service.order.funs import (
+    AICourseBuyRecordDTO,
+    query_buy_record,
+    success_buy_record,
+)
 from flaskr.service.order.models import Order
 from flaskr.service.promo.api import (
     build_coupon_enabled_expression,
@@ -113,7 +117,7 @@ def _should_bind_usage_course(coupon: Coupon, coupon_usage: CouponUsageModel) ->
 
 def send_feishu_coupon_code(
     app: Flask, user_id, discount_code, discount_name, discount_value
-):
+) -> None:
     """Send feishu coupon code."""
     with app.app_context():
         user_info = load_user_aggregate(user_id)
@@ -139,7 +143,9 @@ def send_feishu_coupon_code(
         send_notify(app, title, msgs)
 
 
-def use_coupon_code(app: Flask, user_id, coupon_code, order_id):
+def use_coupon_code(
+    app: Flask, user_id, coupon_code, order_id
+) -> AICourseBuyRecordDTO | None:
     """Use coupon code.
 
     Args:

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -183,7 +183,7 @@ class AICourseBuyRecordDTO:
 
 
 # to do : add to plugins
-def send_order_feishu(app: Flask, record_id: str):
+def send_order_feishu(app: Flask, record_id: str) -> None:
     """Send order feishu."""
     order_info = query_buy_record(app, record_id)
     if order_info is None:
@@ -242,7 +242,7 @@ def send_order_feishu(app: Flask, record_id: str):
     send_notify(app, title, msgs)
 
 
-def send_revoke_feishu(app: Flask, order_bid: str, user_identify: str):
+def send_revoke_feishu(app: Flask, order_bid: str, user_identify: str) -> None:
     """Send revoke feishu."""
     order: Order = Order.query.filter(Order.order_bid == order_bid).first()
     if not order:
@@ -380,7 +380,7 @@ def _sync_order_campaign_pricing(
 @retry_on_deadlock()
 def init_buy_record(
     app: Flask, user_id: str, course_id: str, active_id: str | None = None
-):
+) -> AICourseBuyRecordDTO:
     """Initialize buy record."""
     creator_bid = get_shifu_creator_bid(app, course_id)
     set_shifu_context(course_id, creator_bid)
@@ -1166,7 +1166,7 @@ def sync_stripe_checkout_session(
     order_id: str,
     session_id: str | None = None,
     expected_user: str | None = None,
-):
+) -> dict[str, object]:
     """Synchronize stripe checkout session."""
     with _app_context_scope(app), unit_of_work():
         order = (
@@ -1232,7 +1232,7 @@ def sync_native_payment_order(
     *,
     expected_user: str | None = None,
     payment_channel: str | None = None,
-):
+) -> dict[str, object]:
     """Synchronize native payment order."""
     with _app_context_scope(app), unit_of_work():
         order = (
@@ -1880,7 +1880,9 @@ def success_buy_record_from_native(
             lock.release()
 
 
-def success_buy_record_from_pingxx(app: Flask, charge_id: str, body: dict):
+def success_buy_record_from_pingxx(
+    app: Flask, charge_id: str, body: dict
+) -> AICourseBuyRecordDTO | None:
     """Success buy record from pingxx."""
     with _app_context_scope(app):
         pingxx_order = (
@@ -1944,7 +1946,7 @@ def success_buy_record_from_pingxx(app: Flask, charge_id: str, body: dict):
     return None
 
 
-def success_buy_record(app: Flask, record_id: str):
+def success_buy_record(app: Flask, record_id: str) -> AICourseBuyRecordDTO | None:
     """Success buy record.
 
     Owns a unit of work so legacy callers (coupon_funcs, order admin) keep

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -159,7 +159,7 @@ class PingxxProvider(PaymentProvider):
         )
 
     @_serialized_pingpp_config
-    def retrieve_charge(self, *, charge_id: str, app: Flask):
+    def retrieve_charge(self, *, charge_id: str, app: Flask) -> object:
         """Retrieve a charge from the payment provider."""
         client = self._ensure_client(app)
         return client.Charge.retrieve(charge_id)

--- a/src/api/flaskr/service/order/pingxx_order.py
+++ b/src/api/flaskr/service/order/pingxx_order.py
@@ -6,7 +6,7 @@ from .payment_providers import PaymentRequest, get_payment_provider
 from .payment_providers.pingxx import PingxxProvider
 
 
-def init_pingxx(app: Flask):
+def init_pingxx(app: Flask) -> object:
     """Initialize pingxx."""
     provider = _get_provider()
     client = provider.ensure_client(app)
@@ -16,7 +16,7 @@ def init_pingxx(app: Flask):
 
 def create_pingxx_order(
     app: Flask, order_no, app_id, channel, amount, client_ip, subject, body, extra=None
-):
+) -> object:
     """Create pingxx order."""
     app.logger.info(
         "create pingxx order,order_no:%s app_id:%s channel:%s amount:%s client_ip:%s subject:%s body:%s extra:%s",

--- a/src/api/flaskr/service/order/raw_snapshots.py
+++ b/src/api/flaskr/service/order/raw_snapshots.py
@@ -29,7 +29,7 @@ _NATIVE_PAYMENT_BID_ATTRS = {
 }
 
 
-def legacy_stripe_snapshot_query():
+def legacy_stripe_snapshot_query() -> object:
     """Return legacy stripe snapshot query."""
     return StripeOrder.query.filter(
         StripeOrder.deleted == 0,
@@ -37,7 +37,7 @@ def legacy_stripe_snapshot_query():
     )
 
 
-def legacy_pingxx_snapshot_query():
+def legacy_pingxx_snapshot_query() -> object:
     """Return legacy pingxx snapshot query."""
     return PingxxOrder.query.filter(
         PingxxOrder.deleted == 0,
@@ -45,7 +45,7 @@ def legacy_pingxx_snapshot_query():
     )
 
 
-def billing_stripe_snapshot_query():
+def billing_stripe_snapshot_query() -> object:
     """Return billing stripe snapshot query."""
     return StripeOrder.query.filter(
         StripeOrder.deleted == 0,
@@ -53,7 +53,7 @@ def billing_stripe_snapshot_query():
     )
 
 
-def billing_pingxx_snapshot_query():
+def billing_pingxx_snapshot_query() -> object:
     """Return billing pingxx snapshot query."""
     return PingxxOrder.query.filter(
         PingxxOrder.deleted == 0,
@@ -61,7 +61,7 @@ def billing_pingxx_snapshot_query():
     )
 
 
-def native_snapshot_model(payment_provider: str):
+def native_snapshot_model(payment_provider: str) -> type[AlipayOrder | WechatPayOrder]:
     """Return native snapshot model."""
     provider = str(payment_provider or "").strip().lower()
     model = _NATIVE_PAYMENT_MODELS.get(provider)
@@ -81,7 +81,7 @@ def native_snapshot_bid_attr(payment_provider: str) -> str:
     return attr
 
 
-def native_snapshot_query(payment_provider: str, biz_domain: str):
+def native_snapshot_query(payment_provider: str, biz_domain: str) -> object:
     """Return native snapshot query."""
     model = native_snapshot_model(payment_provider)
     return model.query.filter(
@@ -90,12 +90,12 @@ def native_snapshot_query(payment_provider: str, biz_domain: str):
     )
 
 
-def legacy_native_snapshot_query(payment_provider: str):
+def legacy_native_snapshot_query(payment_provider: str) -> object:
     """Return legacy native snapshot query."""
     return native_snapshot_query(payment_provider, RAW_BIZ_DOMAIN_ORDER)
 
 
-def billing_native_snapshot_query(payment_provider: str):
+def billing_native_snapshot_query(payment_provider: str) -> object:
     """Return billing native snapshot query."""
     return native_snapshot_query(payment_provider, RAW_BIZ_DOMAIN_BILLING)
 

--- a/src/api/flaskr/service/profile/funcs.py
+++ b/src/api/flaskr/service/profile/funcs.py
@@ -137,7 +137,7 @@ def check_text_content(
     app: Flask,
     user_id: str,
     user_input: str,
-):
+) -> bool:
     """Check text content."""
     check_id = generate_id(app)
     res = check_text(app, check_id, user_input, user_id)
@@ -155,7 +155,7 @@ def check_text_content(
     return res.check_result != CHECK_RESULT_REJECT
 
 
-def get_profile_labels():
+def get_profile_labels() -> dict[str, object]:
     """Return profile labels."""
     return {
         "sys_user_nickname": {
@@ -494,7 +494,7 @@ def update_user_profile_with_lable(
     profiles: list,
     update_all: bool = False,
     course_id: str | None = None,
-):
+) -> bool:
     """Update user profile with lable."""
     app.logger.info("update user profile with lable:%s", course_id)
     profile_labels = get_profile_labels()

--- a/src/api/flaskr/service/profile/profile_manage.py
+++ b/src/api/flaskr/service/profile/profile_manage.py
@@ -209,7 +209,9 @@ def get_profile_variable_usage(app: Flask, parent_id: str) -> dict:
     }
 
 
-def add_profile_item_quick(app: Flask, parent_id: str, key: str, user_id: str):
+def add_profile_item_quick(
+    app: Flask, parent_id: str, key: str, user_id: str
+) -> ProfileItemDefinition:
     """Add profile item quick."""
     with app.app_context():
         if not parent_id:
@@ -221,7 +223,9 @@ def add_profile_item_quick(app: Flask, parent_id: str, key: str, user_id: str):
         return ret
 
 
-def add_profile_item_quick_internal(app: Flask, parent_id: str, key: str, user_id: str):
+def add_profile_item_quick_internal(
+    app: Flask, parent_id: str, key: str, user_id: str
+) -> ProfileItemDefinition:
     """Add profile item quick internal."""
     bind = db.session.get_bind()
     inspector = inspect(bind)
@@ -382,7 +386,7 @@ def add_profile_i18n(
     language: str,
     profile_item_remark: str,
     user_id: str,
-):
+) -> None:
     """Add profile i18n."""
     _ = app
     bind = db.session.get_bind()
@@ -455,7 +459,7 @@ def save_profile_item(
     parent_id: str,
     user_id: str,
     key: str,
-):
+) -> ProfileItemDefinition:
     """Save (create/update) a custom variable definition."""
     with app.app_context():
         normalized_parent_id = parent_id or ""
@@ -521,7 +525,7 @@ def save_profile_item(
         return convert_variable_definition_to_profile_item_definition(definition)
 
 
-def delete_profile_item(app: Flask, user_id: str, profile_id: str):
+def delete_profile_item(app: Flask, user_id: str, profile_id: str) -> bool:
     """Delete profile item."""
     with app.app_context():
         definition = Variable.query.filter(

--- a/src/api/flaskr/service/profile/routes.py
+++ b/src/api/flaskr/service/profile/routes.py
@@ -16,7 +16,7 @@ from flaskr.service.profile.profile_manage import (
 
 
 @inject
-def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles"):
+def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> Flask:
     """Register learner-profile routes on the Flask application."""
 
     @app.route(f"{path_prefix}/get-profile-item-definitions", methods=["GET"])

--- a/src/api/flaskr/service/promo/funcs.py
+++ b/src/api/flaskr/service/promo/funcs.py
@@ -8,6 +8,7 @@ from flaskr.dao import db
 from flaskr.util import generate_id
 from flaskr.util.datetime import now_utc
 from sqlalchemy import and_, func, or_
+from sqlalchemy.sql.elements import ColumnElement
 
 from .consts import (
     COUPON_BATCH_STATUS_ACTIVE,
@@ -63,7 +64,7 @@ def _blank_legacy_bid_expression(column):
     return func.trim(normalized) == ""
 
 
-def build_coupon_enabled_expression(model_or_columns):
+def build_coupon_enabled_expression(model_or_columns) -> ColumnElement[bool]:
     """Build coupon enabled expression."""
     return or_(
         model_or_columns.status == COUPON_BATCH_STATUS_ACTIVE,
@@ -75,7 +76,7 @@ def build_coupon_enabled_expression(model_or_columns):
     )
 
 
-def build_campaign_enabled_expression(model_or_columns):
+def build_campaign_enabled_expression(model_or_columns) -> ColumnElement[bool]:
     """Build campaign enabled expression."""
     return or_(
         model_or_columns.status == PROMO_CAMPAIGN_STATUS_ACTIVE,
@@ -91,7 +92,7 @@ def _app_context_scope(app: Flask):
     return nullcontext() if has_app_context() else app.app_context()
 
 
-def timeout_coupon_code_rollback(app: Flask, user_bid, order_bid):
+def timeout_coupon_code_rollback(app: Flask, user_bid, order_bid) -> None:
     """Timeout coupon code rollback.
 
     Args:

--- a/src/api/flaskr/service/shifu/dtos.py
+++ b/src/api/flaskr/service/shifu/dtos.py
@@ -376,17 +376,17 @@ class ShifuOutlineTreeNode:
             self.position = ""
         self.parent_node = None
 
-    def add_child(self, child: "ShifuOutlineTreeNode"):
+    def add_child(self, child: "ShifuOutlineTreeNode") -> None:
         """Add a child to the node."""
         self.children.append(child)
         child.parent_node = self
 
-    def remove_child(self, child: "ShifuOutlineTreeNode"):
+    def remove_child(self, child: "ShifuOutlineTreeNode") -> None:
         """Remove a child from the node."""
         child.parent_node = None
         self.children.remove(child)
 
-    def get_new_position(self):
+    def get_new_position(self) -> str:
         """Get the new position of the node."""
         if not self.parent_node:
             return self.position

--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -26,7 +26,7 @@ from .models import AiCourseAuth, FavoriteScenario
 from .utils import get_shifu_creator_bid
 
 
-def mark_favorite_shifu(app, user_id: str, shifu_id: str):
+def mark_favorite_shifu(app, user_id: str, shifu_id: str) -> bool:
     """Mark a shifu as favorite for a user.
 
     Args:
@@ -55,7 +55,7 @@ def mark_favorite_shifu(app, user_id: str, shifu_id: str):
 
 
 # unmark favorite shifu
-def unmark_favorite_shifu(app, user_id: str, shifu_id: str):
+def unmark_favorite_shifu(app, user_id: str, shifu_id: str) -> bool:
     """Unmark a shifu as favorite for a user.
 
     Args:
@@ -78,7 +78,9 @@ def unmark_favorite_shifu(app, user_id: str, shifu_id: str):
         return False
 
 
-def mark_or_unmark_favorite_shifu(app, user_id: str, shifu_id: str, is_favorite: bool):
+def mark_or_unmark_favorite_shifu(
+    app, user_id: str, shifu_id: str, is_favorite: bool
+) -> bool:
     """Mark or unmark a shifu as favorite for a user.
 
     Args:
@@ -253,7 +255,7 @@ def shifu_permission_verification(
     user_id: str,
     shifu_id: str,
     auth_type: str,
-):
+) -> bool:
     """Verify the permission of a user to a shifu.
 
     Args:

--- a/src/api/flaskr/service/shifu/models.py
+++ b/src/api/flaskr/service/shifu/models.py
@@ -320,7 +320,7 @@ class DraftShifu(db.Model):
         comment="Last updater user business identifier",
     )
 
-    def clone(self):
+    def clone(self) -> "DraftShifu":
         """Create a detached copy of this draft record."""
         return DraftShifu(
             shifu_bid=self.shifu_bid,
@@ -353,7 +353,7 @@ class DraftShifu(db.Model):
             updated_user_bid=self.updated_user_bid,
         )
 
-    def eq(self, other):
+    def eq(self, other) -> bool:
         """Compare the persisted fields relevant to draft equality."""
         return (
             self.shifu_bid == other.shifu_bid
@@ -381,7 +381,7 @@ class DraftShifu(db.Model):
             and self.use_learner_language == other.use_learner_language
         )
 
-    def get_str_to_check(self):
+    def get_str_to_check(self) -> str:
         """Return normalized draft content for comparison."""
         return f"{self.title} {self.keywords} {self.description} {self.llm_system_prompt} {self.ask_llm_system_prompt}"
 
@@ -522,7 +522,7 @@ class DraftOutlineItem(db.Model):
         comment="Last updater user business identifier",
     )
 
-    def clone(self):
+    def clone(self) -> "DraftOutlineItem":
         """Create a detached copy of this draft record."""
         return DraftOutlineItem(
             outline_item_bid=self.outline_item_bid,
@@ -548,7 +548,7 @@ class DraftOutlineItem(db.Model):
             updated_user_bid=self.updated_user_bid,
         )
 
-    def eq(self, other):
+    def eq(self, other) -> bool:
         """Compare the persisted fields relevant to draft equality."""
         return (
             self.outline_item_bid == other.outline_item_bid
@@ -569,7 +569,7 @@ class DraftOutlineItem(db.Model):
             and self.content == other.content
         )
 
-    def get_str_to_check(self):
+    def get_str_to_check(self) -> str:
         """Return normalized draft content for comparison."""
         return f"{self.title} {self.llm_system_prompt} {self.ask_llm_system_prompt}"
 

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -286,7 +286,7 @@ def _resolve_publish_base_url(app: Flask) -> str:
 
 
 @inject
-def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
+def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     """Register shifu routes."""
     app.logger.info("register shifu routes %s", path_prefix)
 

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -227,7 +227,7 @@ def create_shifu_draft(
     shifu_model: str | None = None,
     shifu_temperature: float | None = None,
     shifu_price: float | None = None,
-):
+) -> ShifuDto:
     """Create a shifu draft.
 
     Args:
@@ -410,7 +410,7 @@ def save_shifu_draft_info(
     ask_temperature: float | None = None,
     ask_system_prompt: str | None = None,
     ask_provider_config: Any = None,
-):
+) -> ShifuDto:
     """Save shifu draft info.
 
     Args:
@@ -719,7 +719,7 @@ def get_shifu_draft_list(
     is_favorite: bool,
     archived: bool = False,
     creator_only: bool = False,
-):
+) -> PageNationDTO:
     """Get shifu draft list.
 
     Args:
@@ -892,7 +892,7 @@ def get_shifu_published_list(
     page_index: int,
     page_size: int,
     creator_only: bool = True,
-):
+) -> PageNationDTO:
     """Get published shifu list."""
     with app.app_context():
         page_index = max(page_index, 1)
@@ -989,11 +989,11 @@ def _set_shifu_archive_state(app, user_id: str, shifu_id: str, archived: bool):
         db.session.commit()
 
 
-def archive_shifu(app, user_id: str, shifu_id: str):
+def archive_shifu(app, user_id: str, shifu_id: str) -> None:
     """Archive shifu."""
     _set_shifu_archive_state(app, user_id, shifu_id, archived=True)
 
 
-def unarchive_shifu(app, user_id: str, shifu_id: str):
+def unarchive_shifu(app, user_id: str, shifu_id: str) -> None:
     """Restore shifu."""
     _set_shifu_archive_state(app, user_id, shifu_id, archived=False)

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -37,6 +37,7 @@ format:
 
 import queue
 import re
+from collections.abc import Iterator
 from typing import Generic, TypeVar
 
 from flask import Flask
@@ -61,7 +62,7 @@ class HistoryItem(BaseModel, Generic[T]):
     children: list["HistoryItem"] = []
     child_count: int = 0
 
-    def to_json(self):
+    def to_json(self) -> str:
         """To json."""
         return self.model_dump_json()
 
@@ -87,7 +88,7 @@ def iter_outline_item_versions_desc(
     *,
     batch_size: int = 200,
     max_rows: int | None = None,
-):
+) -> Iterator[DraftOutlineItem]:
     """Yield draft outline versions newest-first in buffered keyset batches.
 
     Replaces yield_per/stream_results for these scans: a server-side cursor
@@ -303,7 +304,7 @@ def __save_shifu_history(
     return shifu_history
 
 
-def save_shifu_history(app: Flask, user_id: str, shifu_bid: str, row_id: int):
+def save_shifu_history(app: Flask, user_id: str, shifu_bid: str, row_id: int) -> None:
     """Save shifu history.
 
     Args:
@@ -419,7 +420,7 @@ def save_new_outline_history(
     row_id: int,
     parent_bid: str,
     index: int = 0,
-):
+) -> None:
     """Save new outline history.
 
     Args:
@@ -444,7 +445,7 @@ def save_outline_history(
     outline_bid: str,
     row_id: int,
     child_count: int = 0,
-):
+) -> int:
     """Save outline history.
 
     Args:
@@ -475,7 +476,9 @@ def save_outline_history(
     return int(log.id) if log else 0
 
 
-def delete_outline_history(app: Flask, user_id: str, shifu_bid: str, outline_bid: str):
+def delete_outline_history(
+    app: Flask, user_id: str, shifu_bid: str, outline_bid: str
+) -> None:
     """Delete outline history.
 
     Args:
@@ -496,7 +499,7 @@ def save_outline_tree_history(
     shifu_bid: str,
     outline_tree: list[HistoryItem],
     shifu_id: int | None = None,
-):
+) -> None:
     """Save outline tree history.
 
     Args:

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -421,7 +421,7 @@ def create_outline(
     outline_type: str = UNIT_TYPE_GUEST,
     system_prompt: str | None = None,
     is_hidden: bool = False,
-):
+) -> OutlineDto:
     """Create outline.
 
     Args:
@@ -568,7 +568,7 @@ def create_outlines_batch(
     shifu_id: str,
     outlines: list,
     parent_id: str = "",
-):
+) -> list[OutlineDto]:
     """Create multiple outlines atomically with correct sequential positions.
 
     Every row is inserted under a single per-shifu lock inside one transaction,
@@ -653,7 +653,7 @@ def create_outlines_batch(
 
 def reorder_outline_tree(
     app, user_id: str, shifu_id: str, outlines: list[ReorderOutlineItemDto]
-):
+) -> bool:
     """Reorder outline tree.
 
     usage:
@@ -747,7 +747,7 @@ def reorder_outline_tree(
         return True
 
 
-def get_unit_by_id(app, user_id: str, unit_id: str):
+def get_unit_by_id(app, user_id: str, unit_id: str) -> OutlineDto:
     """Get unit by id.
 
     Args:
@@ -798,7 +798,7 @@ def modify_unit(
     unit_system_prompt: str | None = None,
     unit_is_hidden: bool | None = None,
     unit_type: str | None = None,
-):
+) -> OutlineDto:
     """Modify unit.
 
     Args:
@@ -883,7 +883,7 @@ def modify_unit(
         )
 
 
-def delete_unit(app, user_id: str, unit_id: str):
+def delete_unit(app, user_id: str, unit_id: str) -> bool:
     """Delete unit.
 
     Args:

--- a/src/api/flaskr/service/shifu/shifu_publish_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_publish_funcs.py
@@ -63,7 +63,7 @@ def _build_frontend_url(base_url: str, path: str) -> str:
 
 def preview_shifu_draft(
     app, user_id: str, shifu_id: str, variables: dict, base_url: str
-):
+) -> str:
     """Preview shifu draft.
 
     Args:
@@ -89,7 +89,7 @@ def publish_shifu_draft(
     shifu_id: str,
     base_url: str,
     sync_summary: bool = False,
-):
+) -> str:
     """Publish shifu draft will copy all draft data to published data and save history to database and run summary generation in background by default and return published shifu url.
 
     Args:
@@ -259,7 +259,7 @@ def _run_summary_with_error_handling(app, shifu_id, shifu_context_snapshot=None)
             )
 
 
-def get_shifu_summary(app, shifu_id: str):
+def get_shifu_summary(app, shifu_id: str) -> None:
     """Obtain the shifu summary information.
 
     Args:

--- a/src/api/flaskr/service/shifu/utils.py
+++ b/src/api/flaskr/service/shifu/utils.py
@@ -10,7 +10,7 @@ from flask import Flask
 from flaskr.service.resource.models import Resource
 
 
-def get_shifu_res_url(res_bid: str):
+def get_shifu_res_url(res_bid: str) -> str:
     """Get the URL of a resource.
 
     Args:
@@ -43,7 +43,7 @@ def get_shifu_res_url_dict(res_bids: list[str]) -> dict[str, str]:
     return res_url_map
 
 
-def parse_shifu_res_bid(res_url: str):
+def parse_shifu_res_bid(res_url: str) -> str:
     """Parse the resource ID from a URL.
 
     Args:

--- a/src/api/flaskr/service/tts/api.py
+++ b/src/api/flaskr/service/tts/api.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from flaskr.service.tts.cloned_voice_registry import (
     find_ready_cloned_voice,
     find_tracked_cloned_voice,
@@ -31,8 +33,11 @@ from flaskr.service.tts.volcengine_voice_clone import (
 )
 from flaskr.util.deprecation import deprecated_alias_getattr
 
+if TYPE_CHECKING:
+    from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
-def create_streaming_tts_processor(**kwargs: object):
+
+def create_streaming_tts_processor(**kwargs: object) -> StreamingTTSProcessor:
     """Create streaming TTS processor."""
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 

--- a/src/api/flaskr/service/tts/models.py
+++ b/src/api/flaskr/service/tts/models.py
@@ -340,7 +340,7 @@ class TTSMiniMaxClonedVoice(db.Model):
     ready_at = Column(DateTime, nullable=True)
     deleted_at = Column(DateTime, nullable=True)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, object]:
         """Convert model to dictionary."""
         return {
             "audio_bid": self.audio_bid,

--- a/src/api/flaskr/service/tts/tasks.py
+++ b/src/api/flaskr/service/tts/tasks.py
@@ -12,7 +12,7 @@ try:  # pragma: no cover - exercised indirectly when Celery is installed.
     from celery import shared_task
 except ImportError:  # pragma: no cover - local fallback for non-Celery test envs.
 
-    def shared_task(*args: object, **kwargs: object):
+    def shared_task(*args: object, **kwargs: object) -> Callable[..., object]:
         """Register a Celery task with the configured application context."""
         _ = (args, kwargs)
 

--- a/src/api/flaskr/service/user/auth/providers/google.py
+++ b/src/api/flaskr/service/user/auth/providers/google.py
@@ -159,7 +159,7 @@ class GoogleAuthProvider(AuthProvider):
     def _resolve_userinfo_endpoint(self, app) -> str:
         return app.config.get("GOOGLE_OAUTH_USERINFO_ENDPOINT", USERINFO_ENDPOINT)
 
-    def verify(self, app, request):
+    def verify(self, app, request) -> AuthResult:
         """Verify the supplied authentication credential."""
         message = "GoogleAuthProvider only supports OAuth flows"
         raise NotImplementedError(message)

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -30,6 +30,8 @@ from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.util.uuid import generate_id
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from flask import Flask
 
 logger = logging.getLogger(__name__)
@@ -891,7 +893,7 @@ def upsert_wechat_credentials(
 
 
 @contextmanager
-def transactional_session():
+def transactional_session() -> Iterator[None]:
     # Managed manually instead of ``with begin_nested()``: the context
     # manager's __exit__ would emit ROLLBACK TO SAVEPOINT on the wire BEFORE
     # any classification could run, which is exactly what must not happen on

--- a/src/api/flaskr/service/user/utils.py
+++ b/src/api/flaskr/service/user/utils.py
@@ -62,7 +62,7 @@ def _normalize_language_code(language_code: str) -> str:
     return "-".join(normalized_parts)
 
 
-def get_user_language(user):
+def get_user_language(user) -> str:
     """Return user language."""
     language = ""
     if hasattr(user, "user_language") and user.user_language:
@@ -159,7 +159,7 @@ def send_sms_code(
     ip: str | None = None,
     captcha_ticket: str | None = None,
     require_captcha: bool = True,
-):
+) -> dict[str, object]:
     """Send SMS code."""
     phone = normalize_phone_identifier(phone)
     with app.app_context():
@@ -236,7 +236,7 @@ def send_sms_code(
 
 def send_email_code(
     app: Flask, email: str, ip: str | None = None, language: str | None = None
-):
+) -> dict[str, object]:
     """Send email code."""
     del language
     with app.app_context():
@@ -333,7 +333,7 @@ def create_and_commit_user_verify_code(
     verify_code: str,
     verify_code_type: int,
     ip: str | None,
-):
+) -> UserVerifyCode:
     """Create and commit user verify code."""
     user_verify_code = UserVerifyCode(
         phone=phone or "",

--- a/src/api/flaskr/util/compare.py
+++ b/src/api/flaskr/util/compare.py
@@ -3,7 +3,7 @@
 import decimal
 
 
-def compare_decimal(a, b):
+def compare_decimal(a, b) -> bool:
     """Compare decimal."""
     a_temp = decimal.Decimal(str(a or 0)).quantize(
         decimal.Decimal("0.01"), rounding=decimal.ROUND_DOWN

--- a/src/api/flaskr/util/datetime.py
+++ b/src/api/flaskr/util/datetime.py
@@ -52,7 +52,7 @@ def to_utc_iso(value: datetime | None) -> str | None:
     return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
-def get_now_time(app: Flask):
+def get_now_time(app: Flask) -> datetime:
     """Return the current time in the application's configured timezone."""
     timezone_str = app.config.get("DEFAULT_TIMEZONE", "Asia/Shanghai")
     tz = pytz.timezone(timezone_str)

--- a/src/api/gunicorn.conf.py
+++ b/src/api/gunicorn.conf.py
@@ -60,7 +60,7 @@ os.environ["AI_SHIFU_PRELOAD_MASTER"] = "1"
 preload_app = True
 
 
-def post_fork(server, worker):
+def post_fork(server, worker) -> None:
     """Reset per-process resources that must not be shared across fork.
 
     SQLAlchemy connection pools created in the master (the DB init in

--- a/src/api/migrations/env.py
+++ b/src/api/migrations/env.py
@@ -17,7 +17,7 @@ fileConfig(config.config_file_name)
 logger = logging.getLogger("alembic.env")
 
 
-def get_engine():
+def get_engine() -> object:
     try:
         # this works with Flask-SQLAlchemy<3 and Alchemical
         return current_app.extensions["migrate"].db.get_engine()
@@ -26,7 +26,7 @@ def get_engine():
         return current_app.extensions["migrate"].db.engine
 
 
-def get_engine_url():
+def get_engine_url() -> str:
     try:
         return get_engine().url.render_as_string(hide_password=False).replace("%", "%%")
     except AttributeError:
@@ -37,7 +37,7 @@ config.set_main_option("sqlalchemy.url", get_engine_url())
 target_db = current_app.extensions["migrate"].db
 
 
-def include_object(db_object, name, type_, reflected, compare_to):
+def include_object(db_object, name, type_, reflected, compare_to) -> bool:
     """Use the simplest mode to avoid separation."""
     # the system tables
     _ = compare_to
@@ -92,13 +92,13 @@ def include_object(db_object, name, type_, reflected, compare_to):
     return True
 
 
-def get_metadata():
+def get_metadata() -> object:
     if hasattr(target_db, "metadatas"):
         return target_db.metadatas[None]
     return target_db.metadata
 
 
-def run_migrations_offline():
+def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode.
 
     This configures the context with just a URL

--- a/src/api/scripts/generate_env_examples.py
+++ b/src/api/scripts/generate_env_examples.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from flaskr.common.config import ENV_VARS, EnhancedConfig
 
 
-def generate_env_examples():
+def generate_env_examples() -> None:
     """Generate the .env.example.full file."""
     # Create EnhancedConfig instance
     config = EnhancedConfig(ENV_VARS)

--- a/src/api/scripts/inventory/extract_routes.py
+++ b/src/api/scripts/inventory/extract_routes.py
@@ -43,7 +43,7 @@ for base in ("flaskr/route", "flaskr/service", "flaskr/common"):
 results = []
 
 
-def literal(node, env):
+def literal(node, env) -> str:
     """Resolve an AST expression to its route-path text."""
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return node.value
@@ -62,7 +62,7 @@ def literal(node, env):
     return f"<expr:{ast.unparse(node)}>"
 
 
-def config_get_default(node):
+def config_get_default(node) -> str | None:
     """app.config.get('KEY', 'default') -> 'default'."""
     if (
         isinstance(node, ast.Call)
@@ -76,7 +76,7 @@ def config_get_default(node):
     return None
 
 
-def collect_routes(scope_body, env, rel):
+def collect_routes(scope_body, env, rel) -> None:
     """Collect routes."""
     for node in scope_body:
         if (

--- a/src/api/scripts/inventory/filter_vulture.py
+++ b/src/api/scripts/inventory/filter_vulture.py
@@ -23,7 +23,7 @@ LINE_RE = re.compile(
 file_cache = {}
 
 
-def get_lines(path):
+def get_lines(path) -> list[str]:
     """Return cached source lines for one inventory path."""
     if path not in file_cache:
         try:
@@ -34,7 +34,7 @@ def get_lines(path):
     return file_cache[path]
 
 
-def decorators_above(path, lineno):
+def decorators_above(path, lineno) -> list[str]:
     """Collect decorator text for the flagged symbol.
 
     Vulture flags the FIRST decorator's line for decorated defs, so scan

--- a/src/api/scripts/inventory/import_graph.py
+++ b/src/api/scripts/inventory/import_graph.py
@@ -31,7 +31,7 @@ ROOT = str((Path(__file__).resolve().parent / ".." / "..").resolve())
 mods = {}  # module name -> relative file path
 
 
-def add_tree(base_dir):
+def add_tree(base_dir) -> None:
     """Add tree."""
     for dirpath, dirnames, filenames in os.walk(str(Path(ROOT) / base_dir)):
         dirnames[:] = [d for d in dirnames if d != "__pycache__"]
@@ -82,7 +82,7 @@ for name, rel in mods.items():
                     edges[name].add(base + "." + a.name)
 
 
-def resolve(target):
+def resolve(target) -> str | None:
     """Map an imported dotted name to a known project module (or None)."""
     while target:
         if target in mods:

--- a/src/api/scripts/inventory/match_routes.py
+++ b/src/api/scripts/inventory/match_routes.py
@@ -37,7 +37,7 @@ if _grep_executable is None:
 GREP_EXECUTABLE = str(Path(_grep_executable).resolve())
 
 
-def norm(path):
+def norm(path) -> tuple[str, ...]:
     """Normalize a route path into comparable segments."""
     path = path.split("?")[0].rstrip("/")
     segs = []
@@ -51,7 +51,7 @@ def norm(path):
     return tuple(segs)
 
 
-def grep_paths(root):
+def grep_paths(root) -> set[tuple[str, ...]]:
     """Return source paths reported by the route search."""
     if not Path(root).is_dir():
         return set()
@@ -124,7 +124,7 @@ with Path(BACKEND_ROUTES).open(encoding="utf-8") as backend_routes:
         be.append((method, path, norm(path), src))
 
 
-def match(be_segs, fe_segs):
+def match(be_segs, fe_segs) -> bool:
     """Return whether backend and consumer route segments match."""
     if len(be_segs) != len(fe_segs):
         return False

--- a/src/api/scripts/tts_test_report.py
+++ b/src/api/scripts/tts_test_report.py
@@ -306,7 +306,7 @@ def _render_markdown(rows: list[ReportRow], *, output_path: str) -> str:
     return str(out.resolve())
 
 
-def main():
+def main() -> None:
     """Generate the TTS comparison report from captured audio."""
     parser = argparse.ArgumentParser(description="Generate TTS provider HTML report")
     parser.add_argument(

--- a/src/api/tests/api/doc/test_feishu_notify.py
+++ b/src/api/tests/api/doc/test_feishu_notify.py
@@ -43,7 +43,9 @@ class _Response:
         return self._json_value
 
 
-def test_send_notify_returns_metadata_for_successful_non_json_response(monkeypatch):
+def test_send_notify_returns_metadata_for_successful_non_json_response(
+    monkeypatch,
+) -> None:
     app = _App()
     monkeypatch.setattr(
         feishu, "get_config", lambda _key, _default=None: "https://example.test/webhook"
@@ -62,7 +64,7 @@ def test_send_notify_returns_metadata_for_successful_non_json_response(monkeypat
     assert app.logger.warnings == []
 
 
-def test_send_notify_returns_none_for_non_2xx_response(monkeypatch):
+def test_send_notify_returns_none_for_non_2xx_response(monkeypatch) -> None:
     app = _App()
     monkeypatch.setattr(
         feishu, "get_config", lambda _key, _default=None: "https://example.test/webhook"
@@ -79,7 +81,7 @@ def test_send_notify_returns_none_for_non_2xx_response(monkeypatch):
     assert app.logger.warnings
 
 
-def test_send_notify_returns_none_for_request_error(monkeypatch):
+def test_send_notify_returns_none_for_request_error(monkeypatch) -> None:
     app = _App()
     monkeypatch.setattr(
         feishu, "get_config", lambda _key, _default=None: "https://example.test/webhook"

--- a/src/api/tests/command/test_unified_migration_task.py
+++ b/src/api/tests/command/test_unified_migration_task.py
@@ -44,19 +44,19 @@ def _task_with_session(session):
 
 
 @pytest.mark.parametrize("name", ["learn_progress_records", "_bid", "Col1"])
-def test_quote_identifier_quotes_valid_names(name):
+def test_quote_identifier_quotes_valid_names(name) -> None:
     assert _quote_identifier(name) == f"`{name}`"
 
 
 @pytest.mark.parametrize(
     "name", ["", "1table", "users; drop table users", "user`s", "learn progress"]
 )
-def test_quote_identifier_rejects_unsafe_names(name):
+def test_quote_identifier_rejects_unsafe_names(name) -> None:
     with pytest.raises(ValueError, match="Unsafe SQL identifier"):
         _quote_identifier(name)
 
 
-def test_get_table_count_quotes_the_table_name():
+def test_get_table_count_quotes_the_table_name() -> None:
     session = _FakeSession(value=7)
     task = _task_with_session(session)
 
@@ -72,7 +72,7 @@ def test_get_table_count_quotes_the_table_name():
 @pytest.mark.parametrize(
     "table_name", ["learn_progress_records; drop table users", "learn progress"]
 )
-def test_get_table_count_rejects_unsafe_table_names(table_name):
+def test_get_table_count_rejects_unsafe_table_names(table_name) -> None:
     session = _FakeSession()
     task = _task_with_session(session)
 
@@ -83,7 +83,7 @@ def test_get_table_count_rejects_unsafe_table_names(table_name):
     assert session.calls == []
 
 
-def test_table_exists_binds_the_table_name():
+def test_table_exists_binds_the_table_name() -> None:
     session = _FakeSession(value=("learn_progress_records",))
     task = _task_with_session(session)
 
@@ -94,7 +94,7 @@ def test_table_exists_binds_the_table_name():
     assert params == {"table_name": "learn_progress_records"}
 
 
-def test_check_column_exists_binds_table_and_column():
+def test_check_column_exists_binds_table_and_column() -> None:
     session = _FakeSession(value=1)
     task = _task_with_session(session)
 
@@ -114,7 +114,7 @@ def test_check_column_exists_binds_table_and_column():
     }
 
 
-def test_migrate_table_logs_formatted_batch_progress(caplog):
+def test_migrate_table_logs_formatted_batch_progress(caplog) -> None:
     task = UnifiedMigrationTask.__new__(UnifiedMigrationTask)
     task.config = MigrationConfig(batch_size=10)
 

--- a/src/api/tests/common/fixtures/config_data.py
+++ b/src/api/tests/common/fixtures/config_data.py
@@ -3,7 +3,7 @@
 from flaskr.common.config import EnvVar
 
 
-def port_validator(value):
+def port_validator(value) -> bool:
     """Validate port number is in valid range."""
     try:
         port = int(value)
@@ -13,7 +13,7 @@ def port_validator(value):
         return 1 <= port <= 65535
 
 
-def email_validator(value):
+def email_validator(value) -> bool:
     """Validate an email address (test helper)."""
     import re
 

--- a/src/api/tests/common/fixtures/fake_redis.py
+++ b/src/api/tests/common/fixtures/fake_redis.py
@@ -13,7 +13,9 @@ class FakeRedisLock:
         self._key = key
         self._held = False
 
-    def acquire(self, blocking: bool = True, blocking_timeout: int | None = None):
+    def acquire(
+        self, blocking: bool = True, blocking_timeout: int | None = None
+    ) -> bool:
         _ = (blocking, blocking_timeout)
         if self._locks.get(self._key, False):
             return False
@@ -21,7 +23,7 @@ class FakeRedisLock:
         self._held = True
         return True
 
-    def release(self):
+    def release(self) -> None:
         if self._held:
             self._locks.pop(self._key, None)
             self._held = False
@@ -58,7 +60,7 @@ class FakeRedis:
             return True
         return False
 
-    def get(self, key: str):
+    def get(self, key: str) -> bytes | None:
         if key not in self._store or self._is_expired(key):
             return None
         return self._store.get(key)
@@ -69,7 +71,9 @@ class FakeRedis:
             self._is_expired(key)
         return list(self._store)
 
-    def getex(self, key: str, ex: int | None = None, px: int | None = None):
+    def getex(
+        self, key: str, ex: int | None = None, px: int | None = None
+    ) -> bytes | None:
         value = self.get(key)
         if value is None:
             return None
@@ -89,7 +93,7 @@ class FakeRedis:
         xx: bool = False,
         *args: object,
         **kwargs: object,
-    ):
+    ) -> bool:
         _ = kwargs
         if ex is None and args:
             ex = args[0]
@@ -106,7 +110,7 @@ class FakeRedis:
             self._expires.pop(key, None)
         return True
 
-    def setex(self, key: str, time_in_seconds: int, value: Any):
+    def setex(self, key: str, time_in_seconds: int, value: Any) -> bool:
         return self.set(key, value, ex=time_in_seconds)
 
     def delete(self, *keys: str) -> int:
@@ -118,7 +122,7 @@ class FakeRedis:
                 self._expires.pop(key, None)
         return deleted
 
-    def incr(self, key: str, amount: int = 1):
+    def incr(self, key: str, amount: int = 1) -> int:
         current = self.get(key)
         current_value = 0 if current is None else int(current)
         new_value = current_value + amount
@@ -144,12 +148,12 @@ class FakeRedis:
         key: str,
         timeout: int | None = None,
         blocking_timeout: int | None = None,
-    ):
+    ) -> FakeRedisLock:
         _ = (timeout, blocking_timeout)
         return FakeRedisLock(self._locks, key)
 
-    def ping(self):
+    def ping(self) -> bool:
         return True
 
-    def close(self):
+    def close(self) -> None:
         return None

--- a/src/api/tests/common/fixtures/mock_validators.py
+++ b/src/api/tests/common/fixtures/mock_validators.py
@@ -1,7 +1,9 @@
 """Mock validators for testing configuration validation."""
 
+from collections.abc import Callable
 
-def mock_port_validator(value):
+
+def mock_port_validator(value) -> bool:
     """Mock port validator that accepts 1-65535."""
     try:
         port = int(value)
@@ -11,7 +13,7 @@ def mock_port_validator(value):
         return 1 <= port <= 65535
 
 
-def mock_email_validator(value):
+def mock_email_validator(value) -> bool:
     """Mock email validator with simple regex."""
     import re
 
@@ -21,19 +23,19 @@ def mock_email_validator(value):
     return bool(re.match(pattern, str(value)))
 
 
-def always_fail_validator(value):
+def always_fail_validator(value) -> bool:
     """Fail validation always (test helper)."""
     _ = value
     return False
 
 
-def always_pass_validator(value):
+def always_pass_validator(value) -> bool:
     """Pass validation always (test helper)."""
     _ = value
     return True
 
 
-def range_validator(min_val, max_val):
+def range_validator(min_val, max_val) -> Callable[[object], bool]:
     """Create a range validator for numeric values."""
 
     def validator(value):
@@ -47,7 +49,7 @@ def range_validator(min_val, max_val):
     return validator
 
 
-def string_length_validator(min_len=0, max_len=100):
+def string_length_validator(min_len=0, max_len=100) -> Callable[[object], bool]:
     """Create a string length validator."""
 
     def validator(value):
@@ -59,7 +61,7 @@ def string_length_validator(min_len=0, max_len=100):
     return validator
 
 
-def regex_validator(pattern):
+def regex_validator(pattern) -> Callable[[object], bool]:
     """Create a regex-based validator."""
     import re
 
@@ -73,7 +75,7 @@ def regex_validator(pattern):
     return validator
 
 
-def url_validator(value):
+def url_validator(value) -> bool:
     """Mock URL validator."""
     import re
 
@@ -91,7 +93,7 @@ def url_validator(value):
     return bool(url_pattern.match(str(value)))
 
 
-def dependency_validator(depends_on_key):
+def dependency_validator(depends_on_key) -> Callable[[object], bool]:
     """Create a validator that checks if another config key is set."""
     _ = depends_on_key
 

--- a/src/api/tests/common/test_celery_fork_pool_dispose.py
+++ b/src/api/tests/common/test_celery_fork_pool_dispose.py
@@ -17,7 +17,7 @@ from flaskr.dao import db
 from sqlalchemy import text
 
 
-def test_dispose_replaces_the_inherited_pool(app):
+def test_dispose_replaces_the_inherited_pool(app) -> None:
     with app.app_context():
         db.session.execute(text("SELECT 1"))
         db.session.remove()
@@ -32,7 +32,7 @@ def test_dispose_replaces_the_inherited_pool(app):
         db.session.remove()
 
 
-def test_worker_process_init_signal_disposes_pools(app):
+def test_worker_process_init_signal_disposes_pools(app) -> None:
     get_celery_app(app)
     with app.app_context():
         db.session.execute(text("SELECT 1"))
@@ -45,7 +45,7 @@ def test_worker_process_init_signal_disposes_pools(app):
         assert db.engine.pool is not inherited_pool
 
 
-def test_one_failing_bind_does_not_block_the_rest(app, monkeypatch):
+def test_one_failing_bind_does_not_block_the_rest(app, monkeypatch) -> None:
     from flaskr import dao
 
     disposed = []

--- a/src/api/tests/common/test_common_route.py
+++ b/src/api/tests/common/test_common_route.py
@@ -13,7 +13,7 @@ def _shared_i18n_root() -> Path:
 
 def test_common_handler_returns_translated_unexpected_error_for_unhandled_exceptions(
     monkeypatch,
-):
+) -> None:
     monkeypatch.setenv("SHARED_I18N_ROOT", str(_shared_i18n_root()))
     app = Flask(__name__)
     load_translations(app)
@@ -34,7 +34,9 @@ def test_common_handler_returns_translated_unexpected_error_for_unhandled_except
     }
 
 
-def test_common_handler_uses_request_language_for_unhandled_exceptions(monkeypatch):
+def test_common_handler_uses_request_language_for_unhandled_exceptions(
+    monkeypatch,
+) -> None:
     monkeypatch.setenv("SHARED_I18N_ROOT", str(_shared_i18n_root()))
     app = Flask(__name__)
     load_translations(app)
@@ -82,7 +84,7 @@ def test_common_handler_uses_request_language_for_unhandled_exceptions(monkeypat
     }
 
 
-def test_common_handler_uses_json_language_for_patch_requests(monkeypatch):
+def test_common_handler_uses_json_language_for_patch_requests(monkeypatch) -> None:
     monkeypatch.setenv("SHARED_I18N_ROOT", str(_shared_i18n_root()))
     app = Flask(__name__)
     load_translations(app)

--- a/src/api/tests/common/test_config.py
+++ b/src/api/tests/common/test_config.py
@@ -21,7 +21,7 @@ from tests.common.fixtures.config_data import DOCKER_ENV_CONFIG
 class TestConfigInitialization:
     """Test Config class initialization."""
 
-    def test_init_with_valid_flask_app(self, monkeypatch):
+    def test_init_with_valid_flask_app(self, monkeypatch) -> None:
         """Test initialization with valid Flask app."""
         # Set up required environment variables
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db-uri")
@@ -48,7 +48,7 @@ class TestConfigInitialization:
             "Environment configuration validated successfully"
         )
 
-    def test_init_with_missing_required_vars(self, monkeypatch):
+    def test_init_with_missing_required_vars(self, monkeypatch) -> None:
         """Test initialization fails with missing required variables."""
         # Don't set required variables
         monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
@@ -64,7 +64,7 @@ class TestConfigInitialization:
         # Verify error was logged with traceback
         app.logger.exception.assert_called()
 
-    def test_global_instance_set(self, monkeypatch):
+    def test_global_instance_set(self, monkeypatch) -> None:
         """Test that global instance is set on initialization."""
         # Set up environment
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
@@ -90,7 +90,7 @@ class TestConfigInitialization:
 class TestConfigGetItem:
     """Test __getitem__ functionality."""
 
-    def test_getitem_from_enhanced_config(self, monkeypatch):
+    def test_getitem_from_enhanced_config(self, monkeypatch) -> None:
         """Test getting value from enhanced config."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -107,7 +107,7 @@ class TestConfigGetItem:
         # Should get from enhanced config
         assert config["REDIS_HOST"] == "test-redis"
 
-    def test_getitem_fallback_to_parent(self, monkeypatch):
+    def test_getitem_fallback_to_parent(self, monkeypatch) -> None:
         """Test falling back to parent config for unknown keys."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -129,7 +129,7 @@ class TestConfigGetItem:
             assert value == "parent-value"
             parent_config.__getitem__.assert_called_with("UNKNOWN_KEY")
 
-    def test_getitem_returns_none_for_missing(self, monkeypatch):
+    def test_getitem_returns_none_for_missing(self, monkeypatch) -> None:
         """Test returning None for missing keys."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -154,7 +154,7 @@ class TestConfigGetItem:
 class TestConfigSetItem:
     """Test __setitem__ functionality."""
 
-    def test_setitem_updates_parent_and_environ(self, monkeypatch):
+    def test_setitem_updates_parent_and_environ(self, monkeypatch) -> None:
         """Test setting value updates parent config and environment."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -176,7 +176,7 @@ class TestConfigSetItem:
         # Should update environment
         assert os.environ["NEW_VALUE"] == "test-value"
 
-    def test_setitem_clears_cache(self, monkeypatch):
+    def test_setitem_clears_cache(self, monkeypatch) -> None:
         """Test setting value clears the cache."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -204,7 +204,7 @@ class TestConfigSetItem:
 class TestConfigGetMethods:
     """Test typed get methods."""
 
-    def test_get_str(self, monkeypatch):
+    def test_get_str(self, monkeypatch) -> None:
         """Test get_str method."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -219,7 +219,7 @@ class TestConfigGetMethods:
         assert config.get_str("REDIS_HOST") == "test-redis"
         assert isinstance(config.get_str("REDIS_HOST"), str)
 
-    def test_get_int(self, monkeypatch):
+    def test_get_int(self, monkeypatch) -> None:
         """Test get_int method."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -234,7 +234,7 @@ class TestConfigGetMethods:
         assert config.get_int("REDIS_PORT") == 7000
         assert isinstance(config.get_int("REDIS_PORT"), int)
 
-    def test_get_bool(self, monkeypatch):
+    def test_get_bool(self, monkeypatch) -> None:
         """Test get_bool method."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -249,7 +249,7 @@ class TestConfigGetMethods:
         assert config.get_bool("SWAGGER_ENABLED") is True
         assert isinstance(config.get_bool("SWAGGER_ENABLED"), bool)
 
-    def test_get_float(self, monkeypatch):
+    def test_get_float(self, monkeypatch) -> None:
         """Test get_float method."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -264,7 +264,7 @@ class TestConfigGetMethods:
         assert config.get_float("DEFAULT_LLM_TEMPERATURE") == 0.8
         assert isinstance(config.get_float("DEFAULT_LLM_TEMPERATURE"), float)
 
-    def test_get_list(self, monkeypatch):
+    def test_get_list(self, monkeypatch) -> None:
         """Test get_list method."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -284,7 +284,7 @@ class TestConfigGetMethods:
 class TestConfigGetAttr:
     """Test __getattr__ functionality."""
 
-    def test_getattr_from_enhanced_config(self, monkeypatch):
+    def test_getattr_from_enhanced_config(self, monkeypatch) -> None:
         """Test getting attribute from enhanced config."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -301,7 +301,7 @@ class TestConfigGetAttr:
         # Should get from enhanced config
         assert config.REDIS_HOST == "attr-redis"
 
-    def test_getattr_fallback_to_parent(self, monkeypatch):
+    def test_getattr_fallback_to_parent(self, monkeypatch) -> None:
         """Test falling back to parent for unknown attributes."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -324,7 +324,7 @@ class TestConfigGetAttr:
 class TestConfigSetDefault:
     """Test setdefault method."""
 
-    def test_setdefault_existing_value(self, monkeypatch):
+    def test_setdefault_existing_value(self, monkeypatch) -> None:
         """Test setdefault with existing value."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -346,7 +346,7 @@ class TestConfigSetDefault:
         # Parent setdefault should not be called
         parent_config.setdefault.assert_not_called()
 
-    def test_setdefault_missing_value(self, monkeypatch):
+    def test_setdefault_missing_value(self, monkeypatch) -> None:
         """Test setdefault with missing value."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -370,7 +370,7 @@ class TestConfigSetDefault:
 class TestConfigCall:
     """Test __call__ functionality."""
 
-    def test_call_delegates_to_parent(self, monkeypatch):
+    def test_call_delegates_to_parent(self, monkeypatch) -> None:
         """Test that __call__ delegates to parent config."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -394,7 +394,7 @@ class TestConfigCall:
 class TestGetConfigFunction:
     """Test the global get_config function."""
 
-    def test_get_config_with_initialized_instance(self, monkeypatch):
+    def test_get_config_with_initialized_instance(self, monkeypatch) -> None:
         """Test get_config when instance is initialized."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -412,7 +412,7 @@ class TestGetConfigFunction:
         value = get_config("REDIS_HOST")
         assert value == "global-redis"
 
-    def test_get_config_without_initialized_instance(self, monkeypatch):
+    def test_get_config_without_initialized_instance(self, monkeypatch) -> None:
         """Test get_config works before initialization by reading from environment."""
         # Clear global instance
         import flaskr.common.config as config_module
@@ -447,7 +447,7 @@ class TestGetConfigFunction:
 class TestConfigIntegrationWithFlask:
     """Test Config integration with Flask application."""
 
-    def test_config_with_real_flask_app(self, monkeypatch):
+    def test_config_with_real_flask_app(self, monkeypatch) -> None:
         """Test Config with a real Flask application."""
         # Set up comprehensive environment
         for key, value in DOCKER_ENV_CONFIG.items():
@@ -469,7 +469,7 @@ class TestConfigIntegrationWithFlask:
         app.config = config
         assert app.config["SECRET_KEY"] == "docker-secret-key-123456"
 
-    def test_config_priority_enhanced_over_parent(self, monkeypatch):
+    def test_config_priority_enhanced_over_parent(self, monkeypatch) -> None:
         """Test that enhanced config takes priority over parent."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -496,11 +496,13 @@ class TestConfigIntegrationWithFlask:
 class TestExplicitEnvOverride:
     """Test explicit environment override detection."""
 
-    def test_has_explicit_env_override_true_when_key_present(self, monkeypatch):
+    def test_has_explicit_env_override_true_when_key_present(self, monkeypatch) -> None:
         monkeypatch.setenv("REDIS_HOST", "")
         assert has_explicit_env_override("REDIS_HOST") is True
 
-    def test_has_explicit_env_override_false_when_key_missing(self, monkeypatch):
+    def test_has_explicit_env_override_false_when_key_missing(
+        self, monkeypatch
+    ) -> None:
         monkeypatch.delenv("REDIS_HOST", raising=False)
         assert has_explicit_env_override("REDIS_HOST") is False
 
@@ -508,7 +510,7 @@ class TestExplicitEnvOverride:
 class TestRedisPrefixHelpers:
     """Test Redis prefix helpers with partial Flask config state."""
 
-    def test_get_redis_key_prefix_prefers_app_config(self, monkeypatch):
+    def test_get_redis_key_prefix_prefers_app_config(self, monkeypatch) -> None:
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
         monkeypatch.setenv("UNIVERSAL_VERIFICATION_CODE", "123456")
@@ -519,7 +521,9 @@ class TestRedisPrefixHelpers:
 
         assert get_redis_key_prefix(app) == "app:"
 
-    def test_get_redis_derived_prefix_falls_back_to_base_prefix(self, monkeypatch):
+    def test_get_redis_derived_prefix_falls_back_to_base_prefix(
+        self, monkeypatch
+    ) -> None:
         monkeypatch.setenv("REDIS_KEY_PREFIX", "env:")
 
         app = Flask(__name__)

--- a/src/api/tests/common/test_config_enhanced.py
+++ b/src/api/tests/common/test_config_enhanced.py
@@ -18,7 +18,7 @@ from tests.common.fixtures.config_data import (
 class TestEnhancedConfigInitialization:
     """Test EnhancedConfig initialization."""
 
-    def test_init_with_valid_env_vars(self):
+    def test_init_with_valid_env_vars(self) -> None:
         """Test initialization with valid environment variables."""
         config = EnhancedConfig(MINIMAL_ENV_VARS)
 
@@ -26,7 +26,7 @@ class TestEnhancedConfigInitialization:
         assert config._cache == {}
         assert config._validated is False
 
-    def test_init_with_empty_env_vars(self):
+    def test_init_with_empty_env_vars(self) -> None:
         """Test initialization with empty environment variables."""
         config = EnhancedConfig({})
 
@@ -38,7 +38,7 @@ class TestEnhancedConfigInitialization:
 class TestEnhancedConfigValidation:
     """Test environment validation functionality."""
 
-    def test_validate_environment_success(self, monkeypatch):
+    def test_validate_environment_success(self, monkeypatch) -> None:
         """Test successful environment validation."""
         # Set up environment
         for key, value in DOCKER_ENV_CONFIG.items():
@@ -49,7 +49,7 @@ class TestEnhancedConfigValidation:
 
         assert config._validated is True
 
-    def test_validate_missing_required(self, monkeypatch):
+    def test_validate_missing_required(self, monkeypatch) -> None:
         """Test validation fails when required variables are missing."""
         # Set up environment without required variables
         for key, value in MISSING_REQUIRED_ENV.items():
@@ -75,7 +75,7 @@ class TestEnhancedConfigValidation:
                 or "UNIVERSAL_VERIFICATION_CODE" in error_msg
             )
 
-    def test_validate_missing_llm_key(self, monkeypatch):
+    def test_validate_missing_llm_key(self, monkeypatch) -> None:
         """Test validation fails when no LLM API key is configured."""
         # Set up environment without LLM keys
         for key, value in NO_LLM_ENV.items():
@@ -89,7 +89,9 @@ class TestEnhancedConfigValidation:
         error_msg = str(exc_info.value)
         assert "At least one LLM API key must be configured" in error_msg
 
-    def test_validate_creator_customization_requires_encryption_key(self, monkeypatch):
+    def test_validate_creator_customization_requires_encryption_key(
+        self, monkeypatch
+    ) -> None:
         """Test creator customization fails closed without its encryption key."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -119,7 +121,7 @@ class TestEnhancedConfigValidation:
 
         assert "CREATOR_INTEGRATION_ENCRYPTION_KEY" in str(exc_info.value)
 
-    def test_validate_invalid_values(self, monkeypatch):
+    def test_validate_invalid_values(self, monkeypatch) -> None:
         """Test validation fails for invalid values."""
         # Set up environment with invalid values
         for key, value in INVALID_VALUES_ENV.items():
@@ -136,7 +138,7 @@ class TestEnhancedConfigValidation:
         assert "REDIS_PORT" in error_msg  # Invalid port number
         assert "DEFAULT_LLM_TEMPERATURE" in error_msg  # Out of range
 
-    def test_validate_with_validator_exception(self, monkeypatch):
+    def test_validate_with_validator_exception(self, monkeypatch) -> None:
         """Test validation handles validator exceptions."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -164,7 +166,7 @@ class TestEnhancedConfigValidation:
 class TestEnhancedConfigGet:
     """Test get method functionality."""
 
-    def test_get_existing_variable(self, monkeypatch):
+    def test_get_existing_variable(self, monkeypatch) -> None:
         """Test getting an existing environment variable."""
         monkeypatch.setenv("REDIS_HOST", "test-redis")
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
@@ -175,7 +177,7 @@ class TestEnhancedConfigGet:
 
         assert config.get("REDIS_HOST") == "test-redis"
 
-    def test_get_with_default(self, monkeypatch):
+    def test_get_with_default(self, monkeypatch) -> None:
         """Test getting variable with default value."""
         # Don't set REDIS_HOST in environment
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
@@ -187,7 +189,7 @@ class TestEnhancedConfigGet:
         # Should return default value
         assert config.get("REDIS_HOST") == ""
 
-    def test_get_with_type_conversion(self, monkeypatch):
+    def test_get_with_type_conversion(self, monkeypatch) -> None:
         """Test getting variable with type conversion."""
         monkeypatch.setenv("REDIS_PORT", "7000")
         monkeypatch.setenv("DEFAULT_LLM_TEMPERATURE", "0.8")
@@ -204,7 +206,7 @@ class TestEnhancedConfigGet:
         assert config.get("SWAGGER_ENABLED") is True
         assert isinstance(config.get("SWAGGER_ENABLED"), bool)
 
-    def test_get_cached_value(self, monkeypatch):
+    def test_get_cached_value(self, monkeypatch) -> None:
         """Test that values are cached after first retrieval."""
         monkeypatch.setenv("REDIS_HOST", "test-redis")
 
@@ -222,14 +224,14 @@ class TestEnhancedConfigGet:
         value2 = config.get("REDIS_HOST")
         assert value2 == "test-redis"  # Still the cached value
 
-    def test_get_unknown_key(self):
+    def test_get_unknown_key(self) -> None:
         """Test getting unknown configuration key returns None."""
         config = EnhancedConfig(MINIMAL_ENV_VARS)
 
         # Unknown keys should return None to allow fallback in Config class
         assert config.get("UNKNOWN_KEY") is None
 
-    def test_get_empty_value_returns_default(self, monkeypatch):
+    def test_get_empty_value_returns_default(self, monkeypatch) -> None:
         """Test that empty string returns default value."""
         monkeypatch.setenv("REDIS_HOST", "")
 
@@ -241,7 +243,7 @@ class TestEnhancedConfigGet:
 class TestEnhancedConfigDebugPrint:
     """Test debug_print method functionality."""
 
-    def test_debug_print_all_configuration(self, monkeypatch):
+    def test_debug_print_all_configuration(self, monkeypatch) -> None:
         """Test printing all configuration values."""
         for key, value in DOCKER_ENV_CONFIG.items():
             monkeypatch.setenv(key, value)
@@ -263,7 +265,7 @@ class TestEnhancedConfigDebugPrint:
             assert "REDIS" in combined.upper()
             assert "LLM" in combined.upper()
 
-    def test_debug_print_masks_secrets(self, monkeypatch):
+    def test_debug_print_masks_secrets(self, monkeypatch) -> None:
         """Test that secrets are masked in debug output."""
         monkeypatch.setenv("SECRET_KEY", "super-secret-key-12345")
         monkeypatch.setenv("OPENAI_API_KEY", "sk-real-api-key")
@@ -292,7 +294,7 @@ class TestEnhancedConfigDebugPrint:
 class TestEnhancedConfigExport:
     """Test export_env_example functionality."""
 
-    def test_export_basic_structure(self):
+    def test_export_basic_structure(self) -> None:
         """Test basic structure of exported .env.example."""
         config = EnhancedConfig(MINIMAL_ENV_VARS)
 
@@ -304,7 +306,7 @@ class TestEnhancedConfigExport:
         assert "SQLALCHEMY_DATABASE_URI=" in output
         assert "SECRET_KEY=" in output
 
-    def test_export_required_variables(self):
+    def test_export_required_variables(self) -> None:
         """Test that required variables are marked."""
         config = EnhancedConfig(MINIMAL_ENV_VARS)
 
@@ -319,7 +321,7 @@ class TestEnhancedConfigExport:
                 # Check previous line for REQUIRED marker
                 assert "REQUIRED" in lines[i - 1] or "REQUIRED" in lines[i - 2]
 
-    def test_export_optional_without_default(self):
+    def test_export_optional_without_default(self) -> None:
         """Test optional variables without default are marked."""
         env_vars = {
             "OPTIONAL_VAR": EnvVar(
@@ -335,7 +337,7 @@ class TestEnhancedConfigExport:
 
         assert "# (Optional - handled by libraries)" in output
 
-    def test_export_multiline_description(self):
+    def test_export_multiline_description(self) -> None:
         """Test export handles multi-line descriptions."""
         env_vars = {
             "MULTI_DESC": EnvVar(
@@ -355,7 +357,7 @@ Line 3 of description""",
         desc_lines = [line for line in lines if line.startswith("# Line")]
         assert len(desc_lines) == 3
 
-    def test_export_with_types(self):
+    def test_export_with_types(self) -> None:
         """Test export shows type information."""
         config = EnhancedConfig(FULL_TEST_ENV_VARS)
         output = config.export_env_example()
@@ -364,14 +366,14 @@ Line 3 of description""",
         assert "# Type: float" in output
         assert "# Type: bool" in output
 
-    def test_export_with_validators(self):
+    def test_export_with_validators(self) -> None:
         """Test export shows validator information."""
         config = EnhancedConfig(FULL_TEST_ENV_VARS)
         output = config.export_env_example()
 
         assert "# (Has validation)" in output
 
-    def test_export_secret_values_masked(self):
+    def test_export_secret_values_masked(self) -> None:
         """Test that secret default values are masked."""
         env_vars = {
             "SECRET_WITH_DEFAULT": EnvVar(
@@ -389,7 +391,7 @@ Line 3 of description""",
         assert 'SECRET_WITH_DEFAULT=""' in output
         assert "secret-value" not in output
 
-    def test_export_lists_render_without_brackets(self):
+    def test_export_lists_render_without_brackets(self) -> None:
         """Lists should render as comma-separated strings without brackets."""
         env_vars = {
             "EMPTY_LIST": EnvVar(
@@ -416,7 +418,7 @@ Line 3 of description""",
         assert "Optional - default: alpha,beta" in output
         assert "[]" not in output
 
-    def test_export_groups_sorted(self):
+    def test_export_groups_sorted(self) -> None:
         """Test that groups are sorted in output."""
         config = EnhancedConfig(FULL_TEST_ENV_VARS)
         output = config.export_env_example()
@@ -432,7 +434,7 @@ Line 3 of description""",
 class TestEnhancedConfigCache:
     """Test caching mechanism."""
 
-    def test_cache_stores_values(self, monkeypatch):
+    def test_cache_stores_values(self, monkeypatch) -> None:
         """Test that cache stores retrieved values."""
         monkeypatch.setenv("REDIS_HOST", "cached-host")
 
@@ -445,7 +447,7 @@ class TestEnhancedConfigCache:
         assert len(config._cache) == 1
         assert config._cache["REDIS_HOST"] == "cached-host"
 
-    def test_cache_prevents_recomputation(self, monkeypatch):
+    def test_cache_prevents_recomputation(self, monkeypatch) -> None:
         """Test that cached values are not recomputed."""
         monkeypatch.setenv("REDIS_PORT", "6379")
 
@@ -466,7 +468,7 @@ class TestEnhancedConfigCache:
 
             assert value1 == value2 == 6379
 
-    def test_clear_cache(self, monkeypatch):
+    def test_clear_cache(self, monkeypatch) -> None:
         """Test clearing the cache."""
         monkeypatch.setenv("REDIS_HOST", "test-host")
 

--- a/src/api/tests/common/test_config_envvar.py
+++ b/src/api/tests/common/test_config_envvar.py
@@ -19,7 +19,7 @@ from tests.common.fixtures.mock_validators import (
 class TestEnvVarInitialization:
     """Test EnvVar initialization and validation."""
 
-    def test_valid_envvar_with_defaults(self):
+    def test_valid_envvar_with_defaults(self) -> None:
         """Test creating EnvVar with default values."""
         env_var = EnvVar(
             name="TEST_VAR",
@@ -38,7 +38,7 @@ class TestEnvVarInitialization:
         assert env_var.validator is None
         assert env_var.depends_on == []
 
-    def test_valid_envvar_required_no_default(self):
+    def test_valid_envvar_required_no_default(self) -> None:
         """Test creating required EnvVar without default."""
         env_var = EnvVar(
             name="REQUIRED_VAR",
@@ -52,7 +52,7 @@ class TestEnvVarInitialization:
         assert env_var.default is None
         assert env_var.secret is True
 
-    def test_valid_envvar_optional_with_default(self):
+    def test_valid_envvar_optional_with_default(self) -> None:
         """Test creating optional EnvVar with default."""
         env_var = EnvVar(
             name="OPTIONAL_VAR",
@@ -64,7 +64,7 @@ class TestEnvVarInitialization:
         assert env_var.required is False
         assert env_var.default == "optional_default"
 
-    def test_invalid_required_with_default(self):
+    def test_invalid_required_with_default(self) -> None:
         """Test that required=True with default raises ValueError."""
         with pytest.raises(ValueError, match="marked as required") as exc_info:
             EnvVar(
@@ -77,7 +77,7 @@ class TestEnvVarInitialization:
         assert "marked as required" in str(exc_info.value)
         assert "has a default value" in str(exc_info.value)
 
-    def test_envvar_with_custom_validator(self):
+    def test_envvar_with_custom_validator(self) -> None:
         """Test EnvVar with custom validator function."""
         env_var = EnvVar(
             name="PORT",
@@ -90,7 +90,7 @@ class TestEnvVarInitialization:
         assert env_var.validator(8080) is True
         assert env_var.validator(99999) is False
 
-    def test_envvar_with_dependencies(self):
+    def test_envvar_with_dependencies(self) -> None:
         """Test EnvVar with dependencies."""
         env_var = EnvVar(
             name="DEPENDENT_VAR",
@@ -103,7 +103,7 @@ class TestEnvVarInitialization:
 class TestEnvVarTypeConversion:
     """Test type conversion functionality."""
 
-    def test_convert_to_int(self):
+    def test_convert_to_int(self) -> None:
         """Test string to int conversion."""
         env_var = EnvVar(name="INT_VAR", type=int, default=100)
 
@@ -112,7 +112,7 @@ class TestEnvVarTypeConversion:
         assert env_var.convert_type("") == 100  # Empty returns default
         assert env_var.convert_type(None) == 100  # None returns default
 
-    def test_convert_to_float(self):
+    def test_convert_to_float(self) -> None:
         """Test string to float conversion."""
         env_var = EnvVar(name="FLOAT_VAR", type=float, default=1.5)
 
@@ -121,7 +121,7 @@ class TestEnvVarTypeConversion:
         assert env_var.convert_type("10") == 10.0
         assert env_var.convert_type("") == 1.5  # Empty returns default
 
-    def test_convert_to_bool(self):
+    def test_convert_to_bool(self) -> None:
         """Test string to bool conversion."""
         env_var = EnvVar(name="BOOL_VAR", type=bool, default=False)
 
@@ -149,7 +149,7 @@ class TestEnvVarTypeConversion:
         assert env_var.convert_type("") is False
         assert env_var.convert_type(None) is False
 
-    def test_convert_string_remains_string(self):
+    def test_convert_string_remains_string(self) -> None:
         """Test that strings remain strings when type is str."""
         env_var = EnvVar(name="STR_VAR", type=str, default="default")
 
@@ -158,7 +158,7 @@ class TestEnvVarTypeConversion:
         assert env_var.convert_type("") == "default"
         assert env_var.convert_type(None) == "default"
 
-    def test_convert_type_with_invalid_input(self):
+    def test_convert_type_with_invalid_input(self) -> None:
         """Test type conversion with invalid input."""
         from flaskr.common.config import EnvironmentConfigError
 
@@ -174,7 +174,7 @@ class TestEnvVarTypeConversion:
 class TestEnvVarValidation:
     """Test validation functionality."""
 
-    def test_validate_with_no_validator(self):
+    def test_validate_with_no_validator(self) -> None:
         """Test validation when no validator is set."""
         env_var = EnvVar(name="NO_VALIDATOR")
 
@@ -182,7 +182,7 @@ class TestEnvVarValidation:
         assert env_var.validate_value(123) is True
         assert env_var.validate_value(None) is True
 
-    def test_validate_with_port_validator(self):
+    def test_validate_with_port_validator(self) -> None:
         """Test validation with port validator."""
         env_var = EnvVar(
             name="PORT",
@@ -197,7 +197,7 @@ class TestEnvVarValidation:
         assert env_var.validate_value(65536) is False
         assert env_var.validate_value(-1) is False
 
-    def test_validate_with_email_validator(self):
+    def test_validate_with_email_validator(self) -> None:
         """Test validation with email validator."""
         env_var = EnvVar(
             name="EMAIL",
@@ -211,7 +211,7 @@ class TestEnvVarValidation:
         assert env_var.validate_value("@example.com") is False
         assert env_var.validate_value("") is False
 
-    def test_validate_with_always_fail(self):
+    def test_validate_with_always_fail(self) -> None:
         """Test validation with always-fail validator."""
         env_var = EnvVar(
             name="FAIL_VAR",
@@ -221,7 +221,7 @@ class TestEnvVarValidation:
         assert env_var.validate_value("anything") is False
         assert env_var.validate_value(123) is False
 
-    def test_validate_with_range_validator(self):
+    def test_validate_with_range_validator(self) -> None:
         """Test validation with range validator."""
         env_var = EnvVar(
             name="TEMPERATURE",
@@ -239,7 +239,7 @@ class TestEnvVarValidation:
 class TestLLMModelMaxOutputTokensConfig:
     """Verify LLM model max output tokens config behavior."""
 
-    def test_parse_valid_routed_model_limits(self):
+    def test_parse_valid_routed_model_limits(self) -> None:
         assert parse_llm_model_max_output_tokens(
             '{"qwen/deepseek-v4-flash":393216,"gemini-3.5-flash":65536}'
         ) == {
@@ -261,7 +261,7 @@ class TestLLMModelMaxOutputTokensConfig:
             '{"qwen/model": 8192, " qwen/model ": 4096}',
         ],
     )
-    def test_reject_invalid_routed_model_limits(self, value):
+    def test_reject_invalid_routed_model_limits(self, value) -> None:
         env_var = ENV_VARS["LLM_MODEL_MAX_OUTPUT_TOKENS"]
 
         assert env_var.validate_value(value) is False
@@ -275,7 +275,7 @@ class TestLLMModelMaxOutputTokensConfig:
 class TestEnvVarMultilineDescription:
     """Test multi-line description support."""
 
-    def test_single_line_description(self):
+    def test_single_line_description(self) -> None:
         """Test EnvVar with single-line description."""
         env_var = EnvVar(
             name="SINGLE_LINE",
@@ -285,7 +285,7 @@ class TestEnvVarMultilineDescription:
         assert env_var.description == "This is a single line description"
         assert "\n" not in env_var.description
 
-    def test_multi_line_description(self):
+    def test_multi_line_description(self) -> None:
         """Test EnvVar with multi-line description."""
         description = """This is a multi-line description.
 Line 2: More details here.
@@ -300,7 +300,7 @@ Line 3: Even more information."""
         assert "\n" in env_var.description
         assert env_var.description.count("\n") == 2
 
-    def test_empty_description(self):
+    def test_empty_description(self) -> None:
         """Test EnvVar with empty description."""
         env_var = EnvVar(name="NO_DESC")
 
@@ -310,7 +310,7 @@ Line 3: Even more information."""
 class TestEnvVarSecretHandling:
     """Test secret field handling."""
 
-    def test_secret_field_true(self):
+    def test_secret_field_true(self) -> None:
         """Test EnvVar marked as secret."""
         env_var = EnvVar(
             name="API_KEY",
@@ -320,7 +320,7 @@ class TestEnvVarSecretHandling:
 
         assert env_var.secret is True
 
-    def test_secret_field_false(self):
+    def test_secret_field_false(self) -> None:
         """Test EnvVar not marked as secret."""
         env_var = EnvVar(
             name="PUBLIC_VAR",
@@ -330,7 +330,7 @@ class TestEnvVarSecretHandling:
 
         assert env_var.secret is False
 
-    def test_secret_field_default(self):
+    def test_secret_field_default(self) -> None:
         """Test default value of secret field."""
         env_var = EnvVar(name="DEFAULT_SECRET")
 
@@ -340,7 +340,7 @@ class TestEnvVarSecretHandling:
 class TestEnvVarEdgeCases:
     """Test edge cases and corner scenarios."""
 
-    def test_envvar_with_all_fields(self):
+    def test_envvar_with_all_fields(self) -> None:
         """Test EnvVar with all possible fields set."""
         env_var = EnvVar(
             name="COMPLETE_VAR",
@@ -364,7 +364,7 @@ class TestEnvVarEdgeCases:
         assert env_var.group == "complete"
         assert env_var.depends_on == ["DEP1", "DEP2"]
 
-    def test_envvar_minimal_fields(self):
+    def test_envvar_minimal_fields(self) -> None:
         """Test EnvVar with only required field (name)."""
         env_var = EnvVar(name="MINIMAL_VAR")
 
@@ -378,13 +378,13 @@ class TestEnvVarEdgeCases:
         assert env_var.group == "general"
         assert env_var.depends_on == []
 
-    def test_envvar_name_with_special_chars(self):
+    def test_envvar_name_with_special_chars(self) -> None:
         """Test EnvVar name with underscores and numbers."""
         env_var = EnvVar(name="TEST_VAR_123_ABC")
 
         assert env_var.name == "TEST_VAR_123_ABC"
 
-    def test_envvar_group_categorization(self):
+    def test_envvar_group_categorization(self) -> None:
         """Test different group categorizations."""
         groups = ["database", "redis", "auth", "llm", "frontend", "monitoring"]
 

--- a/src/api/tests/common/test_config_fallback.py
+++ b/src/api/tests/common/test_config_fallback.py
@@ -16,7 +16,7 @@ class TestEnvironmentVariableFallback:
     """Test environment variable fallback mechanism."""
 
     @pytest.fixture
-    def setup_app(self, monkeypatch):
+    def setup_app(self, monkeypatch) -> tuple[Flask, Config]:
         """Set up Flask app with required configurations."""
         # Set required environment variables
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db-uri")
@@ -41,7 +41,7 @@ class TestEnvironmentVariableFallback:
 
         return app, config
 
-    def test_fallback_to_env_var_with_warning(self, setup_app):
+    def test_fallback_to_env_var_with_warning(self, setup_app) -> None:
         """Test that undefined config keys fallback to environment variables with warning."""
         app, config = setup_app
 
@@ -59,7 +59,7 @@ class TestEnvironmentVariableFallback:
             "UNDEFINED_VAR_1",
         )
 
-    def test_fallback_cached_no_repeated_warning(self, setup_app, caplog):
+    def test_fallback_cached_no_repeated_warning(self, setup_app, caplog) -> None:
         """Test that cached values don't trigger repeated warnings."""
         _app, config = setup_app
 
@@ -79,7 +79,7 @@ class TestEnvironmentVariableFallback:
         # Only one warning should have been logged
         assert final_warning_count == initial_warning_count
 
-    def test_undefined_var_not_in_env_returns_none(self, setup_app):
+    def test_undefined_var_not_in_env_returns_none(self, setup_app) -> None:
         """Test that undefined variables not in environment return None."""
         _app, config = setup_app
 
@@ -89,7 +89,7 @@ class TestEnvironmentVariableFallback:
         # Should return None
         assert value is None
 
-    def test_defined_var_no_fallback_warning(self, setup_app, caplog):
+    def test_defined_var_no_fallback_warning(self, setup_app, caplog) -> None:
         """Test that defined variables don't trigger fallback warnings."""
         _app, config = setup_app
 
@@ -103,7 +103,7 @@ class TestEnvironmentVariableFallback:
         # No fallback warning should be logged
         assert "not defined in ENV_VARS registry" not in caplog.text
 
-    def test_get_method_with_fallback(self, setup_app, caplog):
+    def test_get_method_with_fallback(self, setup_app, caplog) -> None:
         """Test Config.get() method with fallback."""
         _app, config = setup_app
 
@@ -114,7 +114,7 @@ class TestEnvironmentVariableFallback:
         assert value == "undefined_value_1"
         # Note: config.get() does trigger a warning when falling back to environment variables.
 
-    def test_get_method_with_default(self, setup_app):
+    def test_get_method_with_default(self, setup_app) -> None:
         """Test Config.get() method with default value."""
         _app, config = setup_app
 
@@ -135,11 +135,11 @@ class TestEnhancedConfigFallback:
     """Test EnhancedConfig fallback mechanism."""
 
     @pytest.fixture
-    def enhanced_config(self):
+    def enhanced_config(self) -> EnhancedConfig:
         """Create EnhancedConfig instance."""
         return EnhancedConfig(ENV_VARS)
 
-    def test_enhanced_get_no_fallback(self, enhanced_config, monkeypatch):
+    def test_enhanced_get_no_fallback(self, enhanced_config, monkeypatch) -> None:
         """Test EnhancedConfig.get() does NOT fallback to environment variable."""
         # Set an undefined environment variable
         monkeypatch.setenv("ENHANCED_UNDEFINED_VAR", "enhanced_value")
@@ -154,7 +154,9 @@ class TestEnhancedConfigFallback:
         # (fallback only happens at Config level)
         assert value is None
 
-    def test_enhanced_get_caches_defined_values(self, enhanced_config, monkeypatch):
+    def test_enhanced_get_caches_defined_values(
+        self, enhanced_config, monkeypatch
+    ) -> None:
         """Test that defined values are cached in EnhancedConfig."""
         # Set a defined environment variable
         monkeypatch.setenv("REDIS_HOST", "cached_redis_host")
@@ -174,7 +176,7 @@ class TestEnhancedConfigFallback:
 
         assert value1 == value2 == "cached_redis_host"
 
-    def test_enhanced_get_undefined_not_in_env(self, enhanced_config):
+    def test_enhanced_get_undefined_not_in_env(self, enhanced_config) -> None:
         """Test EnhancedConfig.get() returns None for non-existent vars."""
         # Clear cache
         enhanced_config._cache.clear()
@@ -188,7 +190,7 @@ class TestEnhancedConfigFallback:
 class TestIntegrationWithFlask:
     """Integration tests with Flask application."""
 
-    def test_flask_app_with_custom_env_vars(self, monkeypatch):
+    def test_flask_app_with_custom_env_vars(self, monkeypatch) -> None:
         """Test Flask app can use custom environment variables."""
         # Set required vars
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db-uri")
@@ -219,7 +221,7 @@ class TestIntegrationWithFlask:
         # The warnings are logged by the logger module, not through app.logger
         # So we check that values were retrieved correctly which indicates fallback worked
 
-    def test_setitem_clears_cache_for_fallback(self, monkeypatch):
+    def test_setitem_clears_cache_for_fallback(self, monkeypatch) -> None:
         """Test that setting a value clears the cache."""
         # Set required vars
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db-uri")

--- a/src/api/tests/common/test_config_integration.py
+++ b/src/api/tests/common/test_config_integration.py
@@ -23,7 +23,7 @@ from tests.common.fixtures.config_data import (
 class TestFullConfigurationFlow:
     """Test complete configuration flow from environment to Flask."""
 
-    def test_complete_initialization_flow(self, monkeypatch):
+    def test_complete_initialization_flow(self, monkeypatch) -> None:
         """Test complete initialization from environment variables to Flask app."""
         # Set up production-like environment
         for key, value in PRODUCTION_ENV_CONFIG.items():
@@ -57,7 +57,7 @@ class TestFullConfigurationFlow:
         # 4. Global function access
         assert get_config("REDIS_HOST") == "redis.production.internal"
 
-    def test_docker_environment_setup(self, monkeypatch):
+    def test_docker_environment_setup(self, monkeypatch) -> None:
         """Test configuration with Docker environment."""
         # Set up Docker environment
         for key, value in DOCKER_ENV_CONFIG.items():
@@ -79,7 +79,7 @@ class TestFullConfigurationFlow:
 class TestEnvironmentVariableInterpolation:
     """Test environment variable interpolation in configuration."""
 
-    def test_interpolation_in_config_values(self, monkeypatch):
+    def test_interpolation_in_config_values(self, monkeypatch) -> None:
         """Test that ${VAR} patterns are interpolated."""
         # Set up base variables
         monkeypatch.setenv("DB_HOST", "test-db-host")
@@ -103,7 +103,7 @@ class TestEnvironmentVariableInterpolation:
         assert "test-user:test-pass@test-db-host" in db_uri
         assert "${" not in db_uri  # No uninterpolated variables
 
-    def test_missing_interpolation_variable(self, monkeypatch):
+    def test_missing_interpolation_variable(self, monkeypatch) -> None:
         """Test behavior when interpolated variable is missing."""
         # Set value with missing variable
         monkeypatch.setenv(
@@ -124,7 +124,7 @@ class TestEnvironmentVariableInterpolation:
 class TestConfigurationValidation:
     """Test configuration validation scenarios."""
 
-    def test_missing_all_llm_keys_fails(self, monkeypatch):
+    def test_missing_all_llm_keys_fails(self, monkeypatch) -> None:
         """Test that missing all LLM API keys fails validation."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -139,7 +139,7 @@ class TestConfigurationValidation:
 
         assert "At least one LLM API key must be configured" in str(exc_info.value)
 
-    def test_at_least_one_llm_key_succeeds(self, monkeypatch):
+    def test_at_least_one_llm_key_succeeds(self, monkeypatch) -> None:
         """Test that having at least one LLM key succeeds."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -173,7 +173,7 @@ class TestConfigurationValidation:
             config = Config(app.config, app)
             assert config is not None
 
-    def test_invalid_type_conversion_uses_default(self, monkeypatch):
+    def test_invalid_type_conversion_uses_default(self, monkeypatch) -> None:
         """Test that invalid type conversion falls back to default."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -191,7 +191,7 @@ class TestConfigurationValidation:
 class TestConfigurationExport:
     """Test configuration export functionality."""
 
-    def test_export_env_example_file(self):
+    def test_export_env_example_file(self) -> None:
         """Test exporting configuration as .env.example."""
         enhanced_config = EnhancedConfig(ENV_VARS)
 
@@ -213,7 +213,7 @@ class TestConfigurationExport:
                     "Supported models:" in lines[j] for j in range(max(0, i - 10), i)
                 )
 
-    def test_export_groups_secrets(self):
+    def test_export_groups_secrets(self) -> None:
         """Test that export properly handles secret values."""
         enhanced_config = EnhancedConfig(ENV_VARS)
 
@@ -232,7 +232,7 @@ class TestConfigurationExport:
 class TestConfigurationCaching:
     """Test configuration caching behavior."""
 
-    def test_cache_improves_performance(self, monkeypatch):
+    def test_cache_improves_performance(self, monkeypatch) -> None:
         """Test that caching improves performance."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -259,7 +259,7 @@ class TestConfigurationCaching:
 
             assert value1 == value2 == 6379
 
-    def test_cache_cleared_on_update(self, monkeypatch):
+    def test_cache_cleared_on_update(self, monkeypatch) -> None:
         """Test that cache is cleared when values are updated."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -288,7 +288,7 @@ class TestConfigurationCaching:
 class TestMultiEnvironmentSupport:
     """Test support for multiple environments."""
 
-    def test_switch_between_environments(self, monkeypatch):
+    def test_switch_between_environments(self, monkeypatch) -> None:
         """Test switching between different environment configurations."""
         app = Flask(__name__)
         app.logger = MagicMock()
@@ -322,7 +322,7 @@ class TestMultiEnvironmentSupport:
 class TestErrorHandling:
     """Test error handling in configuration system."""
 
-    def test_detailed_error_messages(self, monkeypatch):
+    def test_detailed_error_messages(self, monkeypatch) -> None:
         """Test that error messages are detailed and helpful."""
         # Missing required variables
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
@@ -340,7 +340,7 @@ class TestErrorHandling:
         # Should include descriptions
         assert "database" in error_msg.lower() or "MySQL" in error_msg
 
-    def test_validation_error_details(self, monkeypatch):
+    def test_validation_error_details(self, monkeypatch) -> None:
         """Test that validation errors provide details."""
         monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "test-db")
         monkeypatch.setenv("SECRET_KEY", "test-key")
@@ -364,7 +364,7 @@ class TestErrorHandling:
 class TestBackwardCompatibility:
     """Test that backward compatibility is properly removed."""
 
-    def test_no_direct_environ_access(self, monkeypatch):
+    def test_no_direct_environ_access(self, monkeypatch) -> None:
         """Test that get_config supports direct os.environ access when not initialized."""
         # Clear global instance to test uninitialized state
         import flaskr.common.config as config_module
@@ -394,7 +394,7 @@ class TestBackwardCompatibility:
         finally:
             config_module.Config._instance = original_instance
 
-    def test_required_means_no_default(self):
+    def test_required_means_no_default(self) -> None:
         """Test that required=True prevents having defaults."""
         with pytest.raises(ValueError, match="marked as required") as exc_info:
             EnvVar(name="TEST", required=True, default="should-fail")

--- a/src/api/tests/common/test_config_trim.py
+++ b/src/api/tests/common/test_config_trim.py
@@ -11,7 +11,7 @@ from flaskr.common.config import (
 class TestEnvironmentVariableTrimming:
     """Test that environment variables are properly trimmed of whitespace."""
 
-    def test_trim_string_values(self, monkeypatch):
+    def test_trim_string_values(self, monkeypatch) -> None:
         """Test that string values are trimmed during get."""
         monkeypatch.setenv("TEST_STRING", "  value with spaces  ")
 
@@ -29,7 +29,7 @@ class TestEnvironmentVariableTrimming:
         assert value == "value with spaces"
         assert value != "  value with spaces  "
 
-    def test_trim_integer_values(self, monkeypatch):
+    def test_trim_integer_values(self, monkeypatch) -> None:
         """Test that integer values are trimmed before conversion."""
         monkeypatch.setenv("TEST_INT", "  42  ")
 
@@ -48,7 +48,7 @@ class TestEnvironmentVariableTrimming:
         assert value == 42
         assert isinstance(value, int)
 
-    def test_trim_boolean_values(self, monkeypatch):
+    def test_trim_boolean_values(self, monkeypatch) -> None:
         """Test that boolean values are trimmed before conversion."""
         monkeypatch.setenv("TEST_BOOL", "  true  ")
 
@@ -66,7 +66,7 @@ class TestEnvironmentVariableTrimming:
 
         assert value is True
 
-    def test_trim_float_values(self, monkeypatch):
+    def test_trim_float_values(self, monkeypatch) -> None:
         """Test that float values are trimmed before conversion."""
         monkeypatch.setenv("TEST_FLOAT", "  3.14  ")
 
@@ -85,7 +85,7 @@ class TestEnvironmentVariableTrimming:
         assert value == 3.14
         assert isinstance(value, float)
 
-    def test_whitespace_only_uses_default(self, monkeypatch):
+    def test_whitespace_only_uses_default(self, monkeypatch) -> None:
         """Test that whitespace-only values use default."""
         monkeypatch.setenv("TEST_WHITESPACE", "   ")
 
@@ -102,7 +102,7 @@ class TestEnvironmentVariableTrimming:
 
         assert value == "default_value"
 
-    def test_trim_in_validation(self, monkeypatch):
+    def test_trim_in_validation(self, monkeypatch) -> None:
         """Test that values are trimmed during validation."""
         # Set required variables with whitespace
         monkeypatch.setenv("REQUIRED_VAR", "  required_value  ")
@@ -127,7 +127,7 @@ class TestEnvironmentVariableTrimming:
         config.validate_environment()
         assert config._validated is True
 
-    def test_trim_list_values(self, monkeypatch):
+    def test_trim_list_values(self, monkeypatch) -> None:
         """Test that list values handle whitespace correctly."""
         monkeypatch.setenv("TEST_LIST", "  item1 , item2 , item3  ")
 
@@ -146,7 +146,7 @@ class TestEnvironmentVariableTrimming:
         # List items should be trimmed individually
         assert value == ["item1", "item2", "item3"]
 
-    def test_trim_with_interpolation(self, monkeypatch):
+    def test_trim_with_interpolation(self, monkeypatch) -> None:
         """Test that trimming works with variable interpolation."""
         monkeypatch.setenv("BASE_VALUE", "  base  ")
         monkeypatch.setenv("INTERPOLATED", "  prefix_${BASE_VALUE}_suffix  ")
@@ -176,7 +176,7 @@ class TestEnvironmentVariableTrimming:
         # So it becomes "prefix_  base  _suffix" which is then returned as-is
         assert interpolated == "prefix_  base  _suffix"
 
-    def test_required_with_whitespace_only_fails(self, monkeypatch):
+    def test_required_with_whitespace_only_fails(self, monkeypatch) -> None:
         """Test that required variables with only whitespace fail validation."""
         monkeypatch.setenv("REQUIRED_VAR", "   ")  # Only whitespace
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
@@ -205,7 +205,7 @@ class TestEnvironmentVariableTrimming:
         assert "Missing required environment variables" in str(exc_info.value)
         assert "REQUIRED_VAR" in str(exc_info.value)
 
-    def test_convert_type_method_trims(self):
+    def test_convert_type_method_trims(self) -> None:
         """Test that EnvVar.convert_type method trims values."""
         env_var = EnvVar(
             name="TEST",

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -9,6 +9,7 @@ helper must resolve the real Session via the registry call form.
 """
 
 import logging
+from typing import Never
 
 import pytest
 from flaskr.dao import (
@@ -59,17 +60,17 @@ def _operational(errno: int) -> OperationalError:
         (_operational(1205), False),
     ],
 )
-def test_abnormal_termination_classification(exc, expected):
+def test_abnormal_termination_classification(exc, expected) -> None:
     assert is_abnormal_stream_termination(exc) is expected
 
 
-def test_protocol_interrupt_checks_orig_and_self():
+def test_protocol_interrupt_checks_orig_and_self() -> None:
     assert is_protocol_interrupt_error(_operational(2014)) is True
     assert is_protocol_interrupt_error(Exception(2013, "raw")) is True
     assert is_protocol_interrupt_error(_operational(1213)) is False
 
 
-def test_scoped_session_does_not_proxy_invalidate():
+def test_scoped_session_does_not_proxy_invalidate() -> None:
     # This gap is WHY invalidate_session must resolve the real Session via
     # the registry call form: db.session.invalidate() raises AttributeError
     # and, wrapped in a broad except, silently does nothing (the production
@@ -77,7 +78,7 @@ def test_scoped_session_does_not_proxy_invalidate():
     assert not hasattr(db.session, "invalidate")
 
 
-def test_invalidate_session_works_on_real_scoped_session(app, caplog):
+def test_invalidate_session_works_on_real_scoped_session(app, caplog) -> None:
     with app.app_context():
         db.session.execute(text("SELECT 1"))
         with caplog.at_level(logging.WARNING):
@@ -85,7 +86,7 @@ def test_invalidate_session_works_on_real_scoped_session(app, caplog):
     assert "invalidate failed" not in caplog.text
 
 
-def test_invalidate_session_uses_fake_sessions_directly():
+def test_invalidate_session_uses_fake_sessions_directly() -> None:
     calls = []
 
     class _Fake:
@@ -96,7 +97,7 @@ def test_invalidate_session_uses_fake_sessions_directly():
     assert calls == [1]
 
 
-def test_cleanup_rolls_back_on_server_delivered_errors():
+def test_cleanup_rolls_back_on_server_delivered_errors() -> None:
     events = []
 
     class _Fake:
@@ -111,7 +112,7 @@ def test_cleanup_rolls_back_on_server_delivered_errors():
     assert events == ["rollback"]
 
 
-def test_cleanup_invalidates_on_interrupting_terminations():
+def test_cleanup_invalidates_on_interrupting_terminations() -> None:
     events = []
 
     class _Fake:
@@ -126,7 +127,7 @@ def test_cleanup_invalidates_on_interrupting_terminations():
     assert events == ["invalidate"]
 
 
-def test_cleanup_escalates_to_invalidate_when_rollback_fails():
+def test_cleanup_escalates_to_invalidate_when_rollback_fails() -> None:
     events = []
 
     class _Fake:
@@ -143,7 +144,7 @@ def test_cleanup_escalates_to_invalidate_when_rollback_fails():
     assert events == ["rollback", "invalidate"]
 
 
-def test_teardown_hook_invalidates_before_session_removal(app, monkeypatch):
+def test_teardown_hook_invalidates_before_session_removal(app, monkeypatch) -> Never:
     """The global teardown guard must fire on abnormal context exits and run BEFORE Flask-SQLAlchemy's remove (reverse registration order)."""
     from flaskr import dao
 
@@ -171,7 +172,7 @@ def test_teardown_hook_invalidates_before_session_removal(app, monkeypatch):
     assert "remove" in order
 
 
-def test_teardown_hook_ignores_ordinary_exceptions(app, monkeypatch):
+def test_teardown_hook_ignores_ordinary_exceptions(app, monkeypatch) -> Never:
     from flaskr import dao
 
     invalidations = []
@@ -190,7 +191,7 @@ def test_teardown_hook_ignores_ordinary_exceptions(app, monkeypatch):
 
 def test_release_session_classified_invalidates_during_propagating_interrupt(
     app, monkeypatch
-):
+) -> None:
     from flaskr import dao
 
     order = []
@@ -241,7 +242,9 @@ def test_release_session_classified_invalidates_during_propagating_interrupt(
         assert order == ["invalidate", "remove"]
 
 
-def test_release_session_classified_ignores_ordinary_exceptions(app, monkeypatch):
+def test_release_session_classified_ignores_ordinary_exceptions(
+    app, monkeypatch
+) -> None:
     from flaskr import dao
 
     invalidations = []
@@ -264,7 +267,7 @@ def test_release_session_classified_ignores_ordinary_exceptions(app, monkeypatch
     assert invalidations == []
 
 
-def test_classifier_covers_driver_interface_and_socket_errors():
+def test_classifier_covers_driver_interface_and_socket_errors() -> None:
     class _DriverInterfaceError(Exception):
         pass
 

--- a/src/api/tests/common/test_gevent_hub_observer.py
+++ b/src/api/tests/common/test_gevent_hub_observer.py
@@ -27,7 +27,7 @@ def _fire(hub, context=None, exc=None):
     return hub.handle_error(context, type(exc), exc, None)
 
 
-def test_observer_logs_and_delegates(caplog):
+def test_observer_logs_and_delegates(caplog) -> None:
     hub = _StubHub()
     logger = logging.getLogger("test-hub-observer")
     assert install_hub_error_observer(logger, hub=hub) is True
@@ -49,7 +49,7 @@ def test_observer_logs_and_delegates(caplog):
     assert "AssertionError" in caplog.text
 
 
-def test_observer_installs_once(caplog):
+def test_observer_installs_once(caplog) -> None:
     hub = _StubHub()
     logger = logging.getLogger("test-hub-observer-once")
     assert install_hub_error_observer(logger, hub=hub) is True
@@ -63,7 +63,7 @@ def test_observer_installs_once(caplog):
     assert caplog.text.count("gevent hub error") == 1
 
 
-def test_logger_failure_never_blocks_the_original_handler():
+def test_logger_failure_never_blocks_the_original_handler() -> None:
     hub = _StubHub()
 
     class _BrokenLogger:
@@ -79,7 +79,7 @@ def test_logger_failure_never_blocks_the_original_handler():
     assert len(hub.calls) == 1
 
 
-def test_unreprable_context_is_still_logged(caplog):
+def test_unreprable_context_is_still_logged(caplog) -> None:
     hub = _StubHub()
     logger = logging.getLogger("test-hub-observer-badrepr")
     install_hub_error_observer(logger, hub=hub)

--- a/src/api/tests/common/test_gunicorn_post_fork_langfuse.py
+++ b/src/api/tests/common/test_gunicorn_post_fork_langfuse.py
@@ -44,7 +44,7 @@ def _make_client() -> Langfuse:
     )
 
 
-def test_reset_clears_singleton_registry_and_rebuilds_resources():
+def test_reset_clears_singleton_registry_and_rebuilds_resources() -> None:
     client = _make_client()
     first_resources = client._resources
     assert LangfuseResourceManager._instances
@@ -60,7 +60,7 @@ def test_reset_clears_singleton_registry_and_rebuilds_resources():
     assert rebuilt._resources is not first_resources
 
 
-def test_reset_allows_registering_a_fresh_tracer_provider():
+def test_reset_allows_registering_a_fresh_tracer_provider() -> None:
     _make_client()
     first_provider = otel_trace_api.get_tracer_provider()
     assert not isinstance(first_provider, otel_trace_api.ProxyTracerProvider)

--- a/src/api/tests/common/test_i18n_loader.py
+++ b/src/api/tests/common/test_i18n_loader.py
@@ -30,7 +30,7 @@ def _isolate_i18n_state(monkeypatch):
     clear_language()
 
 
-def test_load_and_translate_basic():
+def test_load_and_translate_basic() -> None:
     app = Flask(__name__)
 
     # Load translations from shared JSON
@@ -45,7 +45,7 @@ def test_load_and_translate_basic():
     assert t("module.chat.ask") == "追问"
 
 
-def test_french_language_loads_shared_translations():
+def test_french_language_loads_shared_translations() -> None:
     app = Flask(__name__)
 
     load_translations(app)
@@ -55,7 +55,7 @@ def test_french_language_loads_shared_translations():
     assert t("module.chat.ask") == "Demander"
 
 
-def test_language_fallback_to_default():
+def test_language_fallback_to_default() -> None:
     app = Flask(__name__)
 
     load_translations(app)
@@ -65,7 +65,7 @@ def test_language_fallback_to_default():
     assert t("module.chat.ask") == "Ask"
 
 
-def test_existing_language_missing_key_falls_back_to_default():
+def test_existing_language_missing_key_falls_back_to_default() -> None:
     app = Flask(__name__)
 
     load_translations(app)
@@ -82,7 +82,7 @@ def test_existing_language_missing_key_falls_back_to_default():
         fr_translations["MODULE.CHAT.ASK"] = removed_upper
 
 
-def test_flat_section_namespace_loading():
+def test_flat_section_namespace_loading() -> None:
     app = Flask(__name__)
 
     load_translations(app)

--- a/src/api/tests/common/test_i18n_utils.py
+++ b/src/api/tests/common/test_i18n_utils.py
@@ -4,17 +4,17 @@ from flaskr.common.i18n_utils import resolve_markdownflow_output_language
 from markdown_flow import MarkdownFlow, ProcessMode
 
 
-def test_french_locale_uses_native_language_name():
+def test_french_locale_uses_native_language_name() -> None:
     assert resolve_markdownflow_output_language("fr-FR") == "Français"
     assert resolve_markdownflow_output_language("fr_FR") == "Français"
 
 
-def test_existing_english_and_chinese_names_are_unchanged():
+def test_existing_english_and_chinese_names_are_unchanged() -> None:
     assert resolve_markdownflow_output_language("en-US") == "English"
     assert resolve_markdownflow_output_language("zh-CN") == "简体中文"
 
 
-def test_french_native_name_reaches_content_and_interaction_prompts():
+def test_french_native_name_reaches_content_and_interaction_prompts() -> None:
     class CapturingProvider:
         def __init__(self) -> None:
             self.calls = []

--- a/src/api/tests/common/test_log.py
+++ b/src/api/tests/common/test_log.py
@@ -12,7 +12,7 @@ class _FailingResponse:
         raise requests.exceptions.HTTPError(message)
 
 
-def test_feishu_log_handler_does_not_reemit_webhook_failures(monkeypatch):
+def test_feishu_log_handler_does_not_reemit_webhook_failures(monkeypatch) -> None:
     calls = []
 
     def fake_post(*args: object, **kwargs: object):
@@ -40,7 +40,7 @@ def test_feishu_log_handler_does_not_reemit_webhook_failures(monkeypatch):
 
 def test_feishu_log_handler_surfaces_delivery_failure_without_recursion(
     monkeypatch, caplog
-):
+) -> None:
     calls = []
 
     def fake_post(*args: object, **kwargs: object):
@@ -68,7 +68,7 @@ def test_feishu_log_handler_surfaces_delivery_failure_without_recursion(
     assert "Failed to send log to Feishu webhook" in caplog.text
 
 
-def test_feishu_log_handler_reentrancy_guard_blocks_nested_emit(monkeypatch):
+def test_feishu_log_handler_reentrancy_guard_blocks_nested_emit(monkeypatch) -> None:
     calls = []
 
     def fake_post(*args: object, **kwargs: object):
@@ -96,7 +96,7 @@ def test_feishu_log_handler_reentrancy_guard_blocks_nested_emit(monkeypatch):
     assert calls == []
 
 
-def test_feishu_log_handler_truncates_oversized_payload(monkeypatch):
+def test_feishu_log_handler_truncates_oversized_payload(monkeypatch) -> None:
     captured = {}
 
     def fake_post(_url, *, json, timeout):

--- a/src/api/tests/common/test_module_state_owners.py
+++ b/src/api/tests/common/test_module_state_owners.py
@@ -5,7 +5,7 @@ from flaskr import dao
 from flaskr.framework.plugin import plugin_manager as plugin_manager_module
 
 
-def test_database_extension_keeps_one_shared_identity():
+def test_database_extension_keeps_one_shared_identity() -> None:
     app = Flask("stable-database-extension")
     app.config.update(
         SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
@@ -19,7 +19,7 @@ def test_database_extension_keeps_one_shared_identity():
     assert app.extensions["sqlalchemy"] is shared_db
 
 
-def test_redis_initialization_updates_the_owned_client(monkeypatch):
+def test_redis_initialization_updates_the_owned_client(monkeypatch) -> None:
     app = Flask("owned-redis-client")
     app.config.update(
         REDIS_HOST="redis.internal",
@@ -50,7 +50,7 @@ def test_redis_initialization_updates_the_owned_client(monkeypatch):
     }
 
 
-def test_plugin_manager_registry_replaces_one_owned_instance(monkeypatch):
+def test_plugin_manager_registry_replaces_one_owned_instance(monkeypatch) -> None:
     first_app = Flask("first-plugin-manager")
     second_app = Flask("second-plugin-manager")
     monkeypatch.setattr(plugin_manager_module._plugin_manager_state, "manager", None)

--- a/src/api/tests/common/test_pool_desync_detection.py
+++ b/src/api/tests/common/test_pool_desync_detection.py
@@ -7,6 +7,7 @@ recirculating them.
 """
 
 import socket
+from collections.abc import Iterator
 
 import pytest
 from flaskr import dao
@@ -30,7 +31,7 @@ class _FakePyMySQLConnection:
 
 
 @pytest.fixture
-def sock_pair():
+def sock_pair() -> Iterator[tuple[socket.socket, socket.socket]]:
     left, right = socket.socketpair()
     left.setblocking(False)  # noqa: FBT003 -- stdlib socket API
     yield left, right
@@ -38,7 +39,7 @@ def sock_pair():
     right.close()
 
 
-def test_unread_data_detected(sock_pair):
+def test_unread_data_detected(sock_pair) -> None:
     left, right = sock_pair
     conn = _FakePyMySQLConnection(left)
     assert dao._socket_has_unread_data(conn) is False
@@ -47,14 +48,14 @@ def test_unread_data_detected(sock_pair):
     assert dao._socket_has_unread_data(conn) is True
 
 
-def test_connection_without_socket_is_ignored():
+def test_connection_without_socket_is_ignored() -> None:
     class _NoSock:
         pass
 
     assert dao._socket_has_unread_data(_NoSock()) is False
 
 
-def test_unusable_socket_object_is_ignored():
+def test_unusable_socket_object_is_ignored() -> None:
     class _BadSock:
         # No fileno(): select.select raises TypeError for such objects.
         _sock = object()
@@ -62,7 +63,7 @@ def test_unusable_socket_object_is_ignored():
     assert dao._socket_has_unread_data(_BadSock()) is False
 
 
-def test_pool_discards_connection_desynced_during_use(sock_pair):
+def test_pool_discards_connection_desynced_during_use(sock_pair) -> None:
     left, right = sock_pair
     dirty_conn = _FakePyMySQLConnection(left)
     clean_sock_a, clean_sock_b = socket.socketpair()
@@ -98,7 +99,7 @@ def test_pool_discards_connection_desynced_during_use(sock_pair):
         clean_sock_b.close()
 
 
-def test_checkout_rejects_connection_that_became_dirty_in_pool(sock_pair):
+def test_checkout_rejects_connection_that_became_dirty_in_pool(sock_pair) -> None:
     left, right = sock_pair
     dirty_conn = _FakePyMySQLConnection(left)
     clean_sock_a, clean_sock_b = socket.socketpair()
@@ -128,7 +129,7 @@ def test_checkout_rejects_connection_that_became_dirty_in_pool(sock_pair):
         clean_sock_b.close()
 
 
-def test_probe_timeout_waits_for_in_flight_data(sock_pair):
+def test_probe_timeout_waits_for_in_flight_data(sock_pair) -> None:
     """A timed probe must catch data that arrives DURING the wait window: the zero-timeout probe misses an owed response still in flight, which is exactly how a just-interrupted exchange poisons the pool.
 
     A generous test window (far larger than any CI scheduler delay) keeps this
@@ -159,7 +160,7 @@ def test_probe_timeout_waits_for_in_flight_data(sock_pair):
         sender.join()
 
 
-def test_checkin_grace_window_is_a_short_positive_interval():
+def test_checkin_grace_window_is_a_short_positive_interval() -> None:
     # The production checkin window must stay a small positive value: zero
     # reintroduces the arrival race, and anything larger taxes every
     # transaction end. The bound is pinned to the current 2ms on purpose -
@@ -180,7 +181,7 @@ class _FakePingablePyMySQLConnection(_FakePyMySQLConnection):
         self.pings += 1
 
 
-def test_checkout_appends_a_journal_boundary_marker():
+def test_checkout_appends_a_journal_boundary_marker() -> None:
     clean_a, clean_b = socket.socketpair()
     conn = _FakePingablePyMySQLConnection(clean_a)
 

--- a/src/api/tests/common/test_pre_execute_desync_interception.py
+++ b/src/api/tests/common/test_pre_execute_desync_interception.py
@@ -17,7 +17,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import DisconnectionError
 
 
-def test_statement_journal_records_recent_statements(app):
+def test_statement_journal_records_recent_statements(app) -> None:
     with app.app_context():
         db.session.execute(text("SELECT 1"))
         db.session.execute(text("SELECT 2"))
@@ -30,7 +30,7 @@ def test_statement_journal_records_recent_statements(app):
     assert any("SELECT 2" in s for s in statements)
 
 
-def test_pre_execute_probe_blocks_desynced_connection():
+def test_pre_execute_probe_blocks_desynced_connection() -> None:
     left, right = socket.socketpair()
     try:
 
@@ -68,7 +68,7 @@ def test_pre_execute_probe_blocks_desynced_connection():
         right.close()
 
 
-def test_pre_execute_probe_ignores_drivers_without_socket(app):
+def test_pre_execute_probe_ignores_drivers_without_socket(app) -> None:
     # SQLite connections expose no _sock; the whole suite running on SQLite
     # exercises this path implicitly, but assert the direct call is a no-op.
     with app.app_context():

--- a/src/api/tests/common/test_protected_checkout_ping.py
+++ b/src/api/tests/common/test_protected_checkout_ping.py
@@ -8,6 +8,7 @@ record BEFORE any interruption propagates.
 """
 
 import socket
+from collections.abc import Iterator
 
 import pytest
 from flaskr import dao
@@ -39,20 +40,20 @@ def _make_conn(sock, ping_exc=None):
 
 
 @pytest.fixture
-def clean_sock():
+def clean_sock() -> Iterator[socket.socket]:
     left, right = socket.socketpair()
     yield left
     left.close()
     right.close()
 
 
-def test_healthy_ping_passes(clean_sock):
+def test_healthy_ping_passes(clean_sock) -> None:
     record = _FakeRecord()
     dao._reject_desynced_connection_on_checkout(_make_conn(clean_sock), record, None)
     assert record.invalidated_with == []
 
 
-def test_dead_connection_ping_invalidates_and_retries(clean_sock):
+def test_dead_connection_ping_invalidates_and_retries(clean_sock) -> None:
     record = _FakeRecord()
     ping_exc = OSError("dead")
     with pytest.raises(DisconnectionError):
@@ -62,7 +63,7 @@ def test_dead_connection_ping_invalidates_and_retries(clean_sock):
     assert record.invalidated_with == [ping_exc]
 
 
-def test_interrupted_ping_invalidates_before_propagating(clean_sock):
+def test_interrupted_ping_invalidates_before_propagating(clean_sock) -> None:
     record = _FakeRecord()
     with pytest.raises(_FakeGreenletExit):
         dao._reject_desynced_connection_on_checkout(
@@ -74,7 +75,7 @@ def test_interrupted_ping_invalidates_before_propagating(clean_sock):
     assert record.invalidated_with == [None]
 
 
-def test_connections_without_ping_are_skipped(clean_sock):
+def test_connections_without_ping_are_skipped(clean_sock) -> None:
     class _NoPing:
         _sock = clean_sock
 
@@ -83,5 +84,5 @@ def test_connections_without_ping_are_skipped(clean_sock):
     assert record.invalidated_with == []
 
 
-def test_pre_ping_engine_option_defaults_off(app):
+def test_pre_ping_engine_option_defaults_off(app) -> None:
     assert app.config["SQLALCHEMY_ENGINE_OPTIONS"].get("pool_pre_ping") is False

--- a/src/api/tests/common/test_public_urls.py
+++ b/src/api/tests/common/test_public_urls.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import flaskr.common.config as common_config
 import pytest
 from flask import Flask
@@ -14,6 +16,9 @@ from flaskr.common.public_urls import (
     resolve_request_origin,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 def _reset_config_cache(*keys: str) -> None:
     for key in keys:
@@ -21,7 +26,7 @@ def _reset_config_cache(*keys: str) -> None:
 
 
 @pytest.fixture(autouse=True)
-def clear_public_url_config_cache():
+def clear_public_url_config_cache() -> Iterator[None]:
     keys = (
         "HOST_URL",
         "PATH_PREFIX",
@@ -34,7 +39,7 @@ def clear_public_url_config_cache():
     _reset_config_cache(*keys)
 
 
-def test_public_urls_are_derived_from_host_url(monkeypatch: pytest.MonkeyPatch):
+def test_public_urls_are_derived_from_host_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HOST_URL", "https://app.example.com/")
     monkeypatch.setenv("PATH_PREFIX", "/api")
     _reset_config_cache("HOST_URL", "PATH_PREFIX")
@@ -63,7 +68,7 @@ def test_public_urls_are_derived_from_host_url(monkeypatch: pytest.MonkeyPatch):
 
 def test_public_urls_use_path_prefix_for_backend_callbacks(
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     monkeypatch.setenv("HOST_URL", "https://app.example.com")
     monkeypatch.setenv("PATH_PREFIX", "/service-api")
     _reset_config_cache("HOST_URL", "PATH_PREFIX")
@@ -80,7 +85,7 @@ def test_public_urls_use_path_prefix_for_backend_callbacks(
 
 def test_public_urls_fall_back_to_forwarded_request_origin(
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     monkeypatch.delenv("HOST_URL", raising=False)
     monkeypatch.setenv("PATH_PREFIX", "/api")
     _reset_config_cache("HOST_URL", "PATH_PREFIX")
@@ -118,7 +123,7 @@ def test_public_urls_fall_back_to_forwarded_request_origin(
 
 def test_public_urls_prefer_origin_header_when_host_url_missing(
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     monkeypatch.delenv("HOST_URL", raising=False)
     _reset_config_cache("HOST_URL")
 
@@ -137,7 +142,7 @@ def test_public_urls_prefer_origin_header_when_host_url_missing(
         )
 
 
-def test_public_urls_reject_host_url_with_path(monkeypatch: pytest.MonkeyPatch):
+def test_public_urls_reject_host_url_with_path(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HOST_URL", "https://app.example.com/base")
     _reset_config_cache("HOST_URL")
 
@@ -147,7 +152,7 @@ def test_public_urls_reject_host_url_with_path(monkeypatch: pytest.MonkeyPatch):
 
 def test_public_urls_include_non_standard_port_from_forwarded_port(
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     monkeypatch.delenv("HOST_URL", raising=False)
     monkeypatch.setenv("PATH_PREFIX", "/api")
     _reset_config_cache("HOST_URL", "PATH_PREFIX")
@@ -169,7 +174,7 @@ def test_public_urls_include_non_standard_port_from_forwarded_port(
 
 def test_public_urls_omit_standard_port_from_forwarded_port(
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     monkeypatch.delenv("HOST_URL", raising=False)
     monkeypatch.setenv("PATH_PREFIX", "/api")
     _reset_config_cache("HOST_URL", "PATH_PREFIX")
@@ -191,7 +196,7 @@ def test_public_urls_omit_standard_port_from_forwarded_port(
 
 def test_google_callback_can_be_pinned_to_one_shared_url(
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     """One callback for every domain, so Google needs no per-domain entry."""
     monkeypatch.setenv("HOST_URL", "https://app.example.com")
     monkeypatch.setenv(
@@ -207,7 +212,7 @@ def test_google_callback_can_be_pinned_to_one_shared_url(
 
 def test_pinned_google_callback_wins_over_the_request_origin(
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     """A white-label domain must still send Google the shared callback."""
     monkeypatch.delenv("HOST_URL", raising=False)
     monkeypatch.setenv(
@@ -227,7 +232,7 @@ def test_pinned_google_callback_wins_over_the_request_origin(
 
 def test_google_callback_falls_back_to_the_request_origin_when_unpinned(
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     """Without the setting the historical per-origin behavior is kept."""
     monkeypatch.delenv("HOST_URL", raising=False)
     monkeypatch.delenv("GOOGLE_OAUTH_REDIRECT_URI", raising=False)
@@ -245,7 +250,7 @@ def test_google_callback_falls_back_to_the_request_origin_when_unpinned(
 
 def test_malformed_pinned_google_callback_is_rejected(
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     monkeypatch.setenv("HOST_URL", "https://app.example.com")
     monkeypatch.setenv("GOOGLE_OAUTH_REDIRECT_URI", "app.example.com/callback")
     _reset_config_cache("HOST_URL", "GOOGLE_OAUTH_REDIRECT_URI")
@@ -257,7 +262,7 @@ def test_malformed_pinned_google_callback_is_rejected(
 class TestResolveRequestOrigin:
     """The OAuth return origin comes from here, so it must not be caller-driven."""
 
-    def test_a_query_parameter_cannot_nominate_another_domain(self):
+    def test_a_query_parameter_cannot_nominate_another_domain(self) -> None:
         # The attack this guards: starting a login on one domain while naming
         # another customer's verified domain as where to hand the code back.
         app = Flask(__name__)
@@ -267,7 +272,7 @@ class TestResolveRequestOrigin:
         ):
             assert resolve_request_origin() == "https://learn.customer.example"
 
-    def test_falls_back_to_the_forwarded_host(self):
+    def test_falls_back_to_the_forwarded_host(self) -> None:
         # Same-origin calls send no Origin header; the ingress sets these.
         app = Flask(__name__)
         with app.test_request_context(

--- a/src/api/tests/common/test_secret_key_validator.py
+++ b/src/api/tests/common/test_secret_key_validator.py
@@ -12,7 +12,7 @@ from flaskr.common.config import (
 class TestSecretKeyValidator:
     """Test SECRET_KEY validation functionality."""
 
-    def test_secret_key_valid_values(self):
+    def test_secret_key_valid_values(self) -> None:
         """Test that valid SECRET_KEY values pass validation."""
         # Get the actual SECRET_KEY EnvVar from ENV_VARS
         secret_key_env = ENV_VARS["SECRET_KEY"]
@@ -31,7 +31,7 @@ class TestSecretKeyValidator:
                 f"Failed for value: {value!r}"
             )
 
-    def test_secret_key_invalid_values(self):
+    def test_secret_key_invalid_values(self) -> None:
         """Test that invalid SECRET_KEY values fail validation."""
         # Get the actual SECRET_KEY EnvVar from ENV_VARS
         secret_key_env = ENV_VARS["SECRET_KEY"]
@@ -50,17 +50,17 @@ class TestSecretKeyValidator:
                 f"Should have failed for value: {value!r}"
             )
 
-    def test_secret_key_required_field(self):
+    def test_secret_key_required_field(self) -> None:
         """Test that SECRET_KEY is marked as required."""
         secret_key_env = ENV_VARS["SECRET_KEY"]
         assert secret_key_env.required is True
 
-    def test_secret_key_is_secret(self):
+    def test_secret_key_is_secret(self) -> None:
         """Test that SECRET_KEY is marked as secret."""
         secret_key_env = ENV_VARS["SECRET_KEY"]
         assert secret_key_env.secret is True
 
-    def test_environment_validation_with_empty_secret_key(self, monkeypatch):
+    def test_environment_validation_with_empty_secret_key(self, monkeypatch) -> None:
         """Test that environment validation fails with empty SECRET_KEY."""
         # Set required environment variables
         monkeypatch.setenv(
@@ -82,7 +82,9 @@ class TestSecretKeyValidator:
         )
         assert "SECRET_KEY" in error_msg
 
-    def test_environment_validation_with_whitespace_secret_key(self, monkeypatch):
+    def test_environment_validation_with_whitespace_secret_key(
+        self, monkeypatch
+    ) -> None:
         """Test that environment validation fails with whitespace-only SECRET_KEY."""
         # Set required environment variables
         monkeypatch.setenv(
@@ -101,7 +103,7 @@ class TestSecretKeyValidator:
         assert "Missing required environment variables" in error_msg
         assert "SECRET_KEY" in error_msg
 
-    def test_environment_validation_with_valid_secret_key(self, monkeypatch):
+    def test_environment_validation_with_valid_secret_key(self, monkeypatch) -> None:
         """Test that environment validation passes with valid SECRET_KEY."""
         # Set required environment variables
         monkeypatch.setenv(
@@ -116,7 +118,7 @@ class TestSecretKeyValidator:
         config.validate_environment()
         assert config._validated is True
 
-    def test_secret_key_with_special_characters(self, monkeypatch):
+    def test_secret_key_with_special_characters(self, monkeypatch) -> None:
         """Test that SECRET_KEY with special characters works correctly."""
         # Set required environment variables
         monkeypatch.setenv(
@@ -134,7 +136,7 @@ class TestSecretKeyValidator:
         secret_value = config.get("SECRET_KEY")
         assert secret_value == "!@#$%^&*()_+-=[]{}|;:,.<>?/~`"
 
-    def test_secret_key_trimming_during_get(self, monkeypatch):
+    def test_secret_key_trimming_during_get(self, monkeypatch) -> None:
         """Test that SECRET_KEY is trimmed during get operation."""
         # Set SECRET_KEY with surrounding whitespace
         monkeypatch.setenv("SECRET_KEY", "  secret_with_spaces  ")
@@ -152,7 +154,7 @@ class TestSecretKeyValidator:
         assert secret_value == "secret_with_spaces"
         assert secret_value != "  secret_with_spaces  "
 
-    def test_custom_secret_key_validator(self):
+    def test_custom_secret_key_validator(self) -> None:
         """Test creating a custom EnvVar with SECRET_KEY-like validator."""
         custom_env_vars = {
             "CUSTOM_SECRET": EnvVar(

--- a/src/api/tests/common/test_swagger_docstrings.py
+++ b/src/api/tests/common/test_swagger_docstrings.py
@@ -30,13 +30,13 @@ def _swagger_docstrings():
                 yield path.relative_to(API_ROOT), node.name, docstring
 
 
-def test_swagger_sanitizer_omits_framing_newlines():
+def test_swagger_sanitizer_omits_framing_newlines() -> None:
     assert sanitize_swagger_docstring("\nReset the chapter order.\n\n") == (
         "Reset the chapter order."
     )
 
 
-def test_all_swagger_docstrings_keep_valid_yaml_after_summary():
+def test_all_swagger_docstrings_keep_valid_yaml_after_summary() -> None:
     discovered = []
     unparseable = set()
     for path, function_name, docstring in _swagger_docstrings():

--- a/src/api/tests/common/test_unique_session_scope.py
+++ b/src/api/tests/common/test_unique_session_scope.py
@@ -11,14 +11,14 @@ import pytest
 from flaskr.dao import _unique_app_ctx_scope, db
 
 
-def test_scope_token_is_stable_within_a_context(app):
+def test_scope_token_is_stable_within_a_context(app) -> None:
     with app.app_context():
         first = _unique_app_ctx_scope()
         second = _unique_app_ctx_scope()
         assert first == second
 
 
-def test_scope_token_never_repeats_across_contexts(app):
+def test_scope_token_never_repeats_across_contexts(app) -> None:
     tokens = []
     for _ in range(50):
         with app.app_context():
@@ -29,7 +29,7 @@ def test_scope_token_never_repeats_across_contexts(app):
     assert len(set(tokens)) == len(tokens)
 
 
-def test_nested_contexts_get_distinct_tokens(app):
+def test_nested_contexts_get_distinct_tokens(app) -> None:
     with app.app_context():
         outer = _unique_app_ctx_scope()
         with app.app_context():
@@ -38,7 +38,7 @@ def test_nested_contexts_get_distinct_tokens(app):
         assert _unique_app_ctx_scope() == outer
 
 
-def test_sessions_are_isolated_per_context_and_removed_on_teardown(app):
+def test_sessions_are_isolated_per_context_and_removed_on_teardown(app) -> None:
     with app.app_context():
         outer_token = _unique_app_ctx_scope()
         outer_session = db.session()
@@ -58,6 +58,6 @@ def test_sessions_are_isolated_per_context_and_removed_on_teardown(app):
     assert inner_token not in registry_map
 
 
-def test_scope_raises_outside_app_context():
+def test_scope_raises_outside_app_context() -> None:
     with pytest.raises(RuntimeError):
         _unique_app_ctx_scope()

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -5,10 +5,13 @@ import os
 import shutil
 import sys
 import tempfile
+from collections.abc import Iterator
 from importlib import import_module
 from pathlib import Path
 
 import pytest
+from flask import Flask
+from flask.testing import FlaskClient
 
 # Prevent accidental loading of user/global .env files during tests
 os.environ.setdefault("SKIP_LOAD_DOTENV", "1")
@@ -91,7 +94,7 @@ from tests.common.fixtures.fake_redis import FakeRedis
 
 
 @pytest.fixture(scope="session")
-def app():
+def app() -> Iterator[Flask | None]:
     if os.getenv("SKIP_APP_FIXTURE"):
         yield None
         return
@@ -162,18 +165,18 @@ def app():
 
 
 @pytest.fixture
-def test_client(app):
+def test_client(app) -> Iterator[FlaskClient]:
     with app.test_client() as client:
         yield client
 
 
 @pytest.fixture
-def token():
+def token() -> str:
     return ""
 
 
 @pytest.fixture(autouse=True)
-def mock_redis_client(monkeypatch, request):
+def mock_redis_client(monkeypatch, request) -> FakeRedis:
     fake_redis = FakeRedis()
     # test_funcs.py uses its own `@patch` decorators for fine-grained Redis control.
     if "service/config/test_funcs.py" in request.node.nodeid:
@@ -210,7 +213,7 @@ def _should_skip_llm_mock(request) -> bool:
 
 
 @pytest.fixture(autouse=True)
-def mock_llm_calls(monkeypatch, request):
+def mock_llm_calls(monkeypatch, request) -> None:
     if _should_skip_llm_mock(request):
         return
     llm = sys.modules.get("flaskr.api.llm")
@@ -227,7 +230,7 @@ def mock_llm_calls(monkeypatch, request):
 
 
 @pytest.fixture(autouse=True)
-def isolate_env_for_non_app_tests(request):
+def isolate_env_for_non_app_tests(request) -> Iterator[None]:
     if "app" in request.fixturenames:
         yield
         return

--- a/src/api/tests/contract/test_sms_contract.py
+++ b/src/api/tests/contract/test_sms_contract.py
@@ -7,7 +7,7 @@ import pytest
 from flask import Flask
 
 
-def test_send_sms_ali_builds_request_for_generic_template(monkeypatch):
+def test_send_sms_ali_builds_request_for_generic_template(monkeypatch) -> None:
     from flaskr.api.sms import aliyun as sms_aliyun
 
     captured = {}
@@ -50,7 +50,7 @@ def test_send_sms_ali_builds_request_for_generic_template(monkeypatch):
     assert captured["config"].endpoint == "dysmsapi.aliyuncs.com"
 
 
-def test_send_sms_code_ali_builds_request(monkeypatch):
+def test_send_sms_code_ali_builds_request(monkeypatch) -> None:
     from flaskr.api.sms import aliyun as sms_aliyun
 
     captured = {}
@@ -87,7 +87,7 @@ def test_send_sms_code_ali_builds_request(monkeypatch):
     assert captured["config"].endpoint == "dysmsapi.aliyuncs.com"
 
 
-def test_send_sms_code_ali_returns_none_without_keys(monkeypatch):
+def test_send_sms_code_ali_returns_none_without_keys(monkeypatch) -> None:
     from flaskr.api.sms import aliyun as sms_aliyun
 
     def fake_client(_config):
@@ -109,7 +109,7 @@ def test_send_sms_code_ali_returns_none_without_keys(monkeypatch):
     assert result is None
 
 
-def test_send_sms_code_ali_handles_client_error(monkeypatch):
+def test_send_sms_code_ali_handles_client_error(monkeypatch) -> None:
     from flaskr.api.sms import aliyun as sms_aliyun
 
     class DummyError(Exception):
@@ -148,7 +148,9 @@ def test_send_sms_code_ali_handles_client_error(monkeypatch):
     assert captured["assert_message"] == "boom"
 
 
-def test_send_sms_ali_returns_none_when_provider_response_is_not_ok(monkeypatch):
+def test_send_sms_ali_returns_none_when_provider_response_is_not_ok(
+    monkeypatch,
+) -> None:
     from flaskr.api.sms import aliyun as sms_aliyun
 
     class FakeClient:
@@ -194,7 +196,7 @@ def test_send_sms_ali_returns_none_when_provider_response_is_not_ok(monkeypatch)
 )
 def test_send_sms_ali_logs_recipient_throttle_as_warning(
     monkeypatch, caplog, provider_message
-):
+) -> None:
     from flaskr.api.sms import aliyun as sms_aliyun
 
     class FakeClient:
@@ -239,7 +241,9 @@ def test_send_sms_ali_logs_recipient_throttle_as_warning(
     assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
 
 
-def test_send_sms_ali_logs_illegal_recipient_number_as_warning(monkeypatch, caplog):
+def test_send_sms_ali_logs_illegal_recipient_number_as_warning(
+    monkeypatch, caplog
+) -> None:
     from flaskr.api.sms import aliyun as sms_aliyun
 
     class FakeClient:

--- a/src/api/tests/golden/conftest.py
+++ b/src/api/tests/golden/conftest.py
@@ -35,10 +35,14 @@ import os
 from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 
 from tests.common.fixtures.fake_llm import FakeLLMResponse
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 GOLDEN_DIR = Path(__file__).parent
 FIXTURES_DIR = GOLDEN_DIR / "fixtures"
@@ -104,7 +108,7 @@ def _iter_golden_completion(messages) -> list[str]:
     return list(GOLDEN_LLM_CHUNKS)
 
 
-def golden_chat_llm(*args: object, **kwargs: object):
+def golden_chat_llm(*args: object, **kwargs: object) -> Iterator[FakeLLMResponse]:
     messages = kwargs.get("messages")
     if messages is None:
         for arg in args:
@@ -121,7 +125,7 @@ def golden_chat_llm(*args: object, **kwargs: object):
         )
 
 
-def golden_invoke_llm(*args: object, **kwargs: object):
+def golden_invoke_llm(*args: object, **kwargs: object) -> Iterator[FakeLLMResponse]:
     yield from golden_chat_llm(*args, **kwargs)
 
 
@@ -134,7 +138,7 @@ def golden_get_current_models(_app) -> list[dict[str, str]]:
 
 
 @pytest.fixture(autouse=True)
-def golden_llm(monkeypatch):
+def golden_llm(monkeypatch) -> None:
     """Patch a deterministic fake LLM into every namespace the /run path uses."""
     import sys
 
@@ -166,13 +170,13 @@ def golden_llm(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def golden_sse_settings(app, monkeypatch):
+def golden_sse_settings(app, monkeypatch) -> None:
     """Disable timing-dependent SSE heartbeats for deterministic transcripts."""
     monkeypatch.setitem(app.config, "SSE_HEARTBEAT_INTERVAL", 0)
 
 
 @pytest.fixture(autouse=True)
-def golden_disable_risk_audit_commit(monkeypatch):
+def golden_disable_risk_audit_commit(monkeypatch) -> None:
     """Skip the risk-control audit side-write on SQLite.
 
     ``add_risk_control_result`` commits through a nested ``app.app_context()``
@@ -225,7 +229,7 @@ def seed_golden_user(app, user_bid: str) -> None:
 
 
 @pytest.fixture
-def golden_shifu(app):
+def golden_shifu(app) -> SimpleNamespace:
     """Seed a published, free shifu with one chapter and one runnable lesson.
 
     Idempotent: existing golden rows are removed before reseeding so every

--- a/src/api/tests/golden/test_api_json_golden.py
+++ b/src/api/tests/golden/test_api_json_golden.py
@@ -62,7 +62,7 @@ JSON_GOLDEN_CASES = [
 )
 def test_json_endpoint_golden(
     app, test_client, monkeypatch, golden_shifu, fixture_key, path
-):
+) -> None:
     _ = golden_shifu
     seed_golden_user(app, JSON_USER_BID)
     mock_validate_user(monkeypatch, JSON_USER_BID)

--- a/src/api/tests/golden/test_run_sse_golden.py
+++ b/src/api/tests/golden/test_run_sse_golden.py
@@ -56,7 +56,7 @@ def _prepare_user(app, monkeypatch, user_bid: str) -> None:
     mock_validate_user(monkeypatch, user_bid)
 
 
-def test_run_fresh_start_golden(app, test_client, monkeypatch, golden_shifu):
+def test_run_fresh_start_golden(app, test_client, monkeypatch, golden_shifu) -> None:
     user_bid = "golden-user-fresh-0001"
     _prepare_user(app, monkeypatch, user_bid)
 
@@ -86,7 +86,7 @@ def test_run_fresh_start_golden(app, test_client, monkeypatch, golden_shifu):
     )
 
 
-def test_run_continue_golden(app, test_client, monkeypatch, golden_shifu):
+def test_run_continue_golden(app, test_client, monkeypatch, golden_shifu) -> None:
     user_bid = "golden-user-continue-0001"
     _prepare_user(app, monkeypatch, user_bid)
 
@@ -109,7 +109,9 @@ def test_run_continue_golden(app, test_client, monkeypatch, golden_shifu):
     )
 
 
-def test_run_interaction_input_golden(app, test_client, monkeypatch, golden_shifu):
+def test_run_interaction_input_golden(
+    app, test_client, monkeypatch, golden_shifu
+) -> None:
     user_bid = "golden-user-interact-0001"
     _prepare_user(app, monkeypatch, user_bid)
 
@@ -146,7 +148,7 @@ def test_run_interaction_input_golden(app, test_client, monkeypatch, golden_shif
     )
 
 
-def test_run_ask_flow_golden(app, test_client, monkeypatch, golden_shifu):
+def test_run_ask_flow_golden(app, test_client, monkeypatch, golden_shifu) -> None:
     user_bid = "golden-user-ask-0001"
     _prepare_user(app, monkeypatch, user_bid)
 

--- a/src/api/tests/migrations/test_fresh_mysql_upgrade.py
+++ b/src/api/tests/migrations/test_fresh_mysql_upgrade.py
@@ -24,7 +24,7 @@ def _get_expected_head() -> str:
     return ScriptDirectory.from_config(config).get_current_head()
 
 
-def test_alembic_migrations_have_single_head():
+def test_alembic_migrations_have_single_head() -> None:
     config = Config(str(API_ROOT / "migrations" / "alembic.ini"))
     config.set_main_option("script_location", str(API_ROOT / "migrations"))
     heads = ScriptDirectory.from_config(config).get_heads()
@@ -138,7 +138,7 @@ def _migration_subprocess_script() -> str:
     )
 
 
-def test_fresh_mysql_upgrade_reaches_head():
+def test_fresh_mysql_upgrade_reaches_head() -> None:
     base_uri = _get_base_mysql_uri()
     temp_uri, database_name = _create_temp_database(base_uri)
     expected_head = _get_expected_head()

--- a/src/api/tests/migrations/test_learner_profile_migration.py
+++ b/src/api/tests/migrations/test_learner_profile_migration.py
@@ -36,7 +36,7 @@ def _load_migration_module(path=MIGRATION_PATH):
     return module
 
 
-def test_learner_profile_column_remains_nullable_for_rolling_writers():
+def test_learner_profile_column_remains_nullable_for_rolling_writers() -> None:
     from flaskr.service.user.models import UserInfo
 
     migration = _load_migration_module()
@@ -75,14 +75,14 @@ def test_learner_profile_column_remains_nullable_for_rolling_writers():
     assert UserInfo.__table__.c.learner_profile.nullable is True
 
 
-def test_learner_profile_revision_extends_the_existing_main_head():
+def test_learner_profile_revision_extends_the_existing_main_head() -> None:
     migration = _load_migration_module()
 
     assert migration.revision == "c8f1a2d3e4b5"
     assert migration.down_revision == "b8d5f0a2c3e4"
 
 
-def test_merge_revision_joins_learner_profile_and_tts_provider_heads():
+def test_merge_revision_joins_learner_profile_and_tts_provider_heads() -> None:
     migration = _load_migration_module(MERGE_MIGRATION_PATH)
 
     assert migration.revision == "f9a2b3c4d5e6"

--- a/src/api/tests/route/test_user_language_context.py
+++ b/src/api/tests/route/test_user_language_context.py
@@ -10,7 +10,7 @@ from flaskr.route.user import register_user_handler
 
 def test_authenticated_request_prefers_accept_language_for_runtime_context(
     monkeypatch,
-):
+) -> None:
     app = Flask(__name__)
     app.config["SECRET_KEY"] = "test"
     monkeypatch.setattr(
@@ -37,7 +37,7 @@ def test_authenticated_request_prefers_accept_language_for_runtime_context(
 
 def test_authenticated_request_normalizes_accept_language_for_runtime_context(
     monkeypatch,
-):
+) -> None:
     app = Flask(__name__)
     app.config["SECRET_KEY"] = "test"
     monkeypatch.setattr(
@@ -64,7 +64,7 @@ def test_authenticated_request_normalizes_accept_language_for_runtime_context(
 
 def test_authenticated_request_reads_json_payload_language_for_runtime_context(
     monkeypatch,
-):
+) -> None:
     app = Flask(__name__)
     app.config["SECRET_KEY"] = "test"
     monkeypatch.setattr(

--- a/src/api/tests/scripts/test_observability_consistency_probes.py
+++ b/src/api/tests/scripts/test_observability_consistency_probes.py
@@ -178,7 +178,7 @@ def _probe(env, *, now: datetime):
     )
 
 
-def test_wallet_snapshot_probe_uses_current_consumable_bucket_total():
+def test_wallet_snapshot_probe_uses_current_consumable_bucket_total() -> None:
     now = datetime(2026, 7, 19, 12, 0, 0)
     env = _build_db()
     _insert_wallet(
@@ -206,7 +206,7 @@ def test_wallet_snapshot_probe_uses_current_consumable_bucket_total():
     assert result["sample"][0]["current_consumable_bucket_available_credits"] == 0
 
 
-def test_wallet_snapshot_probe_allows_manual_grants_without_subscription():
+def test_wallet_snapshot_probe_allows_manual_grants_without_subscription() -> None:
     now = datetime(2026, 7, 19, 12, 0, 0)
     env = _build_db()
     _insert_wallet(
@@ -232,7 +232,7 @@ def test_wallet_snapshot_probe_allows_manual_grants_without_subscription():
     assert result["findings_count"] == 0
 
 
-def test_wallet_snapshot_probe_counts_reserved_future_buckets_separately():
+def test_wallet_snapshot_probe_counts_reserved_future_buckets_separately() -> None:
     now = datetime(2026, 7, 19, 12, 0, 0)
     env = _build_db()
     _insert_wallet(
@@ -260,7 +260,9 @@ def test_wallet_snapshot_probe_counts_reserved_future_buckets_separately():
     assert result["findings_count"] == 0
 
 
-def test_wallet_snapshot_probe_allows_subscription_and_topup_with_active_subscription():
+def test_wallet_snapshot_probe_allows_subscription_and_topup_with_active_subscription() -> (
+    None
+):
     now = datetime(2026, 7, 19, 12, 0, 0)
     env = _build_db()
     _insert_wallet(

--- a/src/api/tests/service/billing/billing_write_routes_test_helpers.py
+++ b/src/api/tests/service/billing/billing_write_routes_test_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import flaskr.common.config as common_config
 import flaskr.service.billing.checkout as billing_checkout_module
@@ -95,6 +96,9 @@ from tests.service.billing.route_loader import (
     load_billing_routes_module,
     load_register_billing_routes,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 __all__ = [
     "ALLOCATION_INTERVAL_PER_CYCLE",
@@ -363,7 +367,7 @@ def add_trial_subscription_state(
         dao.db.session.commit()
 
 
-def billing_write_client(monkeypatch):
+def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
     monkeypatch.setenv("HOST_URL", "https://billing.example.com")
     monkeypatch.setenv("PATH_PREFIX", "/api")
     _reset_config_cache("HOST_URL", "PATH_PREFIX")

--- a/src/api/tests/service/billing/route_loader.py
+++ b/src/api/tests/service/billing/route_loader.py
@@ -7,7 +7,10 @@ import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from types import ModuleType
+
+    from flask import Flask
 
 _ROUTE_PACKAGE = "flaskr.route"
 _ROUTE_COMMON = f"{_ROUTE_PACKAGE}.common"
@@ -38,5 +41,5 @@ def load_billing_routes_module() -> ModuleType:
     return importlib.import_module(_BILLING_ROUTES_MODULE)
 
 
-def load_register_billing_routes():
+def load_register_billing_routes() -> Callable[..., Flask]:
     return load_billing_routes_module().register_billing_routes

--- a/src/api/tests/service/billing/test_admin_billing_routes.py
+++ b/src/api/tests/service/billing/test_admin_billing_routes.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from decimal import Decimal
 from io import BytesIO
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import flaskr.service.billing.campaigns as billing_campaigns_module
 import flaskr.service.billing.customization as billing_customization_module
@@ -82,6 +83,9 @@ from tests.service.billing.route_loader import (
     load_register_billing_routes,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 billing_routes_module = load_billing_routes_module()
 register_billing_routes = load_register_billing_routes()
 
@@ -131,7 +135,7 @@ def _freeze_billing_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
-def admin_billing_client(monkeypatch):
+def admin_billing_client(monkeypatch) -> Iterator[dict[str, object]]:
     _freeze_billing_wall_clock(monkeypatch)
 
     app = Flask(__name__)

--- a/src/api/tests/service/billing/test_admin_ops_state.py
+++ b/src/api/tests/service/billing/test_admin_ops_state.py
@@ -42,7 +42,7 @@ def _patch_config_store(monkeypatch):
     return store
 
 
-def test_admin_billing_ops_state_updates_under_redis_lock(app, monkeypatch):
+def test_admin_billing_ops_state_updates_under_redis_lock(app, monkeypatch) -> None:
     redis = _TrackingRedis()
     store = _patch_config_store(monkeypatch)
     monkeypatch.setattr(dao._redis_state, "client", redis)

--- a/src/api/tests/service/billing/test_billing_admission.py
+++ b/src/api/tests/service/billing/test_billing_admission.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -39,9 +40,12 @@ from flaskr.util.datetime import now_utc
 
 from tests.common.fixtures.bill_products import build_bill_products
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_admission_app(monkeypatch):
+def billing_admission_app(monkeypatch) -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/billing/test_billing_callbacks.py
+++ b/src/api/tests/service/billing/test_billing_callbacks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -37,9 +38,12 @@ from flaskr.service.order.payment_providers.base import PaymentNotificationResul
 
 from tests.common.fixtures.bill_products import build_bill_products
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_callback_app():
+def billing_callback_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -53,9 +54,14 @@ from flaskr.util.datetime import now_utc
 
 from tests.common.fixtures.bill_products import build_bill_products
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from flask.testing import FlaskCliRunner
+
 
 @pytest.fixture
-def billing_cli_runner():
+def billing_cli_runner() -> FlaskCliRunner:
     app = Flask(__name__)
     app.testing = True
 
@@ -68,7 +74,7 @@ def billing_cli_runner():
 
 
 @pytest.fixture
-def billing_cli_db_app():
+def billing_cli_db_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/billing/test_billing_credit_audit.py
+++ b/src/api/tests/service/billing/test_billing_credit_audit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -28,9 +29,12 @@ from flaskr.service.billing.models import (
 )
 from sqlalchemy import event
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_credit_audit_app():
+def billing_credit_audit_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/billing/test_billing_daily_aggregate_rebuild.py
+++ b/src/api/tests/service/billing/test_billing_daily_aggregate_rebuild.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -30,9 +31,12 @@ from flaskr.service.billing.models import (
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYPE_LLM
 from flaskr.service.metering.models import BillUsageRecord
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_daily_rebuild_app(tmp_path):
+def billing_daily_rebuild_app(tmp_path) -> Iterator[Flask]:
     db_path = tmp_path / "billing-daily-rebuild.sqlite"
     db_uri = f"sqlite:///{db_path}"
 

--- a/src/api/tests/service/billing/test_billing_daily_ledger_aggregates.py
+++ b/src/api/tests/service/billing/test_billing_daily_ledger_aggregates.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -20,9 +21,12 @@ from flaskr.service.billing.daily_aggregates import (
 )
 from flaskr.service.billing.models import BillingDailyLedgerSummary, CreditLedgerEntry
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_daily_ledger_app(tmp_path):
+def billing_daily_ledger_app(tmp_path) -> Iterator[Flask]:
     db_path = tmp_path / "billing-daily-ledger.sqlite"
     db_uri = f"sqlite:///{db_path}"
 

--- a/src/api/tests/service/billing/test_billing_daily_usage_aggregates.py
+++ b/src/api/tests/service/billing/test_billing_daily_usage_aggregates.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -28,9 +29,12 @@ from flaskr.service.billing.models import (
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYPE_LLM
 from flaskr.service.metering.models import BillUsageRecord
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_daily_usage_app(tmp_path):
+def billing_daily_usage_app(tmp_path) -> Iterator[Flask]:
     db_path = tmp_path / "billing-daily-usage.sqlite"
     db_uri = f"sqlite:///{db_path}"
 

--- a/src/api/tests/service/billing/test_billing_domains.py
+++ b/src/api/tests/service/billing/test_billing_domains.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import flaskr.service.billing.domains as billing_domains
 import pytest
@@ -31,12 +32,15 @@ from tests.service.billing.route_loader import (
     load_register_billing_routes,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 billing_routes_module = load_billing_routes_module()
 register_billing_routes = load_register_billing_routes()
 
 
 @pytest.fixture
-def billing_domain_client(monkeypatch):
+def billing_domain_client(monkeypatch) -> Iterator[dict[str, object]]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/billing/test_billing_error_specificity.py
+++ b/src/api/tests/service/billing/test_billing_error_specificity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import Never
 
 import flaskr.service.billing.checkout as checkout_module
 import flaskr.service.billing.credit_notifications as credit_notifications_module
@@ -35,7 +36,9 @@ class _LockFactory:
         return _UnavailableLock()
 
 
-def test_subscription_checkout_lock_conflict_returns_busy_error(app, monkeypatch):
+def test_subscription_checkout_lock_conflict_returns_busy_error(
+    app, monkeypatch
+) -> Never:
     monkeypatch.setattr(checkout_module.cache_provider, "cache", _LockFactory())
 
     message = "lock body should not execute"
@@ -49,7 +52,7 @@ def test_subscription_checkout_lock_conflict_returns_busy_error(app, monkeypatch
     assert exc_info.value.code == ERROR_CODE["server.billing.subscriptionCheckoutBusy"]
 
 
-def test_manual_plan_grant_lock_conflict_returns_busy_error(app, monkeypatch):
+def test_manual_plan_grant_lock_conflict_returns_busy_error(app, monkeypatch) -> None:
     monkeypatch.setattr(manual_plan_grants_module.redis, "lock", _LockFactory().lock)
 
     with pytest.raises(AppError) as exc_info:
@@ -64,7 +67,7 @@ def test_manual_plan_grant_lock_conflict_returns_busy_error(app, monkeypatch):
     assert exc_info.value.code == ERROR_CODE["server.billing.manualPlanGrantBusy"]
 
 
-def test_manual_credit_grant_failure_returns_specific_error(app, monkeypatch):
+def test_manual_credit_grant_failure_returns_specific_error(app, monkeypatch) -> None:
     monkeypatch.setattr(
         manual_credit_grants_module,
         "grant_manual_credit_wallet_balance",
@@ -93,7 +96,7 @@ def test_manual_credit_grant_failure_returns_specific_error(app, monkeypatch):
 
 def test_credit_notification_policy_save_failure_returns_specific_error(
     app, monkeypatch
-):
+) -> None:
     monkeypatch.setattr(
         credit_notifications_module, "add_config", lambda *_, **__: False
     )

--- a/src/api/tests/service/billing/test_billing_ownership.py
+++ b/src/api/tests/service/billing/test_billing_ownership.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from flask import Flask
 from flaskr import dao
@@ -17,9 +19,12 @@ from flaskr.service.metering.consts import (
 from flaskr.service.metering.models import BillUsageRecord
 from flaskr.service.shifu.models import DraftShifu, PublishedShifu
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_ownership_app():
+def billing_ownership_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/billing/test_billing_primitives.py
+++ b/src/api/tests/service/billing/test_billing_primitives.py
@@ -7,21 +7,21 @@ from datetime import datetime
 from flaskr.service.billing.primitives import coerce_datetime, normalize_json_object
 
 
-def test_coerce_datetime_normalizes_epoch_to_utc_naive():
+def test_coerce_datetime_normalizes_epoch_to_utc_naive() -> None:
     assert coerce_datetime(0) is None
     assert coerce_datetime("0") is None
     assert coerce_datetime(1772000000) == datetime(2026, 2, 25, 6, 13, 20)
     assert coerce_datetime("1772000000") == datetime(2026, 2, 25, 6, 13, 20)
 
 
-def test_coerce_datetime_normalizes_offset_iso_to_utc_naive():
+def test_coerce_datetime_normalizes_offset_iso_to_utc_naive() -> None:
     assert coerce_datetime("2026-01-01T00:00:00+08:00") == datetime(
         2025, 12, 31, 16, 0, 0
     )
     assert coerce_datetime("2026-01-01T00:00:00Z") == datetime(2026, 1, 1, 0, 0, 0)
 
 
-def test_normalize_json_object_serializes_datetimes_as_utc_z():
+def test_normalize_json_object_serializes_datetimes_as_utc_z() -> None:
     payload = normalize_json_object(
         {"metadata_time": datetime(2026, 1, 1, 0, 0, 0)}
     ).to_metadata_json()

--- a/src/api/tests/service/billing/test_billing_renewal_compensation.py
+++ b/src/api/tests/service/billing/test_billing_renewal_compensation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -27,6 +28,9 @@ from flaskr.service.order.payment_providers.base import PaymentNotificationResul
 
 from tests.common.fixtures.bill_products import build_bill_products
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 _MONTHLY_PLAN_CREDITS = Decimal("5.0000000000")
 
 
@@ -35,7 +39,9 @@ def _utc_epoch(value: datetime) -> int:
 
 
 @pytest.fixture
-def billing_renewal_compensation_env(monkeypatch: pytest.MonkeyPatch):
+def billing_renewal_compensation_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[dict[str, object]]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from decimal import Decimal
 from io import BytesIO
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import flaskr.service.billing.campaigns as billing_campaigns_module
 import flaskr.service.billing.entitlements as billing_entitlements_module
@@ -89,6 +90,11 @@ from tests.service.billing.route_loader import (
     load_register_billing_routes,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from flask.testing import FlaskClient
+
 register_billing_routes = load_register_billing_routes()
 billing_routes_module = load_billing_routes_module()
 
@@ -131,7 +137,7 @@ def _seed_products_with_yearly_entitlements():
 
 
 @pytest.fixture
-def billing_test_client(monkeypatch):
+def billing_test_client(monkeypatch) -> Iterator[FlaskClient]:
     _freeze_billing_wall_clock(monkeypatch)
 
     app = Flask(__name__)

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -6,6 +6,7 @@ import sys
 import types
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -50,13 +51,16 @@ from flaskr.util.datetime import now_utc
 
 from tests.common.fixtures.bill_products import build_bill_products
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 def _utc_epoch(value: datetime) -> int:
     return int(value.replace(tzinfo=UTC).timestamp())
 
 
 @pytest.fixture
-def billing_subscription_sms_app(tmp_path):
+def billing_subscription_sms_app(tmp_path) -> Iterator[Flask]:
     db_path = tmp_path / "billing-subscription-sms.sqlite"
     db_uri = f"sqlite:///{db_path}"
 

--- a/src/api/tests/service/billing/test_billing_tasks.py
+++ b/src/api/tests/service/billing/test_billing_tasks.py
@@ -10,6 +10,7 @@ import types
 from datetime import datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -61,9 +62,12 @@ from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD, BILL_USAGE_TYP
 from flaskr.service.metering.models import BillUsageRecord
 from flaskr.util.datetime import now_utc
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_task_integration_app(tmp_path):
+def billing_task_integration_app(tmp_path) -> Iterator[Flask]:
     db_path = tmp_path / "billing-task.sqlite"
     db_uri = f"sqlite:///{db_path}"
 

--- a/src/api/tests/service/billing/test_billing_trial_credits.py
+++ b/src/api/tests/service/billing/test_billing_trial_credits.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask, jsonify, request
@@ -42,6 +43,9 @@ from tests.service.billing.route_loader import (
     load_register_billing_routes,
 )
 
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
+
 billing_routes_module = load_billing_routes_module()
 register_billing_routes = load_register_billing_routes()
 
@@ -60,7 +64,7 @@ def _seed_creator(*, user_bid: str, is_creator: bool = True) -> None:
 
 
 @pytest.fixture
-def trial_billing_client(monkeypatch):
+def trial_billing_client(monkeypatch) -> FlaskClient:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/billing/test_billing_write_routes_checkout.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_checkout.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from tests.service.billing import (
@@ -34,9 +36,12 @@ from tests.service.billing.billing_write_routes_test_helpers import (
     timedelta,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_write_client(monkeypatch):
+def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
     yield from write_route_helpers.billing_write_client(monkeypatch)
 
 

--- a/src/api/tests/service/billing/test_billing_write_routes_preorder.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_preorder.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from tests.service.billing import (
@@ -42,6 +44,9 @@ from tests.service.billing.billing_write_routes_test_helpers import (
     to_utc_iso,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 def test_mark_preorder_effective_applied_preserves_terminal_preorder_states() -> None:
     absorbed_order = BillingOrder(
@@ -69,7 +74,7 @@ def test_mark_preorder_effective_applied_preserves_terminal_preorder_states() ->
 
 
 @pytest.fixture
-def billing_write_client(monkeypatch):
+def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
     yield from write_route_helpers.billing_write_client(monkeypatch)
 
 

--- a/src/api/tests/service/billing/test_billing_write_routes_refund_auth.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_refund_auth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from tests.service.billing import (
@@ -22,9 +24,12 @@ from tests.service.billing.billing_write_routes_test_helpers import (
     add_active_subscription,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_write_client(monkeypatch):
+def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
     yield from write_route_helpers.billing_write_client(monkeypatch)
 
 

--- a/src/api/tests/service/billing/test_billing_write_routes_subscription_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_subscription_lifecycle.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from tests.service.billing import (
@@ -56,9 +58,12 @@ from tests.service.billing.billing_write_routes_test_helpers import (
     to_utc_iso,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_write_client(monkeypatch):
+def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
     yield from write_route_helpers.billing_write_client(monkeypatch)
 
 

--- a/src/api/tests/service/billing/test_billing_write_routes_topup.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_topup.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from tests.service.billing import (
@@ -36,9 +38,12 @@ from tests.service.billing.billing_write_routes_test_helpers import (
     timedelta,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_write_client(monkeypatch):
+def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
     yield from write_route_helpers.billing_write_client(monkeypatch)
 
 

--- a/src/api/tests/service/billing/test_creator_customization.py
+++ b/src/api/tests/service/billing/test_creator_customization.py
@@ -35,7 +35,7 @@ def _require_saas_config_plugin() -> None:
 
 def test_creator_integration_uses_encrypted_unified_config_and_versions(
     app, monkeypatch
-):
+) -> None:
     _require_saas_config_plugin()
     app.config["CREATOR_INTEGRATION_ENCRYPTION_KEY"] = Fernet.generate_key().decode()
     monkeypatch.setattr(customization, "is_creator_customization_enabled", lambda: True)
@@ -135,7 +135,7 @@ def test_creator_integration_uses_encrypted_unified_config_and_versions(
         assert edited_context.secret_config["secret_key"] == "sk_test_owner_2"
 
 
-def test_admin_creator_customization_draft_uses_short_saas_storage_keys(app):
+def test_admin_creator_customization_draft_uses_short_saas_storage_keys(app) -> None:
     _require_saas_config_plugin()
     app.config["CREATOR_INTEGRATION_ENCRYPTION_KEY"] = Fernet.generate_key().decode()
 
@@ -198,7 +198,9 @@ def test_admin_creator_customization_draft_uses_short_saas_storage_keys(app):
         )
 
 
-def test_admin_creator_customization_draft_mobile_identity_fits_saas_storage(app):
+def test_admin_creator_customization_draft_mobile_identity_fits_saas_storage(
+    app,
+) -> None:
     _require_saas_config_plugin()
     app.config["CREATOR_INTEGRATION_ENCRYPTION_KEY"] = Fernet.generate_key().decode()
 
@@ -224,7 +226,7 @@ def test_admin_creator_customization_draft_mobile_identity_fits_saas_storage(app
         assert all(len(row.user_bid) <= 36 for row in rows)
 
 
-def test_admin_draft_storage_identity_folds_email_case_only(monkeypatch):
+def test_admin_draft_storage_identity_folds_email_case_only(monkeypatch) -> None:
     """Email drafts key on the lowercased address; phone keys stay byte-identical."""
     monkeypatch.setattr(
         contact_identifiers,
@@ -261,7 +263,7 @@ def test_admin_draft_storage_identity_folds_email_case_only(monkeypatch):
 
 def test_admin_creator_customization_draft_email_identity_is_case_insensitive(
     app, monkeypatch
-):
+) -> None:
     """An overseas draft must reload no matter how the operator typed the email."""
     _require_saas_config_plugin()
     app.config["CREATOR_INTEGRATION_ENCRYPTION_KEY"] = Fernet.generate_key().decode()
@@ -294,7 +296,7 @@ def test_admin_creator_customization_draft_email_identity_is_case_insensitive(
         assert all(len(row.user_bid) <= 36 for row in rows)
 
 
-def test_expired_custom_payment_never_falls_back_to_platform(app, monkeypatch):
+def test_expired_custom_payment_never_falls_back_to_platform(app, monkeypatch) -> None:
     _require_saas_config_plugin()
     app.config["CREATOR_INTEGRATION_ENCRYPTION_KEY"] = Fernet.generate_key().decode()
     monkeypatch.setattr(customization, "is_creator_customization_enabled", lambda: True)
@@ -339,7 +341,7 @@ def test_expired_custom_payment_never_falls_back_to_platform(app, monkeypatch):
             raise AssertionError(message)
 
 
-def test_callback_token_requires_valid_integration_secret_key(app):
+def test_callback_token_requires_valid_integration_secret_key(app) -> None:
     app.config["CREATOR_INTEGRATION_ENCRYPTION_KEY"] = ""
     with pytest.raises(RuntimeError, match="CREATOR_INTEGRATION_ENCRYPTION_KEY"):
         customization._build_callback_token(app, "integration-1")
@@ -353,7 +355,7 @@ def test_callback_token_requires_valid_integration_secret_key(app):
     assert token.startswith("integration-1.")
 
 
-def test_stripe_credential_probe_rejects_fake_keys(app):
+def test_stripe_credential_probe_rejects_fake_keys(app) -> None:
     app.config["TESTING"] = True
 
     with pytest.raises(ValueError, match="Stripe publishable key"):
@@ -381,7 +383,7 @@ def test_stripe_credential_probe_rejects_fake_keys(app):
         )
 
 
-def test_creator_integration_requires_encryption_key(app, monkeypatch):
+def test_creator_integration_requires_encryption_key(app, monkeypatch) -> None:
     _require_saas_config_plugin()
     app.config["CREATOR_INTEGRATION_ENCRYPTION_KEY"] = ""
     monkeypatch.setattr(customization, "is_creator_customization_enabled", lambda: True)
@@ -408,7 +410,7 @@ def test_creator_integration_requires_encryption_key(app, monkeypatch):
             )
 
 
-def test_creator_integration_probe_failure_does_not_activate(app, monkeypatch):
+def test_creator_integration_probe_failure_does_not_activate(app, monkeypatch) -> None:
     _require_saas_config_plugin()
     app.config["CREATOR_INTEGRATION_ENCRYPTION_KEY"] = Fernet.generate_key().decode()
     monkeypatch.setattr(customization, "is_creator_customization_enabled", lambda: True)
@@ -449,7 +451,9 @@ def test_creator_integration_probe_failure_does_not_activate(app, monkeypatch):
         )
 
 
-def test_failed_integration_draft_keeps_existing_active_config(app, monkeypatch):
+def test_failed_integration_draft_keeps_existing_active_config(
+    app, monkeypatch
+) -> None:
     _require_saas_config_plugin()
     app.config["TESTING"] = True
     app.config["CREATOR_INTEGRATION_ENCRYPTION_KEY"] = Fernet.generate_key().decode()
@@ -579,7 +583,7 @@ def test_failed_integration_draft_keeps_existing_active_config(app, monkeypatch)
         assert context.secret_config["secret_key"] == "sk_test_current"
 
 
-def test_creator_branding_reuses_unified_config(app, monkeypatch):
+def test_creator_branding_reuses_unified_config(app, monkeypatch) -> None:
     _require_saas_config_plugin()
     monkeypatch.setattr(customization, "is_creator_customization_enabled", lambda: True)
     with app.app_context():
@@ -605,7 +609,9 @@ def test_creator_branding_reuses_unified_config(app, monkeypatch):
         }
 
 
-def test_creator_brand_logo_upload_uses_courses_oss_and_can_be_saved(app, monkeypatch):
+def test_creator_brand_logo_upload_uses_courses_oss_and_can_be_saved(
+    app, monkeypatch
+) -> None:
     _require_saas_config_plugin()
     monkeypatch.setattr(customization, "is_creator_customization_enabled", lambda: True)
 
@@ -662,7 +668,7 @@ def test_creator_brand_logo_upload_uses_courses_oss_and_can_be_saved(app, monkey
 
 def test_unavailable_saas_plugin_keeps_optional_customization_reads_empty(
     app, monkeypatch
-):
+) -> None:
     def missing_plugin(name):
         if name.startswith("flaskr.plugins.ai_shifu_saas_plugin"):
             raise ModuleNotFoundError(name=name)
@@ -686,7 +692,7 @@ def test_unavailable_saas_plugin_keeps_optional_customization_reads_empty(
         )
 
 
-def test_installed_but_disabled_saas_plugin_falls_back(app, monkeypatch):
+def test_installed_but_disabled_saas_plugin_falls_back(app, monkeypatch) -> None:
     """A deployment can ship the plugin package without configuring its database; SAAS_PLUGIN_ENABLED then stays false and the plugin bind points at an unreachable host, so customization reads must not touch it."""
 
     class _ExplodingModule:
@@ -721,7 +727,7 @@ def test_installed_but_disabled_saas_plugin_falls_back(app, monkeypatch):
         )
 
 
-def test_creator_brand_favicon_upload_converts_png_to_ico(app, monkeypatch):
+def test_creator_brand_favicon_upload_converts_png_to_ico(app, monkeypatch) -> None:
     monkeypatch.setattr(customization, "is_creator_customization_enabled", lambda: True)
 
     uploaded = {}
@@ -795,7 +801,7 @@ def test_creator_brand_favicon_upload_converts_png_to_ico(app, monkeypatch):
             )
 
 
-def test_runtime_branding_falls_back_to_square_logo_for_favicon(app):
+def test_runtime_branding_falls_back_to_square_logo_for_favicon(app) -> None:
     from flaskr.service.billing import runtime_config as runtime_config_module
 
     with app.app_context():
@@ -819,7 +825,7 @@ def test_runtime_branding_falls_back_to_square_logo_for_favicon(app):
         assert branding.favicon_url == "/storage/brand/favicon.ico"
 
 
-def test_creator_branding_home_url_roundtrip(app, monkeypatch):
+def test_creator_branding_home_url_roundtrip(app, monkeypatch) -> None:
     monkeypatch.setattr(customization, "is_creator_customization_enabled", lambda: True)
 
     def missing_plugin(name):
@@ -885,7 +891,9 @@ def test_creator_branding_home_url_roundtrip(app, monkeypatch):
             )
 
 
-def test_creator_brand_logo_upload_rejects_invalid_or_oversized_image(app, monkeypatch):
+def test_creator_brand_logo_upload_rejects_invalid_or_oversized_image(
+    app, monkeypatch
+) -> None:
     monkeypatch.setattr(customization, "is_creator_customization_enabled", lambda: True)
     with app.app_context():
         grant_creator_manual_entitlement(
@@ -916,7 +924,7 @@ def test_creator_brand_logo_upload_rejects_invalid_or_oversized_image(app, monke
                 raise AssertionError(message)
 
 
-def test_creator_brand_logo_upload_normalizes_square_variant(app, monkeypatch):
+def test_creator_brand_logo_upload_normalizes_square_variant(app, monkeypatch) -> None:
     uploaded = {}
 
     def fake_upload_to_storage(_app, **kwargs: object):
@@ -953,7 +961,9 @@ def test_creator_brand_logo_upload_normalizes_square_variant(app, monkeypatch):
         assert normalized.size == (96, 96)
 
 
-def test_creator_brand_logo_upload_preserves_wide_retina_variant(app, monkeypatch):
+def test_creator_brand_logo_upload_preserves_wide_retina_variant(
+    app, monkeypatch
+) -> None:
     uploaded = {}
 
     def fake_upload_to_storage(_app, **kwargs: object):
@@ -990,7 +1000,7 @@ def test_creator_brand_logo_upload_preserves_wide_retina_variant(app, monkeypatc
         assert normalized.size == (440, 64)
 
 
-def test_custom_wechat_identifiers_are_scoped_by_app_id(app, monkeypatch):
+def test_custom_wechat_identifiers_are_scoped_by_app_id(app, monkeypatch) -> None:
     set_shifu_context("shifu-1", "creator-wechat-1")
     monkeypatch.setattr(
         user_service,
@@ -1008,7 +1018,7 @@ def test_custom_wechat_identifiers_are_scoped_by_app_id(app, monkeypatch):
 
 def test_custom_wechat_identifiers_fail_when_integration_resolution_fails(
     app, monkeypatch
-):
+) -> None:
     set_shifu_context("shifu-1", "creator-wechat-broken")
     monkeypatch.setattr(
         user_service,
@@ -1022,7 +1032,7 @@ def test_custom_wechat_identifiers_fail_when_integration_resolution_fails(
         clear_shifu_context()
 
 
-def test_custom_wechat_identifiers_require_custom_app_id(app, monkeypatch):
+def test_custom_wechat_identifiers_require_custom_app_id(app, monkeypatch) -> None:
     set_shifu_context("shifu-1", "creator-wechat-missing-app")
     monkeypatch.setattr(
         user_service,

--- a/src/api/tests/service/billing/test_credit_grant_allocation_views.py
+++ b/src/api/tests/service/billing/test_credit_grant_allocation_views.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 from datetime import datetime
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -37,9 +38,12 @@ from flaskr.service.billing.models import (
 )
 from sqlalchemy import text
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_view_app():
+def billing_view_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -9,6 +9,7 @@ import time as time_module
 from datetime import datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -68,9 +69,12 @@ from flaskr.service.user.repository import (
     upsert_credential,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def credit_notifications_app(tmp_path):
+def credit_notifications_app(tmp_path) -> Iterator[Flask]:
     db_path = tmp_path / "credit-notifications.sqlite"
     db_uri = f"sqlite:///{db_path}"
 

--- a/src/api/tests/service/billing/test_grant_manual_entitlement.py
+++ b/src/api/tests/service/billing/test_grant_manual_entitlement.py
@@ -13,7 +13,7 @@ def _cleanup(app, creator_bid: str) -> None:
         dao.db.session.commit()
 
 
-def test_grant_manual_entitlement_is_immediately_active(app):
+def test_grant_manual_entitlement_is_immediately_active(app) -> None:
     """A freshly granted manual entitlement must resolve as active right away.
 
     Regression guard for the same-second race: effective_from is back-dated so

--- a/src/api/tests/service/billing/test_operation_credit_reservations.py
+++ b/src/api/tests/service/billing/test_operation_credit_reservations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -34,9 +35,12 @@ from flaskr.service.metering.consts import (
     BILL_USAGE_TYPE_TTS,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def operation_credit_app():
+def operation_credit_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/billing/test_operator_credit_orders.py
+++ b/src/api/tests/service/billing/test_operator_credit_orders.py
@@ -229,7 +229,7 @@ def _build_app() -> Flask:
     return app
 
 
-def test_build_operator_credit_orders_page_returns_operator_view():
+def test_build_operator_credit_orders_page_returns_operator_view() -> None:
     app = _build_app()
 
     result = build_operator_credit_orders_page(
@@ -254,7 +254,7 @@ def test_build_operator_credit_orders_page_returns_operator_view():
     assert result.items[0].valid_to is not None
 
 
-def test_build_operator_credit_orders_page_supports_product_keyword_search():
+def test_build_operator_credit_orders_page_supports_product_keyword_search() -> None:
     app = _build_app()
 
     result = build_operator_credit_orders_page(
@@ -268,7 +268,9 @@ def test_build_operator_credit_orders_page_supports_product_keyword_search():
     assert result.items[0].bill_order_bid == "bill-order-topup-1"
 
 
-def test_build_operator_credit_orders_page_filters_orders_with_available_credits():
+def test_build_operator_credit_orders_page_filters_orders_with_available_credits() -> (
+    None
+):
     app = _build_app()
 
     result = build_operator_credit_orders_page(
@@ -282,7 +284,7 @@ def test_build_operator_credit_orders_page_filters_orders_with_available_credits
     assert result.items[0].bill_order_bid == "bill-order-topup-1"
 
 
-def test_build_operator_credit_orders_page_supports_status_label_filter():
+def test_build_operator_credit_orders_page_supports_status_label_filter() -> None:
     app = _build_app()
 
     result = build_operator_credit_orders_page(
@@ -296,7 +298,7 @@ def test_build_operator_credit_orders_page_supports_status_label_filter():
     assert result.items[0].bill_order_bid == "bill-order-topup-1"
 
 
-def test_build_operator_credit_orders_page_keeps_orders_for_deleted_products():
+def test_build_operator_credit_orders_page_keeps_orders_for_deleted_products() -> None:
     app = _build_app()
 
     with app.app_context():
@@ -334,7 +336,9 @@ def test_build_operator_credit_orders_page_keeps_orders_for_deleted_products():
     assert searched_result.items[0].product_code == "creator-topup-small"
 
 
-def test_build_operator_credit_orders_page_sorts_all_status_by_latest_created_at():
+def test_build_operator_credit_orders_page_sorts_all_status_by_latest_created_at() -> (
+    None
+):
     app = _build_app()
 
     with app.app_context():
@@ -390,7 +394,7 @@ def test_build_operator_credit_orders_page_sorts_all_status_by_latest_created_at
     ]
 
 
-def test_build_operator_credit_orders_overview_returns_aggregates():
+def test_build_operator_credit_orders_overview_returns_aggregates() -> None:
     app = _build_app()
 
     result = build_operator_credit_orders_overview(app)
@@ -408,7 +412,9 @@ def test_build_operator_credit_orders_overview_returns_aggregates():
     assert result.paid_amount_totals_by_currency == {"CNY": 19900}
 
 
-def test_build_operator_credit_orders_overview_uses_available_credits_and_currency_map():
+def test_build_operator_credit_orders_overview_uses_available_credits_and_currency_map() -> (
+    None
+):
     app = _build_app()
 
     with app.app_context():
@@ -474,7 +480,7 @@ def test_build_operator_credit_orders_overview_uses_available_credits_and_curren
     }
 
 
-def test_get_operator_credit_order_detail_returns_grant_and_metadata():
+def test_get_operator_credit_order_detail_returns_grant_and_metadata() -> None:
     app = _build_app()
 
     detail = get_operator_credit_order_detail(

--- a/src/api/tests/service/billing/test_rate_references.py
+++ b/src/api/tests/service/billing/test_rate_references.py
@@ -36,7 +36,7 @@ def _rate(
     )
 
 
-def test_llm_credit_1x_unit_cost_uses_fixed_config(monkeypatch, app):
+def test_llm_credit_1x_unit_cost_uses_fixed_config(monkeypatch, app) -> None:
     values = {
         "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS": "0.066667",
         "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
@@ -67,7 +67,7 @@ def test_llm_credit_1x_unit_cost_uses_fixed_config(monkeypatch, app):
         assert rate_references.load_llm_credit_1x_unit_cost() == Decimal("0.000066667")
 
 
-def test_llm_credit_1x_unit_cost_rejects_missing_or_invalid_config(monkeypatch):
+def test_llm_credit_1x_unit_cost_rejects_missing_or_invalid_config(monkeypatch) -> None:
     for raw_value in [None, "", "bad", "0", "-1"]:
         monkeypatch.setattr(
             credit_rate_references,

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -23,9 +24,14 @@ from flaskr.service.billing.runtime_config import (
     build_runtime_billing_context,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from flask.testing import FlaskClient
+
 
 @pytest.fixture
-def runtime_config_client(monkeypatch):
+def runtime_config_client(monkeypatch) -> Iterator[FlaskClient]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -53,9 +54,12 @@ from flaskr.service.metering.consts import (
 from flaskr.service.metering.models import BillUsageRecord
 from flaskr.service.shifu.models import DraftShifu
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def billing_settlement_app():
+def billing_settlement_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(
@@ -1617,7 +1621,9 @@ def test_build_usage_metric_charges_uses_superseded_rate_for_old_settlement_time
         assert charge["consumed_credits"] == Decimal("2.00")
 
 
-def test_resolve_credit_multiplier_label_uses_utc_default_settlement(monkeypatch):
+def test_resolve_credit_multiplier_label_uses_utc_default_settlement(
+    monkeypatch,
+) -> None:
     from flaskr.service.billing import charges
 
     utc_sentinel = datetime(2026, 1, 1, 0, 0, 0)

--- a/src/api/tests/service/common/test_contact_identifiers.py
+++ b/src/api/tests/service/common/test_contact_identifiers.py
@@ -12,7 +12,7 @@ from flaskr.service.common.models import AppError
 
 
 @pytest.fixture
-def login_methods(monkeypatch):
+def login_methods(monkeypatch) -> set[str]:
     def _set(value: str) -> None:
         monkeypatch.setattr(
             contact_identifiers,

--- a/src/api/tests/service/common/test_dto_base.py
+++ b/src/api/tests/service/common/test_dto_base.py
@@ -45,7 +45,7 @@ class RenamedDTO(AutoJsonMixin, BaseModel):
     data: list[str] = Field(default_factory=list)
 
 
-def test_json_emits_fields_in_declaration_order_with_identity_keys():
+def test_json_emits_fields_in_declaration_order_with_identity_keys() -> None:
     dto = SampleDTO(text="hello", number=7, flag=True)
     payload = dto.__json__()
     assert list(payload.keys()) == [
@@ -63,7 +63,7 @@ def test_json_emits_fields_in_declaration_order_with_identity_keys():
     assert payload["flag"] is True
 
 
-def test_int_and_bool_fields_are_coerced_like_hand_written_json():
+def test_int_and_bool_fields_are_coerced_like_hand_written_json() -> None:
     dto = SampleDTO(text="x", number=7, flag=True)
     # simulate un-validated assignment, which pydantic allows by default
     object.__setattr__(dto, "number", "9")
@@ -73,7 +73,7 @@ def test_int_and_bool_fields_are_coerced_like_hand_written_json():
     assert payload["flag"] is False
 
 
-def test_none_decimal_and_datetime_leaves_pass_through_raw():
+def test_none_decimal_and_datetime_leaves_pass_through_raw() -> None:
     naive = datetime(2026, 7, 3, 12, 0, 0)
     dto = SampleDTO(
         text="x",
@@ -89,7 +89,7 @@ def test_none_decimal_and_datetime_leaves_pass_through_raw():
     assert payload["child"] is None
 
 
-def test_fmt_sink_serializes_generated_payload():
+def test_fmt_sink_serializes_generated_payload() -> None:
     aware = datetime(2026, 7, 3, 20, 0, 0, tzinfo=timezone(timedelta(hours=8)))
     dto = SampleDTO(
         text="x",
@@ -105,7 +105,7 @@ def test_fmt_sink_serializes_generated_payload():
     assert data["happened_at"].endswith("Z")
 
 
-def test_nested_dto_and_lists_are_serialized_recursively():
+def test_nested_dto_and_lists_are_serialized_recursively() -> None:
     child = ChildDTO(name="a", count=1)
     dto = SampleDTO(
         text="x",
@@ -125,7 +125,7 @@ def test_nested_dto_and_lists_are_serialized_recursively():
     assert payload["tags"] == ["t1", "t2"]
 
 
-def test_key_overrides_and_exclusions():
+def test_key_overrides_and_exclusions() -> None:
     dto = RenamedDTO(page=2, internal_state=5, data=["a", "b"])
     payload = dto.__json__()
     assert payload == {"page": 2, "items": ["a", "b"]}

--- a/src/api/tests/service/common/test_pagination.py
+++ b/src/api/tests/service/common/test_pagination.py
@@ -9,7 +9,7 @@ from flaskr.service.common.pagination import (
 )
 
 
-def test_constants_keep_admin_defaults():
+def test_constants_keep_admin_defaults() -> None:
     assert DEFAULT_PAGE_INDEX == 1
     assert DEFAULT_PAGE_SIZE == 20
     assert MAX_PAGE_SIZE == 100
@@ -42,5 +42,5 @@ def test_constants_keep_admin_defaults():
         (2.9, 30.7, (2, 30)),
     ],
 )
-def test_normalize_pagination(page_index, page_size, expected):
+def test_normalize_pagination(page_index, page_size, expected) -> None:
     assert normalize_pagination(page_index, page_size) == expected

--- a/src/api/tests/service/common/test_storage.py
+++ b/src/api/tests/service/common/test_storage.py
@@ -28,7 +28,7 @@ def _make_storage_app(monkeypatch, tmp_path, provider: str) -> Flask:
     return app
 
 
-def test_upload_to_storage_auto_falls_back_to_local(monkeypatch, tmp_path):
+def test_upload_to_storage_auto_falls_back_to_local(monkeypatch, tmp_path) -> None:
     app = _make_storage_app(monkeypatch, tmp_path, "auto")
 
     result = upload_to_storage(
@@ -44,7 +44,7 @@ def test_upload_to_storage_auto_falls_back_to_local(monkeypatch, tmp_path):
     assert (tmp_path / "default" / "example").read_bytes() == b"hello"
 
 
-def test_storage_route_serves_nested_object_key(monkeypatch, tmp_path):
+def test_storage_route_serves_nested_object_key(monkeypatch, tmp_path) -> None:
     app = _make_storage_app(monkeypatch, tmp_path, "local")
     client = app.test_client()
 
@@ -63,7 +63,7 @@ def test_storage_route_serves_nested_object_key(monkeypatch, tmp_path):
     assert response.headers["Content-Type"].startswith("audio/mpeg")
 
 
-def test_storage_route_guesses_mimetype_by_magic(monkeypatch, tmp_path):
+def test_storage_route_guesses_mimetype_by_magic(monkeypatch, tmp_path) -> None:
     app = _make_storage_app(monkeypatch, tmp_path, "local")
     client = app.test_client()
 
@@ -82,7 +82,7 @@ def test_storage_route_guesses_mimetype_by_magic(monkeypatch, tmp_path):
     assert response.headers["Content-Type"].startswith("image/jpeg")
 
 
-def test_upload_audio_to_oss_uses_storage_layer(monkeypatch, tmp_path):
+def test_upload_audio_to_oss_uses_storage_layer(monkeypatch, tmp_path) -> None:
     app = _make_storage_app(monkeypatch, tmp_path, "auto")
 
     audio_bytes = b"ID3" + b"\x00" * 8
@@ -98,7 +98,7 @@ def test_upload_audio_to_oss_uses_storage_layer(monkeypatch, tmp_path):
 def test_read_storage_bytes_fetches_from_oss_when_local_file_is_missing(
     monkeypatch,
     tmp_path,
-):
+) -> None:
     from flaskr.service.common import storage
     from flaskr.service.common.oss_utils import OSSConfig
 

--- a/src/api/tests/service/common/test_umami_client.py
+++ b/src/api/tests/service/common/test_umami_client.py
@@ -17,7 +17,7 @@ def _mock_config(monkeypatch, values: dict[str, object]) -> None:
     )
 
 
-def test_get_course_visit_count_30d_counts_all_metric_pages(app, monkeypatch):
+def test_get_course_visit_count_30d_counts_all_metric_pages(app, monkeypatch) -> None:
     _mock_config(
         monkeypatch,
         {
@@ -63,7 +63,7 @@ def test_get_course_visit_count_30d_counts_all_metric_pages(app, monkeypatch):
     assert calls[0]["headers"]["x-umami-api-key"] == "api-key"
 
 
-def test_get_course_visit_count_30d_uses_cached_value(app, monkeypatch):
+def test_get_course_visit_count_30d_uses_cached_value(app, monkeypatch) -> None:
     _mock_config(
         monkeypatch,
         {
@@ -99,7 +99,7 @@ def test_get_course_visit_count_30d_uses_cached_value(app, monkeypatch):
 
 def test_get_course_visit_count_30d_returns_zero_without_required_config(
     app, monkeypatch
-):
+) -> None:
     _mock_config(
         monkeypatch,
         {
@@ -116,11 +116,11 @@ def test_get_course_visit_count_30d_returns_zero_without_required_config(
         assert umami_client.get_course_visit_count_30d(app, "course-1") == 0
 
 
-def test_build_course_visit_event_name_normalizes_non_ascii_to_match_frontend():
+def test_build_course_visit_event_name_normalizes_non_ascii_to_match_frontend() -> None:
     assert umami_client.build_course_visit_event_name("课程-1") == "course_visit___-1"
 
 
-def test_get_course_visit_count_30d_caches_failures_briefly(app, monkeypatch):
+def test_get_course_visit_count_30d_caches_failures_briefly(app, monkeypatch) -> None:
     _mock_config(
         monkeypatch,
         {
@@ -151,7 +151,7 @@ def test_get_course_visit_count_30d_caches_failures_briefly(app, monkeypatch):
     assert request_count["value"] == 1
 
 
-def test_get_course_visit_count_30d_uses_event_name_cache_key(app, monkeypatch):
+def test_get_course_visit_count_30d_uses_event_name_cache_key(app, monkeypatch) -> None:
     _mock_config(
         monkeypatch,
         {
@@ -175,7 +175,7 @@ def test_get_course_visit_count_30d_uses_event_name_cache_key(app, monkeypatch):
 
 def test_get_course_visit_count_30d_returns_fetched_value_when_cache_write_fails(
     app, monkeypatch
-):
+) -> None:
     _mock_config(
         monkeypatch,
         {
@@ -221,7 +221,7 @@ def test_get_course_visit_count_30d_returns_fetched_value_when_cache_write_fails
 
 def test_get_course_visit_count_30d_returns_zero_when_failure_cache_write_fails(
     app, monkeypatch
-):
+) -> None:
     _mock_config(
         monkeypatch,
         {
@@ -269,7 +269,7 @@ def test_get_course_visit_count_30d_returns_zero_when_failure_cache_write_fails(
 
 def test_get_course_visit_count_30d_waits_for_cache_on_lock_contention(
     app, monkeypatch
-):
+) -> None:
     _mock_config(
         monkeypatch,
         {
@@ -321,7 +321,7 @@ def test_get_course_visit_count_30d_waits_for_cache_on_lock_contention(
     assert sleep_calls == [umami_client.UMAMI_CACHE_LOCK_WAIT_SECONDS]
 
 
-def test_login_for_access_token_rechecks_cache_when_lock_is_busy(monkeypatch):
+def test_login_for_access_token_rechecks_cache_when_lock_is_busy(monkeypatch) -> None:
     _mock_config(
         monkeypatch,
         {
@@ -361,7 +361,9 @@ def test_login_for_access_token_rechecks_cache_when_lock_is_busy(monkeypatch):
     )
 
 
-def test_login_for_access_token_returns_token_when_cache_write_fails(monkeypatch):
+def test_login_for_access_token_returns_token_when_cache_write_fails(
+    monkeypatch,
+) -> None:
     _mock_config(
         monkeypatch,
         {

--- a/src/api/tests/service/common/test_uow.py
+++ b/src/api/tests/service/common/test_uow.py
@@ -1,6 +1,7 @@
 """Tests for the unit-of-work transaction boundary (flaskr/dao/uow.py)."""
 
 import threading
+from typing import Never
 
 import pytest
 from flaskr import dao
@@ -21,7 +22,7 @@ def _count(bid: str) -> int:
     return PublishedShifu.query.filter_by(shifu_bid=bid).count()
 
 
-def test_outermost_commits_on_clean_exit(app):
+def test_outermost_commits_on_clean_exit(app) -> None:
     with app.app_context():
         with uow.unit_of_work():
             dao.db.session.add(_make_shifu("uow-commit-1"))
@@ -29,7 +30,7 @@ def test_outermost_commits_on_clean_exit(app):
         assert _count("uow-commit-1") == 1
 
 
-def test_outermost_rolls_back_on_exception(app):
+def test_outermost_rolls_back_on_exception(app) -> None:
     with app.app_context():
 
         def write_then_fail():
@@ -44,7 +45,7 @@ def test_outermost_rolls_back_on_exception(app):
         assert _count("uow-rollback-1") == 0
 
 
-def test_nested_block_joins_outer_transaction(app):
+def test_nested_block_joins_outer_transaction(app) -> None:
     with app.app_context():
 
         def helper():
@@ -66,7 +67,7 @@ def test_nested_block_joins_outer_transaction(app):
         assert _count("uow-nested-outer-1") == 0
 
 
-def test_nested_clean_exit_commits_once_at_outermost(app):
+def test_nested_clean_exit_commits_once_at_outermost(app) -> None:
     with app.app_context():
         with uow.unit_of_work():
             with uow.unit_of_work():
@@ -77,7 +78,7 @@ def test_nested_clean_exit_commits_once_at_outermost(app):
         assert _count("uow-nested-clean-1") == 1
 
 
-def test_in_unit_of_work_flag(app):
+def test_in_unit_of_work_flag(app) -> None:
     with app.app_context():
         assert not uow.in_unit_of_work()
         with uow.unit_of_work():
@@ -85,7 +86,7 @@ def test_in_unit_of_work_flag(app):
         assert not uow.in_unit_of_work()
 
 
-def test_depth_is_isolated_per_thread(app):
+def test_depth_is_isolated_per_thread(app) -> None:
     """The /run producer runs in its own thread; depth must not leak across."""
     seen = {}
 
@@ -99,7 +100,7 @@ def test_depth_is_isolated_per_thread(app):
     assert seen["inside_thread"] is False
 
 
-def test_depth_resets_after_exception(app):
+def test_depth_resets_after_exception(app) -> Never:
     with app.app_context():
         message = "boom"
         with pytest.raises(RuntimeError), uow.unit_of_work():
@@ -107,14 +108,14 @@ def test_depth_resets_after_exception(app):
         assert not uow.in_unit_of_work()
 
 
-def test_on_commit_outside_uow_runs_immediately(app):
+def test_on_commit_outside_uow_runs_immediately(app) -> None:
     calls = []
     with app.app_context():
         uow.on_commit(lambda: calls.append("now"))
     assert calls == ["now"]
 
 
-def test_on_commit_nested_defers_to_outermost_commit(app):
+def test_on_commit_nested_defers_to_outermost_commit(app) -> None:
     calls = []
     with app.app_context():
         with uow.unit_of_work():
@@ -125,7 +126,7 @@ def test_on_commit_nested_defers_to_outermost_commit(app):
         assert calls == ["notified"]
 
 
-def test_on_commit_dropped_on_rollback(app):
+def test_on_commit_dropped_on_rollback(app) -> None:
     calls = []
     with app.app_context():
 
@@ -140,7 +141,7 @@ def test_on_commit_dropped_on_rollback(app):
         assert calls == []
 
 
-def test_on_commit_callback_exception_does_not_propagate(app):
+def test_on_commit_callback_exception_does_not_propagate(app) -> None:
     calls = []
 
     def boom():

--- a/src/api/tests/service/config/test_funcs.py
+++ b/src/api/tests/service/config/test_funcs.py
@@ -34,7 +34,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 
 @pytest.fixture
-def app():
+def app() -> Flask:
     """Provide a minimal Flask app without importing the full backend stack."""
     from flaskr.dao import db
 
@@ -56,7 +56,7 @@ def app():
 
 
 @pytest.fixture(autouse=True)
-def disable_explicit_env_override(monkeypatch):
+def disable_explicit_env_override(monkeypatch) -> None:
     """Default test posture: config helpers should read/write DB-backed values."""
     monkeypatch.setattr(
         "flaskr.service.config.funcs.has_explicit_env_override",
@@ -64,7 +64,7 @@ def disable_explicit_env_override(monkeypatch):
     )
 
 
-def test_service_config_package_exports_override_helpers(app):
+def test_service_config_package_exports_override_helpers(app) -> None:
     """The package-level config API should expose override helpers for plugins."""
     from flaskr.service.config import (
         config_overrides as package_config_overrides,
@@ -88,7 +88,7 @@ def test_service_config_package_exports_override_helpers(app):
 
 def test_runtime_config_smoke_keeps_plugin_config_exports_compatible(
     app, monkeypatch, tmp_path, request
-):
+) -> None:
     """Smoke-test plugin import compatibility through the runtime-config route."""
     plugin_root = (
         tmp_path
@@ -255,7 +255,7 @@ def build_runtime_branding():
 class TestFernetKeyGeneration:
     """Test Fernet key generation functions."""
 
-    def test_get_fernet_key_with_valid_secret_key(self, app):
+    def test_get_fernet_key_with_valid_secret_key(self, app) -> None:
         """Test generating Fernet key from valid SECRET_KEY."""
         with app.app_context():
             app.config["SECRET_KEY"] = "test-secret-key-12345"
@@ -264,7 +264,7 @@ class TestFernetKeyGeneration:
             assert isinstance(key, bytes)
             assert len(key) == 44  # Base64 encoded 32-byte key
 
-    def test_get_fernet_key_with_missing_secret_key(self, app):
+    def test_get_fernet_key_with_missing_secret_key(self, app) -> None:
         """Test that missing SECRET_KEY raises ValueError."""
         with app.app_context():
             # Save original SECRET_KEY if exists
@@ -279,14 +279,14 @@ class TestFernetKeyGeneration:
                 if original_secret_key:
                     app.config["SECRET_KEY"] = original_secret_key
 
-    def test_get_fernet_key_with_empty_secret_key(self, app):
+    def test_get_fernet_key_with_empty_secret_key(self, app) -> None:
         """Test that empty SECRET_KEY raises ValueError."""
         with app.app_context():
             app.config["SECRET_KEY"] = ""
             with pytest.raises(ValueError, match="SECRET_KEY is not configured"):
                 _get_fernet_key(app)
 
-    def test_get_fernet_returns_fernet_instance(self, app):
+    def test_get_fernet_returns_fernet_instance(self, app) -> None:
         """Test that _get_fernet returns a Fernet instance."""
         with app.app_context():
             app.config["SECRET_KEY"] = "test-secret-key-12345"
@@ -300,7 +300,7 @@ class TestFernetKeyGeneration:
 class TestEncryptionDecryption:
     """Test encryption and decryption functions."""
 
-    def test_encrypt_config_encrypts_value(self, app):
+    def test_encrypt_config_encrypts_value(self, app) -> None:
         """Test that _encrypt_config encrypts plain text value."""
         with app.app_context():
             app.config["SECRET_KEY"] = "test-secret-key-12345"
@@ -311,7 +311,7 @@ class TestEncryptionDecryption:
             assert encrypted != plain_value
             assert len(encrypted) > 0
 
-    def test_decrypt_config_decrypts_value(self, app):
+    def test_decrypt_config_decrypts_value(self, app) -> None:
         """Test that _decrypt_config decrypts encrypted value."""
         with app.app_context():
             app.config["SECRET_KEY"] = "test-secret-key-12345"
@@ -320,7 +320,7 @@ class TestEncryptionDecryption:
             decrypted = _decrypt_config(app, encrypted)
             assert decrypted == plain_value
 
-    def test_encrypt_decrypt_roundtrip(self, app):
+    def test_encrypt_decrypt_roundtrip(self, app) -> None:
         """Test that encrypt-decrypt roundtrip preserves original value."""
         with app.app_context():
             app.config["SECRET_KEY"] = "test-secret-key-12345"
@@ -336,14 +336,14 @@ class TestEncryptionDecryption:
                 decrypted = _decrypt_config(app, encrypted)
                 assert decrypted == value
 
-    def test_decrypt_config_with_invalid_token(self, app):
+    def test_decrypt_config_with_invalid_token(self, app) -> None:
         """Test that _decrypt_config raises ValueError for invalid token."""
         with app.app_context():
             app.config["SECRET_KEY"] = "test-secret-key-12345"
             with pytest.raises(ValueError, match="Failed to decrypt config value"):
                 _decrypt_config(app, "invalid-encrypted-token")
 
-    def test_decrypt_config_with_different_secret_key(self, app):
+    def test_decrypt_config_with_different_secret_key(self, app) -> None:
         """Test that decryption fails with different SECRET_KEY."""
         with app.app_context():
             app.config["SECRET_KEY"] = "test-secret-key-12345"
@@ -359,14 +359,14 @@ class TestEncryptionDecryption:
 class TestCacheKeyGeneration:
     """Test cache and lock key generation functions."""
 
-    def test_get_config_cache_key(self, app):
+    def test_get_config_cache_key(self, app) -> None:
         """Test that cache key is generated correctly."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
             key = _get_config_cache_key(app, "test_key")
             assert key == "test:sys:config:test_key"
 
-    def test_get_config_lock_key(self, app):
+    def test_get_config_lock_key(self, app) -> None:
         """Test that lock key is generated correctly."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -376,7 +376,7 @@ class TestCacheKeyGeneration:
     @patch("flaskr.service.config.funcs.get_config_from_common")
     def test_get_config_cache_key_falls_back_to_common_prefix(
         self, mock_get_config_from_common, app
-    ):
+    ) -> None:
         """Fallback to shared config prefix when plain Flask config lacks the key."""
         with app.app_context():
             app.config.pop("REDIS_KEY_PREFIX", None)
@@ -389,7 +389,7 @@ class TestCacheKeyGeneration:
 class TestGetConfig:
     """Test get_config function."""
 
-    def test_config_overrides_override_get_config(self, app):
+    def test_config_overrides_override_get_config(self, app) -> None:
         """Config overrides should win over env and DB-backed lookups."""
         with (
             app.app_context(),
@@ -404,7 +404,7 @@ class TestGetConfig:
             assert has_config_override("test_key") is False
             mock_get_config_from_common.assert_not_called()
 
-    def test_config_overrides_restore_previous_values(self, app):
+    def test_config_overrides_restore_previous_values(self, app) -> None:
         """Nested overrides restore the outer and original values correctly."""
         with app.app_context():
             with config_overrides(
@@ -424,7 +424,7 @@ class TestGetConfig:
     @patch("flaskr.service.config.funcs.get_config_from_common")
     def test_config_overrides_work_without_app_context(
         self, mock_get_config_from_common
-    ):
+    ) -> None:
         """Thread-local overrides should work even without a Flask app context."""
         with config_overrides({"test_key": "override-value"}):
             assert get_config("test_key", "default-value") == "override-value"
@@ -436,7 +436,7 @@ class TestGetConfig:
     @patch("flaskr.service.config.funcs.redis")
     def test_get_config_from_environment(
         self, mock_redis, mock_get_config_from_common, mock_has_override, app
-    ):
+    ) -> None:
         """Test that get_config returns value from environment first."""
         with app.app_context():
             mock_get_config_from_common.return_value = "env-value"
@@ -451,7 +451,7 @@ class TestGetConfig:
     @patch("flaskr.service.config.funcs._decrypt_config")
     def test_get_config_from_cache_plain(
         self, mock_decrypt, mock_redis, mock_get_config_from_common, app
-    ):
+    ) -> None:
         """Test that get_config returns plain value from cache."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -469,7 +469,7 @@ class TestGetConfig:
     @patch("flaskr.service.config.funcs._decrypt_config")
     def test_get_config_from_cache_encrypted(
         self, mock_decrypt, mock_redis, mock_get_config_from_common, app
-    ):
+    ) -> None:
         """Test that get_config decrypts encrypted value from cache."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -495,7 +495,7 @@ class TestGetConfig:
         mock_redis,
         mock_get_config_from_common,
         app,
-    ):
+    ) -> None:
         """Test that get_config returns plain value from database."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -526,7 +526,7 @@ class TestGetConfig:
     @patch("flaskr.service.config.funcs.Config")
     def test_get_config_queries_database_when_default_is_explicit_empty_string(
         self, mock_config_class, mock_redis, mock_get_config_from_common, app
-    ):
+    ) -> None:
         """Explicit caller defaults should not mask DB-backed config keys."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -562,7 +562,7 @@ class TestGetConfig:
         mock_redis,
         mock_get_config_from_common,
         app,
-    ):
+    ) -> None:
         """Test that get_config decrypts encrypted value from database."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -595,7 +595,7 @@ class TestGetConfig:
     @patch("flaskr.service.config.funcs.Config")
     def test_get_config_not_found(
         self, mock_config_class, mock_redis, mock_get_config_from_common, app
-    ):
+    ) -> None:
         """Test that get_config returns None when config not found."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -622,7 +622,7 @@ class TestGetConfig:
     @patch("flaskr.service.config.funcs.Config")
     def test_get_config_uses_common_default_when_database_config_is_missing(
         self, mock_config_class, mock_redis, mock_get_config_from_common, app
-    ):
+    ) -> None:
         """Registered config defaults should survive missing DB rows."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -645,7 +645,9 @@ class TestGetConfig:
 
     @patch("flaskr.service.config.funcs.get_config_from_common")
     @patch("flaskr.service.config.funcs.redis")
-    def test_get_config_lock_failed(self, mock_redis, mock_get_config_from_common, app):
+    def test_get_config_lock_failed(
+        self, mock_redis, mock_get_config_from_common, app
+    ) -> None:
         """Test that get_config returns None when lock acquisition fails."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -663,7 +665,7 @@ class TestGetConfig:
     @patch("flaskr.service.config.funcs.Config")
     def test_get_config_uses_env_when_db_not_ready(
         self, mock_config_class, mock_redis, mock_get_config_from_common, app
-    ):
+    ) -> None:
         """Fallback to environment config when database table is missing."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -703,7 +705,7 @@ class TestAddConfig:
         mock_redis,
         mock_get_config_from_common,
         app,
-    ):
+    ) -> None:
         """Test adding plain text config."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -752,7 +754,7 @@ class TestAddConfig:
         mock_redis,
         mock_get_config_from_common,
         app,
-    ):
+    ) -> None:
         """Test adding encrypted config."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -804,7 +806,7 @@ class TestAddConfig:
         mock_redis,
         mock_get_config_from_common,
         app,
-    ):
+    ) -> None:
         """Test that add_config ignores cached encrypted values when adding."""
         _ = mock_db
         with app.app_context():
@@ -846,7 +848,7 @@ class TestAddConfig:
         mock_redis,
         mock_get_config_from_common,
         app,
-    ):
+    ) -> None:
         """Test that add_config uses cached plain value if exists."""
         _ = mock_db
         with app.app_context():
@@ -871,7 +873,9 @@ class TestAddConfig:
             assert result is True
 
     @patch("flaskr.service.config.funcs.get_config_from_common")
-    def test_add_config_skips_if_env_exists(self, mock_get_config_from_common, app):
+    def test_add_config_skips_if_env_exists(
+        self, mock_get_config_from_common, app
+    ) -> None:
         """Test that add_config skips if environment config exists."""
         with app.app_context():
             with patch(
@@ -895,7 +899,7 @@ class TestAddConfig:
         mock_redis,
         mock_get_config_from_common,
         app,
-    ):
+    ) -> None:
         """DB writes should proceed when the key is not explicitly in os.environ."""
         _ = mock_redis
         with app.app_context():
@@ -921,7 +925,7 @@ class TestAddConfig:
     @patch("flaskr.service.config.funcs.redis")
     def test_add_config_returns_false_if_no_value(
         self, mock_redis, mock_get_config_from_common, app
-    ):
+    ) -> None:
         """Test that add_config returns False if value is empty."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -947,7 +951,7 @@ class TestUpdateConfig:
         mock_redis,
         mock_get_config_from_common,
         app,
-    ):
+    ) -> None:
         """Test updating plain text config."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -990,7 +994,7 @@ class TestUpdateConfig:
         mock_redis,
         mock_get_config_from_common,
         app,
-    ):
+    ) -> None:
         """Test updating encrypted config."""
         _ = mock_db
         with app.app_context():
@@ -1036,7 +1040,7 @@ class TestUpdateConfig:
         mock_redis,
         mock_get_config_from_common,
         app,
-    ):
+    ) -> None:
         """update_config must persist the caller's new value, not a stale cached one, even when the cache is warm (regression: a warm cache used to overwrite the new value and re-persist the old one)."""
         _ = mock_db
         with app.app_context():
@@ -1082,7 +1086,7 @@ class TestUpdateConfig:
         mock_redis,
         mock_get_config_from_common,
         app,
-    ):
+    ) -> None:
         """update_config must persist the caller's new plain value, not a stale cached one, even when the cache is warm."""
         _ = mock_db
         with app.app_context():
@@ -1112,7 +1116,9 @@ class TestUpdateConfig:
             assert result is True
 
     @patch("flaskr.service.config.funcs.get_config_from_common")
-    def test_update_config_skips_if_env_exists(self, mock_get_config_from_common, app):
+    def test_update_config_skips_if_env_exists(
+        self, mock_get_config_from_common, app
+    ) -> None:
         """Test that update_config returns False if environment config exists."""
         with app.app_context():
             with patch(
@@ -1126,7 +1132,7 @@ class TestUpdateConfig:
     @patch("flaskr.service.config.funcs.get_config_from_common")
     def test_update_config_skips_if_empty_env_exists(
         self, mock_get_config_from_common, app
-    ):
+    ) -> None:
         """Test that update_config respects empty string environment overrides."""
         with app.app_context():
             with patch(
@@ -1143,7 +1149,7 @@ class TestUpdateConfig:
     @patch("flaskr.service.config.funcs.Config")
     def test_update_config_not_found(
         self, mock_config_class, mock_db, mock_redis, mock_get_config_from_common, app
-    ):
+    ) -> None:
         """Test that update_config inserts when config not found."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -1166,7 +1172,7 @@ class TestUpdateConfig:
     @patch("flaskr.service.config.funcs.redis")
     def test_update_config_returns_false_if_no_value(
         self, mock_redis, mock_get_config_from_common, app
-    ):
+    ) -> None:
         """Test that update_config returns False if value is empty."""
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
@@ -1179,26 +1185,26 @@ class TestUpdateConfig:
 class TestConfigCache:
     """Test ConfigCache model."""
 
-    def test_config_cache_defaults(self):
+    def test_config_cache_defaults(self) -> None:
         """Test ConfigCache default values."""
         cache = ConfigCache()
         assert cache.is_encrypted is False
         assert cache.value == ""
 
-    def test_config_cache_with_values(self):
+    def test_config_cache_with_values(self) -> None:
         """Test ConfigCache with explicit values."""
         cache = ConfigCache(is_encrypted=True, value="test-value")
         assert cache.is_encrypted is True
         assert cache.value == "test-value"
 
-    def test_config_cache_serialization(self):
+    def test_config_cache_serialization(self) -> None:
         """Test ConfigCache JSON serialization."""
         cache = ConfigCache(is_encrypted=True, value="test-value")
         json_str = cache.model_dump_json()
         assert isinstance(json_str, str)
         assert "test-value" in json_str
 
-    def test_config_cache_deserialization(self):
+    def test_config_cache_deserialization(self) -> None:
         """Test ConfigCache JSON deserialization."""
         json_str = '{"is_encrypted": true, "value": "test-value"}'
         cache = ConfigCache.model_validate_json(json_str)

--- a/src/api/tests/service/creator_analytics/conftest.py
+++ b/src/api/tests/service/creator_analytics/conftest.py
@@ -30,6 +30,7 @@ from flaskr.service.user.models import UserInfo
 from flaskr.util.datetime import now_utc
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from datetime import datetime
 
 
@@ -67,7 +68,7 @@ def _isolate_creator_analytics_tables(app):
 
 
 @pytest.fixture
-def mock_request_user(monkeypatch):
+def mock_request_user(monkeypatch) -> Callable[[str, bool], None]:
     """Return a helper that installs a fake authenticated user."""
 
     def _install(user_id: str = "teacher-1", is_creator: bool = True) -> None:

--- a/src/api/tests/service/creator_analytics/test_credit_detail.py
+++ b/src/api/tests/service/creator_analytics/test_credit_detail.py
@@ -82,7 +82,9 @@ def _seed_usage_with_ledger(
 # ---------------------------------------------------------------------------
 
 
-def test_credit_detail_returns_summary_and_rows(mock_request_user, test_client, app):
+def test_credit_detail_returns_summary_and_rows(
+    mock_request_user, test_client, app
+) -> None:
     """3 paired usage / ledger rows → summary aggregates them and rows list each charge.
 
     amount stored as a negative number; API returns the absolute value as `credits`.
@@ -142,7 +144,7 @@ def test_credit_detail_returns_summary_and_rows(mock_request_user, test_client, 
 
 def test_credit_detail_excludes_non_usage_ledger_entries(
     mock_request_user, test_client, app
-):
+) -> None:
     """A non-USAGE ledger entry must never appear in the result.
 
     Entries such as subscription or topup must be excluded even if their source_bid happens to
@@ -186,7 +188,7 @@ def test_credit_detail_excludes_non_usage_ledger_entries(
 
 def test_credit_detail_summary_unique_wallets_counts_distinct_creators(
     mock_request_user, test_client, app
-):
+) -> None:
     """Most courses bill against a single wallet (the author's), but subscription / proxy-payment / sponsorship scenarios can split charges across multiple wallets for the same shifu.
 
     The summary must surface this as a distinct count so a caller does not treat the per-row
@@ -237,7 +239,7 @@ def test_credit_detail_summary_unique_wallets_counts_distinct_creators(
 
 def test_credit_detail_user_cannot_query_other_shifu(
     mock_request_user, test_client, app
-):
+) -> None:
     mock_request_user(user_id="teacher-1")
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-mine", user_id="teacher-1")
@@ -257,7 +259,7 @@ def test_credit_detail_user_cannot_query_other_shifu(
 
 def test_credit_detail_results_are_scoped_to_requested_shifu(
     mock_request_user, test_client, app
-):
+) -> None:
     """Even when the caller owns multiple shifu, only the requested one's rows surface — the join is anchored on bill_usage.shifu_bid."""
     mock_request_user(user_id="teacher-1")
     with app.app_context():
@@ -289,7 +291,9 @@ def test_credit_detail_results_are_scoped_to_requested_shifu(
 # ---------------------------------------------------------------------------
 
 
-def test_credit_detail_filters_by_usage_scene(mock_request_user, test_client, app):
+def test_credit_detail_filters_by_usage_scene(
+    mock_request_user, test_client, app
+) -> None:
     mock_request_user(user_id="teacher-1")
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
@@ -316,7 +320,9 @@ def test_credit_detail_filters_by_usage_scene(mock_request_user, test_client, ap
     assert all(row["usage_scene"] == 1203 for row in data["rows"])
 
 
-def test_credit_detail_filters_by_usage_type(mock_request_user, test_client, app):
+def test_credit_detail_filters_by_usage_type(
+    mock_request_user, test_client, app
+) -> None:
     mock_request_user(user_id="teacher-1")
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
@@ -343,7 +349,9 @@ def test_credit_detail_filters_by_usage_type(mock_request_user, test_client, app
     assert all(row["usage_type"] == 1101 for row in data["rows"])
 
 
-def test_credit_detail_filters_by_date_range(mock_request_user, test_client, app):
+def test_credit_detail_filters_by_date_range(
+    mock_request_user, test_client, app
+) -> None:
     """start_date and end_date are inclusive bounds on bill_usage.created_at."""
     mock_request_user(user_id="teacher-1")
     today = datetime(2026, 5, 16, 10, 0, 0)
@@ -383,7 +391,9 @@ def test_credit_detail_filters_by_date_range(mock_request_user, test_client, app
     assert float(data["summary"]["total_credits"]) == pytest.approx(2.0)
 
 
-def test_credit_detail_rejects_invalid_scene_value(mock_request_user, test_client, app):
+def test_credit_detail_rejects_invalid_scene_value(
+    mock_request_user, test_client, app
+) -> None:
     mock_request_user(user_id="teacher-1")
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
@@ -393,7 +403,9 @@ def test_credit_detail_rejects_invalid_scene_value(mock_request_user, test_clien
     assert payload["code"] == 11002  # invalidDsl
 
 
-def test_credit_detail_rejects_end_before_start(mock_request_user, test_client, app):
+def test_credit_detail_rejects_end_before_start(
+    mock_request_user, test_client, app
+) -> None:
     mock_request_user(user_id="teacher-1")
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
@@ -414,7 +426,7 @@ def test_credit_detail_rejects_end_before_start(mock_request_user, test_client, 
 # ---------------------------------------------------------------------------
 
 
-def test_credit_detail_pagination(mock_request_user, test_client, app):
+def test_credit_detail_pagination(mock_request_user, test_client, app) -> None:
     mock_request_user(user_id="teacher-1")
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
@@ -438,7 +450,7 @@ def test_credit_detail_pagination(mock_request_user, test_client, app):
 
 def test_credit_detail_empty_when_bill_usage_has_no_ledger_entries(
     mock_request_user, test_client, app
-):
+) -> None:
     """If settlement failed for every usage row (no ledger entry exists), the join collapses to zero rows — surfaces as empty summary."""
     mock_request_user(user_id="teacher-1")
     with app.app_context():
@@ -459,7 +471,9 @@ def test_credit_detail_empty_when_bill_usage_has_no_ledger_entries(
     assert data["rows"] == []
 
 
-def test_credit_detail_rejects_limit_above_max(mock_request_user, test_client, app):
+def test_credit_detail_rejects_limit_above_max(
+    mock_request_user, test_client, app
+) -> None:
     mock_request_user(user_id="teacher-1")
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a", user_id="teacher-1")
@@ -476,7 +490,7 @@ def test_credit_detail_rejects_limit_above_max(mock_request_user, test_client, a
 
 def test_credit_detail_emits_audit_log(
     mock_request_user, test_client, app, monkeypatch
-):
+) -> None:
     """Each call must log user_id + shifu_bid + row count + filter summary so retroactive auditing can reconstruct who hit credit-detail.
 
     Uses the same `monkeypatch app.logger.info` capture pattern as the

--- a/src/api/tests/service/creator_analytics/test_query.py
+++ b/src/api/tests/service/creator_analytics/test_query.py
@@ -40,7 +40,9 @@ def _post(test_client, body):
 # ---------------------------------------------------------------------------
 
 
-def test_progress_count_returns_expected_rows(mock_request_user, test_client, app):
+def test_progress_count_returns_expected_rows(
+    mock_request_user, test_client, app
+) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -73,7 +75,7 @@ def test_progress_count_returns_expected_rows(mock_request_user, test_client, ap
 
 def test_shifu_user_archives_query_runs_without_deleted_column(
     mock_request_user, test_client, app
-):
+) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -104,7 +106,9 @@ def test_shifu_user_archives_query_runs_without_deleted_column(
 # ---------------------------------------------------------------------------
 
 
-def test_user_cannot_query_a_shifu_they_do_not_own(mock_request_user, test_client, app):
+def test_user_cannot_query_a_shifu_they_do_not_own(
+    mock_request_user, test_client, app
+) -> None:
     mock_request_user(user_id="teacher-1")
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-mine", user_id="teacher-1")
@@ -128,7 +132,7 @@ def test_user_cannot_query_a_shifu_they_do_not_own(mock_request_user, test_clien
 
 def test_query_results_are_scoped_to_the_requested_shifu(
     mock_request_user, test_client, app
-):
+) -> None:
     """Even if rows exist for another shifu, only the requested one is counted."""
     mock_request_user(user_id="teacher-1")
     with app.app_context():
@@ -155,7 +159,9 @@ def test_query_results_are_scoped_to_the_requested_shifu(
 # ---------------------------------------------------------------------------
 
 
-def test_unknown_table_yields_invalid_table_error(mock_request_user, test_client, app):
+def test_unknown_table_yields_invalid_table_error(
+    mock_request_user, test_client, app
+) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -169,7 +175,7 @@ def test_unknown_table_yields_invalid_table_error(mock_request_user, test_client
 
 def test_unknown_column_yields_invalid_column_error(
     mock_request_user, test_client, app
-):
+) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -186,7 +192,9 @@ def test_unknown_column_yields_invalid_column_error(
     assert response.get_json(force=True)["code"] == 11004
 
 
-def test_select_shifu_bid_directly_is_rejected(mock_request_user, test_client, app):
+def test_select_shifu_bid_directly_is_rejected(
+    mock_request_user, test_client, app
+) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -203,7 +211,7 @@ def test_select_shifu_bid_directly_is_rejected(mock_request_user, test_client, a
     assert response.get_json(force=True)["code"] == 11004
 
 
-def test_like_leading_wildcard_is_rejected(mock_request_user, test_client, app):
+def test_like_leading_wildcard_is_rejected(mock_request_user, test_client, app) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -221,7 +229,9 @@ def test_like_leading_wildcard_is_rejected(mock_request_user, test_client, app):
     assert response.get_json(force=True)["code"] == 11002
 
 
-def test_limit_above_configured_max_is_rejected(mock_request_user, test_client, app):
+def test_limit_above_configured_max_is_rejected(
+    mock_request_user, test_client, app
+) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -243,7 +253,7 @@ def test_limit_above_configured_max_is_rejected(mock_request_user, test_client, 
 # ---------------------------------------------------------------------------
 
 
-def test_bill_usage_table_is_rejected(mock_request_user, test_client, app):
+def test_bill_usage_table_is_rejected(mock_request_user, test_client, app) -> None:
     """`bill_usage` is removed from the whitelist; queries return 11003.
 
     Creators may only query credit consumption via `bill_daily_usage_metrics`;
@@ -273,7 +283,7 @@ def test_bill_usage_table_is_rejected(mock_request_user, test_client, app):
 
 def test_conversation_replay_returns_ordered_qa_pairs(
     mock_request_user, test_client, app, monkeypatch
-):
+) -> None:
     """End-to-end: select user_bid + generated_content for a lesson's Q&A, verify the rows come back chronologically and an audit log is emitted."""
     mock_request_user(user_id="teacher-1")
     with app.app_context():
@@ -344,7 +354,7 @@ def test_conversation_replay_returns_ordered_qa_pairs(
 
 def test_conversation_replay_rejects_disallowed_type(
     mock_request_user, test_client, app
-):
+) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -369,7 +379,7 @@ def test_conversation_replay_rejects_disallowed_type(
 
 def test_user_users_lookup_returns_nicknames_for_known_user_bids(
     mock_request_user, test_client, app, monkeypatch
-):
+) -> None:
     mock_request_user(user_id="teacher-1")
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -413,7 +423,7 @@ def test_user_users_lookup_returns_nicknames_for_known_user_bids(
 
 def test_user_users_lookup_redacts_phone_in_nickname(
     mock_request_user, test_client, app
-):
+) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -441,7 +451,7 @@ def test_user_users_lookup_redacts_phone_in_nickname(
 
 def test_user_users_lookup_without_view_permission_is_rejected(
     mock_request_user, test_client, app
-):
+) -> None:
     mock_request_user(user_id="teacher-1")
     with app.app_context():
         # teacher-2 owns shifu-other, teacher-1 has no access
@@ -464,7 +474,7 @@ def test_user_users_lookup_without_view_permission_is_rejected(
 
 def test_user_users_lookup_without_where_user_bid_is_rejected(
     mock_request_user, test_client, app
-):
+) -> None:
     """Cannot list every learner's nickname — must supply user_bid candidates."""
     mock_request_user()
     with app.app_context():
@@ -489,7 +499,7 @@ def test_user_users_lookup_without_where_user_bid_is_rejected(
 
 def test_user_users_lookup_by_phone_returns_masked_user_identify(
     mock_request_user, test_client, app
-):
+) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -518,7 +528,7 @@ def test_user_users_lookup_by_phone_returns_masked_user_identify(
 
 def test_user_users_lookup_by_email_returns_masked_user_identify(
     mock_request_user, test_client, app
-):
+) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -548,7 +558,7 @@ def test_user_users_lookup_by_email_returns_masked_user_identify(
 
 def test_user_users_nickname_redacted_and_user_identify_masked_independently(
     mock_request_user, test_client, app
-):
+) -> None:
     """Nickname PII fully redacted; user_identify column partially masked — independent."""
     mock_request_user()
     with app.app_context():
@@ -581,7 +591,7 @@ def test_user_users_nickname_redacted_and_user_identify_masked_independently(
 
 def test_user_users_user_identify_in_filter_rejected(
     mock_request_user, test_client, app
-):
+) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -607,7 +617,7 @@ def test_user_users_user_identify_in_filter_rejected(
 
 def test_user_users_lookup_by_phone_audit_log_emitted(
     mock_request_user, test_client, app, monkeypatch
-):
+) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -652,7 +662,7 @@ def test_user_users_lookup_by_phone_audit_log_emitted(
 
 def test_fallback_engine_uses_primary_db_with_warning(
     mock_request_user, test_client, app, caplog
-):
+) -> None:
     """Leaving ANALYTICS_DATABASE_URI empty should fall back to the primary engine."""
     mock_request_user()
     app.config["ANALYTICS_DATABASE_URI"] = ""
@@ -680,7 +690,7 @@ def test_fallback_engine_uses_primary_db_with_warning(
         assert engine is db.engine
 
 
-def test_dedicated_engine_replacement_disposes_previous_owner(app, monkeypatch):
+def test_dedicated_engine_replacement_disposes_previous_owner(app, monkeypatch) -> None:
     class _FakeEngine:
         def __init__(self, uri: str) -> None:
             self.uri = uri
@@ -725,7 +735,7 @@ def test_dedicated_engine_replacement_disposes_previous_owner(app, monkeypatch):
 
 def test_bill_daily_sum_credits_for_production_usage(
     mock_request_user, test_client, app
-):
+) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -772,7 +782,7 @@ def test_bill_daily_sum_credits_for_production_usage(
     assert total == pytest.approx(30.0)
 
 
-def test_bill_daily_split_by_usage_type(mock_request_user, test_client, app):
+def test_bill_daily_split_by_usage_type(mock_request_user, test_client, app) -> None:
     mock_request_user()
     with app.app_context():
         seed_owned_course(shifu_bid="shifu-a")
@@ -814,7 +824,7 @@ def test_bill_daily_split_by_usage_type(mock_request_user, test_client, app):
 
 def test_bill_daily_creator_bid_grouping_shows_callers_own_wallet(
     mock_request_user, test_client, app
-):
+) -> None:
     """The author can now group by creator_bid to confirm which wallet is being deducted for the course; shifu_bid isolation guarantees the grouping only returns the caller's own bid."""
     mock_request_user(user_id="teacher-1")
     with app.app_context():
@@ -866,7 +876,9 @@ def test_bill_daily_creator_bid_grouping_shows_callers_own_wallet(
 # ---------------------------------------------------------------------------
 
 
-def test_followup_count_excludes_rerolled_history(mock_request_user, test_client, app):
+def test_followup_count_excludes_rerolled_history(
+    mock_request_user, test_client, app
+) -> None:
     """A learner can re-roll a follow-up question; the old block flips to status=0.
 
     The PDF §6 trap is "status=0 history rows must not be counted as live follow-ups".
@@ -922,7 +934,9 @@ def test_followup_count_excludes_rerolled_history(mock_request_user, test_client
     assert data["rows"] == [[2]]
 
 
-def test_followup_count_per_lesson_by_outline(mock_request_user, test_client, app):
+def test_followup_count_per_lesson_by_outline(
+    mock_request_user, test_client, app
+) -> None:
     """Group by outline_item_bid answers "follow-up questions per lesson".
 
     Requires both `outline_item_bid` selectable / filterable / groupable AND aggregate
@@ -990,7 +1004,7 @@ def test_followup_count_per_lesson_by_outline(mock_request_user, test_client, ap
 
 def test_shifu_published_returns_current_title_excluding_history(
     mock_request_user, test_client, app
-):
+) -> None:
     """Rename scenario: the same shifu_bid has historical PublishedShifu rows (deleted=1) plus the current row (deleted=0).
 
     The query must return only the current row — historical titles must not be presented as
@@ -1036,7 +1050,7 @@ def test_shifu_published_returns_current_title_excluding_history(
 
 def test_shifu_published_excludes_other_creators_rows(
     mock_request_user, test_client, app
-):
+) -> None:
     """Creator scoping excludes other creators' rows.
 
     Even if a co-author or shared user had view permission on the same shifu_bid, the
@@ -1080,7 +1094,7 @@ def test_shifu_published_excludes_other_creators_rows(
 
 def test_shifu_meta_aggregate_rejected_at_http_layer(
     mock_request_user, test_client, app
-):
+) -> None:
     """The DSL validator must reject aggregate on metadata tables before SQL is built.
 
     Verifies the HTTP error code is the standard invalidDsl.
@@ -1105,7 +1119,7 @@ def test_shifu_meta_aggregate_rejected_at_http_layer(
 
 def test_shifu_meta_title_like_searches_callers_courses(
     mock_request_user, test_client, app
-):
+) -> None:
     """Title `like` with trailing-% is the canonical "find my course by name" path.
 
     Combined with creator_scoped filtering, the caller only sees their own matches.

--- a/src/api/tests/service/dashboard/test_dashboard_routes.py
+++ b/src/api/tests/service/dashboard/test_dashboard_routes.py
@@ -245,7 +245,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         now = datetime(2025, 1, 15, 10, 0, 0)
@@ -367,7 +367,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         in_range = datetime(2025, 1, 10, 9, 0, 0)
@@ -466,7 +466,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
         with app.app_context():
             self._seed_dashboard_course(shifu_bid="course-timezone", title="Course TZ")
@@ -503,7 +503,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         in_range = datetime(2025, 2, 10, 9, 0, 0)
@@ -560,7 +560,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         now = datetime(2025, 2, 10, 9, 0, 0)
@@ -604,7 +604,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         now = datetime(2025, 2, 10, 9, 0, 0)
@@ -649,7 +649,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         now = datetime(2025, 2, 10, 9, 0, 0)
@@ -694,7 +694,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         now = datetime(2025, 2, 10, 9, 0, 0)
@@ -753,7 +753,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         with app.app_context():
@@ -834,7 +834,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
         monkeypatch.setattr(
             "flaskr.service.dashboard.funcs.get_dynamic_config",
@@ -868,7 +868,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
         monkeypatch.setattr(
             "flaskr.service.shifu.demo_courses.get_dynamic_config",
@@ -903,7 +903,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
         monkeypatch.setattr(
             "flaskr.service.shifu.demo_courses.get_dynamic_config",
@@ -942,7 +942,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         draft_created_at = datetime(2025, 1, 1, 8, 0, 0)
@@ -1288,7 +1288,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         now = datetime(2026, 4, 10, 12, 0, 0)
@@ -1446,7 +1446,7 @@ class TestDashboardRoutes:
         app,
         query_string,
         expected_param,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         with app.app_context():
@@ -1508,7 +1508,7 @@ class TestDashboardRoutes:
         app,
         path,
         expected_param,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         with app.app_context():
@@ -1529,7 +1529,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         with app.app_context():
@@ -1698,7 +1698,7 @@ class TestDashboardRoutes:
         app,
         query_string,
         expected_param,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         with app.app_context():
@@ -1721,7 +1721,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         now = now_utc().replace(microsecond=0)
@@ -1962,7 +1962,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         now = now_utc().replace(microsecond=0)
@@ -2070,7 +2070,7 @@ class TestDashboardRoutes:
         app,
         query_string,
         expected_param,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         with app.app_context():
@@ -2094,7 +2094,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         with app.app_context():
@@ -2118,7 +2118,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         with app.app_context():
@@ -2146,7 +2146,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         joined_at = datetime(2026, 3, 4, 9, 15, 0)
@@ -2218,7 +2218,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         with app.app_context():
@@ -2334,7 +2334,7 @@ class TestDashboardRoutes:
         monkeypatch,
         test_client,
         app,
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         with app.app_context():

--- a/src/api/tests/service/learn/run/test_run_disconnect_e2e.py
+++ b/src/api/tests/service/learn/run/test_run_disconnect_e2e.py
@@ -110,7 +110,7 @@ def _load_rows(app, user_bid: str):
 def test_mid_stream_close_discards_staged_block_and_rerun_resumes(
     app,
     golden_shifu,  # noqa: F811 - fixture imported from tests.golden.conftest
-):
+) -> None:
     user_bid = "golden-user-disconnect-0001"
     seed_golden_user(app, user_bid)
 
@@ -179,7 +179,7 @@ def test_mid_stream_close_discards_staged_block_and_rerun_resumes(
 def test_close_before_any_stream_leaves_no_generated_blocks(
     app,
     golden_shifu,  # noqa: F811 - fixture imported from tests.golden.conftest
-):
+) -> None:
     """Closing right after the first event discards everything staged.
 
     The first yielded events precede any LLM stream (outline updates /

--- a/src/api/tests/service/learn/run/test_run_emitter.py
+++ b/src/api/tests/service/learn/run/test_run_emitter.py
@@ -88,7 +88,7 @@ class _RecordingEmitter:
 class EmitterAccessorTests(unittest.TestCase):
     """Verify emitter accessor behavior."""
 
-    def test_lazy_creation_and_caching(self):
+    def test_lazy_creation_and_caching(self) -> None:
         ctx = _make_context()
 
         emitter = ctx._event_emitter
@@ -101,35 +101,35 @@ class EmitterAccessorTests(unittest.TestCase):
 class WrapperDelegationTests(unittest.TestCase):
     """Verify wrapper delegation behavior."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.ctx = _make_context()
         self.emitter = _RecordingEmitter()
         self.ctx.__dict__["_run_event_emitter"] = self.emitter
 
-    def test_render_outline_updates_delegates(self):
+    def test_render_outline_updates_delegates(self) -> None:
         updates = [object()]
         events = list(self.ctx._render_outline_updates(updates, new_chapter=True))
         assert events == ["outline-event"]
         assert self.emitter.calls == [("render_outline_updates", updates, True)]
 
-    def test_emit_next_chapter_interaction_delegates(self):
+    def test_emit_next_chapter_interaction_delegates(self) -> None:
         progress = object()
         events = list(self.ctx._emit_next_chapter_interaction(progress))
         assert events == ["next-event"]
         assert self.emitter.calls == [("emit_next_chapter_interaction", progress)]
 
-    def test_emit_lesson_feedback_interaction_delegates(self):
+    def test_emit_lesson_feedback_interaction_delegates(self) -> None:
         progress = object()
         events = list(self.ctx._emit_lesson_feedback_interaction(progress))
         assert events == ["feedback-event"]
         assert self.emitter.calls == [("emit_lesson_feedback_interaction", progress)]
 
-    def test_is_access_gate_blocking_interaction_delegates(self):
+    def test_is_access_gate_blocking_interaction_delegates(self) -> None:
         parsed = {"buttons": []}
         assert self.ctx._is_access_gate_blocking_interaction(parsed)
         assert self.emitter.calls == [("is_access_gate_blocking_interaction", parsed)]
 
-    def test_maybe_emit_feedback_after_access_gate_delegates(self):
+    def test_maybe_emit_feedback_after_access_gate_delegates(self) -> None:
         parsed = {"buttons": []}
         progress = object()
         events = list(
@@ -144,23 +144,23 @@ class WrapperDelegationTests(unittest.TestCase):
             ("maybe_emit_feedback_after_access_gate", parsed, progress, True)
         ]
 
-    def test_emit_feedback_after_exception_gate_delegates(self):
+    def test_emit_feedback_after_exception_gate_delegates(self) -> None:
         events = list(self.ctx._emit_feedback_after_exception_gate())
         assert events == ["exception-feedback-event"]
         assert self.emitter.calls == [("emit_feedback_after_exception_gate",)]
 
-    def test_ensure_current_attend_for_gate_interaction_delegates(self):
+    def test_ensure_current_attend_for_gate_interaction_delegates(self) -> None:
         assert self.ctx._ensure_current_attend_for_gate_interaction() == "attend"
         assert self.emitter.calls == [("ensure_current_attend_for_gate_interaction",)]
 
-    def test_emit_current_progress_gate_interaction_delegates(self):
+    def test_emit_current_progress_gate_interaction_delegates(self) -> None:
         events = list(self.ctx._emit_current_progress_gate_interaction("content"))
         assert events == ["gate-interaction-event"]
         assert self.emitter.calls == [
             ("emit_current_progress_gate_interaction", "content")
         ]
 
-    def test_emit_completion_tail_interactions_delegates(self):
+    def test_emit_completion_tail_interactions_delegates(self) -> None:
         progress = object()
         events = list(
             self.ctx._emit_completion_tail_interactions(
@@ -178,7 +178,7 @@ class WrapperDelegationTests(unittest.TestCase):
 class EmitterContextSeamTests(unittest.TestCase):
     """The emitter must dispatch cross-calls through the context wrappers so instance-level overrides on the context keep taking effect."""
 
-    def test_completion_tail_uses_context_overrides(self):
+    def test_completion_tail_uses_context_overrides(self) -> None:
         ctx = _make_context()
         calls: list[str] = []
 
@@ -204,7 +204,7 @@ class EmitterContextSeamTests(unittest.TestCase):
         assert calls == ["next", "feedback"]
         assert events == ["next-event", "feedback-event"]
 
-    def test_access_gate_feedback_uses_context_overrides(self):
+    def test_access_gate_feedback_uses_context_overrides(self) -> None:
         ctx = _make_context()
         calls: list[str] = []
 
@@ -245,7 +245,7 @@ class EmitterPayloadSmokeTests(unittest.TestCase):
         with cls.app.app_context():
             dao.db.create_all()
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.app = self.__class__.app
         self.ctx = _make_context()
         self.ctx.app = self.app
@@ -261,7 +261,7 @@ class EmitterPayloadSmokeTests(unittest.TestCase):
             LearnGeneratedBlock.query.delete()
             dao.db.session.commit()
 
-    def test_next_chapter_payload_constructed_by_emitter(self):
+    def test_next_chapter_payload_constructed_by_emitter(self) -> None:
         with self.app.app_context():
             events = list(
                 self.ctx._event_emitter.emit_next_chapter_interaction(

--- a/src/api/tests/service/learn/run/test_run_recorder.py
+++ b/src/api/tests/service/learn/run/test_run_recorder.py
@@ -91,7 +91,7 @@ def _fail_next_flush(monkeypatch, exc: Exception) -> None:
     monkeypatch.setattr(dao.db.session, "flush", _boom)
 
 
-def test_failed_pointer_step_rolls_back_whole(recorder_app, monkeypatch):
+def test_failed_pointer_step_rolls_back_whole(recorder_app, monkeypatch) -> None:
     """Mid-step failure: the flip is neither durable nor left dirty in the session, so a later unrelated commit cannot persist it (dirty-row fix)."""
     attend = _seed_attend()
     recorder = RunRecorder(recorder_app)
@@ -120,7 +120,9 @@ def test_failed_pointer_step_rolls_back_whole(recorder_app, monkeypatch):
     assert row.block_position == 3
 
 
-def test_failed_placeholder_batch_rolls_back_all_records(recorder_app, monkeypatch):
+def test_failed_placeholder_batch_rolls_back_all_records(
+    recorder_app, monkeypatch
+) -> None:
     """The placeholder batch is one step: on failure no partial rows remain."""
     recorder = RunRecorder(recorder_app)
     records = [
@@ -150,7 +152,7 @@ def test_failed_placeholder_batch_rolls_back_all_records(recorder_app, monkeypat
 
 def test_failed_finalize_leaves_staged_block_state_uncorrupted(
     recorder_app, monkeypatch
-):
+) -> None:
     """Block-finalize failure: neither the staged block nor the cursor advance survives — the pre-stream state is fully restored."""
     attend = _seed_attend()
     recorder = RunRecorder(recorder_app)
@@ -196,7 +198,7 @@ def test_failed_finalize_leaves_staged_block_state_uncorrupted(
     )
 
 
-def test_disconnect_mid_stream_resumes_from_last_finalized_block(recorder_app):
+def test_disconnect_mid_stream_resumes_from_last_finalized_block(recorder_app) -> None:
     """Session-level model of a mid-stream disconnect: block N finalized (durable step), block N+1 staged when the session's connection is invalidated — the same add/flush/invalidate sequence the producer's GeneratorExit handler in ``runscript_v2`` performs, exercised here directly against the recorder session rather than through the generator chain.
 
     The re-run must see block N and the advanced cursor, and no trace of block N+1. An
@@ -247,7 +249,7 @@ def test_disconnect_mid_stream_resumes_from_last_finalized_block(recorder_app):
     )
 
 
-def test_finalize_persists_generation_prompt(recorder_app):
+def test_finalize_persists_generation_prompt(recorder_app) -> None:
     """finalize_streamed_block stores the exact sent user message so context rebuilds can replay it verbatim; omitting it defaults to empty string."""
     attend = _seed_attend()
     recorder = RunRecorder(recorder_app)
@@ -285,7 +287,7 @@ def test_finalize_persists_generation_prompt(recorder_app):
     assert stored_default.generation_prompt == ""
 
 
-def test_commit_pending_step_makes_collaborator_writes_durable(recorder_app):
+def test_commit_pending_step_makes_collaborator_writes_durable(recorder_app) -> None:
     """The transitional ask-path step commits rows staged elsewhere."""
     recorder = RunRecorder(recorder_app)
     staged = _build_block("gb-ask-0001", 0)

--- a/src/api/tests/service/learn/test_ask_provider_adapters.py
+++ b/src/api/tests/service/learn/test_ask_provider_adapters.py
@@ -46,7 +46,7 @@ class _FakeResponse:
         return self._json_data
 
 
-def test_dify_adapter_streams_success_content(app, monkeypatch):
+def test_dify_adapter_streams_success_content(app, monkeypatch) -> None:
     adapter = module.DifyAskProviderAdapter()
     request_state = {}
 
@@ -103,7 +103,7 @@ def test_dify_adapter_streams_success_content(app, monkeypatch):
     )
 
 
-def test_coze_adapter_timeout_raises_timeout_error(app, monkeypatch):
+def test_coze_adapter_timeout_raises_timeout_error(app, monkeypatch) -> None:
     adapter = module.CozeAskProviderAdapter()
 
     monkeypatch.setattr(
@@ -138,7 +138,9 @@ def test_coze_adapter_timeout_raises_timeout_error(app, monkeypatch):
         )
 
 
-def test_stream_ask_provider_response_raises_error_for_unsupported_provider(app):
+def test_stream_ask_provider_response_raises_error_for_unsupported_provider(
+    app,
+) -> None:
     with pytest.raises(module.AskProviderConfigError):
         list(
             module.stream_ask_provider_response(
@@ -152,7 +154,7 @@ def test_stream_ask_provider_response_raises_error_for_unsupported_provider(app)
         )
 
 
-def test_coze_adapter_http_error_raises_provider_error(app, monkeypatch):
+def test_coze_adapter_http_error_raises_provider_error(app, monkeypatch) -> None:
     adapter = module.CozeAskProviderAdapter()
 
     monkeypatch.setattr(
@@ -192,7 +194,7 @@ def test_coze_adapter_http_error_raises_provider_error(app, monkeypatch):
         )
 
 
-def test_coze_workflow_adapter_streams_success_content(app, monkeypatch):
+def test_coze_workflow_adapter_streams_success_content(app, monkeypatch) -> None:
     adapter = module.CozeWorkflowAskProviderAdapter()
     request_state = {}
 
@@ -256,7 +258,9 @@ def test_coze_workflow_adapter_streams_success_content(app, monkeypatch):
     )
 
 
-def test_coze_workflow_adapter_nonzero_code_raises_provider_error(app, monkeypatch):
+def test_coze_workflow_adapter_nonzero_code_raises_provider_error(
+    app, monkeypatch
+) -> None:
     adapter = module.CozeWorkflowAskProviderAdapter()
 
     monkeypatch.setattr(
@@ -299,7 +303,7 @@ def test_coze_workflow_adapter_nonzero_code_raises_provider_error(app, monkeypat
         )
 
 
-def test_dify_adapter_missing_shifu_config_raises_config_error(app):
+def test_dify_adapter_missing_shifu_config_raises_config_error(app) -> None:
     adapter = module.DifyAskProviderAdapter()
 
     with pytest.raises(module.AskProviderConfigError, match="base_url/api_key"):
@@ -314,7 +318,7 @@ def test_dify_adapter_missing_shifu_config_raises_config_error(app):
         )
 
 
-def test_coze_adapter_missing_shifu_config_raises_config_error(app):
+def test_coze_adapter_missing_shifu_config_raises_config_error(app) -> None:
     adapter = module.CozeAskProviderAdapter()
 
     with pytest.raises(module.AskProviderConfigError, match="api_key is required"):
@@ -329,7 +333,7 @@ def test_coze_adapter_missing_shifu_config_raises_config_error(app):
         )
 
 
-def test_coze_workflow_adapter_missing_shifu_config_raises_config_error(app):
+def test_coze_workflow_adapter_missing_shifu_config_raises_config_error(app) -> None:
     adapter = module.CozeWorkflowAskProviderAdapter()
 
     with pytest.raises(
@@ -346,7 +350,7 @@ def test_coze_workflow_adapter_missing_shifu_config_raises_config_error(app):
         )
 
 
-def test_coze_adapter_uses_default_base_url_when_missing(app, monkeypatch):
+def test_coze_adapter_uses_default_base_url_when_missing(app, monkeypatch) -> None:
     adapter = module.CozeAskProviderAdapter()
     request_state = {}
 
@@ -390,7 +394,7 @@ def test_coze_adapter_uses_default_base_url_when_missing(app, monkeypatch):
     assert [chunk.content for chunk in chunks] == ["ok"]
 
 
-def test_volc_knowledge_adapter_streams_success_content(app, monkeypatch):
+def test_volc_knowledge_adapter_streams_success_content(app, monkeypatch) -> None:
     adapter = module.VolcKnowledgeAskProviderAdapter()
 
     monkeypatch.setattr(
@@ -452,7 +456,7 @@ def test_volc_knowledge_adapter_streams_success_content(app, monkeypatch):
     assert request_state["headers"]["X-Content-Sha256"]
 
 
-def test_volc_knowledge_adapter_missing_config_raises_error(app):
+def test_volc_knowledge_adapter_missing_config_raises_error(app) -> None:
     adapter = module.VolcKnowledgeAskProviderAdapter()
 
     with pytest.raises(module.AskProviderConfigError, match="account_id/ak/sk"):
@@ -472,7 +476,9 @@ def test_volc_knowledge_adapter_missing_config_raises_error(app):
         )
 
 
-def test_get_biji_knowledge_adapter_synthesizes_with_llm_context(app, monkeypatch):
+def test_get_biji_knowledge_adapter_synthesizes_with_llm_context(
+    app, monkeypatch
+) -> None:
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
 
     monkeypatch.setattr(
@@ -576,7 +582,7 @@ def test_get_biji_knowledge_adapter_synthesizes_with_llm_context(app, monkeypatc
 
 def test_get_biji_knowledge_adapter_skips_results_without_title_or_content(
     app, monkeypatch
-):
+) -> None:
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
 
     monkeypatch.setattr(
@@ -633,7 +639,7 @@ def test_get_biji_knowledge_adapter_skips_results_without_title_or_content(
 
 def test_get_biji_knowledge_adapter_empty_results_synthesizes_with_empty_context(
     app, monkeypatch
-):
+) -> None:
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
 
     monkeypatch.setattr(
@@ -675,7 +681,9 @@ def test_get_biji_knowledge_adapter_empty_results_synthesizes_with_empty_context
     assert [chunk.content for chunk in chunks] == ["fallback answer"]
 
 
-def test_get_biji_knowledge_adapter_without_runtime_emits_snippets(app, monkeypatch):
+def test_get_biji_knowledge_adapter_without_runtime_emits_snippets(
+    app, monkeypatch
+) -> None:
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
 
     monkeypatch.setattr(
@@ -725,7 +733,7 @@ def test_get_biji_knowledge_adapter_without_runtime_emits_snippets(app, monkeypa
     ]
 
 
-def test_get_biji_knowledge_adapter_missing_config_raises_error(app):
+def test_get_biji_knowledge_adapter_missing_config_raises_error(app) -> None:
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
 
     with pytest.raises(
@@ -747,7 +755,9 @@ def test_get_biji_knowledge_adapter_missing_config_raises_error(app):
         )
 
 
-def test_get_biji_knowledge_adapter_timeout_raises_timeout_error(app, monkeypatch):
+def test_get_biji_knowledge_adapter_timeout_raises_timeout_error(
+    app, monkeypatch
+) -> None:
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
 
     def _raise_timeout(*_args: object, **_kwargs: object):
@@ -774,7 +784,9 @@ def test_get_biji_knowledge_adapter_timeout_raises_timeout_error(app, monkeypatc
         )
 
 
-def test_get_biji_knowledge_adapter_http_error_raises_provider_error(app, monkeypatch):
+def test_get_biji_knowledge_adapter_http_error_raises_provider_error(
+    app, monkeypatch
+) -> None:
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
     http_error = requests.HTTPError("bad request")
 
@@ -810,7 +822,7 @@ def test_get_biji_knowledge_adapter_http_error_raises_provider_error(app, monkey
 
 def test_get_biji_knowledge_adapter_api_error_includes_message_and_reason(
     app, monkeypatch
-):
+) -> None:
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
 
     monkeypatch.setattr(
@@ -854,7 +866,7 @@ def test_get_biji_knowledge_adapter_api_error_includes_message_and_reason(
 
 def test_get_biji_knowledge_adapter_maps_business_errors_to_user_messages(
     app, monkeypatch
-):
+) -> None:
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
     cases = [
         # Auth failures arrive as HTTP 401 with a business error body.
@@ -906,7 +918,7 @@ def test_get_biji_knowledge_adapter_maps_business_errors_to_user_messages(
             )
 
 
-def test_render_knowledge_rule_and_section():
+def test_render_knowledge_rule_and_section() -> None:
     rule = common.render_knowledge_rule()
     section = common.render_knowledge_section("retrieved material", include_rule=False)
     section_with_rule = common.render_knowledge_section(
@@ -921,7 +933,7 @@ def test_render_knowledge_rule_and_section():
     assert "{knowledge_rule}" not in section
 
 
-def test_apply_knowledge_context_fills_rule_and_section_placeholders():
+def test_apply_knowledge_context_fills_rule_and_section_placeholders() -> None:
     prompt = (
         "# rules\n- learned rule\n{knowledge_rule}\n- unlearned rule\n\n"
         "{knowledge_section}\n\n# settings"
@@ -939,7 +951,7 @@ def test_apply_knowledge_context_fills_rule_and_section_placeholders():
     assert filled.count(rule) == 1
 
 
-def test_apply_knowledge_context_removes_rule_and_section_without_knowledge():
+def test_apply_knowledge_context_removes_rule_and_section_without_knowledge() -> None:
     prompt = (
         "# rules\n- learned rule\n{knowledge_rule}\n- unlearned rule\n\n"
         "{knowledge_section}\n\n# settings"
@@ -951,7 +963,7 @@ def test_apply_knowledge_context_removes_rule_and_section_without_knowledge():
     assert filled == "# rules\n- learned rule\n- unlearned rule\n\n# settings"
 
 
-def test_apply_knowledge_context_appends_section_for_legacy_prompts():
+def test_apply_knowledge_context_appends_section_for_legacy_prompts() -> None:
     prompt = "legacy prompt without placeholder"
 
     filled = common.apply_knowledge_context(prompt, "retrieved material")
@@ -967,13 +979,13 @@ def test_apply_knowledge_context_appends_section_for_legacy_prompts():
     assert common.render_knowledge_rule() in filled
 
 
-def test_apply_knowledge_context_keeps_legacy_prompt_without_knowledge():
+def test_apply_knowledge_context_keeps_legacy_prompt_without_knowledge() -> None:
     prompt = "legacy prompt without placeholder"
 
     assert common.apply_knowledge_context(prompt, "") == prompt
 
 
-def test_apply_knowledge_to_messages_updates_first_system_message():
+def test_apply_knowledge_to_messages_updates_first_system_message() -> None:
     messages = [
         {"role": "system", "content": "rules {knowledge_section} end"},
         {"role": "user", "content": "question"},
@@ -988,7 +1000,7 @@ def test_apply_knowledge_to_messages_updates_first_system_message():
     assert messages[0]["content"] == "rules {knowledge_section} end"
 
 
-def test_apply_knowledge_to_messages_prepends_system_when_missing():
+def test_apply_knowledge_to_messages_prepends_system_when_missing() -> None:
     messages = [{"role": "user", "content": "question"}]
 
     updated = common.apply_knowledge_to_messages(messages, "retrieved material")
@@ -1001,7 +1013,7 @@ def test_apply_knowledge_to_messages_prepends_system_when_missing():
     assert unchanged == messages
 
 
-def test_llm_adapter_streams_from_runtime_factory(app):
+def test_llm_adapter_streams_from_runtime_factory(app) -> None:
     adapter = module.LlmAskProviderAdapter()
 
     runtime = module.AskProviderRuntime(
@@ -1029,7 +1041,7 @@ def test_llm_adapter_streams_from_runtime_factory(app):
     assert [chunk.content for chunk in chunks] == ["hello", " world"]
 
 
-def test_llm_adapter_missing_runtime_raises_config_error(app):
+def test_llm_adapter_missing_runtime_raises_config_error(app) -> None:
     adapter = module.LlmAskProviderAdapter()
 
     with pytest.raises(module.AskProviderConfigError, match="llm runtime"):
@@ -1044,7 +1056,7 @@ def test_llm_adapter_missing_runtime_raises_config_error(app):
         )
 
 
-def test_stream_ask_provider_response_uses_llm_adapter_runtime(app):
+def test_stream_ask_provider_response_uses_llm_adapter_runtime(app) -> None:
     runtime = module.AskProviderRuntime(
         llm_stream_factory=lambda: iter([types.SimpleNamespace(result="from-llm")])
     )

--- a/src/api/tests/service/learn/test_ask_provider_langfuse.py
+++ b/src/api/tests/service/learn/test_ask_provider_langfuse.py
@@ -28,7 +28,7 @@ class _DummySpan:
         return generation
 
 
-def test_stream_provider_with_langfuse_links_generation_to_parent_span():
+def test_stream_provider_with_langfuse_links_generation_to_parent_span() -> None:
     app = Flask("ask-provider-langfuse")
     span = _DummySpan(trace_id="trace-1", span_id="follow-up-span-1")
     provider_stream = [
@@ -62,7 +62,7 @@ def test_stream_provider_with_langfuse_links_generation_to_parent_span():
     )
 
 
-def test_stream_provider_with_langfuse_uses_request_trace_id_fallback():
+def test_stream_provider_with_langfuse_uses_request_trace_id_fallback() -> None:
     app = Flask("ask-provider-langfuse-fallback")
     span = _DummySpan(trace_id="", span_id="follow-up-span-2")
 

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -171,7 +171,7 @@ _HAS_RUN_ASYNC = hasattr(RunScriptContextV2, "_run_async_in_safe_context")
 class OutlinePathGuardTests(unittest.TestCase):
     """Verify outline path guard behavior."""
 
-    def test_get_next_outline_item_ignores_missing_current_outline_item(self):
+    def test_get_next_outline_item_ignores_missing_current_outline_item(self) -> None:
         ctx = _make_context()
         ctx._struct = HistoryItem(bid="shifu-bid", id=1, type="shifu", children=[])
         ctx._current_outline_item = None
@@ -193,7 +193,7 @@ class OutlinePathGuardTests(unittest.TestCase):
 
         assert result == []
 
-    def test_find_outline_path_returns_path_when_outline_exists(self):
+    def test_find_outline_path_returns_path_when_outline_exists(self) -> None:
         root = HistoryItem(
             bid="shifu-bid",
             id=1,
@@ -207,7 +207,7 @@ class OutlinePathGuardTests(unittest.TestCase):
 
         assert [item.bid for item in path] == ["shifu-bid", "outline-bid"]
 
-    def test_find_outline_path_raises_app_error_when_outline_missing(self):
+    def test_find_outline_path_raises_app_error_when_outline_missing(self) -> None:
         root = HistoryItem(bid="shifu-bid", id=1, type="shifu", children=[])
 
         with (
@@ -229,7 +229,7 @@ class OutlinePathGuardTests(unittest.TestCase):
 class CollectAsyncGeneratorTests(unittest.TestCase):
     """Verify collect async generator behavior."""
 
-    def test_without_running_loop(self):
+    def test_without_running_loop(self) -> None:
         ctx = _make_context()
 
         async def sample():
@@ -240,7 +240,7 @@ class CollectAsyncGeneratorTests(unittest.TestCase):
 
         assert result == ["one", "two"]
 
-    def test_inside_running_loop(self):
+    def test_inside_running_loop(self) -> None:
         ctx = _make_context()
 
         async def sample():
@@ -260,7 +260,7 @@ class CollectAsyncGeneratorTests(unittest.TestCase):
 class RunAsyncInSafeContextTests(unittest.TestCase):
     """Verify run async in safe context behavior."""
 
-    def test_without_running_loop(self):
+    def test_without_running_loop(self) -> None:
         ctx = _make_context()
 
         async def sample():
@@ -268,7 +268,7 @@ class RunAsyncInSafeContextTests(unittest.TestCase):
 
         assert ctx._run_async_in_safe_context(sample) == "result"
 
-    def test_inside_running_loop(self):
+    def test_inside_running_loop(self) -> None:
         ctx = _make_context()
 
         async def sample():
@@ -298,7 +298,7 @@ class NextChapterInteractionTests(unittest.TestCase):
         with cls.app.app_context():
             dao.db.create_all()
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.app = self.__class__.app
         self.ctx = _make_context()
         self.ctx.app = self.app
@@ -314,7 +314,7 @@ class NextChapterInteractionTests(unittest.TestCase):
             LearnGeneratedBlock.query.delete()
             dao.db.session.commit()
 
-    def test_emits_and_persists_button_once(self):
+    def test_emits_and_persists_button_once(self) -> None:
         with self.app.app_context():
             events = list(
                 self.ctx._emit_next_chapter_interaction(self.ctx._current_attend)
@@ -346,7 +346,7 @@ class NextChapterInteractionTests(unittest.TestCase):
 class AccessGateFeedbackHelperTests(unittest.TestCase):
     """Verify access gate feedback helper behavior."""
 
-    def test_detects_blocking_access_gate(self):
+    def test_detects_blocking_access_gate(self) -> None:
         ctx = _make_context()
         ctx._is_paid = False
         ctx._user_info = types.SimpleNamespace(mobile="")
@@ -368,7 +368,7 @@ class AccessGateFeedbackHelperTests(unittest.TestCase):
 class CompletionTailInteractionTests(unittest.TestCase):
     """Verify completion tail interaction behavior."""
 
-    def test_emits_feedback_and_next_when_both_conditions_met(self):
+    def test_emits_feedback_and_next_when_both_conditions_met(self) -> None:
         ctx = _make_context()
         calls: list[str] = []
 
@@ -394,7 +394,7 @@ class CompletionTailInteractionTests(unittest.TestCase):
         assert calls == ["next", "feedback"]
         assert events == ["next-event", "feedback-event"]
 
-    def test_skips_next_when_no_next_outline(self):
+    def test_skips_next_when_no_next_outline(self) -> None:
         ctx = _make_context()
         calls: list[str] = []
 
@@ -420,7 +420,7 @@ class CompletionTailInteractionTests(unittest.TestCase):
         assert calls == ["feedback"]
         assert events == ["feedback-event"]
 
-    def test_emits_only_next_when_not_completed(self):
+    def test_emits_only_next_when_not_completed(self) -> None:
         ctx = _make_context()
         calls: list[str] = []
 
@@ -450,7 +450,9 @@ class CompletionTailInteractionTests(unittest.TestCase):
 class RuntimeOutlineBlockCountTests(unittest.TestCase):
     """Verify runtime outline block count behavior."""
 
-    def test_get_next_outline_item_uses_runtime_block_count_for_leaf_outline(self):
+    def test_get_next_outline_item_uses_runtime_block_count_for_leaf_outline(
+        self,
+    ) -> None:
         ctx = _make_context()
         ctx.app = Flask("runtime-outline-block-count-tests")
         ctx._preview_mode = False
@@ -519,7 +521,7 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
 
         assert get_outline_item_mock.call_args.kwargs.get("outline_item_id") == 1
 
-    def test_get_run_script_info_uses_outline_row_id_from_struct(self):
+    def test_get_run_script_info_uses_outline_row_id_from_struct(self) -> None:
         ctx = _make_context()
         ctx.app = Flask("runtime-outline-row-id-tests")
         ctx._preview_mode = False
@@ -584,7 +586,7 @@ class ExceptionGateFeedbackTests(unittest.TestCase):
         with cls.app.app_context():
             dao.db.create_all()
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.app = self.__class__.app
         self.ctx = _make_context()
         self.ctx.app = self.app
@@ -598,7 +600,7 @@ class ExceptionGateFeedbackTests(unittest.TestCase):
             LearnProgressRecord.query.delete()
             dao.db.session.commit()
 
-    def test_emits_feedback_for_latest_completed_progress(self):
+    def test_emits_feedback_for_latest_completed_progress(self) -> None:
         with self.app.app_context():
             progress = LearnProgressRecord(
                 progress_record_bid="progress-1",
@@ -629,12 +631,12 @@ class ExceptionGateFeedbackTests(unittest.TestCase):
             assert len(events) == 1
             assert events[0].type == GeneratedType.INTERACTION
 
-    def test_skips_when_no_completed_progress(self):
+    def test_skips_when_no_completed_progress(self) -> None:
         with self.app.app_context():
             events = list(self.ctx._emit_feedback_after_exception_gate())
             assert events == []
 
-    def test_skips_completed_progress_without_generated_blocks(self):
+    def test_skips_completed_progress_without_generated_blocks(self) -> None:
         with self.app.app_context():
             dao.db.session.add(
                 LearnProgressRecord(
@@ -668,7 +670,7 @@ class ExceptionGateInteractionPersistenceTests(unittest.TestCase):
         with cls.app.app_context():
             dao.db.create_all()
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.app = self.__class__.app
         self.ctx = _make_context()
         self.ctx.app = self.app
@@ -683,7 +685,7 @@ class ExceptionGateInteractionPersistenceTests(unittest.TestCase):
             LearnProgressRecord.query.delete()
             dao.db.session.commit()
 
-    def test_emits_gate_interaction_without_existing_progress(self):
+    def test_emits_gate_interaction_without_existing_progress(self) -> None:
         with self.app.app_context():
             events = list(
                 self.ctx._emit_current_progress_gate_interaction(
@@ -704,7 +706,7 @@ class ExceptionGateInteractionPersistenceTests(unittest.TestCase):
 class StreamTtsGateTests(unittest.TestCase):
     """Verify stream TTS gate behavior."""
 
-    def test_should_stream_tts_respects_preview_and_listen(self):
+    def test_should_stream_tts_respects_preview_and_listen(self) -> None:
         ctx = _make_context()
 
         ctx._input_type = "normal"
@@ -723,7 +725,7 @@ class StreamTtsGateTests(unittest.TestCase):
         ctx._input_type = "ask"
         assert not ctx._should_stream_tts()
 
-    def test_iter_stream_result_with_idle_callback_drains_while_waiting(self):
+    def test_iter_stream_result_with_idle_callback_drains_while_waiting(self) -> None:
         app = Flask("stream-tts-idle-drain")
         ctx = _make_context()
         ctx.app = app
@@ -751,7 +753,7 @@ class StreamTtsGateTests(unittest.TestCase):
         assert outputs[-1] == ("item", "chunk-1")
         assert idle_ticks
 
-    def test_iter_stream_result_with_idle_callback_stops_and_cleans_up(self):
+    def test_iter_stream_result_with_idle_callback_stops_and_cleans_up(self) -> None:
         app = Flask("stream-tts-stop")
         ctx = _make_context()
         ctx.app = app
@@ -822,7 +824,7 @@ class ReloadFromElementBidTests(unittest.TestCase):
         with cls.app.app_context():
             dao.db.create_all()
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.app = self.__class__.app
         self.ctx = _make_context()
         self.ctx.app = self.app
@@ -836,7 +838,7 @@ class ReloadFromElementBidTests(unittest.TestCase):
             LearnProgressRecord.query.delete()
             dao.db.session.commit()
 
-    def test_reload_element_bid_realigns_progress_to_source_block(self):
+    def test_reload_element_bid_realigns_progress_to_source_block(self) -> None:
         with self.app.app_context():
             progress = LearnProgressRecord(
                 progress_record_bid="progress-1",
@@ -942,7 +944,7 @@ class ReloadFromElementBidTests(unittest.TestCase):
             assert later_element is not None
             assert later_element.status == 0
 
-    def test_reload_preserves_ask_and_answer_blocks(self):
+    def test_reload_preserves_ask_and_answer_blocks(self) -> None:
         with self.app.app_context():
             progress = LearnProgressRecord(
                 progress_record_bid="progress-ask-keep",
@@ -1058,7 +1060,7 @@ class ReloadFromElementBidTests(unittest.TestCase):
 class StreamTtsTeardownTests(unittest.TestCase):
     """Verify stream TTS teardown behavior."""
 
-    def test_teardown_flushes_content_then_finalizes_tts(self):
+    def test_teardown_flushes_content_then_finalizes_tts(self) -> None:
         app = Flask("stream-tts-teardown")
         ctx = _make_context()
         ctx.app = app
@@ -1095,7 +1097,7 @@ class StreamTtsTeardownTests(unittest.TestCase):
         assert processor.finalize_calls == [False]
         assert ctx._element_index_cursor == 5
 
-    def test_teardown_skips_emit_on_generator_exit(self):
+    def test_teardown_skips_emit_on_generator_exit(self) -> None:
         app = Flask("stream-tts-teardown-generator-exit")
         ctx = _make_context()
         ctx.app = app
@@ -1138,7 +1140,7 @@ class StreamTtsTeardownTests(unittest.TestCase):
 class MdflowContextCompatibilityTests(unittest.TestCase):
     """Verify MarkdownFlow context compatibility behavior."""
 
-    def test_init_ignores_visual_mode_when_api_missing(self):
+    def test_init_ignores_visual_mode_when_api_missing(self) -> None:
         class FakeMarkdownFlow:
             def __init__(self, *args: object, **kwargs: object) -> None:
                 self.args = args
@@ -1152,7 +1154,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
 
         assert isinstance(context._mdflow, FakeMarkdownFlow)
 
-    def test_init_calls_visual_mode_when_api_exists(self):
+    def test_init_calls_visual_mode_when_api_exists(self) -> None:
         class FakeMarkdownFlow:
             def __init__(self, *args: object, **kwargs: object) -> None:
                 _ = (args, kwargs)
@@ -1169,7 +1171,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
 
         assert not context._mdflow.visual_mode
 
-    def test_init_uses_explicit_output_language_when_enabled(self):
+    def test_init_uses_explicit_output_language_when_enabled(self) -> None:
         class FakeMarkdownFlow:
             def __init__(self, *args: object, **kwargs: object) -> None:
                 _ = (args, kwargs)
@@ -1194,7 +1196,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
 
         assert context._mdflow.output_language == "简体中文"
 
-    def test_filter_context_removes_stale_english_output_instruction(self):
+    def test_filter_context_removes_stale_english_output_instruction(self) -> None:
         context = [
             {
                 "role": "user",
@@ -1215,7 +1217,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
 class RuntimeOutputLanguageTests(unittest.TestCase):
     """Verify runtime output language behavior."""
 
-    def test_runtime_language_overrides_stale_profile_language(self):
+    def test_runtime_language_overrides_stale_profile_language(self) -> None:
         with patch(
             "flaskr.service.learn.context_v2.get_current_language",
             return_value="zh-CN",
@@ -1226,7 +1228,7 @@ class RuntimeOutputLanguageTests(unittest.TestCase):
 
         assert output_language == "zh-CN"
 
-    def test_runtime_language_overlays_stale_production_prompt_variables(self):
+    def test_runtime_language_overlays_stale_production_prompt_variables(self) -> None:
         stored_profile = {
             "sys_user_language": "zh-CN",
             "language": "zh-CN",
@@ -1249,7 +1251,9 @@ class RuntimeOutputLanguageTests(unittest.TestCase):
         assert stored_profile["sys_user_language"] == "zh-CN"
         assert stored_profile["language"] == "zh-CN"
 
-    def test_runtime_language_keeps_profile_variables_when_feature_is_disabled(self):
+    def test_runtime_language_keeps_profile_variables_when_feature_is_disabled(
+        self,
+    ) -> None:
         stored_profile = {
             "sys_user_language": "zh-CN",
             "language": "zh-CN",
@@ -1272,7 +1276,7 @@ class RuntimeOutputLanguageTests(unittest.TestCase):
 class PreviewResolveLlmSettingsTests(unittest.TestCase):
     """Verify preview resolve LLM settings behavior."""
 
-    def test_falls_back_to_allowlist_when_persisted_model_not_allowed(self):
+    def test_falls_back_to_allowlist_when_persisted_model_not_allowed(self) -> None:
         app = Flask("preview-llm-settings")
         app.config.update(
             DEFAULT_LLM_MODEL="",
@@ -1311,7 +1315,7 @@ class PreviewResolveLlmSettingsTests(unittest.TestCase):
 class PreviewResolveVariablesTests(unittest.TestCase):
     """Verify preview resolve variables behavior."""
 
-    def test_injects_request_language_when_missing(self):
+    def test_injects_request_language_when_missing(self) -> None:
         app = Flask("preview-variables")
         preview_ctx = RunScriptPreviewContextV2(app)
         preview_request = PlaygroundPreviewRequest(block_index=0)
@@ -1337,7 +1341,7 @@ class PreviewResolveVariablesTests(unittest.TestCase):
         assert variables.get("sys_user_nickname") == "017"
         mock_fetch.assert_called_once_with(app, "user-1", "shifu-1")
 
-    def test_empty_sys_user_language_uses_request_language(self):
+    def test_empty_sys_user_language_uses_request_language(self) -> None:
         app = Flask("preview-variables-empty-language")
         preview_ctx = RunScriptPreviewContextV2(app)
         preview_request = PlaygroundPreviewRequest(
@@ -1364,7 +1368,7 @@ class PreviewResolveVariablesTests(unittest.TestCase):
         assert variables.get("sys_user_language") == "zh-CN"
         assert variables.get("language") == "zh-CN"
 
-    def test_request_language_overrides_stale_profile_language(self):
+    def test_request_language_overrides_stale_profile_language(self) -> None:
         app = Flask("preview-variables-request-language")
         preview_ctx = RunScriptPreviewContextV2(app)
         preview_request = PlaygroundPreviewRequest(
@@ -1385,7 +1389,7 @@ class PreviewResolveVariablesTests(unittest.TestCase):
         assert variables.get("sys_user_language") == "zh-CN"
         assert variables.get("language") == "zh-CN"
 
-    def test_keeps_existing_sys_user_language(self):
+    def test_keeps_existing_sys_user_language(self) -> None:
         app = Flask("preview-variables-existing")
         preview_ctx = RunScriptPreviewContextV2(app)
         preview_request = PlaygroundPreviewRequest(
@@ -1433,7 +1437,9 @@ class CoursePromptCompositionTests(unittest.TestCase):
         )
         assert prompt.count(LEARNER_PROFILE_PROMPT_MARKER) == 1
 
-    def test_runtime_getter_returns_course_prompt_with_current_learner_profile(self):
+    def test_runtime_getter_returns_course_prompt_with_current_learner_profile(
+        self,
+    ) -> None:
         app = Flask("runtime-course-prompt-profile")
         ctx = _make_context()
         ctx.app = app
@@ -1463,7 +1469,7 @@ class CoursePromptCompositionTests(unittest.TestCase):
         )
         ctx._shifu_model.query.filter.assert_not_called()
 
-    def test_formal_preview_composes_request_prompt_with_current_learner(self):
+    def test_formal_preview_composes_request_prompt_with_current_learner(self) -> None:
         app = Flask("preview-course-prompt-profile")
         preview_ctx = RunScriptPreviewContextV2(app)
         preview_request = PlaygroundPreviewRequest(
@@ -1495,7 +1501,9 @@ class CoursePromptCompositionTests(unittest.TestCase):
         assert "FALLBACK RULE" not in prompt
         mock_load.assert_called_once_with("user-1")
 
-    def test_formal_preview_uses_current_explicit_nickname_without_profile_text(self):
+    def test_formal_preview_uses_current_explicit_nickname_without_profile_text(
+        self,
+    ) -> None:
         app = Flask("preview-course-prompt-nickname")
         preview_ctx = RunScriptPreviewContextV2(app)
         preview_request = PlaygroundPreviewRequest(
@@ -1531,7 +1539,7 @@ class CoursePromptCompositionTests(unittest.TestCase):
             == 'Preferred form of address (learner-authored): "Current Learner"'
         )
 
-    def test_formal_preview_reloads_profile_for_each_request(self):
+    def test_formal_preview_reloads_profile_for_each_request(self) -> None:
         app = Flask("preview-course-prompt-profile-refresh")
         preview_ctx = RunScriptPreviewContextV2(app)
         preview_request = PlaygroundPreviewRequest(
@@ -1572,7 +1580,9 @@ class CoursePromptCompositionTests(unittest.TestCase):
         assert cleared_prompt == "PREVIEW COURSE RULE"
         assert mock_load.call_args_list == [call("user-1"), call("user-1")]
 
-    def test_formal_preview_recomposes_client_envelope_for_current_learner(self):
+    def test_formal_preview_recomposes_client_envelope_for_current_learner(
+        self,
+    ) -> None:
         app = Flask("preview-course-prompt-current-account")
         preview_ctx = RunScriptPreviewContextV2(app)
         prompt_for_previous_account = build_course_prompt(
@@ -1618,7 +1628,7 @@ class CoursePromptCompositionTests(unittest.TestCase):
         assert "PREVIOUS ACCOUNT PROFILE" not in current_prompt
         assert cleared_prompt == "PREVIEW COURSE RULE"
 
-    def test_preview_learner_lookup_failure_cleans_the_database_session(self):
+    def test_preview_learner_lookup_failure_cleans_the_database_session(self) -> None:
         app = Flask("preview-course-prompt-lookup-failure")
         preview_ctx = RunScriptPreviewContextV2(app)
         lookup_error = RuntimeError("database unavailable")
@@ -1645,7 +1655,7 @@ class CoursePromptCompositionTests(unittest.TestCase):
 class PreviewRunLlmLoggingTests(unittest.TestCase):
     """Verify preview run LLM logging behavior."""
 
-    def test_complete_logs_full_preview_output(self):
+    def test_complete_logs_full_preview_output(self) -> None:
         app = Flask("preview-run-llm-logging")
         parent_observation = object()
         provider = RUNLLMProvider(
@@ -1701,7 +1711,7 @@ class PreviewRunLlmLoggingTests(unittest.TestCase):
 class LangfuseTraceFinalizationTests(unittest.TestCase):
     """Verify langfuse trace finalization behavior."""
 
-    def test_runtime_context_uses_current_langfuse_client(self):
+    def test_runtime_context_uses_current_langfuse_client(self) -> None:
         app = Flask("runtime-langfuse-client")
         sentinel_client = object()
         captured = {}
@@ -1759,7 +1769,7 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
         assert captured["client"] is sentinel_client
         assert captured["trace_payload"]["id"] == "req-trace-1"
 
-    def test_set_input_normalizes_structured_value_for_trace(self):
+    def test_set_input_normalizes_structured_value_for_trace(self) -> None:
         ctx = _make_context()
         ctx._trace_args = {}
 
@@ -1768,7 +1778,7 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
         assert ctx._trace_args["input"] == "Python, Go, Beginner"
         assert ctx._trace_args["input_type"] == "select"
 
-    def test_set_input_normalizes_python_literal_string_for_trace(self):
+    def test_set_input_normalizes_python_literal_string_for_trace(self) -> None:
         ctx = _make_context()
         ctx._trace_args = {}
 
@@ -1776,7 +1786,7 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
 
         assert ctx._trace_args["input"] == "Python, Go"
 
-    def test_runtime_finalize_skips_empty_output_overwrite(self):
+    def test_runtime_finalize_skips_empty_output_overwrite(self) -> None:
         ctx = _make_context()
         ctx._trace = _FakeLangfuseTrace()
         ctx._trace_root_span = _FakeLangfuseSpan()
@@ -1796,7 +1806,7 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
         }
         assert ctx._trace_root_span.end_kwargs == {}
 
-    def test_runtime_finalize_uses_accumulated_output(self):
+    def test_runtime_finalize_uses_accumulated_output(self) -> None:
         ctx = _make_context()
         ctx._trace = _FakeLangfuseTrace()
         ctx._trace_root_span = _FakeLangfuseSpan()
@@ -1816,7 +1826,7 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
             "output": "chunk-1chunk-2",
         }
 
-    def test_append_langfuse_output_normalizes_python_literal_string(self):
+    def test_append_langfuse_output_normalizes_python_literal_string(self) -> None:
         ctx = _make_context()
         ctx._langfuse_output_chunks = []
 
@@ -1828,7 +1838,7 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
 class PreviewLangfuseTraceTests(unittest.TestCase):
     """Verify preview langfuse trace behavior."""
 
-    def test_stream_preview_sets_session_id_and_finalizes_root_span(self):
+    def test_stream_preview_sets_session_id_and_finalizes_root_span(self) -> None:
         app = Flask("preview-langfuse-trace")
         preview_ctx = RunScriptPreviewContextV2(app)
         preview_request = PlaygroundPreviewRequest(block_index=0)
@@ -1959,7 +1969,7 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
 class PreviewElementizationTests(unittest.TestCase):
     """Verify preview elementization behavior."""
 
-    def test_preview_content_events_preserve_stream_parts(self):
+    def test_preview_content_events_preserve_stream_parts(self) -> None:
         app = Flask("preview-content-events")
         preview_ctx = RunScriptPreviewContextV2(app)
 
@@ -1979,7 +1989,7 @@ class PreviewElementizationTests(unittest.TestCase):
         assert events[0].type == GeneratedType.CONTENT
         assert events[0].get_mdflow_stream_parts() == [("Hello preview", "text", 0)]
 
-    def test_preview_content_stream_emits_element_and_done(self):
+    def test_preview_content_stream_emits_element_and_done(self) -> None:
         app = Flask("preview-content-stream")
         preview_ctx = RunScriptPreviewContextV2(app)
         adapter = PreviewElementRunAdapter(
@@ -2029,7 +2039,9 @@ class PreviewElementizationTests(unittest.TestCase):
         assert messages[-1].type == GeneratedType.DONE.value
         assert messages[-1].is_terminal
 
-    def test_preview_content_uses_formatted_elements_when_top_level_content_empty(self):
+    def test_preview_content_uses_formatted_elements_when_top_level_content_empty(
+        self,
+    ) -> None:
         app = Flask("preview-content-formatted-elements")
         preview_ctx = RunScriptPreviewContextV2(app)
         adapter = PreviewElementRunAdapter(
@@ -2078,7 +2090,7 @@ class PreviewElementizationTests(unittest.TestCase):
 
     def test_preview_interaction_validation_uses_formatted_elements_when_content_empty(
         self,
-    ):
+    ) -> None:
         app = Flask("preview-interaction-validation-formatted-elements")
         preview_ctx = RunScriptPreviewContextV2(app)
         adapter = PreviewElementRunAdapter(
@@ -2128,7 +2140,9 @@ class PreviewElementizationTests(unittest.TestCase):
         assert messages[-1].type == GeneratedType.DONE.value
         assert messages[-1].is_terminal
 
-    def test_preview_interaction_stream_emits_interaction_element_and_done(self):
+    def test_preview_interaction_stream_emits_interaction_element_and_done(
+        self,
+    ) -> None:
         app = Flask("preview-interaction-stream")
         preview_ctx = RunScriptPreviewContextV2(app)
         adapter = PreviewElementRunAdapter(
@@ -2207,7 +2221,7 @@ def _make_preview_store(
 class PreviewSentPromptCaptureTests(unittest.TestCase):
     """The preview flow stores the exact user message markdown-flow sent to the LLM (LLMResult.prompt) instead of a locally re-rendered block, so the replayed preview context stays byte-identical to the sent request."""
 
-    def test_iter_preview_generated_events_captures_prompt(self):
+    def test_iter_preview_generated_events_captures_prompt(self) -> None:
         app = Flask("preview-prompt-capture")
         preview_ctx = RunScriptPreviewContextV2(app)
         sent_prompt_chunks: list[str] = []
@@ -2237,7 +2251,7 @@ class PreviewSentPromptCaptureTests(unittest.TestCase):
 
         assert sent_prompt_chunks == ["P-PREVIEW"]
 
-    def test_update_preview_context_prefers_sent_prompt(self):
+    def test_update_preview_context_prefers_sent_prompt(self) -> None:
         app = Flask("preview-prompt-store")
         preview_ctx = RunScriptPreviewContextV2(app)
         appended: list[tuple] = []
@@ -2274,7 +2288,7 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
         for idx in indices:
             store.append_context(doc, idx, f"u{idx}", f"a{idx}")
 
-    def test_sequential_blocks_accumulate(self):
+    def test_sequential_blocks_accumulate(self) -> None:
         store, _cache, doc = _make_preview_store()
         self._populate(store, doc, [0, 1, 2, 3])
         messages = store.get_context(doc, 4)
@@ -2289,7 +2303,7 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
             {"role": "assistant", "content": "a3"},
         ]
 
-    def test_reselect_drops_entries_at_or_above_block_index(self):
+    def test_reselect_drops_entries_at_or_above_block_index(self) -> None:
         store, _cache, doc = _make_preview_store()
         self._populate(store, doc, [0, 1, 2, 3])
         messages = store.get_context(doc, 2)
@@ -2302,7 +2316,7 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
         persisted = store.load()
         assert [entry["block_index"] for entry in persisted["entries"]] == [0, 1]
 
-    def test_repeated_reselect_does_not_grow(self):
+    def test_repeated_reselect_does_not_grow(self) -> None:
         store, _cache, doc = _make_preview_store()
         self._populate(store, doc, [0, 1, 2, 3])
         for _ in range(5):
@@ -2318,7 +2332,7 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
         assert index_counts.get(0) == 1
         assert index_counts.get(1) == 1
 
-    def test_backtrack_to_earlier_block(self):
+    def test_backtrack_to_earlier_block(self) -> None:
         store, _cache, doc = _make_preview_store()
         self._populate(store, doc, [0, 1, 2, 3])
         messages = store.get_context(doc, 1)
@@ -2329,19 +2343,19 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
         persisted = store.load()
         assert [entry["block_index"] for entry in persisted["entries"]] == [0]
 
-    def test_block_index_zero_clears(self):
+    def test_block_index_zero_clears(self) -> None:
         store, cache, doc = _make_preview_store()
         self._populate(store, doc, [0, 1, 2])
         assert store.get_context(doc, 0) == []
         assert cache.store == {}
 
-    def test_document_hash_change_clears(self):
+    def test_document_hash_change_clears(self) -> None:
         store, cache, _doc = _make_preview_store(doc="doc-A")
         self._populate(store, "doc-A", [0, 1, 2])
         assert store.get_context("doc-B", 3) == []
         assert cache.store == {}
 
-    def test_legacy_flat_schema_clears(self):
+    def test_legacy_flat_schema_clears(self) -> None:
         store, cache, doc = _make_preview_store()
         store.save(
             {
@@ -2355,12 +2369,12 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
         assert store.get_context(doc, 3) == []
         assert cache.store == {}
 
-    def test_append_skips_when_both_empty(self):
+    def test_append_skips_when_both_empty(self) -> None:
         store, cache, doc = _make_preview_store()
         store.append_context(doc, 2, None, None)
         assert cache.store == {}
 
-    def test_append_user_only_and_assistant_only(self):
+    def test_append_user_only_and_assistant_only(self) -> None:
         store, _cache, doc = _make_preview_store()
         store.append_context(doc, 1, "user-only", None)
         store.append_context(doc, 2, None, "assistant-only")
@@ -2370,7 +2384,7 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
             {"role": "assistant", "content": "assistant-only"},
         ]
 
-    def test_missing_document_hash_clears_entries(self):
+    def test_missing_document_hash_clears_entries(self) -> None:
         store, cache, doc = _make_preview_store()
         store.save(
             {"entries": [{"block_index": 1, "user": "stale", "assistant": "stale"}]}
@@ -2378,7 +2392,7 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
         assert store.get_context(doc, 3) == []
         assert cache.store == {}
 
-    def test_empty_document_hash_clears_entries(self):
+    def test_empty_document_hash_clears_entries(self) -> None:
         store, cache, doc = _make_preview_store()
         store.save(
             {
@@ -2389,7 +2403,7 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
         assert store.get_context(doc, 3) == []
         assert cache.store == {}
 
-    def test_replace_context_pairs_messages_with_sentinel_index(self):
+    def test_replace_context_pairs_messages_with_sentinel_index(self) -> None:
         store, _cache, doc = _make_preview_store()
         store.replace_context(
             doc,
@@ -2413,7 +2427,7 @@ class PreviewContextStoreTruncationTests(unittest.TestCase):
 class RuntimeExceptionLangfuseTests(unittest.TestCase):
     """Verify runtime exception langfuse behavior."""
 
-    def test_run_emits_gate_interaction_after_paid_exception(self):
+    def test_run_emits_gate_interaction_after_paid_exception(self) -> None:
         app = Flask("runtime-langfuse-paid")
         ctx = _make_context()
 
@@ -2460,7 +2474,7 @@ class BuildContextFromBlocksTests(unittest.TestCase):
             ),
         ]
 
-    def test_interaction_block_kept_as_raw_assistant_message(self):
+    def test_interaction_block_kept_as_raw_assistant_message(self) -> None:
         app = Flask(__name__)
         with app.app_context():
             messages = MdflowContextV2.build_context_from_blocks(
@@ -2474,7 +2488,7 @@ class BuildContextFromBlocksTests(unittest.TestCase):
         assert len(interaction_msgs) == 1
         assert "%{{nickname}}" in interaction_msgs[0]["content"]
 
-    def test_transform_expands_interaction_without_adjacent_users(self):
+    def test_transform_expands_interaction_without_adjacent_users(self) -> None:
         app = Flask(__name__)
         with app.app_context():
             messages = MdflowContextV2.build_context_from_blocks(
@@ -2516,7 +2530,7 @@ class BuildContextGenerationPromptReplayTests(unittest.TestCase):
         "The next interaction will appear immediately after this content."
     )
 
-    def test_stored_prompt_replayed_verbatim_ignoring_current_variables(self):
+    def test_stored_prompt_replayed_verbatim_ignoring_current_variables(self) -> None:
         blocks = [
             types.SimpleNamespace(
                 type=BLOCK_TYPE_MDCONTENT_VALUE,
@@ -2535,7 +2549,7 @@ class BuildContextGenerationPromptReplayTests(unittest.TestCase):
         assert messages[0]["role"] == "user"
         assert messages[0]["content"] == self.STORED_PROMPT
 
-    def test_missing_or_empty_prompt_falls_back_to_current_rendering(self):
+    def test_missing_or_empty_prompt_falls_back_to_current_rendering(self) -> None:
         blocks = [
             # Legacy row persisted before the column existed.
             types.SimpleNamespace(
@@ -2631,7 +2645,7 @@ class StreamContentBlockPromptCaptureTests(unittest.TestCase):
             dao.db.session.rollback()
         return ctx, events
 
-    def test_llm_prompt_captured_and_passed_to_finalize(self):
+    def test_llm_prompt_captured_and_passed_to_finalize(self) -> None:
         ctx, _events = self._run_stream_phase(
             [
                 LLMResult(content="Hello ", type="text", number=0, prompt="P-EXACT"),
@@ -2642,7 +2656,7 @@ class StreamContentBlockPromptCaptureTests(unittest.TestCase):
         assert finalize_call.kwargs["generation_prompt"] == "P-EXACT"
         assert finalize_call.args[1] == "Hello world"
 
-    def test_promptless_stream_falls_back_to_rendered_block_source(self):
+    def test_promptless_stream_falls_back_to_rendered_block_source(self) -> None:
         ctx, _events = self._run_stream_phase(
             [LLMResult(content="Preserved Alice text.", type="text", number=0)]
         )
@@ -2691,7 +2705,7 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
             ),
         ]
 
-    def test_selection_attached_via_user_answer_field(self):
+    def test_selection_attached_via_user_answer_field(self) -> None:
         app = Flask(__name__)
         with app.app_context():
             messages = MdflowContextV2.build_context_from_blocks(
@@ -2708,7 +2722,7 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
             },
         ]
 
-    def test_empty_selection_carries_empty_user_answer(self):
+    def test_empty_selection_carries_empty_user_answer(self) -> None:
         app = Flask(__name__)
         with app.app_context():
             messages = MdflowContextV2.build_context_from_blocks(
@@ -2723,7 +2737,7 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
             USER_ANSWER_CONTEXT_KEY: "",
         }
 
-    def test_library_expands_answer_and_skips_empty_turns(self):
+    def test_library_expands_answer_and_skips_empty_turns(self) -> None:
         """End-to-end: the context built here goes through markdown-flow's message transform and comes out with the real answer, no raw ?[...] syntax, and no fabricated "ok" for unanswered interactions."""
         app = Flask(__name__)
         with app.app_context():
@@ -2753,7 +2767,7 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
             {"role": "assistant", "content": "reply zero"},
         ]
 
-    def test_variable_free_text_input_carries_the_learner_answer(self):
+    def test_variable_free_text_input_carries_the_learner_answer(self) -> None:
         document = "Content one.\n---\n?[...What is your name?]\n---\nSecond content."
         app = Flask(__name__)
         with app.app_context():

--- a/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
+++ b/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
@@ -16,7 +16,7 @@ def _make_context_stub(app):
     return stub
 
 
-def test_stream_producer_stops_when_consumer_exits_early(app):
+def test_stream_producer_stops_when_consumer_exits_early(app) -> None:
     stop_streaming = threading.Event()
 
     def endless_stream():
@@ -47,7 +47,7 @@ def test_stream_producer_stops_when_consumer_exits_early(app):
     )
 
 
-def test_early_consumer_exit_invalidates_producer_session(app, monkeypatch):
+def test_early_consumer_exit_invalidates_producer_session(app, monkeypatch) -> None:
     from flaskr.service.learn import context_v2
 
     invalidations = []
@@ -81,7 +81,9 @@ def test_early_consumer_exit_invalidates_producer_session(app, monkeypatch):
     assert invalidations == ["mdflow stream producer abort"]
 
 
-def test_natural_exhaustion_does_not_invalidate_producer_session(app, monkeypatch):
+def test_natural_exhaustion_does_not_invalidate_producer_session(
+    app, monkeypatch
+) -> None:
     from flaskr.service.learn import context_v2
 
     invalidations = []
@@ -110,7 +112,7 @@ def test_natural_exhaustion_does_not_invalidate_producer_session(app, monkeypatc
     assert invalidations == []
 
 
-def test_tts_finalize_failure_runs_classified_cleanup(app, monkeypatch):
+def test_tts_finalize_failure_runs_classified_cleanup(app, monkeypatch) -> None:
     """A DB failure swallowed by the TTS finalize wrapper must still run the classified cleanup so an interrupted exchange discards the connection."""
     import types
 

--- a/src/api/tests/service/learn/test_context_v2_tts_runtime_voice.py
+++ b/src/api/tests/service/learn/test_context_v2_tts_runtime_voice.py
@@ -5,7 +5,9 @@ from types import SimpleNamespace
 from flask import Flask
 
 
-def test_context_v2_tts_processor_uses_runtime_minimax_voice_fallback(monkeypatch):
+def test_context_v2_tts_processor_uses_runtime_minimax_voice_fallback(
+    monkeypatch,
+) -> None:
     from flaskr.dao import db
     from flaskr.service.learn.context_v2 import RunScriptContextV2
     from flaskr.service.shifu.models import DraftShifu

--- a/src/api/tests/service/learn/test_element_protocol.py
+++ b/src/api/tests/service/learn/test_element_protocol.py
@@ -9,12 +9,18 @@ Covers:
 """
 
 import types
+from typing import TYPE_CHECKING
 
 import pytest
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from flask import Flask
+
 
 @pytest.fixture
-def adapter_app():
+def adapter_app() -> "Iterator[Flask]":
     import flaskr.service.learn.models  # noqa: F401
     from flask import Flask
     from flaskr import dao
@@ -197,7 +203,7 @@ def _setup_handle_input_ask_test_doubles(
 class TestElementType:
     """Verify element type behavior."""
 
-    def test_new_enum_values(self):
+    def test_new_enum_values(self) -> None:
         from flaskr.service.learn.learn_dtos import ElementType
 
         expected = {
@@ -219,20 +225,20 @@ class TestElementType:
         actual = {et.value for et in ElementType if not et.name.startswith("_")}
         assert actual == expected
 
-    def test_legacy_aliases_exist(self):
+    def test_legacy_aliases_exist(self) -> None:
         from flaskr.service.learn.learn_dtos import ElementType
 
         assert ElementType._SANDBOX.value == "sandbox"
         assert ElementType._PICTURE.value == "picture"
         assert ElementType._VIDEO.value == "video"
 
-    def test_invalid_value_raises(self):
+    def test_invalid_value_raises(self) -> None:
         from flaskr.service.learn.learn_dtos import ElementType
 
         with pytest.raises(ValueError, match="nonexistent"):
             ElementType("nonexistent")
 
-    def test_element_type_codes_complete(self):
+    def test_element_type_codes_complete(self) -> None:
         from flaskr.service.learn.learn_dtos import ElementType
         from flaskr.service.learn.listen_element_types import ELEMENT_TYPE_CODES
 
@@ -242,7 +248,7 @@ class TestElementType:
                 continue
             assert et in ELEMENT_TYPE_CODES, f"Missing code for {et}"
 
-    def test_legacy_mapping(self):
+    def test_legacy_mapping(self) -> None:
         from flaskr.service.learn.learn_dtos import ElementType
         from flaskr.service.learn.listen_element_types import LEGACY_ELEMENT_TYPE_MAP
 
@@ -272,7 +278,7 @@ class TestElementDTONewFields:
         defaults.update(overrides)
         return ElementDTO(**defaults)
 
-    def test_default_values(self):
+    def test_default_values(self) -> None:
         dto = self._make_dto()
         assert dto.is_renderable is True
         assert dto.is_new is True
@@ -282,7 +288,7 @@ class TestElementDTONewFields:
         assert dto.audio_url == ""
         assert dto.audio_segments == []
 
-    def test_json_includes_new_fields(self):
+    def test_json_includes_new_fields(self) -> None:
         dto = self._make_dto(
             is_renderable=False,
             is_new=False,
@@ -301,7 +307,7 @@ class TestElementDTONewFields:
         assert result["audio_url"] == "https://example.com/audio.mp3"
         assert len(result["audio_segments"]) == 1
 
-    def test_json_field_order(self):
+    def test_json_field_order(self) -> None:
         dto = self._make_dto()
         result = dto.__json__()
         keys = list(result.keys())
@@ -314,7 +320,7 @@ class TestElementDTONewFields:
         assert "audio_url" in keys
         assert "audio_segments" in keys
 
-    def test_final_json_marks_all_audio_segments_final(self):
+    def test_final_json_marks_all_audio_segments_final(self) -> None:
         dto = self._make_dto(
             is_final=True,
             audio_url="https://example.com/audio.mp3",
@@ -335,7 +341,7 @@ class TestElementDTONewFields:
             True,
         ]
 
-    def test_non_final_json_preserves_audio_segment_flags(self):
+    def test_non_final_json_preserves_audio_segment_flags(self) -> None:
         dto = self._make_dto(
             is_final=False,
             audio_segments=[
@@ -355,7 +361,7 @@ class TestElementDTONewFields:
 class TestRunMarkdownFlowDTO:
     """Verify run markdown flow DTO behavior."""
 
-    def test_private_mdflow_stream_parts_do_not_leak_into_json(self):
+    def test_private_mdflow_stream_parts_do_not_leak_into_json(self) -> None:
         from flaskr.service.learn.learn_dtos import GeneratedType, RunMarkdownFlowDTO
 
         dto = RunMarkdownFlowDTO(
@@ -382,14 +388,14 @@ class TestRunMarkdownFlowDTO:
 class TestTypeStateMachine:
     """Verify type state machine behavior."""
 
-    def test_initial_state_is_idle(self):
+    def test_initial_state_is_idle(self) -> None:
         from flaskr.service.learn.type_state_machine import TypeState, TypeStateMachine
 
         sm = TypeStateMachine()
         assert sm.state == TypeState.IDLE
         assert not sm.is_terminated
 
-    def test_content_start_transitions_to_building(self):
+    def test_content_start_transitions_to_building(self) -> None:
         from flaskr.service.learn.type_state_machine import (
             TypeInput,
             TypeState,
@@ -401,7 +407,7 @@ class TestTypeStateMachine:
         assert out == "element"
         assert sm.state == TypeState.BUILDING
 
-    def test_content_start_with_is_new_false_transitions_to_patching(self):
+    def test_content_start_with_is_new_false_transitions_to_patching(self) -> None:
         from flaskr.service.learn.type_state_machine import (
             TypeInput,
             TypeState,
@@ -413,7 +419,7 @@ class TestTypeStateMachine:
         assert out == "element"
         assert sm.state == TypeState.PATCHING
 
-    def test_incremental_update_transitions_to_patching(self):
+    def test_incremental_update_transitions_to_patching(self) -> None:
         from flaskr.service.learn.type_state_machine import (
             TypeInput,
             TypeState,
@@ -426,7 +432,7 @@ class TestTypeStateMachine:
         assert out == "element"
         assert sm.state == TypeState.PATCHING
 
-    def test_block_break_returns_to_idle(self):
+    def test_block_break_returns_to_idle(self) -> None:
         from flaskr.service.learn.type_state_machine import (
             TypeInput,
             TypeState,
@@ -439,7 +445,7 @@ class TestTypeStateMachine:
         assert out == "break"
         assert sm.state == TypeState.IDLE
 
-    def test_audio_segment_preserves_state(self):
+    def test_audio_segment_preserves_state(self) -> None:
         from flaskr.service.learn.type_state_machine import (
             TypeInput,
             TypeState,
@@ -452,7 +458,7 @@ class TestTypeStateMachine:
         assert out == "audio_segment"
         assert sm.state == TypeState.BUILDING
 
-    def test_audio_complete_preserves_state(self):
+    def test_audio_complete_preserves_state(self) -> None:
         from flaskr.service.learn.type_state_machine import (
             TypeInput,
             TypeState,
@@ -465,7 +471,7 @@ class TestTypeStateMachine:
         assert out == "audio_complete"
         assert sm.state == TypeState.BUILDING
 
-    def test_done_terminates(self):
+    def test_done_terminates(self) -> None:
         from flaskr.service.learn.type_state_machine import (
             TypeInput,
             TypeState,
@@ -479,7 +485,7 @@ class TestTypeStateMachine:
         assert sm.state == TypeState.TERMINATED
         assert sm.is_terminated
 
-    def test_error_terminates(self):
+    def test_error_terminates(self) -> None:
         from flaskr.service.learn.type_state_machine import (
             TypeInput,
             TypeStateMachine,
@@ -490,7 +496,7 @@ class TestTypeStateMachine:
         assert out == "error"
         assert sm.is_terminated
 
-    def test_feed_after_terminated_raises(self):
+    def test_feed_after_terminated_raises(self) -> None:
         from flaskr.service.learn.type_state_machine import (
             TypeInput,
             TypeStateMachine,
@@ -501,7 +507,7 @@ class TestTypeStateMachine:
         with pytest.raises(ValueError, match="already terminated"):
             sm.feed(TypeInput.CONTENT_START)
 
-    def test_reset(self):
+    def test_reset(self) -> None:
         from flaskr.service.learn.type_state_machine import (
             TypeInput,
             TypeState,
@@ -514,7 +520,7 @@ class TestTypeStateMachine:
         assert sm.state == TypeState.IDLE
         assert not sm.is_terminated
 
-    def test_full_lifecycle(self):
+    def test_full_lifecycle(self) -> None:
         """Test a realistic sequence: content -> audio -> break -> content -> done."""
         from flaskr.service.learn.type_state_machine import (
             TypeInput,
@@ -545,7 +551,7 @@ class TestTypeStateMachine:
 class TestVisualKindMapping:
     """Verify visual kind mapping behavior."""
 
-    def test_known_mappings(self):
+    def test_known_mappings(self) -> None:
         from flaskr.service.learn.learn_dtos import ElementType
         from flaskr.service.learn.listen_element_types import (
             _element_type_for_visual_kind,
@@ -565,7 +571,7 @@ class TestVisualKindMapping:
         assert _element_type_for_visual_kind("title") == ElementType.TITLE
         assert _element_type_for_visual_kind("text") == ElementType.TEXT
 
-    def test_unknown_defaults_to_text(self):
+    def test_unknown_defaults_to_text(self) -> None:
         from flaskr.service.learn.learn_dtos import ElementType
         from flaskr.service.learn.listen_element_types import (
             _element_type_for_visual_kind,
@@ -585,7 +591,7 @@ def _require_app(app):
         pytest.skip("App fixture disabled")
 
 
-def test_is_new_false_applies_to_target_element_in_records(app):
+def test_is_new_false_applies_to_target_element_in_records(app) -> None:
     """is_new=false elements should be merged into their target in records output."""
     _require_app(app)
     import json
@@ -693,7 +699,7 @@ def test_is_new_false_applies_to_target_element_in_records(app):
     assert result.elements[0].is_final is True
 
 
-def test_records_ordered_by_sequence_number(app):
+def test_records_ordered_by_sequence_number(app) -> None:
     """Records should be sorted by sequence_number, run_event_seq, id."""
     _require_app(app)
     import json
@@ -772,7 +778,7 @@ def test_records_ordered_by_sequence_number(app):
     assert bids == ["el-a", "el-b", "el-c"]
 
 
-def test_records_merge_follow_up_history_after_anchor_element(app):
+def test_records_merge_follow_up_history_after_anchor_element(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -955,7 +961,7 @@ def test_records_merge_follow_up_history_after_anchor_element(app):
     ]
 
 
-def test_include_non_navigable_returns_events(app):
+def test_include_non_navigable_returns_events(app) -> None:
     """include_non_navigable=true should return full events stream."""
     _require_app(app)
     import json
@@ -1079,7 +1085,7 @@ def test_include_non_navigable_returns_events(app):
         assert "audio_complete" not in event_types
 
 
-def test_legacy_element_type_deserialized_to_new_enum(app):
+def test_legacy_element_type_deserialized_to_new_enum(app) -> None:
     """Legacy element_type values like 'sandbox' should map to new enum."""
     _require_app(app)
     import json
@@ -1147,7 +1153,7 @@ def test_legacy_element_type_deserialized_to_new_enum(app):
     assert result.elements[0].is_marker is True
 
 
-def test_non_text_elements_are_never_speakable_in_records(app):
+def test_non_text_elements_are_never_speakable_in_records(app) -> None:
     """Non-text elements must normalize is_speakable to false."""
     _require_app(app)
     import json
@@ -1225,7 +1231,7 @@ def test_non_text_elements_are_never_speakable_in_records(app):
     assert result.elements[0].is_speakable is False
 
 
-def test_interaction_elements_backfill_user_input_from_generated_blocks(app):
+def test_interaction_elements_backfill_user_input_from_generated_blocks(app) -> None:
     """Interaction record elements should expose submitted user input."""
     _require_app(app)
     import json
@@ -1320,7 +1326,7 @@ def test_interaction_elements_backfill_user_input_from_generated_blocks(app):
     assert element.payload.user_input == "agree"
 
 
-def test_live_interaction_events_use_ui_role_and_generated_input(adapter_app):
+def test_live_interaction_events_use_ui_role_and_generated_input(adapter_app) -> None:
     from flaskr.dao import db
     from flaskr.service.learn.const import ROLE_TEACHER
     from flaskr.service.learn.learn_dtos import (
@@ -1383,7 +1389,7 @@ def test_live_interaction_events_use_ui_role_and_generated_input(adapter_app):
         assert persisted.role == "ui"
 
 
-def test_backfill_populates_sequence_number_and_audio_url(app):
+def test_backfill_populates_sequence_number_and_audio_url(app) -> None:
     """Backfill should assign sequence_number and extract audio_url from payload."""
     _require_app(app)
 
@@ -1484,7 +1490,7 @@ def test_backfill_populates_sequence_number_and_audio_url(app):
 class TestElementPayloadAsks:
     """Verify element payload asks behavior."""
 
-    def test_payload_asks_none_by_default(self):
+    def test_payload_asks_none_by_default(self) -> None:
         from flaskr.service.learn.learn_dtos import ElementPayloadDTO
 
         payload = ElementPayloadDTO()
@@ -1492,7 +1498,7 @@ class TestElementPayloadAsks:
         serialized = payload.__json__()
         assert "asks" not in serialized
 
-    def test_payload_asks_serialization(self):
+    def test_payload_asks_serialization(self) -> None:
         from flaskr.service.learn.learn_dtos import ElementPayloadDTO
 
         asks = [
@@ -1503,14 +1509,14 @@ class TestElementPayloadAsks:
         serialized = payload.__json__()
         assert serialized["asks"] == asks
 
-    def test_payload_asks_empty_list_serialization(self):
+    def test_payload_asks_empty_list_serialization(self) -> None:
         from flaskr.service.learn.learn_dtos import ElementPayloadDTO
 
         payload = ElementPayloadDTO(asks=[])
         serialized = payload.__json__()
         assert serialized["asks"] == []
 
-    def test_payload_asks_deserialization(self):
+    def test_payload_asks_deserialization(self) -> None:
         from flaskr.service.learn.learn_dtos import ElementPayloadDTO
         from flaskr.service.learn.listen_element_payloads import (
             _deserialize_payload,
@@ -1526,14 +1532,14 @@ class TestElementPayloadAsks:
         restored = _deserialize_payload(raw)
         assert restored.asks == asks
 
-    def test_payload_asks_deserialization_missing(self):
+    def test_payload_asks_deserialization_missing(self) -> None:
         from flaskr.service.learn.listen_element_payloads import _deserialize_payload
 
         raw = '{"audio": null, "previous_visuals": []}'
         restored = _deserialize_payload(raw)
         assert restored.asks is None
 
-    def test_payload_asks_deserialization_invalid_type(self):
+    def test_payload_asks_deserialization_invalid_type(self) -> None:
         from flaskr.service.learn.listen_element_payloads import _deserialize_payload
 
         raw = '{"audio": null, "previous_visuals": [], "asks": "not_a_list"}'
@@ -1549,12 +1555,12 @@ class TestElementPayloadAsks:
 class TestGeneratedTypeAsk:
     """Verify generated type ask behavior."""
 
-    def test_ask_enum_exists(self):
+    def test_ask_enum_exists(self) -> None:
         from flaskr.service.learn.learn_dtos import GeneratedType
 
         assert GeneratedType.ASK.value == "ask"
 
-    def test_ask_not_in_legacy_types(self):
+    def test_ask_not_in_legacy_types(self) -> None:
         from flaskr.service.learn.learn_dtos import GeneratedType
 
         legacy = {
@@ -1569,7 +1575,7 @@ class TestGeneratedTypeAsk:
 class TestAskContextLoading:
     """Tests for _is_valid_asks and _load_ask_context."""
 
-    def test_is_valid_asks_true(self):
+    def test_is_valid_asks_true(self) -> None:
         from flaskr.service.learn.handle_input_ask import _is_valid_asks
 
         asks = [
@@ -1578,19 +1584,19 @@ class TestAskContextLoading:
         ]
         assert _is_valid_asks(asks) is True
 
-    def test_is_valid_asks_empty(self):
+    def test_is_valid_asks_empty(self) -> None:
         from flaskr.service.learn.handle_input_ask import _is_valid_asks
 
         assert _is_valid_asks([]) is False
         assert _is_valid_asks(None) is False
 
-    def test_is_valid_asks_student_only(self):
+    def test_is_valid_asks_student_only(self) -> None:
         from flaskr.service.learn.handle_input_ask import _is_valid_asks
 
         asks = [{"role": "student", "content": "q"}]
         assert _is_valid_asks(asks) is False
 
-    def test_load_context_from_follow_up_elements(self):
+    def test_load_context_from_follow_up_elements(self) -> None:
         import types
 
         from flaskr.service.learn.handle_input_ask import _load_ask_context
@@ -1627,7 +1633,7 @@ class TestAskContextLoading:
         assert result[1] == {"role": "user", "content": "q1"}
         assert result[2] == {"role": "assistant", "content": "a1"}
 
-    def test_load_context_fallback_to_legacy_payload_asks(self):
+    def test_load_context_fallback_to_legacy_payload_asks(self) -> None:
         import types
 
         from flaskr.service.learn.handle_input_ask import _load_ask_context
@@ -1656,7 +1662,7 @@ class TestAskContextLoading:
         assert result[1] == {"role": "user", "content": "q1"}
         assert result[2] == {"role": "assistant", "content": "a1"}
 
-    def test_load_context_fallback_to_none(self):
+    def test_load_context_fallback_to_none(self) -> None:
         import types
 
         from flaskr.service.learn.handle_input_ask import _load_ask_context
@@ -1671,12 +1677,12 @@ class TestAskContextLoading:
         result = _load_ask_context(anchor, [], 10)
         assert result is None
 
-    def test_load_context_none_element(self):
+    def test_load_context_none_element(self) -> None:
         from flaskr.service.learn.handle_input_ask import _load_ask_context
 
         assert _load_ask_context(None, [], 10) is None
 
-    def test_load_context_truncation(self):
+    def test_load_context_truncation(self) -> None:
         import types
 
         from flaskr.service.learn.handle_input_ask import _load_ask_context
@@ -1707,7 +1713,7 @@ class TestAskContextLoading:
 class TestHandleAskAdapter:
     """Tests for ListenElementRunAdapter._handle_ask()."""
 
-    def test_handle_ask_creates_standalone_question_element(self, adapter_app):
+    def test_handle_ask_creates_standalone_question_element(self, adapter_app) -> None:
         import json
 
         from flaskr.dao import db
@@ -1770,7 +1776,7 @@ class TestHandleAskAdapter:
             assert ask_rows[0].content_text == "user question here"
             assert ask_rows[0].role == "student"
 
-    def test_process_ask_persists_without_streaming(self, adapter_app):
+    def test_process_ask_persists_without_streaming(self, adapter_app) -> None:
         import json
 
         from flaskr.dao import db
@@ -1840,7 +1846,7 @@ class TestHandleAskAdapter:
             assert ask_row.role == "student"
             assert payload["anchor_element_bid"] == "anchor_elem_2"
 
-    def test_handle_ask_sets_anchor_bid_state(self, adapter_app):
+    def test_handle_ask_sets_anchor_bid_state(self, adapter_app) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import (
             ElementPayloadDTO,
@@ -1891,7 +1897,7 @@ class TestHandleAskAdapter:
             assert adapter._current_ask_anchor_bid == "anchor_elem_3"
             assert adapter._current_ask_element_bid
 
-    def test_process_creates_standalone_answer_element(self, adapter_app):
+    def test_process_creates_standalone_answer_element(self, adapter_app) -> None:
         import json
 
         from flaskr.dao import db
@@ -2002,7 +2008,7 @@ class TestHandleAskAdapter:
 
     def test_process_streams_multi_chunk_follow_up_answer_but_persists_only_final_row(
         self, adapter_app
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import (
             ElementPayloadDTO,
@@ -2115,7 +2121,9 @@ class TestHandleAskAdapter:
             assert answer_rows[0].content_text == "hello world"
             assert answer_rows[0].target_element_bid == logical_answer_bid
 
-    def test_process_creates_answer_element_for_patched_anchor_bid(self, adapter_app):
+    def test_process_creates_answer_element_for_patched_anchor_bid(
+        self, adapter_app
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import (
             ElementPayloadDTO,
@@ -2231,7 +2239,7 @@ class TestHandleAskAdapter:
             assert answer_row is not None
             assert answer_row.content_text == "answer"
 
-    def test_answer_audio_events_do_not_attach_audio(self, adapter_app):
+    def test_answer_audio_events_do_not_attach_audio(self, adapter_app) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import (
             AudioCompleteDTO,
@@ -2336,7 +2344,7 @@ class TestHandleAskAdapter:
 
     def test_handle_input_ask_provider_stream_returns_answer_element(
         self, adapter_app, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn import handle_input_ask as module
         from flaskr.service.learn.learn_dtos import (
@@ -2452,7 +2460,7 @@ class TestHandleAskAdapter:
 
     def test_handle_input_ask_provider_only_error_returns_answer_element(
         self, adapter_app, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn import handle_input_ask as module
         from flaskr.service.learn.ask_provider_adapters import AskProviderError
@@ -2580,7 +2588,7 @@ class TestHandleAskAdapter:
 class TestRunMarkdownFlowDTOAnchorBid:
     """Verify run markdown flow DTO anchor bid behavior."""
 
-    def test_default_anchor_element_bid_empty(self):
+    def test_default_anchor_element_bid_empty(self) -> None:
         from flaskr.service.learn.learn_dtos import GeneratedType, RunMarkdownFlowDTO
 
         dto = RunMarkdownFlowDTO(
@@ -2593,7 +2601,7 @@ class TestRunMarkdownFlowDTOAnchorBid:
         serialized = dto.__json__()
         assert "anchor_element_bid" not in serialized
 
-    def test_anchor_element_bid_set(self):
+    def test_anchor_element_bid_set(self) -> None:
         from flaskr.service.learn.learn_dtos import GeneratedType, RunMarkdownFlowDTO
 
         dto = RunMarkdownFlowDTO(
@@ -2611,7 +2619,7 @@ class TestRunMarkdownFlowDTOAnchorBid:
 class TestElementChangeTypeSemantics:
     """Verify element change type semantics behavior."""
 
-    def test_text_patch_keeps_render_change_type(self, adapter_app):
+    def test_text_patch_keeps_render_change_type(self, adapter_app) -> None:
         from flaskr.service.learn.learn_dtos import (
             ElementChangeType,
             ElementType,
@@ -2659,7 +2667,7 @@ class TestElementChangeTypeSemantics:
 
     def test_gitdiff_element_uses_diff_change_type_without_forcing_patch(
         self, adapter_app
-    ):
+    ) -> None:
         from flaskr.service.learn.learn_dtos import (
             ElementChangeType,
             ElementType,
@@ -2705,7 +2713,7 @@ class TestElementChangeTypeSemantics:
             assert diff_events[0].target_element_bid == diff_events[0].element_bid
             assert diff_events[1].target_element_bid == diff_events[0].element_bid
 
-    def test_html_after_text_creates_new_element(self, adapter_app):
+    def test_html_after_text_creates_new_element(self, adapter_app) -> None:
         from flaskr.service.learn.learn_dtos import (
             ElementType,
             GeneratedType,
@@ -2755,7 +2763,9 @@ class TestElementChangeTypeSemantics:
             assert html_events[1].target_element_bid in ("", None)
             assert html_events[0].element_bid != html_events[1].element_bid
 
-    def test_html_only_stream_does_not_keep_audio_on_finalize(self, adapter_app):
+    def test_html_only_stream_does_not_keep_audio_on_finalize(
+        self, adapter_app
+    ) -> None:
         from flaskr.service.learn.learn_dtos import (
             AudioCompleteDTO,
             AudioSegmentDTO,
@@ -2830,7 +2840,9 @@ class TestElementChangeTypeSemantics:
             assert all(item.audio_url == "" for item in html_events)
             assert all(item.is_speakable is False for item in html_events)
 
-    def test_chunked_html_table_stream_stays_single_html_element(self, adapter_app):
+    def test_chunked_html_table_stream_stays_single_html_element(
+        self, adapter_app
+    ) -> None:
         from flaskr.service.learn.learn_dtos import (
             ElementType,
             GeneratedType,
@@ -2886,7 +2898,9 @@ class TestElementChangeTypeSemantics:
             assert html_events[3].target_element_bid in ("", None)
             assert len({item.element_bid for item in html_events}) == 1
 
-    def test_mdflow_stream_elements_are_not_rebuilt_from_av_contract(self, adapter_app):
+    def test_mdflow_stream_elements_are_not_rebuilt_from_av_contract(
+        self, adapter_app
+    ) -> None:
         from flaskr.service.learn.learn_dtos import (
             AudioCompleteDTO,
             ElementType,
@@ -3009,7 +3023,7 @@ class TestElementChangeTypeSemantics:
 
     def test_pending_audio_skips_image_stream_and_binds_to_following_text(
         self, adapter_app
-    ):
+    ) -> None:
         from flaskr.service.learn.learn_dtos import (
             AudioCompleteDTO,
             AudioSegmentDTO,
@@ -3124,7 +3138,7 @@ class TestElementChangeTypeSemantics:
 
     def test_fallback_text_patch_keeps_bound_audio_during_in_progress_history(
         self, adapter_app
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.const import ROLE_TEACHER
         from flaskr.service.learn.learn_dtos import (
@@ -3236,7 +3250,7 @@ class TestElementChangeTypeSemantics:
 
     def test_stream_text_patch_keeps_bound_audio_during_in_progress_history(
         self, adapter_app
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.const import ROLE_TEACHER
         from flaskr.service.learn.learn_dtos import (
@@ -3346,7 +3360,7 @@ class TestElementChangeTypeSemantics:
 
     def test_live_audio_patches_mirror_progressive_subtitles_on_same_element(
         self, adapter_app
-    ):
+    ) -> None:
         from flaskr.service.learn.learn_dtos import (
             AudioCompleteDTO,
             AudioSegmentDTO,
@@ -3579,7 +3593,9 @@ class TestElementChangeTypeSemantics:
             },
         ]
 
-    def test_live_audio_patches_do_not_rewrite_same_count_updates(self, adapter_app):
+    def test_live_audio_patches_do_not_rewrite_same_count_updates(
+        self, adapter_app
+    ) -> None:
         from flaskr.service.learn.learn_dtos import (
             AudioCompleteDTO,
             AudioSegmentDTO,
@@ -3725,7 +3741,9 @@ class TestElementChangeTypeSemantics:
         ] == [(0, 160), (220, 360)]
         assert final_patch.payload.audio.duration_ms == 360
 
-    def test_live_audio_patches_preserve_incoming_middle_cues(self, adapter_app):
+    def test_live_audio_patches_preserve_incoming_middle_cues(
+        self, adapter_app
+    ) -> None:
         from flaskr.service.learn.learn_dtos import (
             AudioCompleteDTO,
             AudioSegmentDTO,
@@ -3891,7 +3909,9 @@ class TestElementChangeTypeSemantics:
         ] == [(0, 140), (140, 250), (250, 360)]
         assert final_patch.payload.audio.duration_ms == 360
 
-    def test_explicit_stream_audio_waits_for_matching_text_element(self, adapter_app):
+    def test_explicit_stream_audio_waits_for_matching_text_element(
+        self, adapter_app
+    ) -> None:
         from flaskr.service.learn.learn_dtos import (
             AudioCompleteDTO,
             AudioSegmentDTO,

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -147,7 +147,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_non_listen_uses_run_tts_processor(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -223,7 +223,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_non_listen_ignores_cache_with_stale_voice(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -330,7 +330,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_non_listen_ignores_segmented_listen_cache(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -459,7 +459,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_listen_uses_text_elements_only(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -666,7 +666,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_listen_falls_back_to_legacy_block_text(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -729,7 +729,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_listen_finishes_non_speakable_legacy_block(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -780,7 +780,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_listen_finishes_markup_only_legacy_block(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -831,7 +831,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_listen_fast_path_skips_markup_positions(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -967,7 +967,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_listen_ignores_cached_markup_position(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -1093,7 +1093,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_listen_finishes_markup_only_elements(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -1184,7 +1184,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_preview_listen_falls_back_to_block_tts_without_final_elements(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -1258,7 +1258,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_preview_listen_reuses_cached_block_audio(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -1355,7 +1355,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_listen_preserves_position_after_short_text(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -1468,7 +1468,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_listen_reuses_partial_segment_cache(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -1632,7 +1632,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_listen_ignores_cache_with_stale_voice(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -1754,7 +1754,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_listen_ignores_cache_with_mismatched_subtitles(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import GeneratedType
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio
@@ -1874,7 +1874,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
     def test_stream_generated_block_audio_listen_raises_when_finalize_has_no_complete(
         self, monkeypatch
-    ):
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.common.models import AppError
         from flaskr.service.learn.learn_funcs import stream_generated_block_audio

--- a/src/api/tests/service/learn/test_get_current_attend_placeholders.py
+++ b/src/api/tests/service/learn/test_get_current_attend_placeholders.py
@@ -94,7 +94,7 @@ def _rows_by_bid() -> dict[str, list[LearnProgressRecord]]:
     return rows
 
 
-def test_placeholders_carry_each_ancestors_own_bid(attend_app):
+def test_placeholders_carry_each_ancestors_own_bid(attend_app) -> None:
     """One call creates exactly one row per outline node on the parent path, each stamped with that node's own bid — not N copies of the leaf's bid."""
     _seed_leaf_outline_row()
     ctx = _make_context(attend_app)
@@ -113,7 +113,7 @@ def test_placeholders_carry_each_ancestors_own_bid(attend_app):
         assert row.progress_record_bid
 
 
-def test_existing_ancestor_record_is_reused_not_duplicated(attend_app):
+def test_existing_ancestor_record_is_reused_not_duplicated(attend_app) -> None:
     """An ancestor that already has a non-reset record keeps it; only the missing nodes get placeholders."""
     _seed_leaf_outline_row()
     existing = LearnProgressRecord(
@@ -140,7 +140,7 @@ def test_existing_ancestor_record_is_reused_not_duplicated(attend_app):
     assert len(rows[LEAF_BID]) == 1
 
 
-def test_second_call_returns_leaf_record_without_new_rows(attend_app):
+def test_second_call_returns_leaf_record_without_new_rows(attend_app) -> None:
     """A repeat call finds the leaf row via the fast path and stages nothing."""
     _seed_leaf_outline_row()
     ctx = _make_context(attend_app)
@@ -157,7 +157,7 @@ def test_second_call_returns_leaf_record_without_new_rows(attend_app):
     )
 
 
-def test_direct_ancestor_call_stamps_own_bids(attend_app):
+def test_direct_ancestor_call_stamps_own_bids(attend_app) -> None:
     """The hot-path call shape: ``render_outline_updates`` calls ``_get_current_attend`` with ANCESTOR bids directly on chapter/unit transitions.
 
     Each created row must carry its own node's bid, and the returned record must be the

--- a/src/api/tests/service/learn/test_handle_input_ask_provider.py
+++ b/src/api/tests/service/learn/test_handle_input_ask_provider.py
@@ -296,7 +296,7 @@ def _collect_content_chunks(events):
 
 def test_handle_input_ask_provider_only_returns_provider_error_without_llm(
     app, monkeypatch
-):
+) -> None:
     from flaskr.service.learn import handle_input_ask as module
 
     ask_provider_config = {
@@ -365,7 +365,7 @@ def test_handle_input_ask_provider_only_returns_provider_error_without_llm(
     ] == ("[REDACTED]")
 
 
-def test_handle_input_ask_provider_then_llm_falls_back_to_llm(app, monkeypatch):
+def test_handle_input_ask_provider_then_llm_falls_back_to_llm(app, monkeypatch) -> None:
     from flaskr.service.learn import handle_input_ask as module
 
     ask_provider_config = {
@@ -433,7 +433,9 @@ def test_handle_input_ask_provider_then_llm_falls_back_to_llm(app, monkeypatch):
     assert events[-1].type == GeneratedType.BREAK
 
 
-def test_handle_input_ask_get_biji_synthesizes_via_context_factory(app, monkeypatch):
+def test_handle_input_ask_get_biji_synthesizes_via_context_factory(
+    app, monkeypatch
+) -> None:
     from flaskr.service.learn import handle_input_ask as module
 
     ask_provider_config = {
@@ -508,7 +510,7 @@ def test_handle_input_ask_get_biji_synthesizes_via_context_factory(app, monkeypa
     assert events[-1].type == GeneratedType.BREAK
 
 
-def test_handle_input_ask_provider_response_skips_llm(app, monkeypatch):
+def test_handle_input_ask_provider_response_skips_llm(app, monkeypatch) -> None:
     from flaskr.service.learn import handle_input_ask as module
 
     ask_provider_config = {
@@ -574,7 +576,9 @@ def test_handle_input_ask_provider_response_skips_llm(app, monkeypatch):
     assert generation.end_kwargs["metadata"]["status"] == "success"
 
 
-def test_handle_input_ask_dify_uses_context_without_follow_up_prompt(app, monkeypatch):
+def test_handle_input_ask_dify_uses_context_without_follow_up_prompt(
+    app, monkeypatch
+) -> None:
     from flaskr.service.learn import handle_input_ask as module
     from flaskr.service.learn import utils_v2
     from flaskr.service.learn.learner_profile_prompt import build_course_prompt
@@ -666,7 +670,7 @@ def test_handle_input_ask_dify_uses_context_without_follow_up_prompt(app, monkey
 
 def test_handle_input_ask_formats_provider_prompt_with_request_language(
     app, monkeypatch
-):
+) -> None:
     from flaskr.service.learn import handle_input_ask as module
 
     ask_provider_config = {
@@ -760,7 +764,7 @@ def _setup_llm_only_patches(monkeypatch, module, llm_chunks):
     monkeypatch.setattr(module, "stream_ask_provider_response", _fake_stream)
 
 
-def test_answer_content_uses_answer_block_bid(app, monkeypatch):
+def test_answer_content_uses_answer_block_bid(app, monkeypatch) -> None:
     """All teacher-side CONTENT events should use answer block's bid (gb-2)."""
     from flaskr.service.learn import handle_input_ask as module
 
@@ -787,7 +791,7 @@ def test_answer_content_uses_answer_block_bid(app, monkeypatch):
         assert e.generated_block_bid == "gb-2"
 
 
-def test_ask_event_emitted(app, monkeypatch):
+def test_ask_event_emitted(app, monkeypatch) -> None:
     """An ASK event should be emitted with anchor_element_bid."""
     from flaskr.service.learn import handle_input_ask as module
 
@@ -815,7 +819,7 @@ def test_ask_event_emitted(app, monkeypatch):
     assert ask_events[0].anchor_element_bid == "elem_anchor_123"
 
 
-def test_ask_event_uses_ask_block_bid(app, monkeypatch):
+def test_ask_event_uses_ask_block_bid(app, monkeypatch) -> None:
     """ASK and teacher content both use the answer block bid."""
     from flaskr.service.learn import handle_input_ask as module
 
@@ -846,7 +850,7 @@ def test_ask_event_uses_ask_block_bid(app, monkeypatch):
     assert content_events[0].generated_block_bid == "gb-2"
 
 
-def test_guardrail_uses_answer_block_bid(app, monkeypatch):
+def test_guardrail_uses_answer_block_bid(app, monkeypatch) -> None:
     """When guardrail triggers, CONTENT events should still use answer block bid."""
     from flaskr.service.learn import handle_input_ask as module
 
@@ -885,7 +889,7 @@ def test_guardrail_uses_answer_block_bid(app, monkeypatch):
 
 def test_handle_input_ask_nests_follow_up_span_under_parent_observation(
     app, monkeypatch
-):
+) -> None:
     from flaskr.service.learn import handle_input_ask as module
 
     ask_provider_config = {
@@ -937,7 +941,9 @@ def test_handle_input_ask_nests_follow_up_span_under_parent_observation(
     assert context.langfuse_outputs == ["provider-answer"]
 
 
-def test_handle_input_ask_guardrail_finalizes_trace_and_root_span(app, monkeypatch):
+def test_handle_input_ask_guardrail_finalizes_trace_and_root_span(
+    app, monkeypatch
+) -> None:
     from flaskr.service.learn import handle_input_ask as module
 
     ask_provider_config = {"provider": "llm", "mode": "provider_then_llm", "config": {}}

--- a/src/api/tests/service/learn/test_learn_dtos_slide.py
+++ b/src/api/tests/service/learn/test_learn_dtos_slide.py
@@ -13,11 +13,11 @@ from flaskr.service.learn.legacy_record_builder import (
 )
 
 
-def test_generated_type_excludes_new_slide():
+def test_generated_type_excludes_new_slide() -> None:
     assert "new_slide" not in {item.value for item in GeneratedType}
 
 
-def test_audio_segment_dto_payload_has_no_legacy_fields():
+def test_audio_segment_dto_payload_has_no_legacy_fields() -> None:
     dto = AudioSegmentDTO(
         segment_index=0,
         audio_data="ZmFrZS1hdWRpbw==",
@@ -31,7 +31,7 @@ def test_audio_segment_dto_payload_has_no_legacy_fields():
     assert "slide_id" not in payload
 
 
-def test_audio_segment_dto_payload_can_include_subtitle_cues():
+def test_audio_segment_dto_payload_can_include_subtitle_cues() -> None:
     dto = AudioSegmentDTO(
         segment_index=0,
         audio_data="ZmFrZS1hdWRpbw==",
@@ -54,7 +54,7 @@ def test_audio_segment_dto_payload_can_include_subtitle_cues():
     assert payload["subtitle_cues"][0]["position"] == 2
 
 
-def test_audio_complete_dto_payload_has_no_legacy_fields():
+def test_audio_complete_dto_payload_has_no_legacy_fields() -> None:
     dto = AudioCompleteDTO(
         audio_url="https://example.com/a.mp3",
         audio_bid="audio-1",
@@ -76,7 +76,7 @@ def test_audio_complete_dto_payload_has_no_legacy_fields():
     assert payload["subtitle_cues"][0]["text"] == "Hello world."
 
 
-def test_audio_dto_payload_can_include_stream_binding_fields():
+def test_audio_dto_payload_can_include_stream_binding_fields() -> None:
     segment = AudioSegmentDTO(
         segment_index=0,
         audio_data="ZmFrZS1hdWRpbw==",
@@ -104,7 +104,7 @@ def test_audio_dto_payload_can_include_stream_binding_fields():
     assert complete_payload["stream_element_type"] == "text"
 
 
-def test_legacy_learn_record_payload_has_no_legacy_fields():
+def test_legacy_learn_record_payload_has_no_legacy_fields() -> None:
     record = LegacyGeneratedBlockRecord(
         generated_block_bid="gen-1",
         content="hello",

--- a/src/api/tests/service/learn/test_learn_funcs.py
+++ b/src/api/tests/service/learn/test_learn_funcs.py
@@ -58,18 +58,18 @@ class LearnRecordLoadTests(unittest.TestCase):
         with cls.app.app_context():
             dao.db.create_all()
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.ctx = self.app.app_context()
         self.ctx.push()
         LearnGeneratedBlock.query.delete()
         LearnProgressRecord.query.delete()
         dao.db.session.commit()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         dao.db.session.remove()
         self.ctx.pop()
 
-    def test_learn_record_loads_generated_and_input_content_separately(self):
+    def test_learn_record_loads_generated_and_input_content_separately(self) -> None:
         """Ensure learn record loading uses generated content and real user input."""
         progress = LearnProgressRecord(
             progress_record_bid="progress-1",
@@ -154,7 +154,7 @@ class LearnRecordLoadTests(unittest.TestCase):
         # Interaction blocks should not carry like status in API responses.
         assert interaction_record.like_status == LikeStatus.NONE
 
-    def test_mdflow_context_loads_generated_and_user_inputs(self):
+    def test_mdflow_context_loads_generated_and_user_inputs(self) -> None:
         """Verify mdflow run uses generated content for context and real user input values."""
         progress = LearnProgressRecord(
             progress_record_bid="progress-ctx",
@@ -303,7 +303,7 @@ class LearnRecordLoadTests(unittest.TestCase):
             not in FakeMarkdownFlow.last_context[1]["content"]
         )
 
-    def test_run_progresses_across_content_blocks_until_interaction(self):
+    def test_run_progresses_across_content_blocks_until_interaction(self) -> None:
         """A single run should keep advancing through content blocks and stop at interaction."""
         progress = LearnProgressRecord(
             progress_record_bid="progress-run-continue",
@@ -440,7 +440,9 @@ class LearnRecordLoadTests(unittest.TestCase):
         assert progress.block_position == 2
         assert not ctx._can_continue
 
-    def test_run_inner_skips_duplicate_fixed_output_after_interaction_input(self):
+    def test_run_inner_skips_duplicate_fixed_output_after_interaction_input(
+        self,
+    ) -> None:
         """Avoid replaying an already generated fixed output after interaction submit."""
         progress = LearnProgressRecord(
             progress_record_bid="progress-skip-dup",
@@ -567,7 +569,7 @@ class LearnRecordLoadTests(unittest.TestCase):
             == 1
         )
 
-    def test_run_inner_realigns_index_to_pending_interaction_after_submit(self):
+    def test_run_inner_realigns_index_to_pending_interaction_after_submit(self) -> None:
         """If index drifts to content, realign to pending interaction before consuming input."""
         progress = LearnProgressRecord(
             progress_record_bid="progress-realign",
@@ -690,7 +692,7 @@ class LearnRecordLoadTests(unittest.TestCase):
         assert ctx._run_type == RunType.INPUT
         assert ctx._can_continue
 
-    def test_run_inner_does_not_realign_on_empty_auto_input(self):
+    def test_run_inner_does_not_realign_on_empty_auto_input(self) -> None:
         """Empty auto-run input should not be treated as a real interaction submit."""
         progress = LearnProgressRecord(
             progress_record_bid="progress-empty-input",

--- a/src/api/tests/service/learn/test_learn_record.py
+++ b/src/api/tests/service/learn/test_learn_record.py
@@ -42,7 +42,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
         with cls.app.app_context():
             dao.db.create_all()
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.app = self.__class__.app
         self.ctx = self.app.app_context()
         self.ctx.push()
@@ -52,7 +52,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
         dao.db.session.query(LogPublishedStruct).delete()
         dao.db.session.commit()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         dao.db.session.remove()
         self.ctx.pop()
 
@@ -124,7 +124,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
         dao.db.session.commit()
         return block
 
-    def test_appends_virtual_button_when_completed(self):
+    def test_appends_virtual_button_when_completed(self) -> None:
         self._seed_struct(["outline-1", "outline-2"])
         progress = self._create_progress(LEARN_STATUS_COMPLETED)
 
@@ -143,7 +143,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
         assert CONTEXT_INTERACTION_NEXT in result.records[0].content
         assert is_lesson_feedback_interaction(result.records[1].content)
 
-    def test_uses_persisted_button_when_present(self):
+    def test_uses_persisted_button_when_present(self) -> None:
         self._seed_struct(["outline-1", "outline-2"])
         progress = self._create_progress(LEARN_STATUS_COMPLETED)
         button_label = _("server.learn.nextChapterButton")
@@ -181,7 +181,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
         assert CONTEXT_INTERACTION_NEXT in record.content
         assert is_lesson_feedback_interaction(result.records[1].content)
 
-    def test_no_button_when_not_completed(self):
+    def test_no_button_when_not_completed(self) -> None:
         self._seed_struct(["outline-1", "outline-2"])
         progress = self._create_progress(LEARN_STATUS_IN_PROGRESS)
 
@@ -197,7 +197,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
 
         assert result.records == []
 
-    def test_feedback_when_completed_without_next(self):
+    def test_feedback_when_completed_without_next(self) -> None:
         self._seed_struct(["outline-1"])
         progress = self._create_progress(LEARN_STATUS_COMPLETED)
 
@@ -214,7 +214,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
         assert len(result.records) == 1
         assert is_lesson_feedback_interaction(result.records[0].content)
 
-    def test_feedback_after_pay_gate_when_in_progress(self):
+    def test_feedback_after_pay_gate_when_in_progress(self) -> None:
         self._seed_struct(["outline-1"])
         progress = self._create_progress(LEARN_STATUS_IN_PROGRESS)
         self._add_interaction_block(progress, "?[去支付//_sys_pay]")
@@ -233,7 +233,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
         assert "_sys_pay" in result.records[0].content
         assert is_lesson_feedback_interaction(result.records[1].content)
 
-    def test_feedback_after_login_gate_when_in_progress(self):
+    def test_feedback_after_login_gate_when_in_progress(self) -> None:
         self._seed_struct(["outline-1"])
         progress = self._create_progress(LEARN_STATUS_IN_PROGRESS)
         self._add_interaction_block(progress, "?[去登录//_sys_login]")
@@ -252,7 +252,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
         assert "_sys_login" in result.records[0].content
         assert is_lesson_feedback_interaction(result.records[1].content)
 
-    def test_no_next_button_when_completed_with_pay_gate(self):
+    def test_no_next_button_when_completed_with_pay_gate(self) -> None:
         self._seed_struct(["outline-1", "outline-2"])
         progress = self._create_progress(LEARN_STATUS_COMPLETED)
         self._add_interaction_block(progress, "?[去支付//_sys_pay]")
@@ -272,7 +272,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
         assert CONTEXT_INTERACTION_NEXT not in result.records[0].content
         assert is_lesson_feedback_interaction(result.records[1].content)
 
-    def test_inserts_fallback_next_before_existing_feedback(self):
+    def test_inserts_fallback_next_before_existing_feedback(self) -> None:
         self._seed_struct(["outline-1", "outline-2"])
         progress = self._create_progress(LEARN_STATUS_COMPLETED)
         self._add_interaction_block(
@@ -295,7 +295,7 @@ class LearnRecordFallbackTests(unittest.TestCase):
         assert CONTEXT_INTERACTION_NEXT in result.records[0].content
         assert is_lesson_feedback_interaction(result.records[1].content)
 
-    def test_moves_existing_feedback_to_tail_when_next_already_persisted(self):
+    def test_moves_existing_feedback_to_tail_when_next_already_persisted(self) -> None:
         self._seed_struct(["outline-1", "outline-2"])
         progress = self._create_progress(LEARN_STATUS_COMPLETED)
         button_label = _("server.learn.nextChapterButton")

--- a/src/api/tests/service/learn/test_learn_record_slides.py
+++ b/src/api/tests/service/learn/test_learn_record_slides.py
@@ -11,7 +11,7 @@ def _require_app(app):
         pytest.skip("App fixture disabled")
 
 
-def test_get_learn_record_omits_legacy_fields_and_keeps_audio_positions(app):
+def test_get_learn_record_omits_legacy_fields_and_keeps_audio_positions(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -104,7 +104,7 @@ def test_get_learn_record_omits_legacy_fields_and_keeps_audio_positions(app):
     assert all("slide_id" not in audio.__json__() for audio in record.audios)
 
 
-def test_get_learn_record_omits_legacy_fields_for_answer_blocks(app):
+def test_get_learn_record_omits_legacy_fields_for_answer_blocks(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db

--- a/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
+++ b/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import ResourceClosedError
 
 
 @pytest.fixture
-def invalidations(monkeypatch):
+def invalidations(monkeypatch) -> list[str]:
     calls = []
 
     def release_db_session(app: object, *, source: str) -> None:
@@ -39,7 +39,7 @@ def _iter_stream(app, helper, iter_factory):
         return response.response
 
 
-def test_sse_close_invalidates_session(app, invalidations):
+def test_sse_close_invalidates_session(app, invalidations) -> None:
     def factory():
         yield {"type": "chunk"}
         yield {"type": "chunk2"}
@@ -58,7 +58,7 @@ def test_sse_close_invalidates_session(app, invalidations):
     assert invalidations == ["learn stream_sse_response close"]
 
 
-def test_sse_protocol_error_invalidates_session(app, invalidations):
+def test_sse_protocol_error_invalidates_session(app, invalidations) -> None:
     def factory():
         yield {"type": "chunk"}
         message = "desynced"
@@ -79,7 +79,7 @@ def test_sse_protocol_error_invalidates_session(app, invalidations):
     assert invalidations == ["learn stream_sse_response desync"]
 
 
-def test_sse_business_error_does_not_invalidate(app, invalidations):
+def test_sse_business_error_does_not_invalidate(app, invalidations) -> None:
     def factory():
         yield {"type": "chunk"}
         message = "business"
@@ -100,7 +100,7 @@ def test_sse_business_error_does_not_invalidate(app, invalidations):
     assert invalidations == []
 
 
-def test_passthrough_close_invalidates_session(app, invalidations):
+def test_passthrough_close_invalidates_session(app, invalidations) -> None:
     def factory():
         yield "data: 1\n\n"
         yield "data: 2\n\n"
@@ -119,7 +119,7 @@ def test_passthrough_close_invalidates_session(app, invalidations):
     assert invalidations == ["learn stream_passthrough_response close"]
 
 
-def test_passthrough_close_disguised_as_runtime_error(app, invalidations):
+def test_passthrough_close_disguised_as_runtime_error(app, invalidations) -> None:
     def factory():
         yield "data: 1\n\n"
         message = "generator ignored GeneratorExit"
@@ -140,7 +140,7 @@ def test_passthrough_close_disguised_as_runtime_error(app, invalidations):
     assert invalidations == ["learn stream_passthrough_response close"]
 
 
-def test_passthrough_normal_exhaustion_does_not_invalidate(app, invalidations):
+def test_passthrough_normal_exhaustion_does_not_invalidate(app, invalidations) -> None:
     def factory():
         yield "data: 1\n\n"
 

--- a/src/api/tests/service/learn/test_learner_profile_prompt.py
+++ b/src/api/tests/service/learn/test_learner_profile_prompt.py
@@ -17,7 +17,7 @@ def _extract_tag_content(prompt: str, opening_tag: str, closing_tag: str) -> str
     return prompt.split(f"{opening_tag}\n", 1)[1].split(f"\n{closing_tag}", 1)[0]
 
 
-def test_course_prompt_composes_contract_course_and_escaped_profile_once():
+def test_course_prompt_composes_contract_course_and_escaped_profile_once() -> None:
     course_prompt = (
         "  COURSE RULE\n\n"
         "Use the teacher's full course design and presentation choices.\n  "
@@ -79,7 +79,7 @@ def test_course_prompt_composes_contract_course_and_escaped_profile_once():
     )
 
 
-def test_composition_contract_leaves_course_open_and_treats_profile_as_data():
+def test_composition_contract_leaves_course_open_and_treats_profile_as_data() -> None:
     prompt = build_course_prompt(
         "COURSE RULE",
         learner=SimpleNamespace(learner_profile="Use a warm language style"),
@@ -113,7 +113,7 @@ def test_composition_contract_leaves_course_open_and_treats_profile_as_data():
     assert "visual baselines" not in contract
 
 
-def test_course_prompt_formats_only_teacher_authored_course_variables():
+def test_course_prompt_formats_only_teacher_authored_course_variables() -> None:
     learner = SimpleNamespace(learner_profile="称呼：{sys_user_nickname}")
     prompt = build_course_prompt("你好，{sys_user_nickname}", learner=learner)
 
@@ -124,7 +124,9 @@ def test_course_prompt_formats_only_teacher_authored_course_variables():
     assert formatted.count("小雨") == 1
 
 
-def test_course_prompt_uses_explicit_nickname_without_parsing_the_introduction():
+def test_course_prompt_uses_explicit_nickname_without_parsing_the_introduction() -> (
+    None
+):
     learner = SimpleNamespace(
         learner_profile="I work in an office and want to build something with AI.",
         nickname="Alex",
@@ -149,7 +151,7 @@ def test_course_prompt_uses_explicit_nickname_without_parsing_the_introduction()
     )
 
 
-def test_course_prompt_can_personalize_with_only_an_explicit_nickname():
+def test_course_prompt_can_personalize_with_only_an_explicit_nickname() -> None:
     prompt = build_course_prompt(
         "COURSE RULE",
         learner=SimpleNamespace(
@@ -174,7 +176,9 @@ def test_course_prompt_can_personalize_with_only_an_explicit_nickname():
 
 
 @pytest.mark.parametrize("nickname", ["learner@example.com", "+8613800138000"])
-def test_course_prompt_does_not_expose_account_identifier_as_a_nickname(nickname):
+def test_course_prompt_does_not_expose_account_identifier_as_a_nickname(
+    nickname,
+) -> None:
     course_prompt = "COURSE RULE"
 
     assert (
@@ -191,7 +195,7 @@ def test_course_prompt_does_not_expose_account_identifier_as_a_nickname(nickname
     )
 
 
-def test_course_prompt_keeps_composer_placeholder_text_in_course_source():
+def test_course_prompt_keeps_composer_placeholder_text_in_course_source() -> None:
     course_prompt = (
         "Explain these literals unchanged: {course_prompt}, {learner_profile}, "
         "and {composition_contract}."
@@ -207,7 +211,7 @@ def test_course_prompt_keeps_composer_placeholder_text_in_course_source():
     assert prompt.count("偏好简洁表达") == 1
 
 
-def test_course_prompt_marker_text_does_not_disable_composition():
+def test_course_prompt_marker_text_does_not_disable_composition() -> None:
     course_prompt = f"Explain this literal marker: {LEARNER_PROFILE_PROMPT_MARKER}"
 
     prompt = build_course_prompt(
@@ -223,7 +227,7 @@ def test_course_prompt_marker_text_does_not_disable_composition():
     assert prompt.count(LEARNER_PROFILE_PROMPT_MARKER) == 2
 
 
-def test_course_prompt_recomposes_for_the_current_learner():
+def test_course_prompt_recomposes_for_the_current_learner() -> None:
     profile_a = SimpleNamespace(learner_profile="称呼我为小雨")
     profile_b = SimpleNamespace(learner_profile="称呼我为小林")
     prompt_for_a = build_course_prompt("COURSE RULE", learner=profile_a)
@@ -248,7 +252,7 @@ def test_course_prompt_recomposes_for_the_current_learner():
     assert cleared_prompt == "COURSE RULE"
 
 
-def test_course_prompt_recomposes_an_envelope_from_an_older_contract():
+def test_course_prompt_recomposes_an_envelope_from_an_older_contract() -> None:
     older_prompt = (
         "<composition_contract>\n"
         f"{LEARNER_PROFILE_PROMPT_MARKER}\n"
@@ -272,7 +276,7 @@ def test_course_prompt_recomposes_an_envelope_from_an_older_contract():
     assert "<course_prompt>\nCOURSE RULE\n</course_prompt>" in recomposed
 
 
-def test_course_prompt_is_unchanged_without_profile():
+def test_course_prompt_is_unchanged_without_profile() -> None:
     course_prompt = "COURSE RULE  \n"
 
     assert build_course_prompt(course_prompt, learner=None) == course_prompt
@@ -285,7 +289,7 @@ def test_course_prompt_is_unchanged_without_profile():
     )
 
 
-def test_profile_is_not_injected_without_course_prompt():
+def test_profile_is_not_injected_without_course_prompt() -> None:
     learner = SimpleNamespace(learner_profile="称呼我为小雨")
 
     assert build_course_prompt(None, learner=learner) is None

--- a/src/api/tests/service/learn/test_lesson_feedback.py
+++ b/src/api/tests/service/learn/test_lesson_feedback.py
@@ -39,7 +39,7 @@ class LessonFeedbackTests(unittest.TestCase):
         with cls.app.app_context():
             dao.db.create_all()
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.ctx = self.app.app_context()
         self.ctx.push()
         LearnLessonFeedback.query.delete()
@@ -47,11 +47,11 @@ class LessonFeedbackTests(unittest.TestCase):
         LearnProgressRecord.query.delete()
         dao.db.session.commit()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         dao.db.session.remove()
         self.ctx.pop()
 
-    def test_submit_feedback_upserts_single_active_row(self):
+    def test_submit_feedback_upserts_single_active_row(self) -> None:
         progress = LearnProgressRecord(
             progress_record_bid="progress-1",
             shifu_bid="shifu-1",
@@ -117,7 +117,9 @@ class LessonFeedbackTests(unittest.TestCase):
         assert synced_generated_content.get("score") == 3
         assert synced_generated_content.get("comment") == "Need more examples"
 
-    def test_sync_generated_block_does_not_autoflush_pending_duplicate_feedback(self):
+    def test_sync_generated_block_does_not_autoflush_pending_duplicate_feedback(
+        self,
+    ) -> None:
         interaction = LearnGeneratedBlock(
             generated_block_bid="block-1",
             progress_record_bid="progress-1",
@@ -170,7 +172,7 @@ class LessonFeedbackTests(unittest.TestCase):
         assert synced_generated_content.get("comment") == "new"
         dao.db.session.rollback()
 
-    def test_list_feedback_serializes_timestamps_as_utc_iso_z(self):
+    def test_list_feedback_serializes_timestamps_as_utc_iso_z(self) -> None:
         feedback = LearnLessonFeedback(
             bid="feedback-1",
             lesson_feedback_bid="feedback-1",

--- a/src/api/tests/service/learn/test_listen_element_history_subtitles.py
+++ b/src/api/tests/service/learn/test_listen_element_history_subtitles.py
@@ -29,7 +29,7 @@ class TestListenElementHistorySubtitles:
         with cls.app.app_context():
             dao.db.create_all()
 
-    def test_final_elements_are_hydrated_from_persisted_audio_subtitles(self):
+    def test_final_elements_are_hydrated_from_persisted_audio_subtitles(self) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.listen_element_history import (
             get_final_elements_for_generated_block,
@@ -113,7 +113,7 @@ class TestListenElementHistorySubtitles:
         assert element.payload.audio.audio_bid == "audio-history-subtitles"
         assert element.payload.audio.subtitle_cues[0].text == "Hello subtitle history."
 
-    def test_multi_position_audio_is_hydrated_by_speakable_element_order(self):
+    def test_multi_position_audio_is_hydrated_by_speakable_element_order(self) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.listen_element_history import (
             get_final_elements_for_generated_block,
@@ -243,7 +243,9 @@ class TestListenElementHistorySubtitles:
             "audio-history-multi-2",
         ]
 
-    def test_sparse_nonzero_audio_position_hydrates_matching_speakable_order(self):
+    def test_sparse_nonzero_audio_position_hydrates_matching_speakable_order(
+        self,
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.listen_element_history import (
             get_final_elements_for_generated_block,

--- a/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
+++ b/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
@@ -155,7 +155,7 @@ def _make_block(
     return block
 
 
-def test_mdflow_backfill_persists_content_follow_up_and_interaction(app):
+def test_mdflow_backfill_persists_content_follow_up_and_interaction(app) -> None:
     with app.app_context():
         _clear_learn_tables()
         progress = _make_progress(progress_record_bid="progress-mdflow-1")
@@ -260,7 +260,7 @@ def test_mdflow_backfill_persists_content_follow_up_and_interaction(app):
     assert interaction_payload["user_input"] == "Bob"
 
 
-def test_mdflow_backfill_skips_anchorless_follow_up(app):
+def test_mdflow_backfill_skips_anchorless_follow_up(app) -> None:
     with app.app_context():
         _clear_learn_tables()
         progress = _make_progress(progress_record_bid="progress-mdflow-anchorless")
@@ -301,7 +301,7 @@ def test_mdflow_backfill_skips_anchorless_follow_up(app):
     assert active_count == 0
 
 
-def test_mdflow_backfill_skips_orphan_follow_up(app):
+def test_mdflow_backfill_skips_orphan_follow_up(app) -> None:
     with app.app_context():
         _clear_learn_tables()
         progress = _make_progress(progress_record_bid="progress-mdflow-orphan")
@@ -343,7 +343,7 @@ def test_mdflow_backfill_skips_orphan_follow_up(app):
     assert follow_up_count == 0
 
 
-def test_mdflow_backfill_overwrite_replaces_group_rows(app):
+def test_mdflow_backfill_overwrite_replaces_group_rows(app) -> None:
     with app.app_context():
         _clear_learn_tables()
         progress = _make_progress(progress_record_bid="progress-mdflow-overwrite")
@@ -422,7 +422,7 @@ def test_mdflow_backfill_overwrite_replaces_group_rows(app):
     assert rows[-1].content_text.startswith("Fresh content.")
 
 
-def test_mdflow_backfill_batch_respects_after_id_and_limit(app):
+def test_mdflow_backfill_batch_respects_after_id_and_limit(app) -> None:
     with app.app_context():
         _clear_learn_tables()
         progress_1 = _make_progress(progress_record_bid="progress-mdflow-batch-1")

--- a/src/api/tests/service/learn/test_listen_element_payloads.py
+++ b/src/api/tests/service/learn/test_listen_element_payloads.py
@@ -6,7 +6,9 @@ from flaskr.service.learn.listen_element_payloads import (
 )
 
 
-def test_upsert_audio_segment_payload_deduplicates_by_position_and_segment_index():
+def test_upsert_audio_segment_payload_deduplicates_by_position_and_segment_index() -> (
+    None
+):
     existing = [
         {
             "position": 0,
@@ -39,7 +41,7 @@ def test_upsert_audio_segment_payload_deduplicates_by_position_and_segment_index
     ]
 
 
-def test_mark_last_audio_segment_final_keeps_deduplicated_state():
+def test_mark_last_audio_segment_final_keeps_deduplicated_state() -> None:
     audio_segments_by_position = {
         0: _upsert_audio_segment_payload(
             [],

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -33,7 +33,9 @@ def _make_row(
     )
 
 
-def test_find_active_element_row_ids_returns_sorted_ids_from_both_bid_columns(app):
+def test_find_active_element_row_ids_returns_sorted_ids_from_both_bid_columns(
+    app,
+) -> None:
     with app.app_context():
         LearnGeneratedElement.query.delete()
         db.session.commit()
@@ -75,7 +77,9 @@ def test_find_active_element_row_ids_returns_sorted_ids_from_both_bid_columns(ap
         assert row_ids == expected_ids
 
 
-def test_find_active_element_row_ids_sees_rows_flushed_in_current_transaction(app):
+def test_find_active_element_row_ids_sees_rows_flushed_in_current_transaction(
+    app,
+) -> None:
     with app.app_context():
         LearnGeneratedElement.query.delete()
         db.session.commit()
@@ -101,7 +105,9 @@ def test_find_active_element_row_ids_sees_rows_flushed_in_current_transaction(ap
         db.session.rollback()
 
 
-def test_find_active_element_row_ids_invalidates_desynced_connection(app, monkeypatch):
+def test_find_active_element_row_ids_invalidates_desynced_connection(
+    app, monkeypatch
+) -> None:
     class _DesyncedResult:
         def fetchall(self):
             message = (
@@ -166,7 +172,9 @@ def test_find_active_element_row_ids_invalidates_desynced_connection(app, monkey
     assert fake_connection.invalidated == 0
 
 
-def test_deactivate_active_element_rows_retires_rows_without_touching_others(app):
+def test_deactivate_active_element_rows_retires_rows_without_touching_others(
+    app,
+) -> None:
     with app.app_context():
         LearnGeneratedElement.query.delete()
         db.session.commit()
@@ -205,7 +213,7 @@ def test_deactivate_active_element_rows_retires_rows_without_touching_others(app
         assert [row.status for row in rows] == [0, 0, 1]
 
 
-def test_desync_forensics_capture_fingerprints_the_stale_response():
+def test_desync_forensics_capture_fingerprints_the_stale_response() -> None:
     from flaskr.service.learn.listen_element_run_persistence import (
         _describe_desynced_connection,
     )
@@ -247,7 +255,7 @@ def test_desync_forensics_capture_fingerprints_the_stale_response():
     assert "insert_id=4242" in described
 
 
-def test_desync_forensics_survives_missing_raw_connection():
+def test_desync_forensics_survives_missing_raw_connection() -> None:
     from flaskr.service.learn.listen_element_run_persistence import (
         _describe_desynced_connection,
     )
@@ -262,7 +270,7 @@ def test_desync_forensics_survives_missing_raw_connection():
     assert "raw_connection=unavailable" in described
 
 
-def test_desync_forensics_logs_only_packet_header_not_payload():
+def test_desync_forensics_logs_only_packet_header_not_payload() -> None:
     import socket as socket_module
 
     from flaskr.service.learn.listen_element_run_persistence import (

--- a/src/api/tests/service/learn/test_listen_elements.py
+++ b/src/api/tests/service/learn/test_listen_elements.py
@@ -12,7 +12,7 @@ def _require_app(app):
         pytest.skip("App fixture disabled")
 
 
-def test_get_listen_element_record_returns_latest_elements_and_events(app):
+def test_get_listen_element_record_returns_latest_elements_and_events(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -244,7 +244,7 @@ def test_get_listen_element_record_returns_latest_elements_and_events(app):
         assert result_with_events.events[2].content.variable_name == "sys_user_nickname"
 
 
-def test_get_listen_element_record_serializes_progress_time_as_utc(app):
+def test_get_listen_element_record_serializes_progress_time_as_utc(app) -> None:
     _require_app(app)
 
     from datetime import datetime
@@ -319,7 +319,7 @@ def test_get_listen_element_record_serializes_progress_time_as_utc(app):
     assert result.last_progress_updated_at == "2026-06-30T11:57:03Z"
 
 
-def test_get_listen_element_record_treats_naive_progress_time_as_utc(app):
+def test_get_listen_element_record_treats_naive_progress_time_as_utc(app) -> None:
     _require_app(app)
 
     from datetime import datetime
@@ -394,7 +394,9 @@ def test_get_listen_element_record_treats_naive_progress_time_as_utc(app):
     assert result.last_progress_updated_at == "2026-06-30T11:57:03Z"
 
 
-def test_get_listen_element_record_merges_patch_audio_fields_into_target_snapshot(app):
+def test_get_listen_element_record_merges_patch_audio_fields_into_target_snapshot(
+    app,
+) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -519,7 +521,7 @@ def test_get_listen_element_record_merges_patch_audio_fields_into_target_snapsho
 
 def test_get_listen_element_record_returns_all_persisted_elements_across_progress_records(
     app, monkeypatch
-):
+) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -648,7 +650,7 @@ def test_get_listen_element_record_returns_all_persisted_elements_across_progres
 
 def test_get_listen_element_record_keeps_block_order_when_run_sessions_reset_indexes(
     app, monkeypatch
-):
+) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -789,7 +791,9 @@ def test_get_listen_element_record_keeps_block_order_when_run_sessions_reset_ind
         ]
 
 
-def test_get_listen_element_record_ignores_rows_from_inactive_generated_blocks(app):
+def test_get_listen_element_record_ignores_rows_from_inactive_generated_blocks(
+    app,
+) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -1028,7 +1032,7 @@ def test_get_listen_element_record_ignores_rows_from_inactive_generated_blocks(a
 
 def test_get_listen_element_record_dedupes_older_progress_records_with_same_block_position(
     app, monkeypatch
-):
+) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -1149,7 +1153,7 @@ def test_get_listen_element_record_dedupes_older_progress_records_with_same_bloc
 
 def test_get_listen_element_record_includes_persisted_rows_missing_progress_bid(
     app, monkeypatch
-):
+) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -1307,7 +1311,7 @@ def test_get_listen_element_record_includes_persisted_rows_missing_progress_bid(
         }
 
 
-def test_listen_run_persists_content_block_before_element_rows(app):
+def test_listen_run_persists_content_block_before_element_rows(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -1490,7 +1494,7 @@ def test_listen_run_persists_content_block_before_element_rows(app):
     assert {row.content_text for row in rows} == {"Persisted content block"}
 
 
-def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
+def test_listen_run_emits_visual_before_blocking_tts_finalize(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -1805,7 +1809,7 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
     assert first_audio_patch_seq < later_text_seq
 
 
-def test_listen_run_persists_exception_gate_block_before_element_rows(app):
+def test_listen_run_persists_exception_gate_block_before_element_rows(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -1901,7 +1905,7 @@ def test_listen_run_persists_exception_gate_block_before_element_rows(app):
     assert rows[0].generated_block_bid == generated_blocks[0].generated_block_bid
 
 
-def test_get_record_api_returns_element_payload_by_default(app):
+def test_get_record_api_returns_element_payload_by_default(app) -> None:
     _require_app(app)
 
     from flask import request
@@ -1971,7 +1975,9 @@ def test_get_record_api_returns_element_payload_by_default(app):
     assert payload["data"]["events"][0]["type"] == "element"
 
 
-def test_listen_element_adapter_retires_fallback_once_visual_element_arrives(app):
+def test_listen_element_adapter_retires_fallback_once_visual_element_arrives(
+    app,
+) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -2089,7 +2095,9 @@ def test_listen_element_adapter_retires_fallback_once_visual_element_arrives(app
         assert fallback_element_bid not in active_element_bids
 
 
-def test_listen_element_adapter_retires_matching_active_rows_by_primary_key(app):
+def test_listen_element_adapter_retires_matching_active_rows_by_primary_key(
+    app,
+) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -2236,7 +2244,7 @@ def test_listen_element_adapter_retires_matching_active_rows_by_primary_key(app)
     assert latest_row.content_text == "updated"
 
 
-def test_listen_adapter_finalizes_visuals_and_text_as_independent_elements(app):
+def test_listen_adapter_finalizes_visuals_and_text_as_independent_elements(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -2472,7 +2480,7 @@ def test_listen_adapter_finalizes_visuals_and_text_as_independent_elements(app):
         assert json.loads(persisted_rows[1].payload)["previous_visuals"] == []
 
 
-def test_listen_adapter_finalizes_fallback_text_with_embedded_audio(app):
+def test_listen_adapter_finalizes_fallback_text_with_embedded_audio(app) -> None:
     _require_app(app)
 
     from flaskr.service.learn.learn_dtos import (
@@ -2579,7 +2587,7 @@ def test_listen_adapter_finalizes_fallback_text_with_embedded_audio(app):
         assert payload["previous_visuals"] == []
 
 
-def test_listen_adapter_handles_mdflow_stream_metadata_without_av_contract(app):
+def test_listen_adapter_handles_mdflow_stream_metadata_without_av_contract(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -2798,7 +2806,7 @@ def test_listen_adapter_handles_mdflow_stream_metadata_without_av_contract(app):
         assert persisted_segments == []
 
 
-def test_listen_adapter_marks_non_text_after_text_as_new_in_stream(app):
+def test_listen_adapter_marks_non_text_after_text_as_new_in_stream(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -2925,7 +2933,7 @@ def test_listen_adapter_marks_non_text_after_text_as_new_in_stream(app):
         assert element_events[4].target_element_bid in ("", None)
 
 
-def test_listen_adapter_keeps_html_stream_as_single_element_on_break(app):
+def test_listen_adapter_keeps_html_stream_as_single_element_on_break(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -3038,7 +3046,7 @@ def test_listen_adapter_keeps_html_stream_as_single_element_on_break(app):
         assert result.elements[0].is_new is True
 
 
-def test_listen_adapter_preserves_structural_fragment_without_html_target(app):
+def test_listen_adapter_preserves_structural_fragment_without_html_target(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -3128,7 +3136,7 @@ def test_listen_adapter_preserves_structural_fragment_without_html_target(app):
         assert "<style>*{box-sizing:border-box}</style>" in element_events[0].content
 
 
-def test_listen_adapter_marks_type_switch_as_new_when_stream_number_reused(app):
+def test_listen_adapter_marks_type_switch_as_new_when_stream_number_reused(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -3230,7 +3238,7 @@ def test_listen_adapter_marks_type_switch_as_new_when_stream_number_reused(app):
         assert len({item.element_bid for item in element_events}) == 3
 
 
-def test_listen_adapter_marks_reentered_image_slot_as_new_after_text(app):
+def test_listen_adapter_marks_reentered_image_slot_as_new_after_text(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -3326,7 +3334,7 @@ def test_listen_adapter_marks_reentered_image_slot_as_new_after_text(app):
         assert element_events[0].element_bid != element_events[2].element_bid
 
 
-def test_audio_segments_stick_to_first_target_element_without_av_contract(app):
+def test_audio_segments_stick_to_first_target_element_without_av_contract(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -3582,7 +3590,7 @@ def test_audio_segments_stick_to_first_target_element_without_av_contract(app):
         ]
 
 
-def test_late_audio_positions_bind_to_latest_text_without_av_contract(app):
+def test_late_audio_positions_bind_to_latest_text_without_av_contract(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -3911,7 +3919,7 @@ def test_late_audio_positions_bind_to_latest_text_without_av_contract(app):
         ]
 
 
-def test_listen_adapter_binds_buffered_audio_to_text_after_html(app):
+def test_listen_adapter_binds_buffered_audio_to_text_after_html(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -4116,7 +4124,7 @@ def test_listen_adapter_binds_buffered_audio_to_text_after_html(app):
         )
 
 
-def test_audio_stream_number_binding_overrides_position_guessing(app):
+def test_audio_stream_number_binding_overrides_position_guessing(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -4306,7 +4314,7 @@ def test_audio_stream_number_binding_overrides_position_guessing(app):
         ]
 
 
-def test_html_only_stream_does_not_absorb_audio_without_av_contract(app):
+def test_html_only_stream_does_not_absorb_audio_without_av_contract(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -4447,7 +4455,7 @@ def test_html_only_stream_does_not_absorb_audio_without_av_contract(app):
         assert all(row.audio_url == "" for row in persisted_html_rows)
 
 
-def test_duplicate_audio_segment_events_are_deduplicated_in_run_state(app):
+def test_duplicate_audio_segment_events_are_deduplicated_in_run_state(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -4612,7 +4620,7 @@ def test_duplicate_audio_segment_events_are_deduplicated_in_run_state(app):
         ]
 
 
-def test_listen_adapter_streams_subtitle_cues_on_audio_segment_patch(app):
+def test_listen_adapter_streams_subtitle_cues_on_audio_segment_patch(app) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -4741,7 +4749,9 @@ def test_listen_adapter_streams_subtitle_cues_on_audio_segment_patch(app):
         )
 
 
-def test_build_listen_elements_from_legacy_record_interleaves_visuals_and_text(app):
+def test_build_listen_elements_from_legacy_record_interleaves_visuals_and_text(
+    app,
+) -> None:
     _require_app(app)
 
     from flaskr.service.learn.learn_dtos import (
@@ -4835,7 +4845,7 @@ def test_build_listen_elements_from_legacy_record_interleaves_visuals_and_text(a
 
 def test_build_listen_elements_from_legacy_record_prefers_persisted_visual_elements(
     app,
-):
+) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -5052,7 +5062,9 @@ def test_build_listen_elements_from_legacy_record_prefers_persisted_visual_eleme
     ]
 
 
-def test_build_listen_elements_from_legacy_record_keeps_interaction_user_input(app):
+def test_build_listen_elements_from_legacy_record_keeps_interaction_user_input(
+    app,
+) -> None:
     _require_app(app)
 
     from flaskr.service.learn.learn_dtos import (
@@ -5088,7 +5100,9 @@ def test_build_listen_elements_from_legacy_record_keeps_interaction_user_input(a
     assert element.payload.user_input == "agree"
 
 
-def test_backfill_learn_generated_elements_for_progress_persists_clean_elements(app):
+def test_backfill_learn_generated_elements_for_progress_persists_clean_elements(
+    app,
+) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -5273,7 +5287,7 @@ def test_backfill_learn_generated_elements_for_progress_persists_clean_elements(
 
 def test_backfill_learn_generated_elements_for_progress_overwrite_replaces_active_rows(
     app,
-):
+) -> None:
     _require_app(app)
 
     from flaskr.dao import db
@@ -5380,7 +5394,7 @@ def test_backfill_learn_generated_elements_for_progress_overwrite_replaces_activ
 
 def test_backfill_learn_generated_elements_for_progress_overwrite_dry_run_rebuilds_without_stale_rows(
     app,
-):
+) -> None:
     _require_app(app)
 
     from flaskr.dao import db

--- a/src/api/tests/service/learn/test_listen_elements_legacy_record.py
+++ b/src/api/tests/service/learn/test_listen_elements_legacy_record.py
@@ -27,7 +27,7 @@ class TestBuildListenElementsFromLegacyRecord:
         with cls.app.app_context():
             dao.db.create_all()
 
-    def test_prefers_persisted_text_elements_for_audio_positions(self):
+    def test_prefers_persisted_text_elements_for_audio_positions(self) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import (
             AudioCompleteDTO,
@@ -162,7 +162,9 @@ class TestBuildListenElementsFromLegacyRecord:
             "audio-persisted-1",
         ]
 
-    def test_skips_blank_persisted_text_elements_when_binding_audio_positions(self):
+    def test_skips_blank_persisted_text_elements_when_binding_audio_positions(
+        self,
+    ) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import (
             AudioCompleteDTO,
@@ -333,7 +335,7 @@ class TestBuildListenElementsFromLegacyRecord:
             "audio-skip-blank-1",
         ]
 
-    def test_emits_ask_and_answer_with_anchor_for_follow_up_blocks(self):
+    def test_emits_ask_and_answer_with_anchor_for_follow_up_blocks(self) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import (
             BlockType,
@@ -399,7 +401,7 @@ class TestBuildListenElementsFromLegacyRecord:
         assert result.elements[1].payload.anchor_element_bid == anchor_bid
         assert result.elements[2].payload.anchor_element_bid == anchor_bid
 
-    def test_drops_follow_up_blocks_without_any_prior_anchor(self):
+    def test_drops_follow_up_blocks_without_any_prior_anchor(self) -> None:
         from flaskr.dao import db
         from flaskr.service.learn.learn_dtos import (
             BlockType,

--- a/src/api/tests/service/learn/test_listen_slide_builder.py
+++ b/src/api/tests/service/learn/test_listen_slide_builder.py
@@ -4,7 +4,7 @@ from flaskr.service.learn.listen_slide_builder import build_visual_segments_for_
 from flaskr.service.tts.pipeline import build_av_segmentation_contract
 
 
-def test_build_visual_segments_with_boundary_and_pre_visual_text():
+def test_build_visual_segments_with_boundary_and_pre_visual_text() -> None:
     raw = "Before intro.\n\n<svg><text>Chart</text></svg>\n\nAfter chart."
     contract = build_av_segmentation_contract(raw, "block-1")
 
@@ -38,7 +38,7 @@ def test_build_visual_segments_with_boundary_and_pre_visual_text():
     assert mapping[1] == second.segment_id
 
 
-def test_build_visual_segments_for_text_only_content():
+def test_build_visual_segments_for_text_only_content() -> None:
     raw = "Pure narration without any visual."
     contract = build_av_segmentation_contract(raw, "block-2")
 
@@ -58,7 +58,7 @@ def test_build_visual_segments_for_text_only_content():
     assert segments[0].source_span == [0, len(raw)]
 
 
-def test_build_visual_segments_returns_empty_for_non_speakable_content():
+def test_build_visual_segments_returns_empty_for_non_speakable_content() -> None:
     raw = "<svg><text>Only visual</text></svg>"
     contract = build_av_segmentation_contract(raw, "block-3")
 

--- a/src/api/tests/service/learn/test_preview_permissions.py
+++ b/src/api/tests/service/learn/test_preview_permissions.py
@@ -77,7 +77,7 @@ def _assert_no_permission(response) -> None:
     assert payload["message"] == "No permission"
 
 
-def test_preview_course_info_allows_creator(monkeypatch, test_client, app):
+def test_preview_course_info_allows_creator(monkeypatch, test_client, app) -> None:
     shifu_bid = "preview-permission-owner"
     owner_bid = "owner-preview-info"
     _seed_course(app, shifu_bid, owner_bid)
@@ -96,7 +96,7 @@ def test_preview_course_info_allows_creator(monkeypatch, test_client, app):
 
 def test_preview_course_info_allows_active_view_collaborator(
     monkeypatch, test_client, app
-):
+) -> None:
     shifu_bid = "preview-permission-collaborator"
     owner_bid = "owner-preview-collab"
     collaborator_bid = "user-preview-collab"
@@ -122,7 +122,7 @@ def test_preview_course_info_allows_active_view_collaborator(
 
 def test_preview_course_info_rejects_user_without_course_permission(
     monkeypatch, test_client, app
-):
+) -> None:
     shifu_bid = "preview-permission-denied"
     _seed_course(app, shifu_bid, "owner-preview-denied")
     _mock_user(monkeypatch, "user-without-preview")
@@ -137,7 +137,7 @@ def test_preview_course_info_rejects_user_without_course_permission(
 
 def test_preview_course_info_rejects_inactive_or_unknown_permission(
     monkeypatch, test_client, app
-):
+) -> None:
     shifu_bid = "preview-permission-inactive"
     owner_bid = "owner-preview-inactive"
     inactive_user_bid = "user-preview-inactive"
@@ -173,7 +173,9 @@ def test_preview_course_info_rejects_inactive_or_unknown_permission(
     _assert_no_permission(unknown_permission_resp)
 
 
-def test_preview_course_info_allows_publish_collaborator(monkeypatch, test_client, app):
+def test_preview_course_info_allows_publish_collaborator(
+    monkeypatch, test_client, app
+) -> None:
     shifu_bid = "preview-permission-publish"
     owner_bid = "owner-preview-publish"
     collaborator_bid = "user-preview-publish"
@@ -197,7 +199,9 @@ def test_preview_course_info_allows_publish_collaborator(monkeypatch, test_clien
     assert payload["data"]["bid"] == shifu_bid
 
 
-def test_non_preview_course_info_keeps_anonymous_access(monkeypatch, test_client, app):
+def test_non_preview_course_info_keeps_anonymous_access(
+    monkeypatch, test_client, app
+) -> None:
     shifu_bid = "preview-permission-non-preview"
     _seed_course(app, shifu_bid, "owner-non-preview")
     monkeypatch.setattr(
@@ -218,7 +222,7 @@ def test_non_preview_course_info_keeps_anonymous_access(monkeypatch, test_client
 
 def test_editor_preview_denied_before_admission_and_stream(
     monkeypatch, test_client, app
-):
+) -> None:
     shifu_bid = "preview-permission-editor-denied"
     _seed_course(app, shifu_bid, "owner-preview-editor")
     _mock_user(monkeypatch, "user-preview-editor-denied")
@@ -244,7 +248,9 @@ def test_editor_preview_denied_before_admission_and_stream(
     _assert_no_permission(resp)
 
 
-def test_preview_tts_denied_before_admission_and_stream(monkeypatch, test_client, app):
+def test_preview_tts_denied_before_admission_and_stream(
+    monkeypatch, test_client, app
+) -> None:
     shifu_bid = "preview-permission-tts-denied"
     _seed_course(app, shifu_bid, "owner-preview-tts")
     _mock_user(monkeypatch, "user-preview-tts-denied")

--- a/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
+++ b/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
@@ -68,12 +68,12 @@ def _patch_session(monkeypatch, behaviours):
     return session
 
 
-def test_probe_passes_on_healthy_connection(app):
+def test_probe_passes_on_healthy_connection(app) -> None:
     with app.app_context():
         _ensure_healthy_db_connection(app)
 
 
-def test_probe_invalidates_desynced_connection_and_retries(app, monkeypatch):
+def test_probe_invalidates_desynced_connection_and_retries(app, monkeypatch) -> None:
     session = _patch_session(monkeypatch, ["raise", "ok"])
 
     _ensure_healthy_db_connection(app)
@@ -83,7 +83,7 @@ def test_probe_invalidates_desynced_connection_and_retries(app, monkeypatch):
     assert session.rollbacks == 0
 
 
-def test_probe_detects_mismatched_echo_and_retries(app, monkeypatch):
+def test_probe_detects_mismatched_echo_and_retries(app, monkeypatch) -> None:
     session = _patch_session(monkeypatch, ["stale-packet-value", "ok"])
 
     _ensure_healthy_db_connection(app)
@@ -92,7 +92,7 @@ def test_probe_detects_mismatched_echo_and_retries(app, monkeypatch):
     assert session.invalidations == 1
 
 
-def test_probe_raises_after_exhausting_attempts(app, monkeypatch):
+def test_probe_raises_after_exhausting_attempts(app, monkeypatch) -> None:
     session = _patch_session(monkeypatch, ["raise", "raise", "raise"])
 
     with pytest.raises(OperationalError):
@@ -103,7 +103,7 @@ def test_probe_raises_after_exhausting_attempts(app, monkeypatch):
     assert session.rollbacks == 0
 
 
-def test_probe_raises_on_persistent_echo_mismatch(app, monkeypatch):
+def test_probe_raises_on_persistent_echo_mismatch(app, monkeypatch) -> None:
     _patch_session(monkeypatch, ["bad-1", "bad-2", "bad-3"])
 
     with pytest.raises(RuntimeError):

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -1,6 +1,7 @@
 """Verify runscript v2 lock behavior."""
 
 import json
+from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
@@ -36,14 +37,14 @@ class FakeLock:
         self.acquire_calls = 0
         self.release_calls = 0
 
-    def acquire(self, blocking=True):
+    def acquire(self, blocking=True) -> bool:
         _ = blocking
         self.acquire_calls += 1
         if self._acquire_results:
             return self._acquire_results.pop(0)
         return False
 
-    def release(self):
+    def release(self) -> None:
         self.release_calls += 1
 
 
@@ -55,15 +56,15 @@ class FakeCacheProvider:
         self._lock = lock
         self.values: dict[str, bytes] = {}
 
-    def lock(self, *_args: object, **_kwargs: object):
+    def lock(self, *_args: object, **_kwargs: object) -> FakeLock:
         return self._lock
 
-    def setex(self, key: str, _time_in_seconds: int, value):
+    def setex(self, key: str, _time_in_seconds: int, value) -> bool:
         encoded = value if isinstance(value, bytes) else str(value).encode("utf-8")
         self.values[key] = encoded
         return True
 
-    def get(self, key: str):
+    def get(self, key: str) -> object | None:
         return self.values.get(key)
 
     def delete(self, *keys: str) -> int:
@@ -83,7 +84,7 @@ class FakeListenElementAdapter:
         self._seq = 0
         self._run_session_bid = "run-session-1"
 
-    def process(self, events):
+    def process(self, events) -> Iterator[object]:
         for event in events:
             if event.type == GeneratedType.ASK:
                 continue
@@ -138,7 +139,7 @@ def _make_test_app() -> Flask:
     return app
 
 
-def test_sse_chunk_serializes_datetime_as_utc_iso_z():
+def test_sse_chunk_serializes_datetime_as_utc_iso_z() -> None:
     chunk = runscript_v2._to_sse_chunk(
         {
             "created_at": datetime(
@@ -158,7 +159,7 @@ def _patch_fake_element_adapter(monkeypatch):
     )
 
 
-def test_run_script_retries_lock_then_streams(monkeypatch):
+def test_run_script_retries_lock_then_streams(monkeypatch) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -206,7 +207,7 @@ def test_run_script_retries_lock_then_streams(monkeypatch):
         assert events[-1]["is_terminal"] is True
 
 
-def test_run_script_producer_owns_app_context(monkeypatch):
+def test_run_script_producer_owns_app_context(monkeypatch) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -246,7 +247,7 @@ def test_run_script_producer_owns_app_context(monkeypatch):
         assert [event["type"] for event in events] == ["element", "done"]
 
 
-def test_run_script_removes_producer_db_session(monkeypatch):
+def test_run_script_removes_producer_db_session(monkeypatch) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -287,7 +288,9 @@ def test_run_script_removes_producer_db_session(monkeypatch):
         assert remove_calls == ["remove"]
 
 
-def test_run_script_producer_done_survives_db_session_remove_failure(monkeypatch):
+def test_run_script_producer_done_survives_db_session_remove_failure(
+    monkeypatch,
+) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -333,7 +336,7 @@ def test_run_script_producer_done_survives_db_session_remove_failure(monkeypatch
         assert remove_calls == ["remove"]
 
 
-def test_run_script_read_mode_keeps_interaction_after_block_break(monkeypatch):
+def test_run_script_read_mode_keeps_interaction_after_block_break(monkeypatch) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -387,7 +390,7 @@ def test_run_script_read_mode_keeps_interaction_after_block_break(monkeypatch):
         assert events[1]["content"] == "?[%{{name}}...How should I call you?]"
 
 
-def test_run_script_ask_mode_uses_element_protocol(monkeypatch):
+def test_run_script_ask_mode_uses_element_protocol(monkeypatch) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -441,7 +444,7 @@ def test_run_script_ask_mode_uses_element_protocol(monkeypatch):
         assert events[1]["is_terminal"] is True
 
 
-def test_run_script_ask_mode_ignores_listen_flag(monkeypatch):
+def test_run_script_ask_mode_ignores_listen_flag(monkeypatch) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -485,7 +488,9 @@ def test_run_script_ask_mode_ignores_listen_flag(monkeypatch):
         assert events[-1]["is_terminal"] is True
 
 
-def test_run_script_inner_ask_mode_routes_events_through_element_adapter(monkeypatch):
+def test_run_script_inner_ask_mode_routes_events_through_element_adapter(
+    monkeypatch,
+) -> None:
     app = Flask(__name__)
 
     monkeypatch.setattr(
@@ -601,7 +606,7 @@ def test_run_script_inner_ask_mode_routes_events_through_element_adapter(monkeyp
     ]
 
 
-def test_log_run_script_stream_error_does_not_error_for_app_exception():
+def test_log_run_script_stream_error_does_not_error_for_app_exception() -> None:
     app = Flask(__name__)
     info_calls = []
     error_calls = []
@@ -617,7 +622,7 @@ def test_log_run_script_stream_error_does_not_error_for_app_exception():
     assert info_calls[1][0]["description"] == "outline unit does not exist"
 
 
-def test_log_run_script_stream_error_keeps_error_for_unexpected_exception():
+def test_log_run_script_stream_error_keeps_error_for_unexpected_exception() -> None:
     app = Flask(__name__)
     info_calls = []
     error_calls = []
@@ -631,7 +636,7 @@ def test_log_run_script_stream_error_keeps_error_for_unexpected_exception():
     assert error_calls[1][0]["description"] == "boom"
 
 
-def test_run_script_inner_rejects_missing_course_without_default(monkeypatch):
+def test_run_script_inner_rejects_missing_course_without_default(monkeypatch) -> None:
     app = Flask(__name__)
     rollback_calls = []
     remove_calls = []
@@ -674,7 +679,7 @@ def test_run_script_inner_rejects_missing_course_without_default(monkeypatch):
     assert remove_calls == ["remove"]
 
 
-def test_run_script_inner_rolls_back_on_unexpected_exception(monkeypatch):
+def test_run_script_inner_rolls_back_on_unexpected_exception(monkeypatch) -> None:
     app = Flask(__name__)
     session_spy = SimpleNamespace(
         commit=lambda: None,
@@ -770,7 +775,7 @@ def test_run_script_inner_rolls_back_on_unexpected_exception(monkeypatch):
     assert remove_calls == ["remove"]
 
 
-def test_run_script_inner_finalizes_langfuse_after_loop(monkeypatch):
+def test_run_script_inner_finalizes_langfuse_after_loop(monkeypatch) -> None:
     app = Flask(__name__)
     commit_calls = []
 
@@ -874,7 +879,9 @@ def test_run_script_inner_finalizes_langfuse_after_loop(monkeypatch):
     assert commit_calls == ["commit"]
 
 
-def test_run_script_inner_emits_audio_backfill_ready_after_final_commit(monkeypatch):
+def test_run_script_inner_emits_audio_backfill_ready_after_final_commit(
+    monkeypatch,
+) -> None:
     app = Flask(__name__)
     sequence = []
 
@@ -1003,7 +1010,9 @@ def test_run_script_inner_emits_audio_backfill_ready_after_final_commit(monkeypa
     assert ready_event.content.element_bids == ["element-1"]
 
 
-def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(monkeypatch):
+def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(
+    monkeypatch,
+) -> None:
     app = Flask(__name__)
     sequence = []
 
@@ -1118,7 +1127,7 @@ def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(monkeypa
     assert ready_event.content.element_bids == ["element-1"]
 
 
-def test_run_script_listen_keeps_interaction_after_block_done(monkeypatch):
+def test_run_script_listen_keeps_interaction_after_block_done(monkeypatch) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -1171,7 +1180,7 @@ def test_run_script_listen_keeps_interaction_after_block_done(monkeypatch):
         assert events[2]["is_terminal"] is True
 
 
-def test_run_script_lock_busy_returns_busy_and_done(monkeypatch):
+def test_run_script_lock_busy_returns_busy_and_done(monkeypatch) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -1201,7 +1210,7 @@ def test_run_script_lock_busy_returns_busy_and_done(monkeypatch):
         assert events[1]["is_terminal"] is True
 
 
-def test_run_script_listen_lock_busy_returns_element_protocol(monkeypatch):
+def test_run_script_listen_lock_busy_returns_element_protocol(monkeypatch) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -1237,7 +1246,7 @@ def test_run_script_listen_lock_busy_returns_element_protocol(monkeypatch):
 
 def test_run_script_maps_llm_stream_connection_error_to_retryable_message(
     monkeypatch,
-):
+) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -1271,7 +1280,9 @@ def test_run_script_maps_llm_stream_connection_error_to_retryable_message(
         assert events[2]["is_terminal"] is True
 
 
-def test_run_script_maps_standard_timeout_error_to_retryable_message(monkeypatch):
+def test_run_script_maps_standard_timeout_error_to_retryable_message(
+    monkeypatch,
+) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -1307,7 +1318,7 @@ def test_run_script_maps_standard_timeout_error_to_retryable_message(monkeypatch
         assert events[2]["is_terminal"] is True
 
 
-def test_run_script_listen_done_uses_element_protocol(monkeypatch):
+def test_run_script_listen_done_uses_element_protocol(monkeypatch) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -1344,7 +1355,7 @@ def test_run_script_listen_done_uses_element_protocol(monkeypatch):
         assert events[0]["is_terminal"] is True
 
 
-def test_get_run_status_ignores_lock_when_running_marker_missing(monkeypatch):
+def test_get_run_status_ignores_lock_when_running_marker_missing(monkeypatch) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -1364,7 +1375,7 @@ def test_get_run_status_ignores_lock_when_running_marker_missing(monkeypatch):
         assert lock.acquire_calls == 0
 
 
-def test_get_run_status_reports_true_while_stream_is_open(monkeypatch):
+def test_get_run_status_reports_true_while_stream_is_open(monkeypatch) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -1416,7 +1427,9 @@ def test_get_run_status_reports_true_while_stream_is_open(monkeypatch):
         assert status_after.running_time == 0
 
 
-def test_run_script_close_during_data_yield_does_not_raise_runtime_error(monkeypatch):
+def test_run_script_close_during_data_yield_does_not_raise_runtime_error(
+    monkeypatch,
+) -> None:
     app = _make_test_app()
     _patch_fake_element_adapter(monkeypatch)
     with app.app_context():
@@ -1450,7 +1463,7 @@ def test_run_script_close_during_data_yield_does_not_raise_runtime_error(monkeyp
         assert lock.release_calls == 1
 
 
-def test_run_script_propagates_explicit_language_to_producer(monkeypatch):
+def test_run_script_propagates_explicit_language_to_producer(monkeypatch) -> None:
     """The route handler must hand the request language in explicitly.
 
     On Flask >= 3.1 the request teardown (which clears the request-scoped

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -114,7 +114,9 @@ def _start_stream(app):
     return generator
 
 
-def test_generator_exit_invalidates_connection_instead_of_rollback(app, monkeypatch):
+def test_generator_exit_invalidates_connection_instead_of_rollback(
+    app, monkeypatch
+) -> None:
     session = _patch_run_dependencies(monkeypatch, ["chunk-1", "chunk-2"])
 
     with app.app_context():
@@ -126,7 +128,9 @@ def test_generator_exit_invalidates_connection_instead_of_rollback(app, monkeypa
     assert session.removed == 1
 
 
-def test_desync_error_invalidates_connection_instead_of_rollback(app, monkeypatch):
+def test_desync_error_invalidates_connection_instead_of_rollback(
+    app, monkeypatch
+) -> None:
     session = _patch_run_dependencies(
         monkeypatch,
         [
@@ -152,7 +156,7 @@ def test_desync_error_invalidates_connection_instead_of_rollback(app, monkeypatc
     assert session.removed == 1
 
 
-def test_ordinary_error_still_rolls_back_pooled_connection(app, monkeypatch):
+def test_ordinary_error_still_rolls_back_pooled_connection(app, monkeypatch) -> None:
     session = _patch_run_dependencies(
         monkeypatch, ["chunk-1", ValueError("business failure")]
     )
@@ -167,7 +171,7 @@ def test_ordinary_error_still_rolls_back_pooled_connection(app, monkeypatch):
     assert session.removed == 1
 
 
-def test_desync_error_classifier_covers_symptom_family():
+def test_desync_error_classifier_covers_symptom_family() -> None:
     assert _is_protocol_desync_error(ResourceClosedError("no rows"))
     wrapped_2013 = OperationalError(
         "INSERT ...",
@@ -184,7 +188,9 @@ def test_desync_error_classifier_covers_symptom_family():
     assert not _is_protocol_desync_error(wrapped_deadlock)
 
 
-def test_stop_event_cancellation_invalidates_instead_of_rollback(app, monkeypatch):
+def test_stop_event_cancellation_invalidates_instead_of_rollback(
+    app, monkeypatch
+) -> None:
     import threading
 
     session = _patch_run_dependencies(monkeypatch, ["chunk-1"])
@@ -220,7 +226,7 @@ def test_stop_event_cancellation_invalidates_instead_of_rollback(app, monkeypatc
     assert session.rollbacks == 0
 
 
-def test_natural_exhaustion_never_invalidates(app, monkeypatch):
+def test_natural_exhaustion_never_invalidates(app, monkeypatch) -> None:
     session = _patch_run_dependencies(monkeypatch, ["chunk-1", "chunk-2"])
 
     with app.app_context():
@@ -233,7 +239,7 @@ def test_natural_exhaustion_never_invalidates(app, monkeypatch):
     assert session.commits >= 1
 
 
-def test_discard_helper_works_on_real_scoped_session(app, caplog):
+def test_discard_helper_works_on_real_scoped_session(app, caplog) -> None:
     import logging
 
     from flaskr.service.learn.runscript_v2 import _discard_session_connection

--- a/src/api/tests/service/learn/test_runtime_tts_admission.py
+++ b/src/api/tests/service/learn/test_runtime_tts_admission.py
@@ -142,7 +142,7 @@ def _mock_user(monkeypatch, user_id: str, *, is_creator: bool = False):
     return dummy_user
 
 
-def test_stream_passthrough_releases_request_db_session(monkeypatch):
+def test_stream_passthrough_releases_request_db_session(monkeypatch) -> None:
     from flaskr.service.learn import routes
 
     app = Flask(__name__)
@@ -171,7 +171,9 @@ def test_stream_passthrough_releases_request_db_session(monkeypatch):
     assert calls == ["remove", "iterate", "remove"]
 
 
-def test_stream_passthrough_ignores_request_db_session_remove_failure(monkeypatch):
+def test_stream_passthrough_ignores_request_db_session_remove_failure(
+    monkeypatch,
+) -> None:
     from flaskr.service.learn import routes
 
     app = Flask(__name__)
@@ -206,7 +208,7 @@ def test_stream_passthrough_ignores_request_db_session_remove_failure(monkeypatc
     assert calls == ["remove", "iterate", "remove"]
 
 
-def test_stream_sse_logs_business_errors_as_warning(monkeypatch, caplog):
+def test_stream_sse_logs_business_errors_as_warning(monkeypatch, caplog) -> None:
     from flaskr.service.common.models import AppError
     from flaskr.service.learn import routes
 
@@ -239,7 +241,7 @@ def test_stream_sse_logs_business_errors_as_warning(monkeypatch, caplog):
     assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
 
 
-def test_stream_sse_keeps_unexpected_errors_at_error_level(monkeypatch, caplog):
+def test_stream_sse_keeps_unexpected_errors_at_error_level(monkeypatch, caplog) -> None:
     from flaskr.service.learn import routes
 
     app = Flask(__name__)
@@ -270,7 +272,7 @@ def test_stream_sse_keeps_unexpected_errors_at_error_level(monkeypatch, caplog):
 
 def test_stream_sse_emits_error_event_for_business_error_with_factory(
     monkeypatch, caplog
-):
+) -> None:
     from flaskr.service.common.models import AppError
     from flaskr.service.learn import routes
 
@@ -353,7 +355,7 @@ def test_run_route_passes_admission_payload_to_run_script() -> None:
 
 def test_preview_route_skips_admission_and_runtime_slot_for_builtin_demo(
     monkeypatch, test_client, app
-):
+) -> None:
     _ = app
     _mock_user(monkeypatch, "user-preview")
     monkeypatch.setattr(
@@ -398,7 +400,7 @@ def test_preview_route_skips_admission_and_runtime_slot_for_builtin_demo(
 
 def test_run_route_skips_runtime_admission_payload_for_builtin_demo(
     monkeypatch, test_client
-):
+) -> None:
     _mock_user(monkeypatch, "user-run")
 
     monkeypatch.setattr(
@@ -435,7 +437,7 @@ def test_run_route_skips_runtime_admission_payload_for_builtin_demo(
 
 def test_run_route_uses_payload_language_as_generation_snapshot(
     monkeypatch, test_client
-):
+) -> None:
     _mock_user(monkeypatch, "user-run-language")
     captured = {}
 

--- a/src/api/tests/service/learn/test_runtime_tts_voice_id.py
+++ b/src/api/tests/service/learn/test_runtime_tts_voice_id.py
@@ -1,5 +1,6 @@
 """Verify runtime TTS voice ID behavior."""
 
+from collections.abc import Iterator
 from types import SimpleNamespace
 
 import pytest
@@ -13,7 +14,7 @@ from flaskr.service.tts.models import (
 
 
 @pytest.fixture
-def voice_app():
+def voice_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(
@@ -60,7 +61,7 @@ def _add_clone(shifu_bid, voice_id, status, voice_bid, provider="minimax"):
     dao.db.session.commit()
 
 
-def test_non_minimax_provider_returns_voice_id_unchanged(voice_app):
+def test_non_minimax_provider_returns_voice_id_unchanged(voice_app) -> None:
     from flaskr.service.learn import learn_funcs
 
     with voice_app.app_context():
@@ -73,7 +74,7 @@ def test_non_minimax_provider_returns_voice_id_unchanged(voice_app):
         )
 
 
-def test_minimax_empty_voice_id_returns_empty(voice_app):
+def test_minimax_empty_voice_id_returns_empty(voice_app) -> None:
     from flaskr.service.learn import learn_funcs
 
     with voice_app.app_context():
@@ -85,7 +86,7 @@ def test_minimax_empty_voice_id_returns_empty(voice_app):
         )
 
 
-def test_minimax_builtin_voice_is_kept(voice_app, monkeypatch):
+def test_minimax_builtin_voice_is_kept(voice_app, monkeypatch) -> None:
     from flaskr.service.learn import learn_funcs
 
     _patch_provider(monkeypatch)
@@ -98,7 +99,7 @@ def test_minimax_builtin_voice_is_kept(voice_app, monkeypatch):
         )
 
 
-def test_minimax_ready_clone_of_same_shifu_is_kept(voice_app, monkeypatch):
+def test_minimax_ready_clone_of_same_shifu_is_kept(voice_app, monkeypatch) -> None:
     from flaskr.service.learn import learn_funcs
 
     _patch_provider(monkeypatch)
@@ -114,7 +115,7 @@ def test_minimax_ready_clone_of_same_shifu_is_kept(voice_app, monkeypatch):
 
 def test_minimax_ready_clone_of_other_shifu_is_kept_as_manual_custom_voice(
     voice_app, monkeypatch
-):
+) -> None:
     from flaskr.service.learn import learn_funcs
 
     _patch_provider(monkeypatch)
@@ -130,7 +131,9 @@ def test_minimax_ready_clone_of_other_shifu_is_kept_as_manual_custom_voice(
         )
 
 
-def test_minimax_non_ready_clone_of_same_shifu_falls_back(voice_app, monkeypatch):
+def test_minimax_non_ready_clone_of_same_shifu_falls_back(
+    voice_app, monkeypatch
+) -> None:
     from flaskr.service.learn import learn_funcs
 
     _patch_provider(monkeypatch)
@@ -147,7 +150,7 @@ def test_minimax_non_ready_clone_of_same_shifu_falls_back(voice_app, monkeypatch
         )
 
 
-def test_minimax_untracked_custom_voice_falls_back(voice_app, monkeypatch):
+def test_minimax_untracked_custom_voice_falls_back(voice_app, monkeypatch) -> None:
     from flaskr.service.learn import learn_funcs
 
     _patch_provider(monkeypatch)
@@ -162,7 +165,7 @@ def test_minimax_untracked_custom_voice_falls_back(voice_app, monkeypatch):
         )
 
 
-def test_volcengine_builtin_voice_is_kept(voice_app, monkeypatch):
+def test_volcengine_builtin_voice_is_kept(voice_app, monkeypatch) -> None:
     from flaskr.service.learn import learn_funcs
 
     _patch_provider(monkeypatch, built_in=("zh_female_vv_uranus_bigtts",))
@@ -178,7 +181,7 @@ def test_volcengine_builtin_voice_is_kept(voice_app, monkeypatch):
         )
 
 
-def test_volcengine_operator_registered_clone_is_kept(voice_app, monkeypatch):
+def test_volcengine_operator_registered_clone_is_kept(voice_app, monkeypatch) -> None:
     from flaskr.service.learn import learn_funcs
 
     _patch_provider(monkeypatch)
@@ -196,7 +199,7 @@ def test_volcengine_operator_registered_clone_is_kept(voice_app, monkeypatch):
         )
 
 
-def test_volcengine_unregistered_clone_falls_back(voice_app, monkeypatch):
+def test_volcengine_unregistered_clone_falls_back(voice_app, monkeypatch) -> None:
     from flaskr.service.learn import learn_funcs
 
     _patch_provider(monkeypatch)
@@ -209,7 +212,7 @@ def test_volcengine_unregistered_clone_falls_back(voice_app, monkeypatch):
         )
 
 
-def test_volcengine_does_not_accept_minimax_clone_row(voice_app, monkeypatch):
+def test_volcengine_does_not_accept_minimax_clone_row(voice_app, monkeypatch) -> None:
     from flaskr.service.learn import learn_funcs
 
     _patch_provider(monkeypatch)

--- a/src/api/tests/service/learn/test_sse_element_split_from_db.py
+++ b/src/api/tests/service/learn/test_sse_element_split_from_db.py
@@ -219,14 +219,14 @@ class TestSSEElementSplitFromDB:
     """Fetch real blocks and validate SSE element splitting."""
 
     @pytest.fixture(scope="class")
-    def blocks(self, app):
+    def blocks(self, app) -> list[object]:
         """Load 100 latest blocks from the test DB."""
         rows = _fetch_blocks_raw(app, limit=100)
         if not rows:
             pytest.skip("No generated blocks found in test DB")
         return rows
 
-    def test_blocks_loaded(self, blocks):
+    def test_blocks_loaded(self, blocks) -> None:
         """Sanity check: we have data to test with."""
         assert len(blocks) > 0
 
@@ -235,7 +235,7 @@ class TestSSEElementSplitFromDB:
         app,
         blocks,
         request: pytest.FixtureRequest,
-    ):
+    ) -> None:
         """Every block must produce a valid SSE stream without errors."""
         failures = []
         stats = {
@@ -365,7 +365,7 @@ class TestSSEElementSplitFromDB:
         app,
         blocks,
         request: pytest.FixtureRequest,
-    ):
+    ) -> None:
         """Verify SSE JSON output can be parsed back correctly."""
         from flaskr.service.learn.routes import _to_sse_data_line
 
@@ -449,7 +449,7 @@ class TestSSEElementSplitFromDB:
         app,
         blocks,
         request: pytest.FixtureRequest,
-    ):
+    ) -> None:
         """Verify that element splitting does not lose content."""
         sample_blocks = [
             b
@@ -525,7 +525,7 @@ class TestSSEElementSplitFromDB:
         app,
         blocks,
         request: pytest.FixtureRequest,
-    ):
+    ) -> None:
         """Verify element_type is appropriate for the content pattern.
 
         When a block's entire content is a single visual element (e.g. pure SVG),
@@ -595,7 +595,7 @@ class TestSSEElementSplitFromDB:
         app,
         blocks,
         request: pytest.FixtureRequest,
-    ):
+    ) -> None:
         """Diagnose element type inference for blocks whose content is pure visual (SVG, HTML with no speakable text).
 
         These blocks have visual_boundaries in av_contract but no

--- a/src/api/tests/service/learn/test_tts_error_mapping.py
+++ b/src/api/tests/service/learn/test_tts_error_mapping.py
@@ -8,7 +8,7 @@ from flaskr.service.learn.learn_funcs import _yield_with_tts_error_mapping
 from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeoutError
 
 
-def test_rpm_queue_timeout_maps_to_rate_limited_not_unknown(app, caplog):
+def test_rpm_queue_timeout_maps_to_rate_limited_not_unknown(app, caplog) -> None:
     def _body():
         message = "TTS RPM queue wait exceeded 10.00s"
         raise TTSRpmQueueTimeoutError(message)
@@ -34,7 +34,7 @@ def test_rpm_queue_timeout_maps_to_rate_limited_not_unknown(app, caplog):
     assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
 
 
-def test_unexpected_error_still_maps_to_unknown_error(app, caplog):
+def test_unexpected_error_still_maps_to_unknown_error(app, caplog) -> None:
     def _body():
         message = "tts worker crashed"
         raise RuntimeError(message)

--- a/src/api/tests/service/learn/test_tts_synth_concurrency.py
+++ b/src/api/tests/service/learn/test_tts_synth_concurrency.py
@@ -1,5 +1,7 @@
 """Verify TTS synth concurrency behavior."""
 
+from typing import Never
+
 from flaskr import dao
 from flaskr.service.learn import learn_funcs
 from flaskr.service.learn.learn_funcs import (
@@ -19,7 +21,7 @@ class FakeRedis:
         """Initialize the fake Redis test double."""
         self.counters: dict[str, int] = {}
 
-    def eval(self, _script, _numkeys, *args: object):
+    def eval(self, _script, _numkeys, *args: object) -> int:
         key = args[0]
         if len(args) >= 3:  # acquire: key, max_count, ttl
             max_count = int(args[1])
@@ -42,13 +44,13 @@ class ExplodingRedis:
         """Initialize the exploding Redis test double."""
         self.calls = 0
 
-    def eval(self, *_args: object, **_kwargs: object):
+    def eval(self, *_args: object, **_kwargs: object) -> Never:
         self.calls += 1
         message = "redis down"
         raise RuntimeError(message)
 
 
-def test_tts_synth_semaphore_caps_at_limit_and_releases(app, monkeypatch):
+def test_tts_synth_semaphore_caps_at_limit_and_releases(app, monkeypatch) -> None:
     fake = FakeRedis()
     monkeypatch.setattr(dao._redis_state, "client", fake)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 2
@@ -66,7 +68,7 @@ def test_tts_synth_semaphore_caps_at_limit_and_releases(app, monkeypatch):
     assert learn_funcs._tts_synth_sem_acquire(app, "u1", "o2") == _TTS_SLOT_ACQUIRED
 
 
-def test_tts_synth_semaphore_bypasses_without_redis(app, monkeypatch):
+def test_tts_synth_semaphore_bypasses_without_redis(app, monkeypatch) -> None:
     monkeypatch.setattr(dao._redis_state, "client", None)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
 
@@ -75,7 +77,7 @@ def test_tts_synth_semaphore_bypasses_without_redis(app, monkeypatch):
     assert learn_funcs._tts_synth_sem_acquire(app, "u", "o") == _TTS_SLOT_BYPASS
 
 
-def test_tts_synth_semaphore_bypasses_on_redis_error(app, monkeypatch):
+def test_tts_synth_semaphore_bypasses_on_redis_error(app, monkeypatch) -> None:
     boom = ExplodingRedis()
     monkeypatch.setattr(dao._redis_state, "client", boom)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
@@ -84,7 +86,7 @@ def test_tts_synth_semaphore_bypasses_on_redis_error(app, monkeypatch):
     assert boom.calls == 1
 
 
-def test_tts_synth_semaphore_disabled_when_zero(app, monkeypatch):
+def test_tts_synth_semaphore_disabled_when_zero(app, monkeypatch) -> None:
     fake = FakeRedis()
     monkeypatch.setattr(dao._redis_state, "client", fake)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 0
@@ -94,7 +96,7 @@ def test_tts_synth_semaphore_disabled_when_zero(app, monkeypatch):
     assert fake.counters == {}
 
 
-def test_tts_synth_semaphore_ignores_incomplete_key(app, monkeypatch):
+def test_tts_synth_semaphore_ignores_incomplete_key(app, monkeypatch) -> None:
     fake = FakeRedis()
     monkeypatch.setattr(dao._redis_state, "client", fake)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
@@ -105,7 +107,7 @@ def test_tts_synth_semaphore_ignores_incomplete_key(app, monkeypatch):
     assert fake.counters == {}
 
 
-def test_yield_tts_synthesis_sheds_request_when_full(app, monkeypatch):
+def test_yield_tts_synthesis_sheds_request_when_full(app, monkeypatch) -> None:
     fake = FakeRedis()
     monkeypatch.setattr(dao._redis_state, "client", fake)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
@@ -136,7 +138,7 @@ def test_yield_tts_synthesis_sheds_request_when_full(app, monkeypatch):
     assert fake.counters.get(key) == 1
 
 
-def test_yield_tts_synthesis_runs_and_releases_slot(app, monkeypatch):
+def test_yield_tts_synthesis_runs_and_releases_slot(app, monkeypatch) -> None:
     fake = FakeRedis()
     monkeypatch.setattr(dao._redis_state, "client", fake)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
@@ -162,7 +164,7 @@ def test_yield_tts_synthesis_runs_and_releases_slot(app, monkeypatch):
     assert fake.counters.get(key, 0) == 0
 
 
-def test_yield_tts_synthesis_bypass_does_not_release(app, monkeypatch):
+def test_yield_tts_synthesis_bypass_does_not_release(app, monkeypatch) -> None:
     # Redis errors on acquire -> bypass (fail open); the finally must NOT call
     # release, otherwise it would decrement a slot that was never reserved and
     # could steal another request's slot.

--- a/src/api/tests/service/metering/test_billing_boundary.py
+++ b/src/api/tests/service/metering/test_billing_boundary.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from flask import Flask
 from flaskr import dao
@@ -17,9 +19,12 @@ from flaskr.service.metering.consts import (
 )
 from flaskr.service.metering.models import BillUsageRecord
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def metering_billing_boundary_app():
+def metering_billing_boundary_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/metering/test_recording.py
+++ b/src/api/tests/service/metering/test_recording.py
@@ -1,5 +1,7 @@
 """Verify billable usage is persisted and queued for settlement."""
 
+from collections.abc import Iterator
+
 import pytest
 from flask import Flask
 from flaskr import dao
@@ -18,7 +20,7 @@ _BUILTIN_DEMO_SHIFU_BID = "demo-configured-1"
 
 
 @pytest.fixture
-def metering_app():
+def metering_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(
@@ -38,7 +40,7 @@ def metering_app():
         dao.db.drop_all()
 
 
-def test_record_llm_usage_persists(metering_app):
+def test_record_llm_usage_persists(metering_app) -> None:
     with metering_app.app_context():
         context = UsageContext(
             user_bid="user-1",
@@ -71,7 +73,7 @@ def test_record_llm_usage_persists(metering_app):
 def test_record_llm_usage_enqueues_settlement_for_billable_root_usage(
     metering_app,
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     captured: list[str] = []
     monkeypatch.setattr(
         "flaskr.service.metering.recorder._enqueue_usage_settlement",
@@ -97,7 +99,7 @@ def test_record_llm_usage_enqueues_settlement_for_billable_root_usage(
     assert captured == [usage_bid]
 
 
-def test_record_tts_usage_preview_defaults_to_billable_on(metering_app):
+def test_record_tts_usage_preview_defaults_to_billable_on(metering_app) -> None:
     with metering_app.app_context():
         context = UsageContext(
             user_bid="user-2",
@@ -153,7 +155,7 @@ def test_record_tts_usage_preview_defaults_to_billable_on(metering_app):
 def test_record_tts_usage_only_enqueues_root_billable_record(
     metering_app,
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     captured: list[str] = []
     monkeypatch.setattr(
         "flaskr.service.metering.recorder._enqueue_usage_settlement",
@@ -202,7 +204,9 @@ def test_record_tts_usage_only_enqueues_root_billable_record(
     assert captured == [parent_usage_bid]
 
 
-def test_record_debug_usage_respects_explicit_non_billable_override(metering_app):
+def test_record_debug_usage_respects_explicit_non_billable_override(
+    metering_app,
+) -> None:
     with metering_app.app_context():
         context = UsageContext(
             user_bid="user-3",
@@ -229,7 +233,7 @@ def test_record_debug_usage_respects_explicit_non_billable_override(metering_app
 def test_record_llm_usage_skips_settlement_enqueue_for_non_billable_usage(
     metering_app,
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     captured: list[str] = []
     monkeypatch.setattr(
         "flaskr.service.metering.recorder._enqueue_usage_settlement",
@@ -259,7 +263,7 @@ def test_record_llm_usage_skips_settlement_enqueue_for_non_billable_usage(
 def test_record_llm_usage_marks_builtin_demo_course_non_billable(
     metering_app,
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     captured: list[str] = []
     monkeypatch.setattr(
         "flaskr.service.metering.recorder._enqueue_usage_settlement",
@@ -297,7 +301,7 @@ def test_record_llm_usage_marks_builtin_demo_course_non_billable(
 def test_record_tts_usage_marks_builtin_demo_course_non_billable(
     metering_app,
     monkeypatch: pytest.MonkeyPatch,
-):
+) -> None:
     captured: list[str] = []
     monkeypatch.setattr(
         "flaskr.service.metering.recorder._enqueue_usage_settlement",
@@ -337,7 +341,9 @@ def test_record_tts_usage_marks_builtin_demo_course_non_billable(
     assert captured == []
 
 
-def test_persist_cleanup_targets_failed_session_inside_context(app, monkeypatch):
+def test_persist_cleanup_targets_failed_session_inside_context(
+    app, monkeypatch
+) -> None:
     """Cleanup must run inside the pushed context (targeting the session that failed) and classify the failure: ordinary errors roll back, protocol interrupts invalidate."""
     from flask import current_app
     from flaskr.service.metering import recorder as recorder_module
@@ -371,7 +377,7 @@ def test_persist_cleanup_targets_failed_session_inside_context(app, monkeypatch)
     assert events == [("ResourceClosedError", True)]
 
 
-def test_persist_invalidates_on_base_exception_interrupt(app, monkeypatch):
+def test_persist_invalidates_on_base_exception_interrupt(app, monkeypatch) -> None:
     from flaskr.service.metering import recorder as recorder_module
 
     invalidations = []

--- a/src/api/tests/service/metering/test_tts_usage_recorder.py
+++ b/src/api/tests/service/metering/test_tts_usage_recorder.py
@@ -28,7 +28,7 @@ def _audio_settings():
 
 def test_record_tts_usage_persists_supplied_output_without_provider_mapping(
     monkeypatch,
-):
+) -> None:
     app = Flask(__name__)
     captured = {}
     enqueued = []
@@ -77,7 +77,7 @@ def test_record_tts_usage_persists_supplied_output_without_provider_mapping(
     assert enqueued == ["usage-tts-explicit-output"]
 
 
-def test_record_tts_segment_usage_uses_usage_characters_for_output(monkeypatch):
+def test_record_tts_segment_usage_uses_usage_characters_for_output(monkeypatch) -> None:
     captured = {}
 
     monkeypatch.setattr(
@@ -109,7 +109,7 @@ def test_record_tts_segment_usage_uses_usage_characters_for_output(monkeypatch):
     assert kwargs["word_count"] == 52
 
 
-def test_record_tts_segment_usage_falls_back_to_local_length(monkeypatch):
+def test_record_tts_segment_usage_falls_back_to_local_length(monkeypatch) -> None:
     captured = {}
 
     monkeypatch.setattr(
@@ -140,7 +140,7 @@ def test_record_tts_segment_usage_falls_back_to_local_length(monkeypatch):
     assert kwargs["word_count"] == 2
 
 
-def test_record_tts_aggregated_usage_uses_total_usage_characters(monkeypatch):
+def test_record_tts_aggregated_usage_uses_total_usage_characters(monkeypatch) -> None:
     captured = {}
 
     monkeypatch.setattr(

--- a/src/api/tests/service/order/test_admin_datetime_filters.py
+++ b/src/api/tests/service/order/test_admin_datetime_filters.py
@@ -5,17 +5,17 @@ from datetime import datetime
 from flaskr.service.order.admin import _parse_datetime
 
 
-def test_parse_admin_order_datetime_normalizes_utc_z_values():
+def test_parse_admin_order_datetime_normalizes_utc_z_values() -> None:
     assert _parse_datetime("2026-07-01T16:00:00Z") == datetime(2026, 7, 1, 16, 0, 0)
 
 
-def test_parse_admin_order_datetime_normalizes_offset_values_to_utc():
+def test_parse_admin_order_datetime_normalizes_offset_values_to_utc() -> None:
     assert _parse_datetime("2026-07-02T00:00:00+08:00") == datetime(
         2026, 7, 1, 16, 0, 0
     )
 
 
-def test_parse_admin_order_datetime_keeps_legacy_date_only_bounds():
+def test_parse_admin_order_datetime_keeps_legacy_date_only_bounds() -> None:
     assert _parse_datetime("2026-07-02") == datetime(2026, 7, 2, 0, 0, 0)
     assert _parse_datetime("2026-07-02", is_end=True) == datetime(
         2026, 7, 2, 23, 59, 59

--- a/src/api/tests/service/order/test_admin_orders.py
+++ b/src/api/tests/service/order/test_admin_orders.py
@@ -77,7 +77,7 @@ def _mock_operator(
     )
 
 
-def test_list_orders_returns_page_dto():
+def test_list_orders_returns_page_dto() -> None:
     app = Flask(__name__)
     order = DummyOrder()
 
@@ -116,7 +116,7 @@ def test_list_orders_returns_page_dto():
     assert result.data[0].updated_at == datetime(2025, 1, 2, 12, 0, 0)
 
 
-def test_get_order_detail_returns_detail_dto():
+def test_get_order_detail_returns_detail_dto() -> None:
     app = Flask(__name__)
     order = DummyOrder()
 
@@ -156,7 +156,7 @@ def test_get_order_detail_returns_detail_dto():
     assert detail.order.updated_at == datetime(2025, 1, 2, 12, 0, 0)
 
 
-def test_list_operator_orders_returns_page_dto():
+def test_list_operator_orders_returns_page_dto() -> None:
     app = Flask(__name__)
     order = DummyOrder()
 
@@ -195,7 +195,7 @@ def test_list_operator_orders_returns_page_dto():
     assert result.data[0].updated_at == datetime(2025, 1, 2, 12, 0, 0)
 
 
-def test_list_operator_orders_returns_derived_source_and_coupon_codes():
+def test_list_operator_orders_returns_derived_source_and_coupon_codes() -> None:
     app = Flask(__name__)
     order = DummyOrder()
     order.payment_channel = "pingxx"
@@ -236,7 +236,7 @@ def test_list_operator_orders_returns_derived_source_and_coupon_codes():
     assert result.data[0].coupon_codes == ["FREE100"]
 
 
-def test_list_operator_orders_applies_combined_course_query():
+def test_list_operator_orders_applies_combined_course_query() -> None:
     app = Flask(__name__)
     order = DummyOrder()
 
@@ -281,7 +281,7 @@ def test_list_operator_orders_applies_combined_course_query():
     assert isinstance(result, PageNationDTO)
 
 
-def test_list_operator_orders_applies_order_source_filter():
+def test_list_operator_orders_applies_order_source_filter() -> None:
     app = Flask(__name__)
     order = DummyOrder()
 
@@ -327,7 +327,7 @@ def test_list_operator_orders_applies_order_source_filter():
     assert isinstance(result, PageNationDTO)
 
 
-def test_list_operator_orders_reuses_preparsed_status_and_datetimes():
+def test_list_operator_orders_reuses_preparsed_status_and_datetimes() -> None:
     app = Flask(__name__)
     order = DummyOrder()
     start_time = datetime(2026, 4, 1, 0, 0, 0)
@@ -377,7 +377,7 @@ def test_list_operator_orders_reuses_preparsed_status_and_datetimes():
     assert isinstance(result, PageNationDTO)
 
 
-def test_get_operator_order_overview_returns_aggregates():
+def test_get_operator_order_overview_returns_aggregates() -> None:
     app = Flask(__name__)
     summary = SimpleNamespace(
         total_order_count=12,
@@ -405,7 +405,7 @@ def test_get_operator_order_overview_returns_aggregates():
     assert result.paid_amount_total == "456.78"
 
 
-def test_get_operator_order_detail_returns_detail_dto():
+def test_get_operator_order_detail_returns_detail_dto() -> None:
     app = Flask(__name__)
     order = DummyOrder()
 
@@ -447,7 +447,7 @@ def test_get_operator_order_detail_returns_detail_dto():
 def test_admin_operation_orders_route_requires_operator(
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch, is_operator=False)
 
     response = test_client.get(
@@ -463,7 +463,7 @@ def test_admin_operation_orders_route_requires_operator(
 def test_admin_operation_order_detail_route_requires_operator(
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch, is_operator=False)
 
     response = test_client.get(
@@ -479,7 +479,7 @@ def test_admin_operation_order_detail_route_requires_operator(
 def test_admin_operation_credit_orders_route_requires_operator(
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch, is_operator=False)
 
     response = test_client.get(
@@ -495,7 +495,7 @@ def test_admin_operation_credit_orders_route_requires_operator(
 def test_admin_operation_credit_order_detail_route_requires_operator(
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch, is_operator=False)
 
     response = test_client.get(
@@ -511,7 +511,7 @@ def test_admin_operation_credit_order_detail_route_requires_operator(
 def test_admin_operation_credit_orders_route_returns_operator_page(
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     expected = OperatorCreditOrdersPageDTO(
@@ -576,7 +576,7 @@ def test_admin_operation_credit_orders_route_returns_operator_page(
 def test_admin_operation_credit_orders_route_forwards_available_credit_filter(
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     expected = OperatorCreditOrdersPageDTO(
@@ -610,7 +610,7 @@ def test_admin_operation_credit_orders_route_forwards_available_credit_filter(
 def test_admin_operation_credit_orders_route_rejects_invalid_available_credit_filter(
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     response = test_client.get(
@@ -631,7 +631,7 @@ def test_admin_operation_credit_orders_route_rejects_invalid_available_credit_fi
 def test_admin_operation_credit_order_detail_route_returns_detail(
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     expected = OperatorCreditOrderDetailDTO(
@@ -683,7 +683,7 @@ def test_admin_operation_credit_order_detail_route_returns_detail(
     detail_mock.assert_called_once()
 
 
-def test_resolve_order_source_prefers_manual_open_api_and_coupon():
+def test_resolve_order_source_prefers_manual_open_api_and_coupon() -> None:
     source, _ = _resolve_order_source(
         payment_channel="manual",
         coupon_codes=[],
@@ -713,7 +713,7 @@ def test_resolve_order_source_prefers_manual_open_api_and_coupon():
     assert source == ORDER_SOURCE_USER_PURCHASE
 
 
-def test_load_matching_user_bids_for_keyword_ignores_deleted_credentials():
+def test_load_matching_user_bids_for_keyword_ignores_deleted_credentials() -> None:
     user_query = MagicMock()
     user_filtered_query = MagicMock()
     user_query.filter.return_value = user_filtered_query
@@ -754,7 +754,7 @@ def test_load_matching_user_bids_for_keyword_ignores_deleted_credentials():
     assert any("deleted" in str(arg) for arg in filter_args)
 
 
-def test_apply_order_source_filter_treats_null_payment_channel_as_non_special():
+def test_apply_order_source_filter_treats_null_payment_channel_as_non_special() -> None:
     query_mock = MagicMock()
     query_mock.filter.return_value = query_mock
     coupon_order_bid_subquery = SimpleNamespace(

--- a/src/api/tests/service/order/test_buy_record_dto.py
+++ b/src/api/tests/service/order/test_buy_record_dto.py
@@ -3,7 +3,7 @@
 from flaskr.service.order.funs import BuyRecordDTO
 
 
-def test_buy_record_dto_json_includes_payment_payload():
+def test_buy_record_dto_json_includes_payment_payload() -> None:
     dto = BuyRecordDTO(
         record_id="order-1",
         user_id="user-1",

--- a/src/api/tests/service/order/test_import_activation_parse.py
+++ b/src/api/tests/service/order/test_import_activation_parse.py
@@ -69,17 +69,17 @@ def _stub_activation_order_side_effects(monkeypatch) -> None:
         ("  +8613800138004  ", "13800138004"),
     ],
 )
-def test_normalize_mobile_handles_valid_edge_cases(input_phone, expected):
+def test_normalize_mobile_handles_valid_edge_cases(input_phone, expected) -> None:
     assert normalize_mobile(input_phone) == expected
 
 
 @pytest.mark.parametrize("input_phone", ["", None])
-def test_normalize_mobile_rejects_empty_values(input_phone):
+def test_normalize_mobile_rejects_empty_values(input_phone) -> None:
     with pytest.raises(AppError):
         normalize_mobile(input_phone)
 
 
-def test_parse_import_activation_entries_phone_multiple_numbers():
+def test_parse_import_activation_entries_phone_multiple_numbers() -> None:
     text = "12345678901 小明,13245678907,12345675432+美@美;"
     entries = parse_import_activation_entries(text, contact_type="phone")
 
@@ -90,7 +90,7 @@ def test_parse_import_activation_entries_phone_multiple_numbers():
     ]
 
 
-def test_parse_import_activation_entries_rejects_longer_digit_runs():
+def test_parse_import_activation_entries_rejects_longer_digit_runs() -> None:
     text = "123456789012"
     entries = parse_import_activation_entries(text, contact_type="phone")
 
@@ -110,7 +110,7 @@ def test_parse_import_activation_entries_rejects_longer_digit_runs():
         ),
     ],
 )
-def test_parse_import_activation_entries_email_with_nickname(text, expected):
+def test_parse_import_activation_entries_email_with_nickname(text, expected) -> None:
     entries = parse_import_activation_entries(text, contact_type="email")
 
     assert entries == expected
@@ -138,7 +138,7 @@ def test_import_activation_keeps_pre_profile_nickname_behavior(
     profile,
     canonical_nickname,
     has_state,
-):
+) -> None:
     _stub_activation_order_side_effects(monkeypatch)
 
     with app.app_context():
@@ -192,7 +192,7 @@ def test_import_activation_keeps_pre_profile_nickname_behavior(
 def test_import_activation_does_not_consult_profile_state_for_nickname_defaults(
     app,
     monkeypatch,
-):
+) -> None:
     import flaskr.service.order.admin as order_admin
 
     _stub_activation_order_side_effects(monkeypatch)
@@ -299,7 +299,7 @@ def test_import_activation_keeps_nickname_behavior_for_new_users(
     monkeypatch,
     contact_type,
     identifier,
-):
+) -> None:
     _stub_activation_order_side_effects(monkeypatch)
 
     with app.app_context():
@@ -338,7 +338,7 @@ def test_import_activation_identifier_fallback_is_not_profile_prefill(
     monkeypatch,
     contact_type,
     identifier,
-):
+) -> None:
     _stub_activation_order_side_effects(monkeypatch)
 
     with app.app_context():

--- a/src/api/tests/service/order/test_import_activation_permissions.py
+++ b/src/api/tests/service/order/test_import_activation_permissions.py
@@ -64,7 +64,7 @@ def _mock_user(monkeypatch, user_id: str, *, is_creator: bool = True):
 
 def test_admin_import_activation_rejects_shared_permission_user(
     monkeypatch, test_client, app
-):
+) -> None:
     shifu_bid = "import-permission-course-1"
     owner_bid = "owner-import-1"
     shared_bid = "shared-import-1"
@@ -87,7 +87,7 @@ def test_admin_import_activation_rejects_shared_permission_user(
     assert payload["code"] == 401
 
 
-def test_admin_import_activation_allows_owner(monkeypatch, test_client, app):
+def test_admin_import_activation_allows_owner(monkeypatch, test_client, app) -> None:
     shifu_bid = "import-permission-course-2"
     owner_bid = "owner-import-2"
     _seed_shifu(app, shifu_bid, owner_bid)

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import flaskr.common.config as common_config
 import pytest
@@ -24,6 +24,9 @@ from flaskr.service.order.funs import (
 from flaskr.service.order.models import Order, StripeOrder
 from flaskr.service.order.payment_providers import PaymentCreationResult
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 def _reset_config_cache(*keys: str) -> None:
     for key in keys:
@@ -31,14 +34,14 @@ def _reset_config_cache(*keys: str) -> None:
 
 
 @pytest.fixture(autouse=True)
-def clear_legacy_order_url_config_cache():
+def clear_legacy_order_url_config_cache() -> Iterator[None]:
     _reset_config_cache("HOST_URL", "PATH_PREFIX")
     yield
     _reset_config_cache("HOST_URL", "PATH_PREFIX")
 
 
 @pytest.fixture
-def legacy_order_app():
+def legacy_order_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/order/test_native_payment_split_tables.py
+++ b/src/api/tests/service/order/test_native_payment_split_tables.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -28,9 +29,12 @@ from flaskr.service.order.raw_snapshots import (
 from sqlalchemy import inspect
 from sqlalchemy.exc import IntegrityError
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def native_payment_split_app():
+def native_payment_split_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/order/test_order_import_error_specificity.py
+++ b/src/api/tests/service/order/test_order_import_error_specificity.py
@@ -8,7 +8,7 @@ from flaskr.i18n import _
 
 def test_import_activation_orders_unexpected_failure_returns_specific_message(
     app, monkeypatch
-):
+) -> None:
     def raise_unexpected(*_args: object, **_kwargs: object):
         message = "boom"
         raise RuntimeError(message)
@@ -34,7 +34,7 @@ def test_import_activation_orders_unexpected_failure_returns_specific_message(
 
 def test_import_activation_orders_from_entries_unexpected_failure_returns_specific_message(
     app, monkeypatch
-):
+) -> None:
     def raise_unexpected(*_args: object, **_kwargs: object):
         message = "boom"
         raise RuntimeError(message)

--- a/src/api/tests/service/order/test_order_init_lock.py
+++ b/src/api/tests/service/order/test_order_init_lock.py
@@ -11,12 +11,12 @@ class DummyLock:
         self.acquired = 0
         self.released = 0
 
-    def acquire(self, blocking=True):
+    def acquire(self, blocking=True) -> bool:
         _ = blocking
         self.acquired += 1
         return True
 
-    def release(self):
+    def release(self) -> None:
         self.released += 1
 
 
@@ -30,7 +30,7 @@ class DummyRedis:
         self.last_blocking_timeout = None
         self.lock_instance = DummyLock()
 
-    def lock(self, key, timeout=None, blocking_timeout=None):
+    def lock(self, key, timeout=None, blocking_timeout=None) -> object:
         self.last_key = key
         self.last_timeout = timeout
         self.last_blocking_timeout = blocking_timeout
@@ -45,7 +45,7 @@ class DummyApp:
         self.config = {"REDIS_KEY_PREFIX": prefix}
 
 
-def test_order_init_lock_uses_prefixed_key(monkeypatch):
+def test_order_init_lock_uses_prefixed_key(monkeypatch) -> None:
     dummy_redis = DummyRedis()
     monkeypatch.setattr(order_funs, "cache_provider", dummy_redis)
     app = DummyApp(prefix="unit-test")
@@ -60,7 +60,7 @@ def test_order_init_lock_uses_prefixed_key(monkeypatch):
     assert dummy_redis.lock_instance.released == 1
 
 
-def test_order_init_lock_skips_when_cache_provider_errors(monkeypatch):
+def test_order_init_lock_skips_when_cache_provider_errors(monkeypatch) -> None:
     class _BrokenCacheProvider:
         def lock(self, *args: object, **kwargs: object):
             _ = (args, kwargs)

--- a/src/api/tests/service/order/test_payment_channel_resolution.py
+++ b/src/api/tests/service/order/test_payment_channel_resolution.py
@@ -8,7 +8,7 @@ from flaskr.service.order.funs import _resolve_payment_channel
 class TestResolvePaymentChannel:
     """Verify resolve payment channel behavior."""
 
-    def test_pingxx_channel_requires_sub_channel(self):
+    def test_pingxx_channel_requires_sub_channel(self) -> None:
         provider, sub_channel = _resolve_payment_channel(
             payment_channel_hint=None,
             channel_hint="wx_pub_qr",
@@ -17,7 +17,7 @@ class TestResolvePaymentChannel:
         assert provider == "pingxx"
         assert sub_channel == "wx_pub_qr"
 
-    def test_pingxx_channel_missing_sub_channel_raises(self):
+    def test_pingxx_channel_missing_sub_channel_raises(self) -> None:
         with pytest.raises(AppError):
             _resolve_payment_channel(
                 payment_channel_hint=None,
@@ -25,7 +25,7 @@ class TestResolvePaymentChannel:
                 stored_channel="pingxx",
             )
 
-    def test_stripe_checkout_resolution(self):
+    def test_stripe_checkout_resolution(self) -> None:
         provider, sub_channel = _resolve_payment_channel(
             payment_channel_hint=None,
             channel_hint="stripe:checkout_session",
@@ -34,7 +34,7 @@ class TestResolvePaymentChannel:
         assert provider == "stripe"
         assert sub_channel == "checkout_session"
 
-    def test_stripe_hint_defaults_to_payment_intent(self):
+    def test_stripe_hint_defaults_to_payment_intent(self) -> None:
         provider, sub_channel = _resolve_payment_channel(
             payment_channel_hint="stripe",
             channel_hint="",
@@ -43,7 +43,7 @@ class TestResolvePaymentChannel:
         assert provider == "stripe"
         assert sub_channel == "checkout_session"
 
-    def test_stripe_with_stored_channel_defaults(self):
+    def test_stripe_with_stored_channel_defaults(self) -> None:
         provider, sub_channel = _resolve_payment_channel(
             payment_channel_hint=None,
             channel_hint="",
@@ -52,7 +52,9 @@ class TestResolvePaymentChannel:
         assert provider == "stripe"
         assert sub_channel == "checkout_session"
 
-    def test_stripe_only_configuration_overrides_pingxx_default(self, monkeypatch):
+    def test_stripe_only_configuration_overrides_pingxx_default(
+        self, monkeypatch
+    ) -> None:
         def fake_get_config(key, default=None):
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "stripe"
@@ -72,7 +74,9 @@ class TestResolvePaymentChannel:
         # Sub-channel is determined by Stripe defaults (implementation detail).
         assert sub_channel in {"checkout_session", "payment_intent"}
 
-    def test_disabled_payment_channel_raises_for_explicit_request(self, monkeypatch):
+    def test_disabled_payment_channel_raises_for_explicit_request(
+        self, monkeypatch
+    ) -> None:
         def fake_get_config(key, default=None):
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "stripe"
@@ -90,7 +94,7 @@ class TestResolvePaymentChannel:
                 stored_channel="pingxx",
             )
 
-    def test_alipay_qr_prefers_native_when_enabled(self, monkeypatch):
+    def test_alipay_qr_prefers_native_when_enabled(self, monkeypatch) -> None:
         def fake_get_config(key, default=None):
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "alipay,pingxx"
@@ -109,7 +113,9 @@ class TestResolvePaymentChannel:
         assert provider == "alipay"
         assert sub_channel == "alipay_qr"
 
-    def test_alipay_qr_falls_back_to_pingxx_when_native_disabled(self, monkeypatch):
+    def test_alipay_qr_falls_back_to_pingxx_when_native_disabled(
+        self, monkeypatch
+    ) -> None:
         def fake_get_config(key, default=None):
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "pingxx"
@@ -128,7 +134,7 @@ class TestResolvePaymentChannel:
         assert provider == "pingxx"
         assert sub_channel == "alipay_qr"
 
-    def test_wechat_jsapi_prefers_native_when_enabled(self, monkeypatch):
+    def test_wechat_jsapi_prefers_native_when_enabled(self, monkeypatch) -> None:
         def fake_get_config(key, default=None):
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "wechatpay,pingxx"
@@ -147,7 +153,7 @@ class TestResolvePaymentChannel:
         assert provider == "wechatpay"
         assert sub_channel == "wx_pub"
 
-    def test_explicit_wechatpay_defaults_to_qr_channel(self, monkeypatch):
+    def test_explicit_wechatpay_defaults_to_qr_channel(self, monkeypatch) -> None:
         def fake_get_config(key, default=None):
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "wechatpay"
@@ -166,7 +172,9 @@ class TestResolvePaymentChannel:
         assert provider == "wechatpay"
         assert sub_channel == "wx_pub_qr"
 
-    def test_scoped_provider_allows_custom_wechat_when_global_default_is_pingxx(self):
+    def test_scoped_provider_allows_custom_wechat_when_global_default_is_pingxx(
+        self,
+    ) -> None:
         provider, sub_channel = _resolve_payment_channel(
             payment_channel_hint="wechatpay",
             channel_hint="wx_pub_qr",
@@ -176,7 +184,9 @@ class TestResolvePaymentChannel:
         assert provider == "wechatpay"
         assert sub_channel == "wx_pub_qr"
 
-    def test_explicit_native_provider_rejects_unsupported_channel(self, monkeypatch):
+    def test_explicit_native_provider_rejects_unsupported_channel(
+        self, monkeypatch
+    ) -> None:
         def fake_get_config(key, default=None):
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "alipay"

--- a/src/api/tests/service/order/test_pingxx_client_state.py
+++ b/src/api/tests/service/order/test_pingxx_client_state.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 from flaskr.service.order.payment_providers import pingxx
 
 
-def test_pingxx_client_import_is_cached_by_its_state_owner(monkeypatch):
+def test_pingxx_client_import_is_cached_by_its_state_owner(monkeypatch) -> None:
     sentinel = SimpleNamespace()
     monkeypatch.setattr(pingxx._pingpp_client_state, "client", None)
     monkeypatch.setattr(pingxx._pingpp_client_state, "import_error", None)

--- a/src/api/tests/service/order/test_provider_public_urls.py
+++ b/src/api/tests/service/order/test_provider_public_urls.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
 import flaskr.common.config as common_config
 import pytest
@@ -12,6 +13,9 @@ from flaskr.service.order.payment_providers.base import PaymentRequest
 from flaskr.service.order.payment_providers.stripe import StripeProvider
 from flaskr.service.order.payment_providers.wechatpay import WechatPayProvider
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 def _reset_config_cache(*keys: str) -> None:
     for key in keys:
@@ -19,7 +23,7 @@ def _reset_config_cache(*keys: str) -> None:
 
 
 @pytest.fixture(autouse=True)
-def clear_provider_public_url_config_cache():
+def clear_provider_public_url_config_cache() -> Iterator[None]:
     keys = (
         "HOST_URL",
         "PATH_PREFIX",
@@ -31,7 +35,7 @@ def clear_provider_public_url_config_cache():
     _reset_config_cache(*keys)
 
 
-def test_alipay_precreate_uses_host_url_notify_url(monkeypatch):
+def test_alipay_precreate_uses_host_url_notify_url(monkeypatch) -> None:
     monkeypatch.setenv("HOST_URL", "https://pay.example.com")
     monkeypatch.setenv("PATH_PREFIX", "/api")
     _reset_config_cache("HOST_URL", "PATH_PREFIX")
@@ -88,7 +92,7 @@ def test_alipay_precreate_uses_host_url_notify_url(monkeypatch):
     assert result.extra["raw_request"]["notify_url"] == captured["notify_url"]
 
 
-def test_wechatpay_native_uses_host_url_notify_url(monkeypatch):
+def test_wechatpay_native_uses_host_url_notify_url(monkeypatch) -> None:
     monkeypatch.setenv("HOST_URL", "https://pay.example.com")
     monkeypatch.setenv("PATH_PREFIX", "/api")
     monkeypatch.setenv("WECHATPAY_APP_ID", "wx-app-1")
@@ -135,7 +139,7 @@ def test_wechatpay_native_uses_host_url_notify_url(monkeypatch):
 
 def test_stripe_subscription_discount_coupon_uses_lowercase_currency_and_idempotency(
     monkeypatch,
-):
+) -> None:
     captured_coupon: dict[str, object] = {}
     captured_session: dict[str, object] = {}
 
@@ -215,7 +219,7 @@ def test_stripe_subscription_discount_coupon_uses_lowercase_currency_and_idempot
 
 def test_stripe_subscription_discount_coupon_is_cleaned_up_on_session_failure(
     monkeypatch,
-):
+) -> None:
     deleted: list[str] = []
 
     class FakeCoupon:

--- a/src/api/tests/service/order/test_stripe_refund.py
+++ b/src/api/tests/service/order/test_stripe_refund.py
@@ -1,5 +1,7 @@
 """Verify stripe refund behavior."""
 
+from collections.abc import Iterator
+
 import pytest
 from flask import Flask
 from flaskr import dao
@@ -17,13 +19,13 @@ class DummyStripeRefundProvider:
         """Initialize the dummy stripe refund provider test double."""
         self._result = result
 
-    def refund_payment(self, *, request, app):  # pylint: disable=unused-argument
+    def refund_payment(self, *, request, app) -> PaymentRefundResult:  # pylint: disable=unused-argument
         _ = (request, app)
         return self._result
 
 
 @pytest.fixture
-def app():
+def app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(
@@ -54,7 +56,7 @@ def _ensure_order(status, order_bid):
     return order
 
 
-def test_refund_order_payment_updates_status(app, monkeypatch):
+def test_refund_order_payment_updates_status(app, monkeypatch) -> None:
     order_bid = "order-refund-1"
     with app.app_context():
         order = _ensure_order(ORDER_STATUS_SUCCESS, order_bid)
@@ -139,7 +141,7 @@ def test_refund_order_payment_updates_status(app, monkeypatch):
         assert billing_snapshot.status == 0
 
 
-def test_get_payment_details_returns_stripe_payload(app):
+def test_get_payment_details_returns_stripe_payload(app) -> None:
     with app.app_context():
         order_bid = "order-details-1"
         order = _ensure_order(ORDER_STATUS_SUCCESS, order_bid)

--- a/src/api/tests/service/order/test_stripe_webhook.py
+++ b/src/api/tests/service/order/test_stripe_webhook.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -29,6 +30,9 @@ from flaskr.service.order.payment_providers.base import PaymentNotificationResul
 
 from tests.common.fixtures.bill_products import build_bill_products
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 def _load_route_module(module_name: str):
     return importlib.import_module(f"flaskr.route.{module_name}")
@@ -41,13 +45,13 @@ class DummyStripeProvider:
         """Initialize the dummy stripe provider test double."""
         self._notification = notification
 
-    def verify_webhook(self, *, headers, raw_body, app):
+    def verify_webhook(self, *, headers, raw_body, app) -> PaymentNotificationResult:
         del headers, raw_body, app
         return self._notification
 
 
 @pytest.fixture
-def stripe_webhook_app():
+def stripe_webhook_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(
@@ -170,7 +174,9 @@ def _ensure_billing_stripe_raw_snapshot(bill_order_bid):
     return raw_order
 
 
-def test_handle_stripe_webhook_marks_order_paid(stripe_webhook_app, monkeypatch):
+def test_handle_stripe_webhook_marks_order_paid(
+    stripe_webhook_app, monkeypatch
+) -> None:
     with stripe_webhook_app.app_context():
         order = _ensure_order(ORDER_STATUS_TO_BE_PAID, "order-webhook-1")
 
@@ -239,7 +245,9 @@ def test_handle_stripe_webhook_marks_order_paid(stripe_webhook_app, monkeypatch)
         assert refreshed_stripe_order.status == 1
 
 
-def test_stripe_webhook_route_marks_legacy_order_paid(stripe_webhook_app, monkeypatch):
+def test_stripe_webhook_route_marks_legacy_order_paid(
+    stripe_webhook_app, monkeypatch
+) -> None:
     with stripe_webhook_app.app_context():
         order = _ensure_order(ORDER_STATUS_TO_BE_PAID, "order-webhook-route-1")
 
@@ -322,7 +330,7 @@ def test_stripe_webhook_route_marks_legacy_order_paid(stripe_webhook_app, monkey
 
 def test_handle_stripe_webhook_routes_bill_orders_without_regression(
     stripe_webhook_app, monkeypatch
-):
+) -> None:
     with stripe_webhook_app.app_context():
         subscription = _ensure_billing_subscription(
             BILLING_SUBSCRIPTION_STATUS_DRAFT,
@@ -428,7 +436,9 @@ def test_handle_stripe_webhook_routes_bill_orders_without_regression(
         assert len(ledgers) == 1
 
 
-def test_stripe_webhook_route_delegates_bill_orders(stripe_webhook_app, monkeypatch):
+def test_stripe_webhook_route_delegates_bill_orders(
+    stripe_webhook_app, monkeypatch
+) -> None:
     with stripe_webhook_app.app_context():
         subscription = _ensure_billing_subscription(
             BILLING_SUBSCRIPTION_STATUS_DRAFT,
@@ -506,7 +516,7 @@ def test_stripe_webhook_route_delegates_bill_orders(stripe_webhook_app, monkeypa
 
 def test_handle_stripe_webhook_duplicate_paid_event_is_idempotent(
     stripe_webhook_app, monkeypatch
-):
+) -> None:
     with stripe_webhook_app.app_context():
         subscription = _ensure_billing_subscription(
             BILLING_SUBSCRIPTION_STATUS_DRAFT,
@@ -577,7 +587,7 @@ def test_handle_stripe_webhook_duplicate_paid_event_is_idempotent(
 
 def test_handle_stripe_webhook_ignores_stale_subscription_updates(
     stripe_webhook_app, monkeypatch
-):
+) -> None:
     with stripe_webhook_app.app_context():
         subscription = _ensure_billing_subscription(
             BILLING_SUBSCRIPTION_STATUS_ACTIVE,
@@ -634,7 +644,7 @@ def test_handle_stripe_webhook_ignores_stale_subscription_updates(
 
 def test_handle_stripe_webhook_ignores_orphan_billing_event(
     stripe_webhook_app, monkeypatch
-):
+) -> None:
     notification = PaymentNotificationResult(
         order_bid="",
         status="checkout.session.completed",

--- a/src/api/tests/service/order/test_uow_failure_paths.py
+++ b/src/api/tests/service/order/test_uow_failure_paths.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import datetime
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -32,12 +33,15 @@ from flaskr.service.promo.consts import (
 )
 from flaskr.service.promo.models import Coupon, CouponUsage, PromoRedemption
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 USER_ID = "uow-user-1"
 COURSE_ID = "uow-course-1"
 
 
 @pytest.fixture
-def order_app():
+def order_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(
@@ -59,7 +63,7 @@ def order_app():
 
 
 @pytest.fixture
-def stub_shifu(monkeypatch: pytest.MonkeyPatch):
+def stub_shifu(monkeypatch: pytest.MonkeyPatch) -> None:
     def get_shifu_info(app: object, bid: str, preview_mode: object) -> SimpleNamespace:
         del app, bid, preview_mode
         return SimpleNamespace(
@@ -78,7 +82,7 @@ def stub_shifu(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture
-def stub_promo_side_sessions(monkeypatch: pytest.MonkeyPatch):
+def stub_promo_side_sessions(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     """Neutralize the promo helpers that push their own app context.
 
     ``timeout_coupon_code_rollback`` / ``void_promo_campaign_applications``
@@ -131,7 +135,7 @@ def test_init_buy_record_late_failure_persists_nothing(
     order_app: Flask,
     monkeypatch: pytest.MonkeyPatch,
     stub_shifu,
-):
+) -> None:
     """(a) A late failure in init_buy_record must not leave partial rows.
 
     Pre-migration, ``_sync_order_campaign_pricing`` committed the new Order
@@ -169,7 +173,7 @@ def test_init_buy_record_timeout_flip_persists_with_replacement_order(
     monkeypatch: pytest.MonkeyPatch,
     stub_shifu,
     stub_promo_side_sessions,
-):
+) -> None:
     """(b) Clean run: the timeout flip and the new order commit together."""
     _ = stub_shifu
     monkeypatch.setattr(order_funs, "apply_promo_campaigns", lambda *_a, **_k: [])
@@ -193,7 +197,7 @@ def test_init_buy_record_timeout_flip_rolls_back_on_late_failure(
     monkeypatch: pytest.MonkeyPatch,
     stub_shifu,
     stub_promo_side_sessions,
-):
+) -> None:
     """(b) Failure run: the timeout flip joins the caller's transaction.
 
     Decision: the flip is derived state (recomputed from ``created_at`` on
@@ -223,7 +227,7 @@ def test_discount_refresh_failure_keeps_coupon_pricing_untouched(
     order_app: Flask,
     monkeypatch: pytest.MonkeyPatch,
     stub_shifu,
-):
+) -> None:
     """(c) A failure after the discount recalculation leaves pricing intact.
 
     Pre-migration, ``_sync_order_campaign_pricing`` committed the recomputed
@@ -272,7 +276,7 @@ def test_success_buy_record_commits_alone_but_joins_outer_unit_of_work(
     order_app: Flask,
     monkeypatch: pytest.MonkeyPatch,
     stub_shifu,
-):
+) -> None:
     """The key migration property: self-committing at top level, joining when nested — legacy callers (coupon_funcs, admin) and migrated owners both stay correct."""
     _ = stub_shifu
     monkeypatch.setattr(order_funs, "set_user_state", lambda *_a, **_k: None)

--- a/src/api/tests/service/profile/test_profile.py
+++ b/src/api/tests/service/profile/test_profile.py
@@ -9,7 +9,7 @@ from flaskr.service.profile.profile_manage import (
 )
 
 
-def test_add_profile_item_quick_creates_definition(app):
+def test_add_profile_item_quick_creates_definition(app) -> None:
     with app.app_context():
         definition = add_profile_item_quick(
             app,
@@ -23,7 +23,7 @@ def test_add_profile_item_quick_creates_definition(app):
         assert any(item.profile_key == "favorite_color" for item in definitions)
 
 
-def test_hide_unused_profile_items_no_unused(monkeypatch):
+def test_hide_unused_profile_items_no_unused(monkeypatch) -> None:
     calls = []
 
     def fake_get_unused(_app, parent_id):
@@ -48,7 +48,7 @@ def test_hide_unused_profile_items_no_unused(monkeypatch):
     assert ("defs", "shifu_bid") in calls
 
 
-def test_hide_unused_profile_items_updates_hidden(monkeypatch):
+def test_hide_unused_profile_items_updates_hidden(monkeypatch) -> None:
     calls = []
 
     def fake_get_unused(_app, parent_id):
@@ -71,7 +71,7 @@ def test_hide_unused_profile_items_updates_hidden(monkeypatch):
     assert ("update", "shifu_bid", ("v1", "v2"), True, "user_bid") in calls
 
 
-def test_get_profile_variable_usage_groups_keys(monkeypatch):
+def test_get_profile_variable_usage_groups_keys(monkeypatch) -> None:
     calls = []
 
     def fake_get_defs(_app, parent_id=None, _type="all"):

--- a/src/api/tests/service/profile/test_profile_routes.py
+++ b/src/api/tests/service/profile/test_profile_routes.py
@@ -38,7 +38,7 @@ class TestProfileRoutes:
 
     def test_get_profile_item_definitions_passes_type_filter(
         self, monkeypatch, test_client
-    ):
+    ) -> None:
         called = {}
 
         def fake_get_definitions(_app_ctx, parent_id, definition_type):
@@ -61,14 +61,16 @@ class TestProfileRoutes:
         assert payload["code"] == 0
         assert called == {"parent_id": "shifu_1", "definition_type": "text"}
 
-    def test_hide_unused_profile_items_requires_parent(self, monkeypatch, test_client):
+    def test_hide_unused_profile_items_requires_parent(
+        self, monkeypatch, test_client
+    ) -> None:
         self._mock_request_user(monkeypatch)
         resp = test_client.post("/api/profiles/hide-unused-profile-items", json={})
         payload = resp.get_json(force=True)
         assert resp.status_code == 200
         assert payload["code"] != 0
 
-    def test_hide_unused_profile_items_ok(self, monkeypatch, test_client):
+    def test_hide_unused_profile_items_ok(self, monkeypatch, test_client) -> None:
         called = {}
 
         def fake_hide(_app_ctx, parent_id, user_id):
@@ -100,7 +102,7 @@ class TestProfileRoutes:
 
     def test_update_profile_hidden_state_requires_parent(
         self, monkeypatch, test_client
-    ):
+    ) -> None:
         self._mock_request_user(monkeypatch)
         resp = test_client.post(
             "/api/profiles/update-profile-hidden-state",
@@ -110,7 +112,7 @@ class TestProfileRoutes:
         assert resp.status_code == 200
         assert payload["code"] != 0
 
-    def test_update_profile_hidden_state_ok(self, monkeypatch, test_client):
+    def test_update_profile_hidden_state_ok(self, monkeypatch, test_client) -> None:
         called = {}
 
         def fake_update(_app_ctx, parent_id, profile_keys, hidden, user_id):
@@ -146,7 +148,9 @@ class TestProfileRoutes:
         assert called["profile_keys"] == ["k1"]
         assert called["hidden"] is True
 
-    def test_save_profile_item_only_supports_text_type(self, monkeypatch, test_client):
+    def test_save_profile_item_only_supports_text_type(
+        self, monkeypatch, test_client
+    ) -> None:
         self._mock_request_user(monkeypatch)
 
         resp = test_client.post(
@@ -164,7 +168,7 @@ class TestProfileRoutes:
 
     def test_save_profile_item_passes_only_active_fields(
         self, monkeypatch, test_client
-    ):
+    ) -> None:
         called = {}
 
         def fake_save(_app_ctx, profile_id, parent_id, user_id, key):

--- a/src/api/tests/service/profile/test_variable_value_resolution.py
+++ b/src/api/tests/service/profile/test_variable_value_resolution.py
@@ -10,7 +10,9 @@ class _DummyValue:
         self.variable_bid = variable_bid
 
 
-def test_get_latest_variable_value_prefers_key_match_over_non_matching_variable_bid():
+def test_get_latest_variable_value_prefers_key_match_over_non_matching_variable_bid() -> (
+    None
+):
     values = [
         _DummyValue(key="k1", shifu_bid="s1", variable_bid="v-other"),
         _DummyValue(key="k-other", shifu_bid="s1", variable_bid="v1"),
@@ -20,7 +22,7 @@ def test_get_latest_variable_value_prefers_key_match_over_non_matching_variable_
     assert hit is values[0]
 
 
-def test_get_latest_variable_value_prefers_shifu_scoped_key_over_global_key():
+def test_get_latest_variable_value_prefers_shifu_scoped_key_over_global_key() -> None:
     values = [
         _DummyValue(key="k1", shifu_bid="", variable_bid="v1"),
         _DummyValue(key="k1", shifu_bid="s1", variable_bid="v1"),
@@ -30,7 +32,9 @@ def test_get_latest_variable_value_prefers_shifu_scoped_key_over_global_key():
     assert hit is values[1]
 
 
-def test_get_latest_variable_value_falls_back_to_global_key_when_shifu_missing():
+def test_get_latest_variable_value_falls_back_to_global_key_when_shifu_missing() -> (
+    None
+):
     values = [
         _DummyValue(key="k1", shifu_bid="", variable_bid="v1"),
     ]
@@ -39,7 +43,7 @@ def test_get_latest_variable_value_falls_back_to_global_key_when_shifu_missing()
     assert hit is values[0]
 
 
-def test_get_latest_variable_value_global_key_beats_global_variable_bid_value():
+def test_get_latest_variable_value_global_key_beats_global_variable_bid_value() -> None:
     values = [
         _DummyValue(key="k1", shifu_bid="", variable_bid="v-other"),
         _DummyValue(key="k-other", shifu_bid="", variable_bid="v1"),

--- a/src/api/tests/service/promo/test_admin_promotions.py
+++ b/src/api/tests/service/promo/test_admin_promotions.py
@@ -73,7 +73,7 @@ def _isolate_tables(app):
         db.session.remove()
 
 
-def test_promotion_dtos_coerce_empty_and_zero_datetime_values_to_none():
+def test_promotion_dtos_coerce_empty_and_zero_datetime_values_to_none() -> None:
     summary = AdminPromotionSummaryDTO(
         total=0,
         active=0,
@@ -111,7 +111,7 @@ def test_promotion_dtos_coerce_empty_and_zero_datetime_values_to_none():
     assert campaign.channel == ""
 
 
-def test_creator_redemption_empty_result_summary_uses_none_latest_usage_at(app):
+def test_creator_redemption_empty_result_summary_uses_none_latest_usage_at(app) -> None:
     # Exercise the actual empty-result service branch (not just the DTO) so a
     # regression reverting latest_usage_at back to "" would be caught here.
     with app.app_context():
@@ -208,7 +208,9 @@ def _seed_order(
     return order
 
 
-def test_admin_promotions_coupons_route_requires_operator(test_client, monkeypatch):
+def test_admin_promotions_coupons_route_requires_operator(
+    test_client, monkeypatch
+) -> None:
     _mock_operator(monkeypatch, is_operator=False)
 
     response = test_client.get(
@@ -239,7 +241,7 @@ def test_admin_promotions_routes_reject_invalid_status_filter(
     monkeypatch,
     path,
     query_string,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     response = test_client.get(
@@ -253,7 +255,9 @@ def test_admin_promotions_routes_reject_invalid_status_filter(
     assert payload["message"] == "Params Error status"
 
 
-def test_admin_promotions_coupon_routes_round_trip(app, test_client, monkeypatch):
+def test_admin_promotions_coupon_routes_round_trip(
+    app, test_client, monkeypatch
+) -> None:
     _mock_operator(monkeypatch)
     monkeypatch.setattr(
         "flaskr.service.promo.admin.now_utc",
@@ -491,7 +495,7 @@ def test_admin_promotions_coupon_routes_round_trip(app, test_client, monkeypatch
 
 def test_admin_promotions_coupon_list_returns_empty_ops_states_by_default(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
     monkeypatch.setattr(
         "flaskr.service.promo.admin.now_utc",
@@ -536,7 +540,7 @@ def test_admin_promotions_coupon_list_returns_empty_ops_states_by_default(
 
 def test_creator_redemption_code_route_creates_course_scoped_coupon(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_creator(monkeypatch, user_id="creator-1")
 
     with app.app_context():
@@ -580,7 +584,7 @@ def test_creator_redemption_code_route_creates_course_scoped_coupon(
 
 def test_creator_redemption_code_route_rejects_shared_course(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_creator(monkeypatch, user_id="creator-1")
 
     with app.app_context():
@@ -622,7 +626,7 @@ def test_creator_redemption_code_route_rejects_shared_course(
 
 def test_creator_redemption_code_list_shows_only_owned_course_batches(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_creator(monkeypatch, user_id="creator-1")
 
     with app.app_context():
@@ -701,7 +705,7 @@ def test_creator_redemption_code_list_shows_only_owned_course_batches(
 
 def test_creator_redemption_code_list_accepts_utc_date_filter_bounds(
     app, test_client, monkeypatch
-):
+) -> None:
     _ = app
     _mock_creator(monkeypatch, user_id="creator-1")
     captured_filters = {}
@@ -745,7 +749,7 @@ def test_creator_redemption_code_list_accepts_utc_date_filter_bounds(
 
 def test_creator_redemption_code_usage_route_requires_owned_course_coupon(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_creator(monkeypatch, user_id="creator-1")
 
     with app.app_context():
@@ -857,7 +861,7 @@ def test_creator_redemption_code_usage_route_requires_owned_course_coupon(
 
 def test_creator_redemption_code_detail_update_and_status_require_owned_course_coupon(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_creator(monkeypatch, user_id="creator-1")
 
     with app.app_context():
@@ -1018,7 +1022,7 @@ def test_creator_redemption_code_detail_update_and_status_require_owned_course_c
 
 def test_admin_promotions_generic_coupon_requires_code_and_quantity(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1067,7 +1071,9 @@ def test_admin_promotions_generic_coupon_requires_code_and_quantity(
     assert missing_quantity_payload["code"] != 0
 
 
-def test_admin_promotions_serializes_coupon_times_as_utc(app, test_client, monkeypatch):
+def test_admin_promotions_serializes_coupon_times_as_utc(
+    app, test_client, monkeypatch
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1117,7 +1123,7 @@ def test_admin_promotions_serializes_coupon_times_as_utc(app, test_client, monke
 
 def test_admin_promotions_single_use_coupon_generates_sub_codes_only(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1165,7 +1171,7 @@ def test_admin_promotions_single_use_coupon_generates_sub_codes_only(
 
 def test_admin_promotions_single_use_coupon_rejects_unknown_course(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1194,7 +1200,7 @@ def test_admin_promotions_single_use_coupon_rejects_unknown_course(
 
 def test_admin_promotions_single_use_coupon_rejects_oversized_batch(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1224,7 +1230,7 @@ def test_admin_promotions_single_use_coupon_rejects_oversized_batch(
 
 def test_admin_promotions_coupon_usage_falls_back_to_order_course(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1283,7 +1289,7 @@ def test_admin_promotions_coupon_usage_falls_back_to_order_course(
 
 def test_admin_promotions_coupon_usage_list_supports_keyword_filter(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1363,7 +1369,7 @@ def test_admin_promotions_coupon_usage_list_supports_keyword_filter(
 
 def test_admin_promotions_coupon_usage_list_rejects_invalid_status(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1400,7 +1406,7 @@ def test_admin_promotions_coupon_usage_list_rejects_invalid_status(
 
 def test_admin_promotions_coupon_update_keeps_used_records_unchanged(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1500,7 +1506,7 @@ def test_admin_promotions_coupon_update_keeps_used_records_unchanged(
 
 def test_admin_promotions_coupon_code_list_supports_keyword_filter(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1559,7 +1565,9 @@ def test_admin_promotions_coupon_code_list_supports_keyword_filter(
     assert code_payload["data"]["items"][0]["order_bid"] == "order-2"
 
 
-def test_admin_promotions_campaign_routes_round_trip(app, test_client, monkeypatch):
+def test_admin_promotions_campaign_routes_round_trip(
+    app, test_client, monkeypatch
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1711,7 +1719,7 @@ def test_admin_promotions_campaign_routes_round_trip(app, test_client, monkeypat
 
 def test_admin_promotions_campaign_redemptions_support_keyword_filter(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1792,7 +1800,7 @@ def test_admin_promotions_campaign_redemptions_support_keyword_filter(
 
 def test_admin_promotions_campaign_redemptions_summary_only_counts_applied(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1867,7 +1875,9 @@ def test_admin_promotions_campaign_redemptions_summary_only_counts_applied(
     assert redemption_payload["data"]["summary"]["discount_amount"] == "14.85"
 
 
-def test_admin_promotions_campaign_route_rejects_overlap(app, test_client, monkeypatch):
+def test_admin_promotions_campaign_route_rejects_overlap(
+    app, test_client, monkeypatch
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1913,7 +1923,7 @@ def test_admin_promotions_campaign_route_rejects_overlap(app, test_client, monke
 
 def test_admin_promotions_campaign_route_rejects_overlap_with_legacy_enabled_campaign(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -1961,7 +1971,7 @@ def test_admin_promotions_campaign_route_rejects_overlap_with_legacy_enabled_cam
 
 def test_admin_promotions_coupon_list_compatibly_displays_legacy_status_rows(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2080,7 +2090,7 @@ def test_admin_promotions_coupon_list_compatibly_displays_legacy_status_rows(
 
 def test_admin_promotions_campaign_list_compatibly_displays_legacy_status_rows(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2199,7 +2209,7 @@ def test_admin_promotions_campaign_list_compatibly_displays_legacy_status_rows(
 
 def test_admin_promotions_coupon_update_rejects_locked_fields(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2250,7 +2260,7 @@ def test_admin_promotions_coupon_update_rejects_locked_fields(
 
 def test_admin_promotions_coupon_update_allows_changing_only_end_time(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2307,7 +2317,7 @@ def test_admin_promotions_coupon_update_allows_changing_only_end_time(
 
 def test_admin_promotions_coupon_update_ignores_empty_start_time(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2365,7 +2375,7 @@ def test_admin_promotions_coupon_update_ignores_empty_start_time(
 
 def test_admin_promotions_coupon_status_rejects_enabling_expired_coupon(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2403,7 +2413,7 @@ def test_admin_promotions_coupon_status_rejects_enabling_expired_coupon(
 
 def test_admin_promotions_campaign_update_only_allows_name_description_time_and_apply_type(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2462,7 +2472,7 @@ def test_admin_promotions_campaign_update_only_allows_name_description_time_and_
 
 def test_admin_promotions_campaign_update_rejects_channel_and_value_change_before_redemption(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2510,7 +2520,7 @@ def test_admin_promotions_campaign_update_rejects_channel_and_value_change_befor
 
 def test_admin_promotions_campaign_update_allows_changing_only_start_time(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2569,7 +2579,7 @@ def test_admin_promotions_campaign_update_allows_changing_only_start_time(
 
 def test_admin_promotions_campaign_update_ignores_null_end_time(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2629,7 +2639,7 @@ def test_admin_promotions_campaign_update_ignores_null_end_time(
 
 def test_admin_promotions_campaign_update_rejects_apply_type_change_after_redemption(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2694,7 +2704,7 @@ def test_admin_promotions_campaign_update_rejects_apply_type_change_after_redemp
 
 def test_admin_promotions_campaign_update_rejects_channel_and_value_change_after_redemption(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2759,7 +2769,7 @@ def test_admin_promotions_campaign_update_rejects_channel_and_value_change_after
 
 def test_admin_promotions_campaign_status_rejects_enabling_ended_campaign(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2796,7 +2806,7 @@ def test_admin_promotions_campaign_status_rejects_enabling_ended_campaign(
 
 def test_admin_promotions_campaign_status_allows_manual_campaign_overlap_with_auto(
     app, test_client, monkeypatch
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():

--- a/src/api/tests/service/promo/test_promo_error_specificity.py
+++ b/src/api/tests/service/promo/test_promo_error_specificity.py
@@ -25,7 +25,9 @@ def _isolate_coupon_tables(app):
         db.session.commit()
 
 
-def test_generate_unique_coupon_code_failure_returns_specific_error(app, monkeypatch):
+def test_generate_unique_coupon_code_failure_returns_specific_error(
+    app, monkeypatch
+) -> None:
     monkeypatch.setattr(
         promo_admin, "_generate_random_coupon_code", lambda: "DUPLICATE"
     )
@@ -55,7 +57,9 @@ def test_generate_unique_coupon_code_failure_returns_specific_error(app, monkeyp
     )
 
 
-def test_generate_unique_coupon_codes_failure_returns_specific_error(app, monkeypatch):
+def test_generate_unique_coupon_codes_failure_returns_specific_error(
+    app, monkeypatch
+) -> None:
     generated_codes = [f"DUP{i:03d}" for i in range(400)]
     code_iter = iter(generated_codes)
     monkeypatch.setattr(

--- a/src/api/tests/service/referral/test_referral_admin.py
+++ b/src/api/tests/service/referral/test_referral_admin.py
@@ -173,7 +173,7 @@ def _billing_artifacts(
     return order, bucket, ledger
 
 
-def test_operator_referral_detail_includes_inviter_reward_queue(referral_app):
+def test_operator_referral_detail_includes_inviter_reward_queue(referral_app) -> None:
     with referral_app.app_context():
         campaign = ReferralCampaign(
             campaign_bid="campaign-admin-queue",

--- a/src/api/tests/service/referral/test_referral_campaign_admin.py
+++ b/src/api/tests/service/referral/test_referral_campaign_admin.py
@@ -87,7 +87,7 @@ def _payload(**overrides: object):
     return payload
 
 
-def test_operator_referral_campaign_create_list_detail_and_status(referral_app):
+def test_operator_referral_campaign_create_list_detail_and_status(referral_app) -> None:
     with referral_app.app_context():
         _seed_plan_product()
 
@@ -142,7 +142,7 @@ def test_operator_referral_campaign_create_list_detail_and_status(referral_app):
 
 def test_operator_referral_campaign_normalizes_offset_datetimes_to_utc(
     referral_app,
-):
+) -> None:
     with referral_app.app_context():
         _seed_plan_product()
 
@@ -164,7 +164,7 @@ def test_operator_referral_campaign_normalizes_offset_datetimes_to_utc(
 
 def test_operator_referral_campaign_update_changes_future_rule_not_snapshot(
     referral_app,
-):
+) -> None:
     with referral_app.app_context():
         _seed_plan_product()
         result = create_operator_referral_campaign(
@@ -240,7 +240,7 @@ def test_operator_referral_campaign_update_changes_future_rule_not_snapshot(
 
 def test_operator_referral_campaign_list_includes_invite_funnel_counts(
     referral_app,
-):
+) -> None:
     with referral_app.app_context():
         _seed_plan_product()
         result = create_operator_referral_campaign(
@@ -343,7 +343,7 @@ def test_operator_referral_campaign_list_includes_invite_funnel_counts(
 
 def test_operator_referral_campaign_list_uses_null_for_missing_latest_invite_event_at(
     referral_app,
-):
+) -> None:
     with referral_app.app_context():
         _seed_plan_product()
         create_operator_referral_campaign(
@@ -362,7 +362,7 @@ def test_operator_referral_campaign_list_uses_null_for_missing_latest_invite_eve
         assert listed["items"][0]["latest_invite_event_at"] is None
 
 
-def test_operator_referral_campaign_invitations_aggregate_events(referral_app):
+def test_operator_referral_campaign_invitations_aggregate_events(referral_app) -> None:
     with referral_app.app_context():
         _seed_plan_product()
         result = create_operator_referral_campaign(
@@ -469,7 +469,7 @@ def test_operator_referral_campaign_invitations_aggregate_events(referral_app):
         assert item["latest_event_at"] == "2026-06-10T09:04:00Z"
 
 
-def test_operator_referral_filters_accept_user_identifier(referral_app):
+def test_operator_referral_filters_accept_user_identifier(referral_app) -> None:
     with referral_app.app_context():
         _seed_plan_product()
         result = create_operator_referral_campaign(
@@ -554,7 +554,9 @@ def test_operator_referral_filters_accept_user_identifier(referral_app):
         _payload(invitee_eligibility="{broken"),
     ],
 )
-def test_operator_referral_campaign_rejects_invalid_payload(referral_app, payload):
+def test_operator_referral_campaign_rejects_invalid_payload(
+    referral_app, payload
+) -> None:
     with referral_app.app_context():
         _seed_plan_product()
         with pytest.raises(AppError) as exc_info:
@@ -569,7 +571,9 @@ def test_operator_referral_campaign_rejects_invalid_payload(referral_app, payloa
         )
 
 
-def test_operator_referral_campaign_rejects_enabling_ended_campaign(referral_app):
+def test_operator_referral_campaign_rejects_enabling_ended_campaign(
+    referral_app,
+) -> None:
     with referral_app.app_context():
         _seed_plan_product()
         result = create_operator_referral_campaign(
@@ -595,7 +599,7 @@ def test_operator_referral_campaign_rejects_enabling_ended_campaign(referral_app
         )
 
 
-def test_operator_referral_campaign_duplicate_code_is_rejected(referral_app):
+def test_operator_referral_campaign_duplicate_code_is_rejected(referral_app) -> None:
     with referral_app.app_context():
         _seed_plan_product()
         create_operator_referral_campaign(

--- a/src/api/tests/service/referral/test_referral_campaign_admin_routes.py
+++ b/src/api/tests/service/referral/test_referral_campaign_admin_routes.py
@@ -111,7 +111,7 @@ def test_admin_operations_promotions_referral_campaign_routes_round_trip(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     with app.app_context():
         _seed_plan_product()
@@ -165,7 +165,7 @@ def test_admin_operations_referral_campaign_record_routes_are_campaign_scoped(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     with app.app_context():
         _seed_plan_product()
@@ -287,7 +287,7 @@ def test_admin_operations_referral_campaign_record_routes_are_campaign_scoped(
 def test_admin_operations_promotions_referral_campaign_rejects_invalid_status_filter(
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     response = test_client.get(

--- a/src/api/tests/service/referral/test_referral_models.py
+++ b/src/api/tests/service/referral/test_referral_models.py
@@ -55,7 +55,7 @@ def test_referral_models_register_campaign_runtime_tables() -> None:
 
 def test_referral_model_rows_support_configured_campaign_and_reward_snapshot(
     referral_app,
-):
+) -> None:
     with referral_app.app_context():
         campaign = ReferralCampaign(
             campaign_bid="ref-campaign-model-1",
@@ -156,7 +156,9 @@ def test_referral_model_rows_support_configured_campaign_and_reward_snapshot(
         )
 
 
-def test_referral_relation_prevents_duplicate_active_invitee_binding(referral_app):
+def test_referral_relation_prevents_duplicate_active_invitee_binding(
+    referral_app,
+) -> None:
     with referral_app.app_context():
         db.session.add(
             ReferralInviteRelation(

--- a/src/api/tests/service/shifu/test_admin_config_rates.py
+++ b/src/api/tests/service/shifu/test_admin_config_rates.py
@@ -86,7 +86,9 @@ def _seed_default_llm_rates() -> None:
     db.session.commit()
 
 
-def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(monkeypatch, app):
+def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(
+    monkeypatch, app
+) -> None:
     def config_getter(key, default=None):
         return {
             "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
@@ -236,7 +238,9 @@ def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(monkeypatch, ap
         db.session.commit()
 
 
-def test_update_db_only_llm_alias_only_supersedes_explicit_alias(monkeypatch, app):
+def test_update_db_only_llm_alias_only_supersedes_explicit_alias(
+    monkeypatch, app
+) -> None:
     fixed_now = datetime(2026, 7, 20, 13, 30, 43, 990000)
     monkeypatch.setattr(config_rates, "now_utc", lambda: fixed_now)
     monkeypatch.setattr(
@@ -315,7 +319,7 @@ def test_update_db_only_llm_alias_only_supersedes_explicit_alias(monkeypatch, ap
         db.session.commit()
 
 
-def test_update_new_llm_rate_uses_default_metric_ratios(monkeypatch, app):
+def test_update_new_llm_rate_uses_default_metric_ratios(monkeypatch, app) -> None:
     def config_getter(key, default=None):
         return {
             "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
@@ -386,7 +390,9 @@ def test_update_new_llm_rate_uses_default_metric_ratios(monkeypatch, app):
         db.session.commit()
 
 
-def test_operator_rate_config_exposes_fixed_credit_1x_baseline(monkeypatch, app):
+def test_operator_rate_config_exposes_fixed_credit_1x_baseline(
+    monkeypatch, app
+) -> None:
     def config_getter(key, default=None):
         return {
             "DEFAULT_LLM_MODEL": "ark/doubao-seed-2-0-lite-260428",
@@ -431,7 +437,7 @@ def test_operator_rate_config_exposes_fixed_credit_1x_baseline(monkeypatch, app)
         db.session.commit()
 
 
-def test_update_rate_rejects_missing_credit_1x_anchor(monkeypatch, app):
+def test_update_rate_rejects_missing_credit_1x_anchor(monkeypatch, app) -> None:
     def config_getter(key, default=None):
         return {
             "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
@@ -478,7 +484,7 @@ def test_update_rate_rejects_missing_credit_1x_anchor(monkeypatch, app):
 
 def test_operator_rate_config_appends_only_current_exact_db_identities(
     monkeypatch, app
-):
+) -> None:
     fixed_now = datetime(2026, 7, 21, 12, 0, 0)
     monkeypatch.setattr(config_rates, "now_utc", lambda: fixed_now)
     monkeypatch.setattr(
@@ -708,7 +714,7 @@ def test_operator_rate_config_appends_only_current_exact_db_identities(
 )
 def test_create_only_llm_uses_raw_rate_model_without_superseding_alias(
     monkeypatch, app, credits_per_unit, expected_input, expected_cache
-):
+) -> None:
     fixed_now = datetime(2026, 7, 21, 12, 0, 0)
     monkeypatch.setattr(config_rates, "now_utc", lambda: fixed_now)
     monkeypatch.setattr(
@@ -780,7 +786,7 @@ def test_create_only_llm_uses_raw_rate_model_without_superseding_alias(
         db.session.commit()
 
 
-def test_create_only_rejects_duplicate_active_exact_identity(monkeypatch, app):
+def test_create_only_rejects_duplicate_active_exact_identity(monkeypatch, app) -> None:
     fixed_now = datetime(2026, 7, 21, 12, 0, 0)
     monkeypatch.setattr(config_rates, "now_utc", lambda: fixed_now)
     monkeypatch.setattr(
@@ -858,7 +864,7 @@ def test_create_only_rejects_duplicate_active_exact_identity(monkeypatch, app):
 )
 def test_create_only_rejects_invalid_identity_and_fixed_fields(
     monkeypatch, app, overrides
-):
+) -> None:
     monkeypatch.setattr(
         config_rates, "_load_llm_credit_1x_reference_cost", lambda: Decimal(3)
     )
@@ -895,7 +901,9 @@ def test_create_only_rejects_invalid_identity_and_fixed_fields(
     ["0.5", "9999999999.9999999999"],
     ids=["regular", "numeric-max"],
 )
-def test_create_only_tts_allows_empty_default_model(monkeypatch, app, credits_per_unit):
+def test_create_only_tts_allows_empty_default_model(
+    monkeypatch, app, credits_per_unit
+) -> None:
     fixed_now = datetime(2026, 7, 21, 12, 0, 0)
     monkeypatch.setattr(config_rates, "now_utc", lambda: fixed_now)
     monkeypatch.setattr(

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -756,14 +756,14 @@ def _seed_outline(
     )
 
 
-def test_coerce_operator_datetime_accepts_mysql_string_values(app):
+def test_coerce_operator_datetime_accepts_mysql_string_values(app) -> None:
     with app.app_context():
         assert _coerce_operator_datetime("2026-05-20 16:40:51") == datetime(
             2026, 5, 20, 16, 40, 51
         )
 
 
-def test_coerce_operator_datetime_normalizes_offset_values_to_utc(app):
+def test_coerce_operator_datetime_normalizes_offset_values_to_utc(app) -> None:
     with app.app_context():
         assert _coerce_operator_datetime("2026-05-22T10:00:00+08:00") == datetime(
             2026, 5, 22, 2, 0, 0
@@ -777,7 +777,7 @@ def test_admin_operation_course_detail_route_returns_latest_detail(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     monkeypatch.setattr(
         "flaskr.service.shifu.admin.get_course_visit_count_30d",
@@ -1086,7 +1086,7 @@ def test_admin_operation_course_detail_estimates_credit_cost_by_learning_mode(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     monkeypatch.setattr(
         "flaskr.service.shifu.admin.get_course_visit_count_30d",
@@ -1299,7 +1299,7 @@ def test_admin_operation_course_detail_route_sorts_numeric_positions_and_surface
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     updated_at = datetime(2026, 4, 3, 15, 30, 0)
 
@@ -1386,7 +1386,7 @@ def test_admin_operation_course_detail_routes_require_operator(
     test_client,
     monkeypatch,
     path,
-):
+) -> None:
     _mock_operator(monkeypatch, is_operator=False)
 
     response = test_client.get(path, headers={"Token": "test-token"})
@@ -1400,7 +1400,7 @@ def test_admin_operation_course_prompt_route_returns_course_prompt(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     updated_at = datetime(2026, 4, 3, 15, 30, 0)
 
@@ -1435,7 +1435,7 @@ def test_admin_operation_course_chapter_detail_route_returns_prompt_content(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     updated_at = datetime(2026, 4, 3, 15, 30, 0)
 
@@ -1481,7 +1481,7 @@ def test_admin_operation_course_chapter_detail_route_falls_back_to_chapter_and_c
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     updated_at = datetime(2026, 4, 3, 15, 30, 0)
 
@@ -1547,7 +1547,7 @@ def test_admin_operation_course_chapter_detail_route_falls_back_to_course(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     updated_at = datetime(2026, 4, 3, 15, 30, 0)
 
@@ -1612,7 +1612,7 @@ def test_admin_operation_course_detail_route_keeps_empty_draft_outline(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
     updated_at = datetime(2026, 4, 3, 15, 30, 0)
@@ -1651,7 +1651,7 @@ def test_admin_operation_course_detail_route_ignores_soft_deleted_latest_outline
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     updated_at = datetime(2026, 4, 3, 15, 30, 0)
 
@@ -1728,7 +1728,7 @@ def test_admin_operation_course_detail_route_rejects_missing_course(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _ = app
     _mock_operator(monkeypatch)
 
@@ -1746,7 +1746,7 @@ def test_admin_operation_course_chapter_detail_route_rejects_missing_outline_ite
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     updated_at = datetime(2026, 4, 3, 15, 30, 0)
 
@@ -1770,7 +1770,9 @@ def test_admin_operation_course_chapter_detail_route_rejects_missing_outline_ite
     assert payload["code"] == 4009
 
 
-def test_get_operator_course_detail_rejects_blank_shifu_bid_with_params_error(app):
+def test_get_operator_course_detail_rejects_blank_shifu_bid_with_params_error(
+    app,
+) -> None:
     with pytest.raises(AppError) as exc_info:
         get_operator_course_detail(app, shifu_bid="   ")
 
@@ -1779,7 +1781,7 @@ def test_get_operator_course_detail_rejects_blank_shifu_bid_with_params_error(ap
 
 def test_get_operator_course_chapter_detail_rejects_blank_params_with_params_error(
     app,
-):
+) -> None:
     with pytest.raises(AppError) as exc_info:
         get_operator_course_chapter_detail(
             app,
@@ -1793,7 +1795,7 @@ def test_admin_operation_course_users_route_returns_course_related_users(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
     updated_at = datetime(2026, 4, 3, 15, 30, 0)
@@ -1933,7 +1935,7 @@ def test_admin_operation_course_users_route_applies_filters(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
     updated_at = datetime(2026, 4, 3, 15, 30, 0)
@@ -1992,7 +1994,7 @@ def test_admin_operation_course_users_route_marks_redeem_orders_as_paid(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
     updated_at = datetime(2026, 4, 3, 15, 30, 0)
@@ -2065,7 +2067,7 @@ def test_admin_operation_course_detail_metrics_include_credit_usage_and_complete
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     monkeypatch.setattr(
         "flaskr.service.shifu.admin.get_course_visit_count_30d",
@@ -2175,7 +2177,7 @@ def test_admin_operation_course_credit_usages_route_returns_grouped_rows_and_fil
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
 
@@ -2472,7 +2474,7 @@ def test_admin_operation_course_credit_usage_model_labels_are_cached_per_request
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
     load_counts = {"llm": 0, "tts": 0}
@@ -2623,7 +2625,7 @@ def test_admin_operation_course_credit_usages_ignores_blank_model_variant(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
 
@@ -2701,7 +2703,7 @@ def test_admin_operation_course_credit_usages_route_rejects_invalid_filters(
     monkeypatch,
     query,
     field,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2729,7 +2731,7 @@ def test_admin_operation_course_credit_usages_route_rejects_invalid_view(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -2756,7 +2758,7 @@ def test_admin_operation_course_credit_usages_route_rejects_invalid_view(
 def test_admin_operation_course_credit_usages_route_rejects_missing_course(
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     response = test_client.get(
@@ -2774,7 +2776,7 @@ def test_admin_operation_course_credit_usage_details_route_returns_rows_and_summ
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
 
@@ -2871,7 +2873,7 @@ def test_admin_operation_course_credit_usage_details_route_paginates_and_filters
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
 
@@ -2941,7 +2943,7 @@ def test_admin_operation_course_credit_usages_grouped_view_keeps_rows_without_pr
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 2, 9, 0, 0)
 
@@ -3023,7 +3025,7 @@ def test_admin_operation_course_credit_usages_route_aggregates_split_ledgers(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 2, 9, 0, 0)
 
@@ -3113,7 +3115,7 @@ def test_admin_operation_course_follow_ups_route_returns_summary_and_filters(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
     updated_at = datetime(2026, 4, 3, 15, 30, 0)
@@ -3402,7 +3404,7 @@ def test_admin_operation_course_follow_ups_route_returns_summary_and_filters(
 def test_admin_operation_course_follow_ups_route_rejects_inverted_time_range(
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     response = test_client.get(
@@ -3421,7 +3423,7 @@ def test_admin_operation_course_follow_ups_route_rejects_invalid_source_status(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -3451,7 +3453,7 @@ def test_admin_operation_course_follow_ups_route_supports_google_email_credentia
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
 
@@ -3541,7 +3543,7 @@ def test_admin_operation_course_ratings_route_returns_summary_and_filters(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -3775,7 +3777,7 @@ def test_admin_operation_course_ratings_route_rejects_invalid_filters(
     monkeypatch,
     query_string,
     expected_param,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -3803,7 +3805,7 @@ def test_admin_operation_course_follow_up_detail_route_returns_timeline(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
     updated_at = datetime(2026, 4, 3, 15, 30, 0)
@@ -3938,7 +3940,7 @@ def test_admin_operation_course_follow_up_detail_route_skips_intermediate_blocks
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
 
@@ -4061,7 +4063,7 @@ def test_admin_operation_course_follow_up_detail_route_prefers_interaction_sourc
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
 
@@ -4147,7 +4149,7 @@ def test_admin_operation_course_follow_up_detail_route_reads_mdcontent_answer_fr
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
 
@@ -4252,7 +4254,7 @@ def test_admin_operation_course_follow_up_detail_route_reads_inactive_block_sour
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
 
@@ -4340,7 +4342,7 @@ def test_admin_operation_course_follow_up_detail_route_reads_listen_anchor_sourc
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
 
@@ -4441,7 +4443,7 @@ def test_admin_operation_course_follow_up_detail_route_scopes_anchor_source_to_p
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
 
@@ -4553,7 +4555,7 @@ def test_admin_operation_course_follow_up_detail_route_reads_historical_anchor_s
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     created_at = datetime(2026, 4, 1, 9, 0, 0)
 
@@ -4662,7 +4664,7 @@ def test_admin_operation_course_detail_metrics_include_full_coupon_redemptions(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     monkeypatch.setattr(
         "flaskr.service.shifu.admin.get_course_visit_count_30d",
@@ -4739,7 +4741,7 @@ def test_admin_operation_course_detail_metrics_include_full_promo_redemptions(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     monkeypatch.setattr(
         "flaskr.service.shifu.admin.get_course_visit_count_30d",
@@ -4807,7 +4809,7 @@ def test_admin_operation_course_detail_metrics_prefer_paid_price_and_fallback_to
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     monkeypatch.setattr(
         "flaskr.service.shifu.admin.get_course_visit_count_30d",
@@ -4878,7 +4880,7 @@ def test_admin_operation_course_detail_metrics_include_successful_orders_across_
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
     monkeypatch.setattr(
         "flaskr.service.shifu.admin.get_course_visit_count_30d",
@@ -4974,7 +4976,7 @@ def test_admin_operation_course_users_route_rejects_invalid_pagination_params(
     monkeypatch,
     query_string,
     expected_param,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     response = test_client.get(

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -73,7 +73,7 @@ class DummyCourse:
         self.updated_at = updated_at
 
 
-def test_list_operator_courses_prefers_latest_draft_and_formats_contacts():
+def test_list_operator_courses_prefers_latest_draft_and_formats_contacts() -> None:
     app = Flask(__name__)
     updated_start_time = datetime(2025, 4, 2, 0, 0, 0)
     updated_end_time = datetime(2025, 4, 3, 23, 59, 59)
@@ -159,7 +159,7 @@ def test_list_operator_courses_prefers_latest_draft_and_formats_contacts():
     assert latest_mock.call_args_list[1].kwargs["updated_end_time"] is None
 
 
-def test_list_operator_courses_paginates_merged_results():
+def test_list_operator_courses_paginates_merged_results() -> None:
     app = Flask(__name__)
     draft_course = DummyCourse(
         shifu_bid="course-2",
@@ -216,7 +216,9 @@ def test_list_operator_courses_paginates_merged_results():
     assert result.items[0].shifu_bid == "course-1"
 
 
-def test_list_operator_courses_attaches_prompt_flags_for_lightweight_page_items():
+def test_list_operator_courses_attaches_prompt_flags_for_lightweight_page_items() -> (
+    None
+):
     app = Flask(__name__)
     draft_seed = OperatorCourseListSeed(
         id=11,
@@ -283,7 +285,9 @@ def test_list_operator_courses_attaches_prompt_flags_for_lightweight_page_items(
     assert result.items[0].has_course_prompt is True
 
 
-def test_list_operator_courses_uses_latest_activity_for_updater_and_updated_at():
+def test_list_operator_courses_uses_latest_activity_for_updater_and_updated_at() -> (
+    None
+):
     app = Flask(__name__)
     draft_course = DummyCourse(
         shifu_bid="course-activity",
@@ -352,7 +356,7 @@ def test_list_operator_courses_uses_latest_activity_for_updater_and_updated_at()
     assert result.items[0].updated_at == datetime(2025, 4, 5, 9, 0, 0)
 
 
-def test_list_operator_courses_filters_by_latest_activity_updated_range():
+def test_list_operator_courses_filters_by_latest_activity_updated_range() -> None:
     app = Flask(__name__)
     draft_course = DummyCourse(
         shifu_bid="course-activity-filter",
@@ -413,7 +417,7 @@ def test_list_operator_courses_filters_by_latest_activity_updated_range():
     assert latest_mock.call_args_list[0].kwargs["updated_end_time"] is None
 
 
-def test_load_course_activity_map_prefers_latest_outline_activity_row(app):
+def test_load_course_activity_map_prefers_latest_outline_activity_row(app) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     creator_bid = uuid.uuid4().hex[:32]
 
@@ -467,7 +471,9 @@ def test_load_course_activity_map_prefers_latest_outline_activity_row(app):
     assert activity_map[shifu_bid]["updated_at"] == datetime(2025, 4, 5, 10, 0, 0)
 
 
-def test_load_course_activity_map_prefers_outline_when_timestamp_ties_course(app):
+def test_load_course_activity_map_prefers_outline_when_timestamp_ties_course(
+    app,
+) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     creator_bid = uuid.uuid4().hex[:32]
     shared_updated_at = datetime(2025, 4, 5, 10, 0, 0)
@@ -510,7 +516,7 @@ def test_load_course_activity_map_prefers_outline_when_timestamp_ties_course(app
     assert activity_map[shifu_bid]["updated_at"] == shared_updated_at
 
 
-def test_list_operator_courses_filters_out_builtin_demo_courses_only():
+def test_list_operator_courses_filters_out_builtin_demo_courses_only() -> None:
     app = Flask(__name__)
     builtin_demo_course = DummyCourse(
         shifu_bid="course-system",
@@ -579,7 +585,7 @@ def test_list_operator_courses_filters_out_builtin_demo_courses_only():
     }
 
 
-def test_list_operator_courses_skips_system_user_lookup():
+def test_list_operator_courses_skips_system_user_lookup() -> None:
     app = Flask(__name__)
     system_course = DummyCourse(
         shifu_bid="course-system-custom",
@@ -632,7 +638,7 @@ def test_list_operator_courses_skips_system_user_lookup():
     assert "system" not in user_map_mock.call_args.args[0]
 
 
-def test_list_operator_courses_filters_by_course_status():
+def test_list_operator_courses_filters_by_course_status() -> None:
     app = Flask(__name__)
     draft_only_course = DummyCourse(
         shifu_bid="course-draft-only",
@@ -698,7 +704,7 @@ def test_list_operator_courses_filters_by_course_status():
     assert published_result.items[0].course_status == "published"
 
 
-def test_list_operator_courses_applies_quick_filters(monkeypatch):
+def test_list_operator_courses_applies_quick_filters(monkeypatch) -> None:
     class FixedDateTime(datetime):
         @classmethod
         def now(cls, tz=None) -> datetime:  # noqa: ARG003 - matches datetime.now signature
@@ -813,7 +819,9 @@ def test_list_operator_courses_applies_quick_filters(monkeypatch):
     assert [item.shifu_bid for item in paid_result.items] == ["course-paid"]
 
 
-def test_list_operator_courses_rejects_invalid_quick_filter_before_loading_overview():
+def test_list_operator_courses_rejects_invalid_quick_filter_before_loading_overview() -> (
+    None
+):
     app = Flask(__name__)
 
     with (
@@ -830,7 +838,9 @@ def test_list_operator_courses_rejects_invalid_quick_filter_before_loading_overv
     latest_mock.assert_not_called()
 
 
-def test_build_operator_course_overview_returns_expected_counts(app, monkeypatch):
+def test_build_operator_course_overview_returns_expected_counts(
+    app, monkeypatch
+) -> None:
     class FixedDateTime(datetime):
         @classmethod
         def now(cls, tz=None) -> datetime:  # noqa: ARG003 - matches datetime.now signature
@@ -1027,7 +1037,7 @@ def test_build_operator_course_overview_returns_expected_counts(app, monkeypatch
 
 def test_list_operator_courses_sql_path_preserves_merge_visibility_and_activity_order(
     app,
-):
+) -> None:
     creator_bid = uuid.uuid4().hex[:32]
     draft_only_bid = uuid.uuid4().hex[:32]
     published_only_bid = uuid.uuid4().hex[:32]
@@ -1169,7 +1179,9 @@ def test_list_operator_courses_sql_path_preserves_merge_visibility_and_activity_
     assert [item.shifu_bid for item in second_page_result.items] == [draft_only_bid]
 
 
-def test_list_operator_courses_sql_path_falls_back_to_latest_nonempty_models(app):
+def test_list_operator_courses_sql_path_falls_back_to_latest_nonempty_models(
+    app,
+) -> None:
     creator_bid = uuid.uuid4().hex[:32]
     published_with_blank_draft_bid = uuid.uuid4().hex[:32]
     published_history_fallback_bid = uuid.uuid4().hex[:32]
@@ -1265,7 +1277,7 @@ def test_list_operator_courses_sql_path_falls_back_to_latest_nonempty_models(app
     assert historical_fallback.tts_model == "speech-01"
 
 
-def test_list_operator_courses_sql_path_falls_back_to_default_llm_model(app):
+def test_list_operator_courses_sql_path_falls_back_to_default_llm_model(app) -> None:
     creator_bid = uuid.uuid4().hex[:32]
     empty_model_bid = uuid.uuid4().hex[:32]
 
@@ -1303,7 +1315,9 @@ def test_list_operator_courses_sql_path_falls_back_to_default_llm_model(app):
     assert result.items[0].llm_model == "gpt-test"
 
 
-def test_list_operator_courses_sql_path_uses_current_outline_revisions_only(app):
+def test_list_operator_courses_sql_path_uses_current_outline_revisions_only(
+    app,
+) -> None:
     creator_bid = uuid.uuid4().hex[:32]
     shifu_bid = uuid.uuid4().hex[:32]
     outline_item_bid = uuid.uuid4().hex[:32]
@@ -1376,7 +1390,9 @@ def test_list_operator_courses_sql_path_uses_current_outline_revisions_only(app)
     assert filtered_result.items == []
 
 
-def test_list_operator_courses_sql_path_filters_trimmed_builtin_demo_courses(app):
+def test_list_operator_courses_sql_path_filters_trimmed_builtin_demo_courses(
+    app,
+) -> None:
     creator_bid = uuid.uuid4().hex[:32]
     demo_bid = uuid.uuid4().hex[:32]
     normal_bid = uuid.uuid4().hex[:32]
@@ -1429,7 +1445,7 @@ def test_list_operator_courses_sql_path_filters_trimmed_builtin_demo_courses(app
     assert [item.shifu_bid for item in result.items] == [normal_bid]
 
 
-def test_list_operator_courses_sql_path_filters_by_combined_course_query(app):
+def test_list_operator_courses_sql_path_filters_by_combined_course_query(app) -> None:
     matching_bid = uuid.uuid4().hex[:32]
     name_match_bid = uuid.uuid4().hex[:32]
     other_bid = uuid.uuid4().hex[:32]
@@ -1510,7 +1526,7 @@ def test_list_operator_courses_sql_path_filters_by_combined_course_query(app):
     assert find_course_bids_mock.call_count == 2
 
 
-def test_merge_courses_checks_published_visibility_once():
+def test_merge_courses_checks_published_visibility_once() -> None:
     draft_course = DummyCourse(
         shifu_bid="course-draft",
         title="Draft Course",
@@ -1567,16 +1583,16 @@ class FakeColumn:
         """Build a fake less-than-or-equal expression."""
         return ("le", self.name, other)
 
-    def ilike(self, value: str):
+    def ilike(self, value: str) -> tuple[str, str, str]:
         return ("ilike", self.name, value)
 
-    def in_(self, value):
+    def in_(self, value) -> tuple[str, str, object]:
         return ("in", self.name, value)
 
-    def desc(self):
+    def desc(self) -> tuple[str, str]:
         return ("desc", self.name)
 
-    def label(self, alias: str):
+    def label(self, alias: str) -> tuple[str, str, str]:
         return ("label", self.name, alias)
 
 
@@ -1587,7 +1603,7 @@ class FakeMaxExpression:
         """Initialize the fake max expression test double."""
         self.column = column
 
-    def label(self, alias: str):
+    def label(self, alias: str) -> tuple[str, str, str]:
         return ("max", self.column.name, alias)
 
 
@@ -1608,15 +1624,15 @@ class FakeLatestQuery:
         self.grouped_by = []
         self.subquery_value = FakeLatestSubquery()
 
-    def filter(self, *conditions: object):
+    def filter(self, *conditions: object) -> FakeLatestQuery:
         self.filters.extend(conditions)
         return self
 
-    def group_by(self, *columns: object):
+    def group_by(self, *columns: object) -> FakeLatestQuery:
         self.grouped_by.extend(columns)
         return self
 
-    def subquery(self):
+    def subquery(self) -> FakeLatestSubquery:
         return self.subquery_value
 
 
@@ -1639,23 +1655,23 @@ class FakeOuterQuery:
         self.options_calls = []
         self.with_entities_calls = []
 
-    def filter(self, *conditions: object):
+    def filter(self, *conditions: object) -> FakeOuterQuery:
         self.filters.extend(conditions)
         return self
 
-    def options(self, *options: object):
+    def options(self, *options: object) -> FakeOuterQuery:
         self.options_calls.extend(options)
         return self
 
-    def order_by(self, *ordering: object):
+    def order_by(self, *ordering: object) -> FakeOuterQuery:
         self.ordering.extend(ordering)
         return self
 
-    def with_entities(self, *columns: object):
+    def with_entities(self, *columns: object) -> FakeOuterQuery:
         self.with_entities_calls.append(columns)
         return self
 
-    def all(self):
+    def all(self) -> list[object]:
         return self.result
 
 
@@ -1670,7 +1686,7 @@ class FakeSession:
         self.outer_query = outer_query
         self.id_queries = []
 
-    def query(self, target):
+    def query(self, target) -> FakeLatestQuery | FakeOuterQuery | FakeIdQuery:
         if target == ("max", "id", "max_id"):
             return self.latest_query
         if isinstance(target, type) and issubclass(target, FakeModel):
@@ -1721,7 +1737,7 @@ class FakeMappedModel(FakeModel):
     updated_user_bid = FakeColumn("updated_user_bid")
 
 
-def test_load_latest_shifus_filters_on_latest_rows(monkeypatch):
+def test_load_latest_shifus_filters_on_latest_rows(monkeypatch) -> None:
     latest_query = FakeLatestQuery()
     expected_rows = ["latest-course-row"]
     outer_query = FakeOuterQuery(expected_rows)
@@ -1766,7 +1782,9 @@ def test_load_latest_shifus_filters_on_latest_rows(monkeypatch):
     ]
 
 
-def test_load_latest_shifus_skips_loader_options_for_lightweight_queries(monkeypatch):
+def test_load_latest_shifus_skips_loader_options_for_lightweight_queries(
+    monkeypatch,
+) -> None:
     latest_query = FakeLatestQuery()
     outer_query = FakeOuterQuery(
         [

--- a/src/api/tests/service/shifu/test_admin_credit_notifications.py
+++ b/src/api/tests/service/shifu/test_admin_credit_notifications.py
@@ -9,7 +9,7 @@ from flaskr.service.common.models import ERROR_CODE
 from flaskr.service.shifu.admin_operations import credit_notifications as module
 
 
-def test_operator_credit_notification_services_delegate_to_billing(monkeypatch):
+def test_operator_credit_notification_services_delegate_to_billing(monkeypatch) -> None:
     app = Flask(__name__)
     calls: list[tuple[str, object]] = []
 
@@ -102,7 +102,7 @@ def test_operator_credit_notification_services_delegate_to_billing(monkeypatch):
     ]
 
 
-def test_operator_credit_notification_config_preserves_opt_out(monkeypatch):
+def test_operator_credit_notification_config_preserves_opt_out(monkeypatch) -> None:
     app = Flask(__name__)
     saved_payloads: list[tuple[object, dict[str, object], bool, str]] = []
     policies = [{"version": 1}, {"version": 2}]
@@ -135,7 +135,7 @@ def test_operator_credit_notification_config_preserves_opt_out(monkeypatch):
 
 def test_operator_credit_notification_services_pass_operator_audit_context(
     monkeypatch,
-):
+) -> None:
     app = Flask(__name__)
     calls: list[tuple[str, object]] = []
 
@@ -197,7 +197,7 @@ def test_operator_credit_notification_services_pass_operator_audit_context(
 def test_credit_notification_list_route_rejects_invalid_status_filters(
     test_client,
     monkeypatch,
-):
+) -> None:
     dummy_user = SimpleNamespace(
         user_id="operator-1",
         is_operator=True,

--- a/src/api/tests/service/shifu/test_admin_operation_datetime_filters.py
+++ b/src/api/tests/service/shifu/test_admin_operation_datetime_filters.py
@@ -5,21 +5,21 @@ from datetime import datetime
 from flaskr.service.shifu.admin_operations.route import _parse_datetime_filter
 
 
-def test_parse_datetime_filter_normalizes_utc_z_values():
+def test_parse_datetime_filter_normalizes_utc_z_values() -> None:
     assert _parse_datetime_filter(
         "2026-07-01T16:00:00Z",
         field_name="start_time",
     ) == datetime(2026, 7, 1, 16, 0, 0)
 
 
-def test_parse_datetime_filter_normalizes_offset_values_to_utc():
+def test_parse_datetime_filter_normalizes_offset_values_to_utc() -> None:
     assert _parse_datetime_filter(
         "2026-07-02T00:00:00+08:00",
         field_name="start_time",
     ) == datetime(2026, 7, 1, 16, 0, 0)
 
 
-def test_parse_datetime_filter_keeps_legacy_date_only_bounds():
+def test_parse_datetime_filter_keeps_legacy_date_only_bounds() -> None:
     assert _parse_datetime_filter(
         "2026-07-02",
         field_name="start_time",

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -645,7 +645,9 @@ def _seed_user_token(*, user_bid: str, token: str, created_at: datetime):
     return user_token
 
 
-def test_list_operator_users_returns_paginated_summaries_with_resolved_metadata(app):
+def test_list_operator_users_returns_paginated_summaries_with_resolved_metadata(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -701,7 +703,9 @@ def test_list_operator_users_returns_paginated_summaries_with_resolved_metadata(
     assert item.updated_at == datetime(2026, 4, 4, 9, 0, 0)
 
 
-def test_list_operator_users_filters_by_identifier_status_role_and_created_time(app):
+def test_list_operator_users_filters_by_identifier_status_role_and_created_time(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -748,7 +752,9 @@ def test_list_operator_users_filters_by_identifier_status_role_and_created_time(
     assert result.data[0].created_courses == []
 
 
-def test_list_operator_users_filters_creator_role_includes_operator_creators(app):
+def test_list_operator_users_filters_creator_role_includes_operator_creators(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -791,7 +797,7 @@ def test_list_operator_users_filters_creator_role_includes_operator_creators(app
     assert result.data[1].user_roles == ["creator"]
 
 
-def test_list_operator_users_filters_by_email_identifier(app):
+def test_list_operator_users_filters_by_email_identifier(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -822,7 +828,7 @@ def test_list_operator_users_filters_by_email_identifier(app):
     assert result.data[0].created_courses == []
 
 
-def test_list_operator_users_filters_by_combined_user_query(app):
+def test_list_operator_users_filters_by_combined_user_query(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -868,7 +874,7 @@ def test_list_operator_users_filters_by_combined_user_query(app):
 
 def test_list_operator_users_returns_overview_summary_and_applies_quick_filters(
     app, monkeypatch
-):
+) -> None:
     class FixedDateTime(datetime):
         @classmethod
         def now(cls, tz=None) -> datetime:
@@ -982,7 +988,7 @@ def test_list_operator_users_returns_overview_summary_and_applies_quick_filters(
 
 def test_list_operator_users_recent_windows_exclude_future_records_and_keep_microseconds(
     app, monkeypatch
-):
+) -> None:
     class FixedDateTime(datetime):
         @classmethod
         def now(cls, tz=None) -> datetime:
@@ -1111,7 +1117,7 @@ def test_list_operator_users_recent_windows_exclude_future_records_and_keep_micr
     ]
 
 
-def test_list_operator_users_caps_page_size(app):
+def test_list_operator_users_caps_page_size(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -1142,7 +1148,7 @@ def test_list_operator_users_caps_page_size(app):
     assert len(result.data) == 2
 
 
-def test_list_operator_users_returns_learning_and_created_courses(app):
+def test_list_operator_users_returns_learning_and_created_courses(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -1242,7 +1248,7 @@ def test_list_operator_users_returns_learning_and_created_courses(app):
     ]
 
 
-def test_user_course_count_maps_use_lightweight_course_rows(app, monkeypatch):
+def test_user_course_count_maps_use_lightweight_course_rows(app, monkeypatch) -> None:
     load_calls = []
 
     def fake_load_latest_shifus(model, **kwargs: object):
@@ -1284,7 +1290,7 @@ def test_user_course_count_maps_use_lightweight_course_rows(app, monkeypatch):
     ]
 
 
-def test_list_operator_users_includes_creator_credit_summaries(app):
+def test_list_operator_users_includes_creator_credit_summaries(app) -> None:
     with app.app_context():
         active_start_at, active_end_at = _build_active_window()
         future_start_at = active_end_at + timedelta(days=1)
@@ -1382,7 +1388,7 @@ def test_list_operator_users_includes_creator_credit_summaries(app):
     assert regular_item.has_active_subscription is False
 
 
-def test_list_operator_users_filters_by_learner_role(app):
+def test_list_operator_users_filters_by_learner_role(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -1418,7 +1424,7 @@ def test_list_operator_users_filters_by_learner_role(app):
     assert result.data[0].user_roles == ["learner"]
 
 
-def test_get_operator_user_detail_returns_full_summary(app):
+def test_get_operator_user_detail_returns_full_summary(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -1457,7 +1463,7 @@ def test_get_operator_user_detail_returns_full_summary(app):
 
 def test_get_operator_user_detail_returns_registration_login_payment_and_learning_data(
     app,
-):
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -1498,7 +1504,7 @@ def test_get_operator_user_detail_returns_registration_login_payment_and_learnin
     assert item.last_learning_at == datetime(2026, 4, 11, 10, 0, 0)
 
 
-def test_get_operator_user_credits_returns_summary_and_paginated_ledger(app):
+def test_get_operator_user_credits_returns_summary_and_paginated_ledger(app) -> None:
     with app.app_context():
         active_start_at, active_end_at = _build_active_window()
         _seed_user(
@@ -1600,7 +1606,7 @@ def test_get_operator_user_credits_returns_summary_and_paginated_ledger(app):
     assert result.items[0].note_code == ""
 
 
-def test_get_operator_user_credits_hides_reserved_grants_until_available(app):
+def test_get_operator_user_credits_hides_reserved_grants_until_available(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -1699,7 +1705,7 @@ def test_get_operator_user_credits_hides_reserved_grants_until_available(app):
     assert activated_result.total == 2
 
 
-def test_get_operator_user_credits_handles_invalid_source_type(app):
+def test_get_operator_user_credits_handles_invalid_source_type(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -1744,7 +1750,9 @@ def test_get_operator_user_credits_handles_invalid_source_type(app):
     assert result.items[0].display_source_type == "manual"
 
 
-def test_get_operator_user_credits_uses_empty_expiry_for_long_term_balances(app):
+def test_get_operator_user_credits_uses_empty_expiry_for_long_term_balances(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -1786,7 +1794,9 @@ def test_get_operator_user_credits_uses_empty_expiry_for_long_term_balances(app)
     assert result.items == []
 
 
-def test_get_operator_user_credits_maps_usage_rows_to_operator_display_codes(app):
+def test_get_operator_user_credits_maps_usage_rows_to_operator_display_codes(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -1832,7 +1842,9 @@ def test_get_operator_user_credits_maps_usage_rows_to_operator_display_codes(app
     assert result.items[0].note_code == "preview_consume"
 
 
-def test_get_operator_user_credits_enriches_consume_rows_with_course_context(app):
+def test_get_operator_user_credits_enriches_consume_rows_with_course_context(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -1937,7 +1949,7 @@ def test_get_operator_user_credits_enriches_consume_rows_with_course_context(app
 def test_get_operator_user_credits_loads_order_metadata_only_for_order_sources(
     app,
     monkeypatch,
-):
+) -> None:
     captured_source_bids: list[str] = []
     original_load_billing_order_map = user_credits_module._load_billing_order_map
 
@@ -2009,7 +2021,7 @@ def test_get_operator_user_credits_loads_order_metadata_only_for_order_sources(
     assert captured_source_bids == ["order-source-1"]
 
 
-def test_get_operator_user_credits_filters_consume_grant_and_other_rows(app):
+def test_get_operator_user_credits_filters_consume_grant_and_other_rows(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -2224,7 +2236,7 @@ def test_get_operator_user_credits_filters_consume_grant_and_other_rows(app):
 
 def test_get_operator_user_credits_keeps_consume_rows_without_usage_when_unfiltered(
     app,
-):
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -2280,7 +2292,9 @@ def test_get_operator_user_credits_keeps_consume_rows_without_usage_when_unfilte
     assert filtered_result.total == 0
 
 
-def test_get_operator_user_credits_empty_consume_filter_does_not_scan_usage_rows(app):
+def test_get_operator_user_credits_empty_consume_filter_does_not_scan_usage_rows(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -2325,7 +2339,7 @@ def test_get_operator_user_credits_empty_consume_filter_does_not_scan_usage_rows
     assert result.items == []
 
 
-def test_get_operator_user_credit_usage_detail_returns_generated_content(app):
+def test_get_operator_user_credit_usage_detail_returns_generated_content(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -2419,7 +2433,9 @@ def test_get_operator_user_credit_usage_detail_returns_generated_content(app):
     assert result.items[0].output_tokens == 20
 
 
-def test_get_operator_user_credit_usage_detail_uses_ledger_owner_not_usage_user(app):
+def test_get_operator_user_credit_usage_detail_uses_ledger_owner_not_usage_user(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -2498,7 +2514,7 @@ def test_get_operator_user_credit_usage_detail_uses_ledger_owner_not_usage_user(
     assert result.items[0].content == "Owner detail content"
 
 
-def test_get_operator_user_credit_usage_detail_returns_tts_segment_rows(app):
+def test_get_operator_user_credit_usage_detail_returns_tts_segment_rows(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -2619,7 +2635,7 @@ def test_get_operator_user_credit_usage_detail_returns_tts_segment_rows(app):
 
 def test_get_operator_user_credits_excludes_topup_from_available_without_subscription(
     app,
-):
+) -> None:
     with app.app_context():
         manual_grant_expires_at = now_utc().replace(microsecond=0) + timedelta(days=3)
         active_start_at = manual_grant_expires_at - timedelta(days=10)
@@ -2674,7 +2690,7 @@ def test_get_operator_user_credits_excludes_topup_from_available_without_subscri
     assert result.summary.has_active_subscription is False
 
 
-def test_get_operator_user_credits_maps_manual_grant_display_codes(app):
+def test_get_operator_user_credits_maps_manual_grant_display_codes(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -2724,7 +2740,9 @@ def test_get_operator_user_credits_maps_manual_grant_display_codes(app):
     assert result.items[0].note_code == "manual_grant"
 
 
-def test_get_operator_user_detail_serializes_last_learning_at_using_app_timezone(app):
+def test_get_operator_user_detail_serializes_last_learning_at_using_app_timezone(
+    app,
+) -> None:
     with app.app_context():
         original_tz = app.config.get("TZ")
         app.config["TZ"] = "Asia/Shanghai"
@@ -2754,7 +2772,9 @@ def test_get_operator_user_detail_serializes_last_learning_at_using_app_timezone
     assert result.last_learning_at == datetime(2026, 4, 22, 11, 56, 11)
 
 
-def test_get_operator_user_credits_serializes_ledger_time_using_app_timezone(app):
+def test_get_operator_user_credits_serializes_ledger_time_using_app_timezone(
+    app,
+) -> None:
     with app.app_context():
         original_tz = app.config.get("TZ")
         app.config["TZ"] = "Asia/Shanghai"
@@ -2806,7 +2826,9 @@ def test_get_operator_user_credits_serializes_ledger_time_using_app_timezone(app
     assert result.items[0].expires_at == datetime(2026, 4, 29, 16, 29, 9)
 
 
-def test_grant_operator_user_credits_creates_manual_grant_bucket_and_summary(app):
+def test_grant_operator_user_credits_creates_manual_grant_bucket_and_summary(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -2877,7 +2899,7 @@ def test_grant_operator_user_credits_creates_manual_grant_bucket_and_summary(app
     assert ledger.metadata_json["note"] == "ops support"
 
 
-def test_grant_operator_user_credits_is_idempotent_for_repeated_request_id(app):
+def test_grant_operator_user_credits_is_idempotent_for_repeated_request_id(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -2922,7 +2944,9 @@ def test_grant_operator_user_credits_is_idempotent_for_repeated_request_id(app):
     assert len(ledger_entries) == 1
 
 
-def test_grant_operator_user_referral_reward_stacks_bucket_and_expiry(app, monkeypatch):
+def test_grant_operator_user_referral_reward_stacks_bucket_and_expiry(
+    app, monkeypatch
+) -> None:
     class FixedDateTime(datetime):
         @classmethod
         def now(cls, tz=None) -> datetime:
@@ -3019,7 +3043,7 @@ def test_grant_operator_user_referral_reward_stacks_bucket_and_expiry(app, monke
 
 def test_grant_operator_user_referral_reward_extends_empty_active_bucket(
     app, monkeypatch
-):
+) -> None:
     monkeypatch.setattr(
         referral_reward_grants_module,
         "now_utc",
@@ -3099,7 +3123,7 @@ def test_grant_operator_user_referral_reward_extends_empty_active_bucket(
 
 def test_grant_operator_user_referral_reward_is_idempotent_for_repeated_request_id(
     app,
-):
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -3152,7 +3176,7 @@ def test_grant_operator_user_referral_reward_is_idempotent_for_repeated_request_
     assert len(ledger_entries) == 1
 
 
-def test_grant_operator_user_referral_reward_rejects_non_integer_amount(app):
+def test_grant_operator_user_referral_reward_rejects_non_integer_amount(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -3181,7 +3205,7 @@ def test_grant_operator_user_referral_reward_rejects_non_integer_amount(app):
             )
 
 
-def test_grant_operator_user_credits_accepts_legacy_manual_grant_type(app):
+def test_grant_operator_user_credits_accepts_legacy_manual_grant_type(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -3213,7 +3237,7 @@ def test_grant_operator_user_credits_accepts_legacy_manual_grant_type(app):
     assert result.note == "legacy type"
 
 
-def test_grant_operator_user_credits_rejects_unknown_grant_type(app):
+def test_grant_operator_user_credits_rejects_unknown_grant_type(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -3253,7 +3277,7 @@ def test_grant_operator_user_credits_rejects_unknown_grant_type(app):
 
 def test_grant_operator_user_credits_returns_persisted_payload_for_reused_request_id(
     app,
-):
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -3306,7 +3330,7 @@ def test_grant_operator_user_credits_returns_persisted_payload_for_reused_reques
     assert second_result.note == "first grant"
 
 
-def test_grant_operator_user_credits_rejects_regular_user_targets(app):
+def test_grant_operator_user_credits_rejects_regular_user_targets(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -3339,7 +3363,7 @@ def test_grant_operator_user_credits_rejects_regular_user_targets(app):
     )
 
 
-def test_get_operator_user_grant_bootstrap_returns_active_plans(app):
+def test_get_operator_user_grant_bootstrap_returns_active_plans(app) -> None:
     with app.app_context():
         db.session.add_all(
             build_bill_products(product_bids=["bill-product-plan-monthly"])
@@ -3377,7 +3401,7 @@ def test_get_operator_user_grant_bootstrap_returns_active_plans(app):
     assert result.notification_status == "template_pending"
 
 
-def test_grant_operator_user_package_creates_manual_paid_order_and_summary(app):
+def test_grant_operator_user_package_creates_manual_paid_order_and_summary(app) -> None:
     with app.app_context():
         db.session.add_all(
             build_bill_products(product_bids=["bill-product-plan-monthly"])
@@ -3465,7 +3489,7 @@ def test_grant_operator_user_package_creates_manual_paid_order_and_summary(app):
     assert ledger.metadata_json["bill_order_bid"] == result.bill_order_bid
 
 
-def test_grant_operator_user_package_is_idempotent_for_repeated_request_id(app):
+def test_grant_operator_user_package_is_idempotent_for_repeated_request_id(app) -> None:
     with app.app_context():
         db.session.add_all(
             build_bill_products(product_bids=["bill-product-plan-monthly"])
@@ -3509,7 +3533,7 @@ def test_grant_operator_user_package_is_idempotent_for_repeated_request_id(app):
     assert len(orders) == 1
 
 
-def test_grant_operator_user_package_upgrades_active_pingxx_subscription(app):
+def test_grant_operator_user_package_upgrades_active_pingxx_subscription(app) -> None:
     with app.app_context():
         db.session.add_all(
             build_bill_products(
@@ -3576,7 +3600,7 @@ def test_grant_operator_user_package_upgrades_active_pingxx_subscription(app):
     assert subscription.billing_provider == "pingxx"
 
 
-def test_grant_operator_user_package_rejects_active_stripe_subscription(app):
+def test_grant_operator_user_package_rejects_active_stripe_subscription(app) -> None:
     with app.app_context():
         db.session.add_all(
             build_bill_products(
@@ -3626,7 +3650,7 @@ def test_grant_operator_user_package_rejects_active_stripe_subscription(app):
     )
 
 
-def test_list_operator_users_counts_redeem_orders_in_total_paid_amount(app):
+def test_list_operator_users_counts_redeem_orders_in_total_paid_amount(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -3654,7 +3678,9 @@ def test_list_operator_users_counts_redeem_orders_in_total_paid_amount(app):
     assert result.data[0].total_paid_amount == "66"
 
 
-def test_get_operator_user_detail_counts_redeem_orders_in_total_paid_amount(app):
+def test_get_operator_user_detail_counts_redeem_orders_in_total_paid_amount(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -3680,7 +3706,9 @@ def test_get_operator_user_detail_counts_redeem_orders_in_total_paid_amount(app)
     assert item.total_paid_amount == "66"
 
 
-def test_get_operator_user_detail_returns_learning_progress_for_learning_courses(app):
+def test_get_operator_user_detail_returns_learning_progress_for_learning_courses(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -3750,7 +3778,9 @@ def test_get_operator_user_detail_returns_learning_progress_for_learning_courses
     assert item.learning_courses[0].total_lesson_count == 2
 
 
-def test_get_operator_user_detail_uses_latest_progress_state_for_completion(app):
+def test_get_operator_user_detail_uses_latest_progress_state_for_completion(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -3811,7 +3841,9 @@ def test_get_operator_user_detail_uses_latest_progress_state_for_completion(app)
     assert item.learning_courses[0].total_lesson_count == 1
 
 
-def test_get_operator_user_detail_uses_latest_outline_snapshot_for_total_lessons(app):
+def test_get_operator_user_detail_uses_latest_outline_snapshot_for_total_lessons(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -3874,7 +3906,9 @@ def test_get_operator_user_detail_uses_latest_outline_snapshot_for_total_lessons
     assert item.learning_courses[0].total_lesson_count == 1
 
 
-def test_list_operator_users_includes_shared_course_learners_in_learning_courses(app):
+def test_list_operator_users_includes_shared_course_learners_in_learning_courses(
+    app,
+) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -3923,7 +3957,9 @@ def test_list_operator_users_includes_shared_course_learners_in_learning_courses
     ]
 
 
-def test_admin_operation_users_route_requires_operator(test_client, monkeypatch):
+def test_admin_operation_users_route_requires_operator(
+    test_client, monkeypatch
+) -> None:
     _mock_operator(monkeypatch, is_operator=False)
 
     response = test_client.get(
@@ -3939,7 +3975,7 @@ def test_admin_operation_users_route_requires_operator(test_client, monkeypatch)
 def test_admin_operation_users_overview_route_requires_operator(
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch, is_operator=False)
 
     response = test_client.get(
@@ -3956,7 +3992,7 @@ def test_admin_operation_users_overview_route_returns_payload(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -3998,7 +4034,7 @@ def test_admin_operation_users_route_returns_filtered_payload(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -4087,7 +4123,7 @@ def test_admin_operation_users_route_rejects_invalid_filter_params(
     monkeypatch,
     query_string,
     expected_param,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     response = test_client.get(
@@ -4105,7 +4141,7 @@ def test_admin_operation_user_detail_route_returns_payload(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -4160,7 +4196,7 @@ def test_admin_operation_user_credits_route_returns_payload(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -4340,7 +4376,7 @@ def test_admin_operation_user_credits_route_returns_payload(
 def test_admin_operation_user_credits_route_rejects_inverted_time_range(
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     response = test_client.get(
@@ -4359,7 +4395,7 @@ def test_admin_operation_user_credit_grant_route_returns_payload(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -4406,7 +4442,7 @@ def test_admin_operation_user_grant_bootstrap_route_returns_active_plans(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -4452,7 +4488,7 @@ def test_admin_operation_user_grant_bootstrap_route_requires_operator(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch, is_operator=False)
 
     with app.app_context():
@@ -4482,7 +4518,7 @@ def test_admin_operation_user_package_grant_route_returns_payload(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch)
 
     with app.app_context():
@@ -4527,7 +4563,7 @@ def test_admin_operation_user_package_grant_route_requires_operator(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch, is_operator=False)
 
     with app.app_context():
@@ -4565,7 +4601,7 @@ def test_admin_operation_user_credit_grant_route_requires_operator(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch, is_operator=False)
 
     with app.app_context():
@@ -4601,7 +4637,7 @@ def test_admin_operation_user_detail_route_requires_operator(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch, is_operator=False)
 
     with app.app_context():
@@ -4630,7 +4666,7 @@ def test_admin_operation_user_credits_route_requires_operator(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     _mock_operator(monkeypatch, is_operator=False)
 
     with app.app_context():
@@ -4656,7 +4692,7 @@ def test_admin_operation_user_credits_route_requires_operator(
     assert payload["code"] == 401
 
 
-def test_get_operator_user_detail_prefers_latest_auth_credential(app):
+def test_get_operator_user_detail_prefers_latest_auth_credential(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -4706,7 +4742,7 @@ def test_get_operator_user_detail_prefers_latest_auth_credential(app):
     assert result.email == "new@example.com"
 
 
-def test_get_operator_user_detail_ignores_newer_unverified_auth_credential(app):
+def test_get_operator_user_detail_ignores_newer_unverified_auth_credential(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -4789,7 +4825,7 @@ def test_get_operator_user_detail_ignores_newer_unverified_auth_credential(app):
     assert result.email == "new@example.com"
 
 
-def test_get_operator_user_detail_normalizes_unknown_login_methods(app):
+def test_get_operator_user_detail_normalizes_unknown_login_methods(app) -> None:
     with app.app_context():
         _seed_user(
             app,
@@ -4810,7 +4846,7 @@ def test_get_operator_user_detail_normalizes_unknown_login_methods(app):
 
 def test_registration_source_map_skips_user_query_when_users_argument_is_empty(
     app, monkeypatch
-):
+) -> None:
     class ForbiddenUserQuery:
         def filter(self, *_args: object, **_kwargs: object):
             message = "expected no user query when users=[] is provided"
@@ -4840,7 +4876,9 @@ def test_registration_source_map_skips_user_query_when_users_argument_is_empty(
     assert result == {"user-1": "email"}
 
 
-def test_registration_source_map_skips_unknown_provider_when_supported_one_exists(app):
+def test_registration_source_map_skips_unknown_provider_when_supported_one_exists(
+    app,
+) -> None:
     with app.app_context():
         result = admin_module._load_operator_user_registration_source_map(
             ["user-1"],
@@ -4864,7 +4902,9 @@ def test_registration_source_map_skips_unknown_provider_when_supported_one_exist
     assert result == {"user-1": "email"}
 
 
-def test_contact_map_skips_user_query_when_users_argument_is_empty(app, monkeypatch):
+def test_contact_map_skips_user_query_when_users_argument_is_empty(
+    app, monkeypatch
+) -> None:
     class ForbiddenUserQuery:
         def filter(self, *_args: object, **_kwargs: object):
             message = "expected no user query when users=[] is provided"

--- a/src/api/tests/service/shifu/test_admin_voice_clones.py
+++ b/src/api/tests/service/shifu/test_admin_voice_clones.py
@@ -88,7 +88,7 @@ def _seed_voice_clone_rows() -> None:
     db.session.commit()
 
 
-def test_list_operator_voice_clones_returns_owner_course_and_status(app):
+def test_list_operator_voice_clones_returns_owner_course_and_status(app) -> None:
     _prepare_tables(app)
     with app.app_context():
         _clear_rows()
@@ -113,7 +113,7 @@ def test_list_operator_voice_clones_returns_owner_course_and_status(app):
     assert item["charged_credits"] == "1"
 
 
-def test_list_operator_voice_clones_filters_failure_and_provider_code(app):
+def test_list_operator_voice_clones_filters_failure_and_provider_code(app) -> None:
     _prepare_tables(app)
     with app.app_context():
         _clear_rows()
@@ -136,7 +136,7 @@ def test_list_operator_voice_clones_filters_failure_and_provider_code(app):
     assert item["minimax_status_msg"] == "invalid audio"
 
 
-def test_list_operator_voice_clones_filters_voice_name(app):
+def test_list_operator_voice_clones_filters_voice_name(app) -> None:
     _prepare_tables(app)
     with app.app_context():
         _clear_rows()
@@ -153,7 +153,9 @@ def test_list_operator_voice_clones_filters_voice_name(app):
     assert result["items"][0]["voice_bid"] == "voice-ready"
 
 
-def test_list_operator_voice_clones_filters_owner_nickname_without_user_bid(app):
+def test_list_operator_voice_clones_filters_owner_nickname_without_user_bid(
+    app,
+) -> None:
     _prepare_tables(app)
     with app.app_context():
         _clear_rows()
@@ -177,7 +179,7 @@ def test_list_operator_voice_clones_filters_owner_nickname_without_user_bid(app)
     assert user_bid_result["total"] == 0
 
 
-def test_list_operator_voice_clones_filters_course_keyword(app):
+def test_list_operator_voice_clones_filters_course_keyword(app) -> None:
     _prepare_tables(app)
     with app.app_context():
         _clear_rows()
@@ -194,7 +196,7 @@ def test_list_operator_voice_clones_filters_course_keyword(app):
     assert result["items"][0]["voice_bid"] == "voice-ready"
 
 
-def test_list_operator_voice_clones_filters_provider(app):
+def test_list_operator_voice_clones_filters_provider(app) -> None:
     _prepare_tables(app)
     with app.app_context():
         _clear_rows()

--- a/src/api/tests/service/shifu/test_archive.py
+++ b/src/api/tests/service/shifu/test_archive.py
@@ -57,7 +57,7 @@ def _seed_shifu(app, shifu_bid: str, owner_bid: str):
         dao.db.session.commit()
 
 
-def test_archive_then_unarchive_updates_both_tables(app, monkeypatch):
+def test_archive_then_unarchive_updates_both_tables(app, monkeypatch) -> None:
     shifu_bid = "test-archive-toggle"
     owner_bid = "owner-123"
     _seed_shifu(app, shifu_bid, owner_bid)
@@ -110,7 +110,9 @@ def test_archive_then_unarchive_updates_both_tables(app, monkeypatch):
         assert archive.archived_at is None
 
 
-def test_create_shifu_draft_uses_now_utc_for_persisted_timestamps(app, monkeypatch):
+def test_create_shifu_draft_uses_now_utc_for_persisted_timestamps(
+    app, monkeypatch
+) -> None:
     created_at = datetime(2026, 4, 21, 0, 0, 0)
     owner_bid = "owner-create-utc"
     draft_module = _get_draft_module()
@@ -151,7 +153,9 @@ def test_create_shifu_draft_uses_now_utc_for_persisted_timestamps(app, monkeypat
         assert draft.updated_at == created_at
 
 
-def test_create_shifu_draft_initializes_default_chapter_and_lesson(app, monkeypatch):
+def test_create_shifu_draft_initializes_default_chapter_and_lesson(
+    app, monkeypatch
+) -> None:
     owner_bid = "owner-default-outline"
     draft_module = _get_draft_module()
     draft_outline_model, _, draft_struct_model, _ = _get_models()
@@ -213,7 +217,7 @@ def test_create_shifu_draft_initializes_default_chapter_and_lesson(app, monkeypa
 
 def test_default_outline_init_rebuilds_latest_struct_from_empty_history(
     app, monkeypatch
-):
+) -> None:
     owner_bid = "owner-empty-struct-rebuild"
     now_time = datetime(2026, 7, 13, 12, 0, 0)
     draft_module = _get_draft_module()
@@ -309,7 +313,7 @@ def test_default_outline_init_rebuilds_latest_struct_from_empty_history(
 
 def test_create_shifu_draft_skips_risk_check_for_default_outline_content(
     app, monkeypatch
-):
+) -> None:
     owner_bid = "owner-skip-default-outline-risk"
     draft_module = _get_draft_module()
 
@@ -354,7 +358,9 @@ def test_create_shifu_draft_skips_risk_check_for_default_outline_content(
     assert len(draft_risk_calls) == 1
 
 
-def test_create_shifu_draft_raises_when_default_outline_init_fails(app, monkeypatch):
+def test_create_shifu_draft_raises_when_default_outline_init_fails(
+    app, monkeypatch
+) -> None:
     owner_bid = "owner-outline-init-fail"
     draft_module = _get_draft_module()
 
@@ -389,7 +395,7 @@ def test_create_shifu_draft_raises_when_default_outline_init_fails(app, monkeypa
         )
 
 
-def test_archive_requires_creator_permission(app):
+def test_archive_requires_creator_permission(app) -> None:
     shifu_bid = "test-archive-permission"
     creator = "creator-1"
     _seed_shifu(app, shifu_bid, creator)

--- a/src/api/tests/service/shifu/test_ask_config_route.py
+++ b/src/api/tests/service/shifu/test_ask_config_route.py
@@ -3,7 +3,9 @@
 from types import SimpleNamespace
 
 
-def test_ask_config_route_localizes_response_by_user_language(monkeypatch, test_client):
+def test_ask_config_route_localizes_response_by_user_language(
+    monkeypatch, test_client
+) -> None:
     monkeypatch.setattr(
         "flaskr.service.shifu.route.validate_user",
         lambda _app, _token: SimpleNamespace(language="zh-CN"),

--- a/src/api/tests/service/shifu/test_ask_preview_route.py
+++ b/src/api/tests/service/shifu/test_ask_preview_route.py
@@ -95,7 +95,7 @@ def _auth_headers(token: str = _PREVIEW_TOKEN) -> dict[str, str]:
     return {"Token": token}
 
 
-def test_ask_preview_route_success_with_provider(monkeypatch, test_client):
+def test_ask_preview_route_success_with_provider(monkeypatch, test_client) -> None:
     _mock_authenticated_user(monkeypatch)
     fake_langfuse = _FakeLangfuseClient()
 
@@ -156,7 +156,7 @@ def test_ask_preview_route_success_with_provider(monkeypatch, test_client):
     assert trace.updated["output"] == "provider result"
 
 
-def test_ask_preview_route_fallbacks_to_llm(monkeypatch, test_client):
+def test_ask_preview_route_fallbacks_to_llm(monkeypatch, test_client) -> None:
     _mock_authenticated_user(monkeypatch)
 
     def fake_stream_ask_provider_response(*args: object, **kwargs: object):
@@ -205,7 +205,7 @@ def test_ask_preview_route_fallbacks_to_llm(monkeypatch, test_client):
     )
 
 
-def test_ask_preview_route_rejects_empty_query(monkeypatch, test_client):
+def test_ask_preview_route_rejects_empty_query(monkeypatch, test_client) -> None:
     _mock_authenticated_user(monkeypatch)
 
     resp = test_client.post(
@@ -229,7 +229,7 @@ def test_ask_preview_route_rejects_empty_query(monkeypatch, test_client):
 
 def test_ask_preview_route_provider_only_does_not_require_ask_model(
     monkeypatch, test_client
-):
+) -> None:
     _mock_authenticated_user(monkeypatch)
 
     def fake_stream_ask_provider_response(*args: object, **kwargs: object):
@@ -272,7 +272,7 @@ def test_ask_preview_route_provider_only_does_not_require_ask_model(
 
 def test_ask_preview_route_provider_only_accepts_coze_workflow(
     monkeypatch, test_client
-):
+) -> None:
     _mock_authenticated_user(monkeypatch)
 
     def fake_stream_ask_provider_response(*args: object, **kwargs: object):
@@ -315,7 +315,7 @@ def test_ask_preview_route_provider_only_accepts_coze_workflow(
 
 def test_ask_preview_route_provider_only_accepts_get_biji_knowledge(
     monkeypatch, test_client
-):
+) -> None:
     _mock_authenticated_user(monkeypatch)
     captured: dict[str, object] = {}
 
@@ -364,7 +364,9 @@ def test_ask_preview_route_provider_only_accepts_get_biji_knowledge(
     assert runtime.llm_context_stream_factory is not None
 
 
-def test_ask_preview_route_surfaces_friendly_provider_error(monkeypatch, test_client):
+def test_ask_preview_route_surfaces_friendly_provider_error(
+    monkeypatch, test_client
+) -> None:
     _mock_authenticated_user(monkeypatch)
 
     def fake_stream_ask_provider_response(*args: object, **kwargs: object):
@@ -412,7 +414,7 @@ def test_ask_preview_route_surfaces_friendly_provider_error(monkeypatch, test_cl
 
 def test_ask_preview_route_falls_back_to_generic_provider_error(
     monkeypatch, test_client
-):
+) -> None:
     _mock_authenticated_user(monkeypatch)
 
     def fake_stream_ask_provider_response(*args: object, **kwargs: object):
@@ -453,7 +455,7 @@ def test_ask_preview_route_falls_back_to_generic_provider_error(
 
 def test_ask_preview_route_uses_authenticated_creator_for_debug_billing(
     monkeypatch, test_client
-):
+) -> None:
     fake_langfuse = _FakeLangfuseClient()
     captured: dict[str, object] = {}
 
@@ -528,7 +530,7 @@ def test_ask_preview_route_uses_authenticated_creator_for_debug_billing(
 
 def test_ask_preview_route_passes_debug_usage_context_for_creator(
     monkeypatch, test_client
-):
+) -> None:
     fake_langfuse = _FakeLangfuseClient()
     captured: dict[str, object] = {}
 

--- a/src/api/tests/service/shifu/test_ask_provider_registry.py
+++ b/src/api/tests/service/shifu/test_ask_provider_registry.py
@@ -4,7 +4,7 @@ from flaskr.i18n import set_language
 from flaskr.service.shifu import ask_provider_registry as module
 
 
-def test_validate_dify_requires_shifu_level_base_url_and_api_key():
+def test_validate_dify_requires_shifu_level_base_url_and_api_key() -> None:
     is_valid, field = module.validate_ask_provider_specific_config(
         "dify", {"conversation_id": "conv-1"}
     )
@@ -13,7 +13,7 @@ def test_validate_dify_requires_shifu_level_base_url_and_api_key():
     assert field == "base_url"
 
 
-def test_validate_dify_shifu_level_config_success():
+def test_validate_dify_shifu_level_config_success() -> None:
     is_valid, field = module.validate_ask_provider_specific_config(
         "dify",
         {
@@ -27,7 +27,7 @@ def test_validate_dify_shifu_level_config_success():
     assert field is None
 
 
-def test_validate_coze_requires_api_key_and_bot_id():
+def test_validate_coze_requires_api_key_and_bot_id() -> None:
     is_valid, field = module.validate_ask_provider_specific_config(
         "coze",
         {
@@ -39,7 +39,7 @@ def test_validate_coze_requires_api_key_and_bot_id():
     assert field == "bot_id"
 
 
-def test_validate_coze_workflow_requires_api_key_and_workflow_id():
+def test_validate_coze_workflow_requires_api_key_and_workflow_id() -> None:
     is_valid, field = module.validate_ask_provider_specific_config(
         "coze_workflow",
         {
@@ -51,7 +51,7 @@ def test_validate_coze_workflow_requires_api_key_and_workflow_id():
     assert field == "workflow_id"
 
 
-def test_validate_coze_workflow_config_success():
+def test_validate_coze_workflow_config_success() -> None:
     is_valid, field = module.validate_ask_provider_specific_config(
         "coze_workflow",
         {
@@ -65,7 +65,7 @@ def test_validate_coze_workflow_config_success():
     assert field is None
 
 
-def test_validate_volc_knowledge_requires_account_credentials_and_collection():
+def test_validate_volc_knowledge_requires_account_credentials_and_collection() -> None:
     is_valid, field = module.validate_ask_provider_specific_config(
         "volc_knowledge",
         {
@@ -80,7 +80,7 @@ def test_validate_volc_knowledge_requires_account_credentials_and_collection():
     assert field == "sk"
 
 
-def test_validate_volc_knowledge_config_success():
+def test_validate_volc_knowledge_config_success() -> None:
     is_valid, field = module.validate_ask_provider_specific_config(
         "volc_knowledge",
         {
@@ -95,7 +95,7 @@ def test_validate_volc_knowledge_config_success():
     assert field is None
 
 
-def test_validate_get_biji_knowledge_requires_credentials_and_topic():
+def test_validate_get_biji_knowledge_requires_credentials_and_topic() -> None:
     is_valid, field = module.validate_ask_provider_specific_config(
         "get_biji_knowledge",
         {
@@ -109,7 +109,7 @@ def test_validate_get_biji_knowledge_requires_credentials_and_topic():
     assert field == "client_id"
 
 
-def test_validate_get_biji_knowledge_rejects_top_k_out_of_range():
+def test_validate_get_biji_knowledge_rejects_top_k_out_of_range() -> None:
     base_config = {
         "api_key": "gk-live-1",
         "client_id": "cli-1",
@@ -126,7 +126,7 @@ def test_validate_get_biji_knowledge_rejects_top_k_out_of_range():
         assert field == "top_k"
 
 
-def test_validate_get_biji_knowledge_accepts_top_k_boundaries():
+def test_validate_get_biji_knowledge_accepts_top_k_boundaries() -> None:
     base_config = {
         "api_key": "gk-live-1",
         "client_id": "cli-1",
@@ -143,7 +143,7 @@ def test_validate_get_biji_knowledge_accepts_top_k_boundaries():
         assert field is None
 
 
-def test_validate_get_biji_knowledge_config_success():
+def test_validate_get_biji_knowledge_config_success() -> None:
     is_valid, field = module.validate_ask_provider_specific_config(
         "get_biji_knowledge",
         {
@@ -158,7 +158,7 @@ def test_validate_get_biji_knowledge_config_success():
     assert field is None
 
 
-def test_ask_provider_metadata_contains_shifu_level_defaults():
+def test_ask_provider_metadata_contains_shifu_level_defaults() -> None:
     metadata = module.get_ask_provider_metadata()
     providers = {item["provider"]: item for item in metadata.get("providers", [])}
 
@@ -194,7 +194,7 @@ def test_ask_provider_metadata_contains_shifu_level_defaults():
     }
 
 
-def test_ask_provider_metadata_marks_api_key_as_password():
+def test_ask_provider_metadata_marks_api_key_as_password() -> None:
     metadata = module.get_ask_provider_metadata()
     providers = {item["provider"]: item for item in metadata.get("providers", [])}
 
@@ -243,7 +243,7 @@ def test_ask_provider_metadata_marks_api_key_as_password():
     assert get_biji_api_key.get("format") == "password"
 
 
-def test_ask_provider_metadata_includes_all_providers():
+def test_ask_provider_metadata_includes_all_providers() -> None:
     metadata = module.get_ask_provider_metadata()
     providers = {item["provider"] for item in metadata.get("providers", [])}
 
@@ -258,7 +258,7 @@ def test_ask_provider_metadata_includes_all_providers():
     }
 
 
-def test_ask_provider_metadata_exposes_minimal_schema_properties():
+def test_ask_provider_metadata_exposes_minimal_schema_properties() -> None:
     metadata = module.get_ask_provider_metadata()
     providers = {item["provider"]: item for item in metadata.get("providers", [])}
 
@@ -294,7 +294,7 @@ def test_ask_provider_metadata_exposes_minimal_schema_properties():
     assert set(get_biji_fields) == {"api_key", "client_id", "topic_id", "top_k"}
 
 
-def test_ask_provider_metadata_localizes_text_for_zh_cn(app):
+def test_ask_provider_metadata_localizes_text_for_zh_cn(app) -> None:
     _ = app
     set_language("zh-CN")
     try:

--- a/src/api/tests/service/shifu/test_course_copy.py
+++ b/src/api/tests/service/shifu/test_course_copy.py
@@ -249,7 +249,7 @@ def _seed_course_variable(
     _clear_config_caches()
 
 
-def test_copy_course_allows_same_creator_and_clones_latest_draft(app):
+def test_copy_course_allows_same_creator_and_clones_latest_draft(app) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     creator_bid = uuid.uuid4().hex[:32]
     viewer_bid = uuid.uuid4().hex[:32]
@@ -356,7 +356,7 @@ def test_copy_course_allows_same_creator_and_clones_latest_draft(app):
 
 def test_copy_course_creates_missing_target_user_and_grants_creator_role(
     app, monkeypatch
-):
+) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     creator_bid = uuid.uuid4().hex[:32]
     target_email = f"{uuid.uuid4().hex[:10]}@example.com"
@@ -413,7 +413,7 @@ def test_copy_course_creates_missing_target_user_and_grants_creator_role(
         ]
 
 
-def test_copy_course_reuses_existing_google_creator_account(app):
+def test_copy_course_reuses_existing_google_creator_account(app) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     creator_bid = uuid.uuid4().hex[:32]
     target_user_bid = uuid.uuid4().hex[:32]
@@ -467,7 +467,7 @@ def test_copy_course_reuses_existing_google_creator_account(app):
         assert email_credential is not None
 
 
-def test_copy_course_skips_deleted_outlines_and_copies_course_variables(app):
+def test_copy_course_skips_deleted_outlines_and_copies_course_variables(app) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     creator_bid = uuid.uuid4().hex[:32]
     creator_email = _unique_email("variables-owner")
@@ -544,7 +544,7 @@ def test_copy_course_skips_deleted_outlines_and_copies_course_variables(app):
         assert copied_variables[0].variable_bid
 
 
-def test_copy_course_rejects_builtin_demo_course(app):
+def test_copy_course_rejects_builtin_demo_course(app) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     target_email = _unique_email("demo-copy")
 
@@ -581,7 +581,7 @@ def test_copy_course_rejects_builtin_demo_course(app):
         assert DraftShifu.query.filter_by(shifu_bid=shifu_bid, deleted=0).count() == 1
 
 
-def test_copy_course_requires_operator_user_bid(app):
+def test_copy_course_requires_operator_user_bid(app) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     creator_bid = uuid.uuid4().hex[:32]
     creator_email = _unique_email("owner")
@@ -610,7 +610,7 @@ def test_copy_course_requires_operator_user_bid(app):
         assert "operator_user_bid" in exc_info.value.message
 
 
-def test_copy_course_route_for_operator(app, test_client, monkeypatch):
+def test_copy_course_route_for_operator(app, test_client, monkeypatch) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     creator_bid = uuid.uuid4().hex[:32]
     owner_email = _unique_email("route-owner")
@@ -699,7 +699,9 @@ def test_copy_course_route_for_operator(app, test_client, monkeypatch):
     assert risk_checks == expected_risk_checks
 
 
-def test_copy_course_route_rejects_non_object_payload(app, test_client, monkeypatch):
+def test_copy_course_route_rejects_non_object_payload(
+    app, test_client, monkeypatch
+) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     creator_bid = uuid.uuid4().hex[:32]
     owner_email = _unique_email("route-owner")
@@ -724,7 +726,9 @@ def test_copy_course_route_rejects_non_object_payload(app, test_client, monkeypa
     assert payload["code"] == ERROR_CODE["server.common.paramsError"]
 
 
-def test_copy_course_risk_rejection_does_not_create_target_user(app, monkeypatch):
+def test_copy_course_risk_rejection_does_not_create_target_user(
+    app, monkeypatch
+) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     creator_bid = uuid.uuid4().hex[:32]
     target_email = f"{uuid.uuid4().hex[:10]}@example.com"

--- a/src/api/tests/service/shifu/test_create_outlines_batch.py
+++ b/src/api/tests/service/shifu/test_create_outlines_batch.py
@@ -66,7 +66,7 @@ def _positions(shifu_bid: str) -> list[str]:
     return [r.position for r in rows]
 
 
-def test_batch_assigns_unique_sequential_positions(app):
+def test_batch_assigns_unique_sequential_positions(app) -> None:
     shifu_bid = "shifu_batch_1"
     with app.app_context():
         _seed_shifu(shifu_bid)
@@ -95,7 +95,7 @@ def test_batch_assigns_unique_sequential_positions(app):
         assert_outline_tree_publishable(app, shifu_bid)
 
 
-def test_batch_of_many_siblings_never_collides(app):
+def test_batch_of_many_siblings_never_collides(app) -> None:
     shifu_bid = "shifu_batch_many"
     with app.app_context():
         _seed_shifu(shifu_bid)
@@ -112,7 +112,7 @@ def test_batch_of_many_siblings_never_collides(app):
         assert_outline_tree_publishable(app, shifu_bid)
 
 
-def test_batch_nested_under_existing_parent(app):
+def test_batch_nested_under_existing_parent(app) -> None:
     shifu_bid = "shifu_batch_parent"
     with app.app_context():
         _seed_shifu(shifu_bid)
@@ -130,7 +130,7 @@ def test_batch_nested_under_existing_parent(app):
         assert_outline_tree_publishable(app, shifu_bid)
 
 
-def test_sequential_single_creates_still_increment(app):
+def test_sequential_single_creates_still_increment(app) -> None:
     shifu_bid = "shifu_single_seq"
     with app.app_context():
         _seed_shifu(shifu_bid)
@@ -142,7 +142,7 @@ def test_sequential_single_creates_still_increment(app):
         assert_outline_tree_publishable(app, shifu_bid)
 
 
-def test_batch_risk_checks_every_node(app, monkeypatch):
+def test_batch_risk_checks_every_node(app, monkeypatch) -> None:
     """Every node (including nested children) is risk-checked exactly once.
 
     The check runs before the per-shifu lock is taken, so no external network
@@ -171,7 +171,7 @@ def test_batch_risk_checks_every_node(app, monkeypatch):
     assert len(checked) == 4
 
 
-def test_batch_rejects_empty_payload(app):
+def test_batch_rejects_empty_payload(app) -> None:
     shifu_bid = "shifu_batch_empty"
     with app.app_context():
         _seed_shifu(shifu_bid)

--- a/src/api/tests/service/shifu/test_demo_courses.py
+++ b/src/api/tests/service/shifu/test_demo_courses.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from flask import Flask
 from flaskr import dao
 from flaskr.service.shifu.demo_courses import is_builtin_demo_shifu
 from flaskr.service.shifu.models import PublishedShifu
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture
-def demo_course_app():
+def demo_course_app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(

--- a/src/api/tests/service/shifu/test_dtos.py
+++ b/src/api/tests/service/shifu/test_dtos.py
@@ -4,7 +4,7 @@ from flaskr.service.shifu.consts import STATUS_PUBLISHED
 from flaskr.service.shifu.dtos import ShifuDto
 
 
-def test_shifu_dto_json_includes_state():
+def test_shifu_dto_json_includes_state() -> None:
     dto = ShifuDto(
         shifu_id="course-1",
         shifu_name="Course 1",

--- a/src/api/tests/service/shifu/test_guide_course_flag.py
+++ b/src/api/tests/service/shifu/test_guide_course_flag.py
@@ -12,7 +12,7 @@ from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.util.datetime import now_utc
 
 
-def test_get_shifu_draft_list_marks_builtin_guide_course(app, monkeypatch):
+def test_get_shifu_draft_list_marks_builtin_guide_course(app, monkeypatch) -> None:
     user_bid = uuid.uuid4().hex[:32]
     guide_bid = uuid.uuid4().hex[:32]
     regular_bid = uuid.uuid4().hex[:32]

--- a/src/api/tests/service/shifu/test_mdflow_history_routes.py
+++ b/src/api/tests/service/shifu/test_mdflow_history_routes.py
@@ -72,7 +72,7 @@ def _seed_shifu_with_outline(
 
 def test_create_outline_route_rejects_missing_name_without_500(
     monkeypatch, test_client, app
-):
+) -> None:
     shifu_bid = "test-route-create-outline-invalid-name"
     outline_bid = "test-route-create-outline-seed"
     owner_bid = "test-route-create-outline-owner"
@@ -92,7 +92,7 @@ def test_create_outline_route_rejects_missing_name_without_500(
 
 def test_save_mdflow_route_rejects_non_object_json_without_500(
     monkeypatch, test_client, app
-):
+) -> None:
     shifu_bid = "test-route-save-mdflow-invalid-body"
     outline_bid = "test-route-save-mdflow-invalid-outline"
     owner_bid = "test-route-save-mdflow-invalid-owner"
@@ -110,7 +110,9 @@ def test_save_mdflow_route_rejects_non_object_json_without_500(
     assert payload["code"] == ERROR_CODE["server.common.paramsError"]
 
 
-def test_get_mdflow_history_version_detail_route_success(monkeypatch, test_client, app):
+def test_get_mdflow_history_version_detail_route_success(
+    monkeypatch, test_client, app
+) -> None:
     shifu_bid = "test-route-history-detail-1"
     outline_bid = "test-route-outline-1"
     owner_bid = "test-route-owner-1"
@@ -141,7 +143,7 @@ def test_get_mdflow_history_version_detail_route_success(monkeypatch, test_clien
 
 def test_get_mdflow_history_version_detail_route_rejects_invalid_version_id(
     monkeypatch, test_client, app
-):
+) -> None:
     shifu_bid = "test-route-history-detail-2"
     outline_bid = "test-route-outline-2"
     owner_bid = "test-route-owner-2"
@@ -166,7 +168,7 @@ def test_get_mdflow_history_version_detail_route_rejects_invalid_version_id(
 
 def test_restore_mdflow_history_route_returns_deleted_flag(
     monkeypatch, test_client, app
-):
+) -> None:
     shifu_bid = "test-route-history-restore-1"
     outline_bid = "test-route-outline-restore-1"
     owner_bid = "test-route-owner-restore-1"

--- a/src/api/tests/service/shifu/test_minimax_voice_clone_routes.py
+++ b/src/api/tests/service/shifu/test_minimax_voice_clone_routes.py
@@ -126,7 +126,9 @@ def _auth(monkeypatch, user_bid: str = "creator-route") -> None:
     monkeypatch.setattr("flaskr.service.shifu.route.validate_user", lambda *_args: user)
 
 
-def test_minimax_voice_clone_cost_is_zero_without_rate(app, test_client, monkeypatch):
+def test_minimax_voice_clone_cost_is_zero_without_rate(
+    app, test_client, monkeypatch
+) -> None:
     _prepare_minimax_tables(app)
     _auth(monkeypatch)
     monkeypatch.setattr(
@@ -154,7 +156,7 @@ def test_minimax_voice_clone_cost_is_zero_without_rate(app, test_client, monkeyp
     assert payload["data"]["billing_enabled"] is True
 
 
-def test_minimax_validate_custom_voice_id_route(app, test_client, monkeypatch):
+def test_minimax_validate_custom_voice_id_route(app, test_client, monkeypatch) -> None:
     _prepare_minimax_tables(app)
     _auth(monkeypatch)
 
@@ -173,7 +175,7 @@ def test_minimax_voice_clone_submit_creates_queued_voice(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     from flaskr.service.tts.models import (
         TTS_MINIMAX_CLONE_STATUS_QUEUED,
         TTSMiniMaxClonedVoice,
@@ -242,7 +244,7 @@ def test_minimax_voice_clone_submit_rejects_insufficient_credits(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     from flaskr.service.tts.models import TTSMiniMaxClonedVoice
 
     _prepare_minimax_tables(app)
@@ -287,7 +289,7 @@ def test_minimax_voice_routes_only_expose_current_owner_voices(
     app,
     test_client,
     monkeypatch,
-):
+) -> None:
     from flaskr.service.tts.models import (
         TTS_MINIMAX_CLONE_STATUS_FAILED,
         TTS_MINIMAX_CLONE_STATUS_READY,

--- a/src/api/tests/service/shifu/test_operator_voice_clone_register.py
+++ b/src/api/tests/service/shifu/test_operator_voice_clone_register.py
@@ -91,7 +91,9 @@ def _bypass_voice_verification(monkeypatch) -> None:
     )
 
 
-def test_operator_voice_clone_register_requires_operator(app, test_client, monkeypatch):
+def test_operator_voice_clone_register_requires_operator(
+    app, test_client, monkeypatch
+) -> None:
     _prepare_minimax_tables(app)
     _mock_operator(monkeypatch, is_operator=False)
 
@@ -111,7 +113,7 @@ def test_operator_voice_clone_register_requires_operator(app, test_client, monke
 
 def test_operator_voice_clone_register_creates_ready_free_voice(
     app, test_client, monkeypatch
-):
+) -> None:
     from flaskr.service.tts.models import (
         TTS_MINIMAX_CLONE_BILLING_NOT_REQUIRED,
         TTS_MINIMAX_CLONE_STATUS_READY,
@@ -155,7 +157,7 @@ def test_operator_voice_clone_register_creates_ready_free_voice(
 
 def test_operator_voice_clone_register_rejects_non_teacher_owner(
     app, test_client, monkeypatch
-):
+) -> None:
     _prepare_minimax_tables(app)
     _seed_teacher(app, user_bid="not-a-teacher", is_creator=False)
     _mock_operator(monkeypatch)
@@ -195,7 +197,7 @@ def _forbid_minimax_synthesis(monkeypatch) -> None:
 
 def test_operator_voice_clone_register_volcengine_uses_free_status_check(
     app, test_client, monkeypatch
-):
+) -> None:
     from flaskr.service.tts.models import (
         TTS_MINIMAX_CLONE_BILLING_NOT_REQUIRED,
         TTS_MINIMAX_CLONE_STATUS_READY,
@@ -238,7 +240,7 @@ def test_operator_voice_clone_register_volcengine_uses_free_status_check(
 
 def test_operator_voice_clone_register_volcengine_rejects_bad_id_shape(
     app, test_client, monkeypatch
-):
+) -> None:
     _prepare_minimax_tables(app)
     _seed_teacher(app, user_bid="teacher-volc-2")
     _mock_operator(monkeypatch)
@@ -261,7 +263,7 @@ def test_operator_voice_clone_register_volcengine_rejects_bad_id_shape(
 
 def test_operator_voice_clone_register_volcengine_rejects_untrained_voice(
     app, test_client, monkeypatch
-):
+) -> None:
     _prepare_minimax_tables(app)
     _seed_teacher(app, user_bid="teacher-volc-3")
     _mock_operator(monkeypatch)
@@ -285,7 +287,7 @@ def test_operator_voice_clone_register_volcengine_rejects_untrained_voice(
 
 def test_operator_voice_clone_register_rejects_unknown_provider(
     app, test_client, monkeypatch
-):
+) -> None:
     _prepare_minimax_tables(app)
     _seed_teacher(app, user_bid="teacher-volc-4")
     _mock_operator(monkeypatch)
@@ -307,7 +309,7 @@ def test_operator_voice_clone_register_rejects_unknown_provider(
 
 def test_operator_voice_clone_register_same_voice_id_across_providers(
     app, test_client, monkeypatch
-):
+) -> None:
     from flaskr.service.tts.models import TTSMiniMaxClonedVoice
 
     _prepare_minimax_tables(app)
@@ -356,7 +358,7 @@ def test_operator_voice_clone_register_same_voice_id_across_providers(
         assert providers == {"minimax", "volcengine"}
 
 
-def test_teacher_voice_list_filters_by_provider(app, test_client, monkeypatch):
+def test_teacher_voice_list_filters_by_provider(app, test_client, monkeypatch) -> None:
     _prepare_minimax_tables(app)
     _seed_teacher(app, user_bid="teacher-filter")
     _mock_operator(monkeypatch)
@@ -399,7 +401,9 @@ def test_teacher_voice_list_filters_by_provider(app, test_client, monkeypatch):
     }
 
 
-def test_operator_registered_voice_visible_only_to_owner(app, test_client, monkeypatch):
+def test_operator_registered_voice_visible_only_to_owner(
+    app, test_client, monkeypatch
+) -> None:
     _prepare_minimax_tables(app)
     _seed_teacher(app, user_bid="teacher-a", identify="13800000001")
     _seed_teacher(app, user_bid="teacher-b", identify="13800000002")

--- a/src/api/tests/service/shifu/test_outline_history_buffered_pagination.py
+++ b/src/api/tests/service/shifu/test_outline_history_buffered_pagination.py
@@ -38,7 +38,7 @@ def _cleanup():
     db.session.commit()
 
 
-def test_yields_all_versions_newest_first_across_batches(app):
+def test_yields_all_versions_newest_first_across_batches(app) -> None:
     with app.app_context():
         _cleanup()
         expected_ids = _seed_versions(7)
@@ -52,7 +52,7 @@ def test_yields_all_versions_newest_first_across_batches(app):
         _cleanup()
 
 
-def test_max_rows_caps_the_scan(app):
+def test_max_rows_caps_the_scan(app) -> None:
     with app.app_context():
         _cleanup()
         expected_ids = _seed_versions(6)
@@ -68,7 +68,7 @@ def test_max_rows_caps_the_scan(app):
         _cleanup()
 
 
-def test_early_break_leaves_session_usable(app):
+def test_early_break_leaves_session_usable(app) -> None:
     with app.app_context():
         _cleanup()
         expected_ids = _seed_versions(5)
@@ -86,7 +86,7 @@ def test_early_break_leaves_session_usable(app):
         _cleanup()
 
 
-def test_skips_deleted_versions(app):
+def test_skips_deleted_versions(app) -> None:
     with app.app_context():
         _cleanup()
         ids = _seed_versions(4)

--- a/src/api/tests/service/shifu/test_outline_repair.py
+++ b/src/api/tests/service/shifu/test_outline_repair.py
@@ -53,7 +53,7 @@ def _mk_outline(
     return row
 
 
-def test_repair_shifu_outline_structure_dry_run_is_non_destructive(app):
+def test_repair_shifu_outline_structure_dry_run_is_non_destructive(app) -> None:
     with app.app_context():
         _mk_shifu("shifu-dry-run")
         _mk_outline("shifu-dry-run", "root-1", "01")
@@ -76,7 +76,9 @@ def test_repair_shifu_outline_structure_dry_run_is_non_destructive(app):
     assert before_latest_id == after_latest_id
 
 
-def test_repair_shifu_outline_structure_repairs_collision_and_rebuilds_struct(app):
+def test_repair_shifu_outline_structure_repairs_collision_and_rebuilds_struct(
+    app,
+) -> None:
     with app.app_context():
         shifu = _mk_shifu("shifu-repair-1")
         shifu_db_id = shifu.id
@@ -131,7 +133,7 @@ def test_repair_shifu_outline_structure_repairs_collision_and_rebuilds_struct(ap
 
 def test_repair_shifu_outline_structure_skips_invalid_position_format_without_crashing(
     app,
-):
+) -> None:
     with app.app_context():
         _mk_shifu("shifu-invalid-position")
         _mk_outline("shifu-invalid-position", "root-1", "01")
@@ -157,7 +159,9 @@ def test_repair_shifu_outline_structure_skips_invalid_position_format_without_cr
     assert "Unsupported position format" in result.skipped_records[0].reason
 
 
-def test_repair_shifu_outline_structure_requires_user_bid_before_processing(app):
+def test_repair_shifu_outline_structure_requires_user_bid_before_processing(
+    app,
+) -> None:
     with app.app_context():
         _mk_shifu("shifu-user-bid-check")
         _mk_outline("shifu-user-bid-check", "root-1", "01")
@@ -175,7 +179,7 @@ def test_repair_shifu_outline_structure_requires_user_bid_before_processing(app)
     assert "user_bid is required" in str(exc_info.value)
 
 
-def test_repair_shifu_outline_structure_handles_non_numeric_suffixes(app):
+def test_repair_shifu_outline_structure_handles_non_numeric_suffixes(app) -> None:
     with app.app_context():
         _mk_shifu("shifu-nonnumeric-suffix")
         _mk_outline("shifu-nonnumeric-suffix", "root-1", "01")
@@ -205,7 +209,7 @@ def test_repair_shifu_outline_structure_handles_non_numeric_suffixes(app):
     assert result.changed_outline_count == 2
 
 
-def test_repair_shifu_outline_structure_detects_parent_position_mismatch(app):
+def test_repair_shifu_outline_structure_detects_parent_position_mismatch(app) -> None:
     with app.app_context():
         _mk_shifu("shifu-parent-position-mismatch")
         _mk_outline("shifu-parent-position-mismatch", "root-a", "01")

--- a/src/api/tests/service/shifu/test_permissions.py
+++ b/src/api/tests/service/shifu/test_permissions.py
@@ -133,7 +133,7 @@ def _ensure_trial_billing_enabled(monkeypatch):
 class TestShifuPermissions:
     """Verify shifu permissions behavior."""
 
-    def test_list_permissions_only_active(self, monkeypatch, test_client, app):
+    def test_list_permissions_only_active(self, monkeypatch, test_client, app) -> None:
         shifu_bid = "test-permission-list"
         owner_id = "owner-1"
         active_user = "user-active"
@@ -169,7 +169,9 @@ class TestShifuPermissions:
         assert len(items) == 1
         assert items[0]["user_id"] == active_user
 
-    def test_remove_permissions_soft_delete(self, monkeypatch, test_client, app):
+    def test_remove_permissions_soft_delete(
+        self, monkeypatch, test_client, app
+    ) -> None:
         shifu_bid = "test-permission-remove"
         owner_id = "owner-2"
         target_user = "user-target"
@@ -198,7 +200,7 @@ class TestShifuPermissions:
 
     def test_grant_view_permission_does_not_promote_creator(
         self, monkeypatch, test_client, app
-    ):
+    ) -> None:
         shifu_bid = "test-permission-grant-view"
         owner_id = "owner-grant-view"
         target_user = "user-grant-view"
@@ -241,7 +243,7 @@ class TestShifuPermissions:
         app,
         permission: str,
         expected_auth_types: list[str],
-    ):
+    ) -> None:
         shifu_bid = f"test-permission-grant-{permission}"
         owner_id = f"owner-grant-{permission}"
         target_user = f"user-grant-{permission}"

--- a/src/api/tests/service/shifu/test_reorder_outline_conversion.py
+++ b/src/api/tests/service/shifu/test_reorder_outline_conversion.py
@@ -7,7 +7,7 @@ from flaskr.service.shifu.shifu_outline_funcs import (
 )
 
 
-def test_convert_accepts_nested_outline_tree():
+def test_convert_accepts_nested_outline_tree() -> None:
     dtos = convert_outline_to_reorder_outline_item_dto(
         [
             {
@@ -22,7 +22,7 @@ def test_convert_accepts_nested_outline_tree():
     assert [child.bid for child in dtos[0].children] == ["child"]
 
 
-def test_convert_tolerates_null_children():
+def test_convert_tolerates_null_children() -> None:
     # A leaf node may send "children": null instead of omitting the key; it
     # should be treated as an empty child list rather than raising.
     dtos = convert_outline_to_reorder_outline_item_dto(
@@ -32,17 +32,17 @@ def test_convert_tolerates_null_children():
     assert dtos[0].children == []
 
 
-def test_convert_accepts_empty_list():
+def test_convert_accepts_empty_list() -> None:
     assert convert_outline_to_reorder_outline_item_dto([]) == []
 
 
 @pytest.mark.parametrize("bad_value", [None, {}, "outlines", 42])
-def test_convert_rejects_non_list_top_level(bad_value):
+def test_convert_rejects_non_list_top_level(bad_value) -> None:
     with pytest.raises(AppError):
         convert_outline_to_reorder_outline_item_dto(bad_value)
 
 
 @pytest.mark.parametrize("bad_item", ["not-a-dict", 1, ["nested"], None])
-def test_convert_rejects_non_dict_items(bad_item):
+def test_convert_rejects_non_dict_items(bad_item) -> None:
     with pytest.raises(AppError):
         convert_outline_to_reorder_outline_item_dto([bad_item])

--- a/src/api/tests/service/shifu/test_reorder_outline_tree.py
+++ b/src/api/tests/service/shifu/test_reorder_outline_tree.py
@@ -94,7 +94,7 @@ def _latest_outline_by_bid(shifu_bid: str) -> dict[str, DraftOutlineItem]:
     return latest_by_bid
 
 
-def test_reorder_outline_tree_updates_parent_bid_for_cross_parent_move(app):
+def test_reorder_outline_tree_updates_parent_bid_for_cross_parent_move(app) -> None:
     shifu_bid = "shifu_reorder_parent_fix"
     with app.app_context():
         _seed_shifu(shifu_bid)
@@ -129,7 +129,9 @@ def test_reorder_outline_tree_updates_parent_bid_for_cross_parent_move(app):
         assert_outline_tree_publishable(app, shifu_bid)
 
 
-def test_reorder_outline_tree_updates_parent_bid_when_promoting_child_to_root(app):
+def test_reorder_outline_tree_updates_parent_bid_when_promoting_child_to_root(
+    app,
+) -> None:
     shifu_bid = "shifu_reorder_root_fix"
     with app.app_context():
         _seed_shifu(shifu_bid)

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -92,7 +92,7 @@ def _mock_route_permission(monkeypatch, permission_map: dict[str, bool]):
 
 def test_save_shifu_draft_info_keeps_existing_price_when_input_is_none(
     app, monkeypatch
-):
+) -> None:
     from flaskr.service.shifu import shifu_draft_funcs
     from flaskr.service.shifu.models import DraftShifu
 
@@ -130,7 +130,9 @@ def test_save_shifu_draft_info_keeps_existing_price_when_input_is_none(
         assert DraftShifu.query.filter_by(shifu_bid=shifu_bid, deleted=0).count() == 1
 
 
-def test_save_and_get_shifu_draft_info_roundtrip_ask_provider_config(app, monkeypatch):
+def test_save_and_get_shifu_draft_info_roundtrip_ask_provider_config(
+    app, monkeypatch
+) -> None:
     from flaskr.service.shifu import shifu_draft_funcs
     from flaskr.service.shifu.models import DraftShifu
 
@@ -201,7 +203,7 @@ def test_save_and_get_shifu_draft_info_roundtrip_ask_provider_config(app, monkey
     assert detail.ask_provider_config == ask_provider_config
 
 
-def test_save_shifu_draft_info_normalizes_removed_tts_fields(app, monkeypatch):
+def test_save_shifu_draft_info_normalizes_removed_tts_fields(app, monkeypatch) -> None:
     from flaskr.service.shifu import shifu_draft_funcs
     from flaskr.service.shifu.models import DraftShifu
 
@@ -268,7 +270,7 @@ def test_save_shifu_draft_info_normalizes_removed_tts_fields(app, monkeypatch):
 
 def test_save_shifu_draft_info_normalizes_legacy_tts_fields_when_omitted(
     app, monkeypatch
-):
+) -> None:
     from flaskr.service.shifu import shifu_draft_funcs
     from flaskr.service.shifu.models import DraftShifu
 
@@ -342,7 +344,9 @@ def test_save_shifu_draft_info_normalizes_legacy_tts_fields_when_omitted(
         assert latest.tts_emotion == ""
 
 
-def test_save_shifu_draft_info_persists_default_listen_mode_setting(app, monkeypatch):
+def test_save_shifu_draft_info_persists_default_listen_mode_setting(
+    app, monkeypatch
+) -> None:
     from flaskr.service.shifu import shifu_draft_funcs
     from flaskr.service.shifu.models import DraftShifu
 
@@ -400,7 +404,7 @@ def test_save_shifu_draft_info_persists_default_listen_mode_setting(app, monkeyp
 
 def test_save_shifu_draft_info_clears_default_listen_mode_when_tts_is_disabled(
     app, monkeypatch
-):
+) -> None:
     from flaskr.service.shifu import shifu_draft_funcs
     from flaskr.service.shifu.models import DraftShifu
 
@@ -454,7 +458,7 @@ def test_save_shifu_draft_info_clears_default_listen_mode_when_tts_is_disabled(
 )
 def test_save_shifu_detail_route_rejects_invalid_default_listen_mode_enabled(
     app, test_client, monkeypatch, invalid_value
-):
+) -> None:
     shifu_bid = "test-save-shifu-default-listen-invalid"
     owner_bid = "owner-default-listen-invalid"
     _seed_shifu(app, shifu_bid, owner_bid, Decimal("1.23"))
@@ -472,7 +476,9 @@ def test_save_shifu_detail_route_rejects_invalid_default_listen_mode_enabled(
     assert payload["code"] != 0
 
 
-def test_get_draft_meta_route_serializes_utc_timestamp(app, test_client, monkeypatch):
+def test_get_draft_meta_route_serializes_utc_timestamp(
+    app, test_client, monkeypatch
+) -> None:
     from flaskr.service.shifu.models import DraftOutlineItem
 
     shifu_bid = "test-draft-meta-timezone"
@@ -513,7 +519,7 @@ def test_get_draft_meta_route_serializes_utc_timestamp(app, test_client, monkeyp
 
 def test_get_draft_meta_route_allows_view_only_permission(
     app, test_client, monkeypatch
-):
+) -> None:
     from flaskr.service.shifu.models import DraftOutlineItem
 
     shifu_bid = "test-draft-meta-view-only"

--- a/src/api/tests/service/shifu/test_shifu_draft_list.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_list.py
@@ -42,7 +42,7 @@ def _seed_draft(
     dao.db.session.add(draft)
 
 
-def test_get_shifu_draft_list_sorts_by_updated_at_desc_then_id_desc(app):
+def test_get_shifu_draft_list_sorts_by_updated_at_desc_then_id_desc(app) -> None:
     owner_bid = "draft-list-owner"
     with app.app_context():
         DraftShifu.query.filter(
@@ -106,7 +106,7 @@ def test_get_shifu_draft_list_sorts_by_updated_at_desc_then_id_desc(app):
     ]
 
 
-def test_get_shifu_draft_list_prefers_latest_outline_activity(app):
+def test_get_shifu_draft_list_prefers_latest_outline_activity(app) -> None:
     owner_bid = "draft-list-activity-owner"
     with app.app_context():
         DraftOutlineItem.query.filter(
@@ -180,7 +180,7 @@ def test_get_shifu_draft_list_prefers_latest_outline_activity(app):
     ]
 
 
-def test_get_shifu_draft_list_ignores_published_outline_activity(app):
+def test_get_shifu_draft_list_ignores_published_outline_activity(app) -> None:
     owner_bid = "draft-list-published-outline-owner"
     with app.app_context():
         PublishedOutlineItem.query.filter(
@@ -252,7 +252,7 @@ def test_get_shifu_draft_list_ignores_published_outline_activity(app):
     ]
 
 
-def test_get_shifu_draft_list_marks_courses_with_published_versions(app):
+def test_get_shifu_draft_list_marks_courses_with_published_versions(app) -> None:
     owner_bid = "draft-list-published-state-owner"
     with app.app_context():
         PublishedShifu.query.filter(

--- a/src/api/tests/service/shifu/test_shifu_history_manager.py
+++ b/src/api/tests/service/shifu/test_shifu_history_manager.py
@@ -25,7 +25,7 @@ def _seed_shifu(shifu_bid: str, user_bid: str) -> DraftShifu:
     return shifu
 
 
-def test_save_new_outline_history_raises_when_parent_missing(app):
+def test_save_new_outline_history_raises_when_parent_missing(app) -> None:
     shifu_bid = "history-parent-missing"
     user_bid = "creator-history"
 

--- a/src/api/tests/service/shifu/test_shifu_outline_tree.py
+++ b/src/api/tests/service/shifu/test_shifu_outline_tree.py
@@ -30,7 +30,7 @@ def _mk_item(shifu_bid, bid, position, parent_bid=""):
     return item
 
 
-def test_build_outline_tree_lifts_orphan_to_root(app):
+def test_build_outline_tree_lifts_orphan_to_root(app) -> None:
     """An orphan whose parent position is missing is attached at root, and its own subtree stays attached to it — nothing is dropped."""
     shifu_bid = "shifu_orphan_1"
     with app.app_context():
@@ -52,7 +52,7 @@ def test_build_outline_tree_lifts_orphan_to_root(app):
         assert [c.outline_id for c in orphan_node.children] == ["orphan_child"]
 
 
-def test_build_outline_tree_handles_empty_position_without_cycle(app):
+def test_build_outline_tree_handles_empty_position_without_cycle(app) -> None:
     """A degenerate empty position must not become its own child (which would later blow up get_outline_tree_dto with RecursionError).
 
     It is lifted to the root level like any other orphan.
@@ -79,7 +79,7 @@ def test_build_outline_tree_handles_empty_position_without_cycle(app):
         assert {d.bid for d in dtos} == {"root1", "broken"}
 
 
-def test_assert_publishable_passes_when_no_collision(app):
+def test_assert_publishable_passes_when_no_collision(app) -> None:
     """Orphans alone are tolerated (self-healed); publish is not blocked."""
     shifu_bid = "shifu_orphan_2"
     with app.app_context():
@@ -91,7 +91,7 @@ def test_assert_publishable_passes_when_no_collision(app):
         assert_outline_tree_publishable(app, shifu_bid)
 
 
-def test_assert_publishable_raises_on_position_collision(app):
+def test_assert_publishable_raises_on_position_collision(app) -> None:
     """Two live nodes sharing a position cannot be reconciled -> block publish."""
     shifu_bid = "shifu_collision_1"
     with app.app_context():
@@ -106,7 +106,7 @@ def test_assert_publishable_raises_on_position_collision(app):
         assert exc_info.value.code == 4010
 
 
-def test_outline_tree_metadata_loader_does_not_read_content(app):
+def test_outline_tree_metadata_loader_does_not_read_content(app) -> None:
     shifu_bid = "shifu_outline_lightweight_1"
     with app.app_context():
         item = _mk_item(shifu_bid, "root1", "01")

--- a/src/api/tests/service/shifu/test_shifu_public_urls.py
+++ b/src/api/tests/service/shifu/test_shifu_public_urls.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import flaskr.common.config as common_config
 import pytest
@@ -13,6 +14,9 @@ from flaskr import dao
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_PREVIEW
 from flaskr.util.datetime import now_utc
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 def _reset_config_cache(*keys: str) -> None:
     for key in keys:
@@ -20,7 +24,7 @@ def _reset_config_cache(*keys: str) -> None:
 
 
 @pytest.fixture(autouse=True)
-def clear_public_url_config_cache():
+def clear_public_url_config_cache() -> Iterator[None]:
     _reset_config_cache("HOST_URL")
     yield
     _reset_config_cache("HOST_URL")
@@ -109,7 +113,7 @@ def _build_detail_for_base_url(monkeypatch, base_url: str):
     )
 
 
-def test_shifu_detail_urls_prefer_host_url(monkeypatch):
+def test_shifu_detail_urls_prefer_host_url(monkeypatch) -> None:
     from flaskr.service.shifu.route import _get_request_base_url
 
     monkeypatch.setenv("HOST_URL", "https://example.com/")
@@ -126,7 +130,7 @@ def test_shifu_detail_urls_prefer_host_url(monkeypatch):
     assert detail.preview_url == "https://example.com/c/course-1?preview=true"
 
 
-def test_shifu_detail_urls_use_forwarded_https_origin(monkeypatch):
+def test_shifu_detail_urls_use_forwarded_https_origin(monkeypatch) -> None:
     from flaskr.service.shifu.route import _get_request_base_url
 
     monkeypatch.delenv("HOST_URL", raising=False)
@@ -147,7 +151,7 @@ def test_shifu_detail_urls_use_forwarded_https_origin(monkeypatch):
     assert detail.preview_url == "https://forwarded.example.com/c/course-1?preview=true"
 
 
-def test_shifu_preview_endpoint_url_uses_public_base(monkeypatch):
+def test_shifu_preview_endpoint_url_uses_public_base(monkeypatch) -> None:
     from flaskr.service.shifu import shifu_publish_funcs
     from flaskr.service.shifu.route import _get_request_base_url
 
@@ -185,7 +189,7 @@ def test_shifu_preview_endpoint_admits_course_owner_usage_for_collaborator(
     monkeypatch,
     test_client,
     app,
-):
+) -> None:
     shifu_bid = "preview-route-owner-admission"
     owner_bid = "owner-preview-route-admission"
     collaborator_bid = "collaborator-preview-route-admission"
@@ -228,7 +232,7 @@ def test_shifu_preview_endpoint_admits_course_owner_usage_for_collaborator(
     }
 
 
-def test_shifu_publish_url_builder_uses_public_base():
+def test_shifu_publish_url_builder_uses_public_base() -> None:
     from flaskr.service.shifu.shifu_publish_funcs import _build_frontend_url
 
     assert (
@@ -293,7 +297,7 @@ def _seed_white_label(
         dao.db.session.commit()
 
 
-def test_resolve_effective_custom_origin_returns_verified_host(app):
+def test_resolve_effective_custom_origin_returns_verified_host(app) -> None:
     from flaskr.service.billing.domains import resolve_effective_custom_origin
 
     creator_bid = "wl-owner-verified"
@@ -304,7 +308,7 @@ def test_resolve_effective_custom_origin_returns_verified_host(app):
     )
 
 
-def test_resolve_effective_custom_origin_none_when_entitlement_disabled(app):
+def test_resolve_effective_custom_origin_none_when_entitlement_disabled(app) -> None:
     from flaskr.service.billing.domains import resolve_effective_custom_origin
 
     creator_bid = "wl-owner-disabled"
@@ -318,7 +322,7 @@ def test_resolve_effective_custom_origin_none_when_entitlement_disabled(app):
     assert resolve_effective_custom_origin(app, creator_bid) is None
 
 
-def test_resolve_effective_custom_origin_none_when_binding_pending(app):
+def test_resolve_effective_custom_origin_none_when_binding_pending(app) -> None:
     from flaskr.service.billing.consts import (
         BILLING_DOMAIN_BINDING_STATUS_PENDING,
     )
@@ -335,7 +339,7 @@ def test_resolve_effective_custom_origin_none_when_binding_pending(app):
     assert resolve_effective_custom_origin(app, creator_bid) is None
 
 
-def test_publish_base_url_prefers_custom_domain(app, monkeypatch):
+def test_publish_base_url_prefers_custom_domain(app, monkeypatch) -> None:
     from flaskr.common.shifu_context import clear_shifu_context, set_shifu_context
     from flaskr.service.shifu.route import _resolve_publish_base_url
 
@@ -352,7 +356,7 @@ def test_publish_base_url_prefers_custom_domain(app, monkeypatch):
         clear_shifu_context()
 
 
-def test_publish_base_url_falls_back_without_custom_domain(app, monkeypatch):
+def test_publish_base_url_falls_back_without_custom_domain(app, monkeypatch) -> None:
     from flaskr.common.shifu_context import clear_shifu_context, set_shifu_context
     from flaskr.service.shifu.route import _resolve_publish_base_url
 

--- a/src/api/tests/service/shifu/test_shifu_publish_funcs.py
+++ b/src/api/tests/service/shifu/test_shifu_publish_funcs.py
@@ -143,7 +143,7 @@ class _FakeLangfuseClient:
         return root
 
 
-def test_make_ask_prompt_fills_content_and_keeps_runtime_placeholders():
+def test_make_ask_prompt_fills_content_and_keeps_runtime_placeholders() -> None:
     from flaskr.service.shifu import shifu_publish_funcs as module
     from flaskr.util.prompt_loader import load_prompt_template
 
@@ -167,7 +167,7 @@ def test_make_ask_prompt_fills_content_and_keeps_runtime_placeholders():
     assert "<knowledge>" not in result
 
 
-def test_get_summary_updates_trace_and_span_output(monkeypatch):
+def test_get_summary_updates_trace_and_span_output(monkeypatch) -> None:
     from flaskr.api import langfuse as langfuse_module
     from flaskr.service.shifu import shifu_publish_funcs as module
 
@@ -215,7 +215,7 @@ def test_get_summary_updates_trace_and_span_output(monkeypatch):
     assert trace.updated["output"] == "summary result"
 
 
-def test_run_summary_downgrades_shutdown_race_to_warning(monkeypatch):
+def test_run_summary_downgrades_shutdown_race_to_warning(monkeypatch) -> None:
     from unittest.mock import MagicMock
 
     from flaskr.service.shifu import shifu_publish_funcs as module
@@ -243,7 +243,7 @@ def test_run_summary_downgrades_shutdown_race_to_warning(monkeypatch):
     error_mock.assert_not_called()
 
 
-def test_run_summary_logs_error_for_other_failures(monkeypatch):
+def test_run_summary_logs_error_for_other_failures(monkeypatch) -> None:
     from unittest.mock import MagicMock
 
     from flaskr.service.shifu import shifu_publish_funcs as module
@@ -268,7 +268,7 @@ def test_run_summary_logs_error_for_other_failures(monkeypatch):
     warning_mock.assert_not_called()
 
 
-def test_publish_shifu_draft_preserves_outline_updated_at(app, monkeypatch):
+def test_publish_shifu_draft_preserves_outline_updated_at(app, monkeypatch) -> None:
     from flaskr.service.shifu import shifu_publish_funcs as module
 
     monkeypatch.setattr(module, "_run_summary_with_error_handling", lambda *_args: None)

--- a/src/api/tests/service/shifu/test_transfer_creator.py
+++ b/src/api/tests/service/shifu/test_transfer_creator.py
@@ -157,7 +157,7 @@ def _ensure_trial_billing_enabled(app, monkeypatch) -> None:
 
 def test_transfer_creator_creates_missing_user_and_preserves_shared_auth(
     app, monkeypatch
-):
+) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     old_creator_bid = uuid.uuid4().hex[:32]
     viewer_bid = uuid.uuid4().hex[:32]
@@ -228,7 +228,7 @@ def test_transfer_creator_creates_missing_user_and_preserves_shared_auth(
         assert shared_auth is not None
 
 
-def test_transfer_creator_promotes_unregistered_existing_user(app, monkeypatch):
+def test_transfer_creator_promotes_unregistered_existing_user(app, monkeypatch) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     old_creator_bid = uuid.uuid4().hex[:32]
     target_user_bid = uuid.uuid4().hex[:32]
@@ -276,7 +276,7 @@ def test_transfer_creator_promotes_unregistered_existing_user(app, monkeypatch):
 
 def test_transfer_creator_bootstraps_trial_when_target_becomes_creator(
     app, monkeypatch
-):
+) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     old_creator_bid = uuid.uuid4().hex[:32]
     target_user_bid = uuid.uuid4().hex[:32]
@@ -308,7 +308,9 @@ def test_transfer_creator_bootstraps_trial_when_target_becomes_creator(
         assert trial_order.payment_provider == "manual"
 
 
-def test_transfer_creator_skips_post_auth_when_target_already_creator(app, monkeypatch):
+def test_transfer_creator_skips_post_auth_when_target_already_creator(
+    app, monkeypatch
+) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     old_creator_bid = uuid.uuid4().hex[:32]
     target_user_bid = uuid.uuid4().hex[:32]
@@ -338,7 +340,7 @@ def test_transfer_creator_skips_post_auth_when_target_already_creator(app, monke
         assert post_auth_calls == []
 
 
-def test_transfer_creator_route_for_operator(app, test_client, monkeypatch):
+def test_transfer_creator_route_for_operator(app, test_client, monkeypatch) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     old_creator_bid = uuid.uuid4().hex[:32]
     target_user_bid = uuid.uuid4().hex[:32]
@@ -378,7 +380,7 @@ def test_transfer_creator_route_for_operator(app, test_client, monkeypatch):
         assert latest_draft.updated_at > old_updated_at
 
 
-def test_transfer_creator_records_operator_history_entry(app):
+def test_transfer_creator_records_operator_history_entry(app) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     old_creator_bid = uuid.uuid4().hex[:32]
     target_user_bid = uuid.uuid4().hex[:32]
@@ -413,7 +415,7 @@ def test_transfer_creator_records_operator_history_entry(app):
 
 def test_transfer_creator_promotes_existing_viewer_to_owner_permissions(
     app, monkeypatch
-):
+) -> None:
     _ = monkeypatch
     shifu_bid = uuid.uuid4().hex[:32]
     old_creator_bid = uuid.uuid4().hex[:32]
@@ -453,7 +455,7 @@ def test_transfer_creator_promotes_existing_viewer_to_owner_permissions(
         assert permission_map[shifu_bid] == {"view", "edit", "publish"}
 
 
-def test_transfer_creator_invalidates_cached_shifu_creator(app):
+def test_transfer_creator_invalidates_cached_shifu_creator(app) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     old_creator_bid = uuid.uuid4().hex[:32]
     target_user_bid = uuid.uuid4().hex[:32]
@@ -478,7 +480,7 @@ def test_transfer_creator_invalidates_cached_shifu_creator(app):
         assert _get_shifu_creator_bid_cached(app, shifu_bid) == target_user_bid
 
 
-def test_transfer_creator_preserves_existing_target_nickname(app):
+def test_transfer_creator_preserves_existing_target_nickname(app) -> None:
     shifu_bid = uuid.uuid4().hex[:32]
     old_creator_bid = uuid.uuid4().hex[:32]
     target_user_bid = uuid.uuid4().hex[:32]

--- a/src/api/tests/service/tts/test_aliyun_nls_token.py
+++ b/src/api/tests/service/tts/test_aliyun_nls_token.py
@@ -10,7 +10,7 @@ from flaskr.api.tts.aliyun_nls_token import get_aliyun_nls_token
 from flaskr.api.tts.aliyun_provider import AliyunTTSProvider
 
 
-def test_get_aliyun_nls_token_uses_override_when_configured(monkeypatch):
+def test_get_aliyun_nls_token_uses_override_when_configured(monkeypatch) -> None:
     monkeypatch.setenv("ALIYUN_TTS_TOKEN", "override-token")
 
     def fake_get(*args: object, **kwargs: object):
@@ -23,7 +23,7 @@ def test_get_aliyun_nls_token_uses_override_when_configured(monkeypatch):
     assert get_aliyun_nls_token() == "override-token"
 
 
-def test_get_aliyun_nls_token_fetches_and_caches(monkeypatch):
+def test_get_aliyun_nls_token_fetches_and_caches(monkeypatch) -> None:
     monkeypatch.setenv("REDIS_KEY_PREFIX", "test:aliyun:nls-token:")
     monkeypatch.delenv("ALIYUN_TTS_TOKEN", raising=False)
     monkeypatch.setenv("ALIYUN_AK_ID", "my_access_key_id")
@@ -76,7 +76,7 @@ def test_get_aliyun_nls_token_fetches_and_caches(monkeypatch):
     assert signature == unquote(expected_signature)
 
 
-def test_get_aliyun_nls_token_refresh_falls_back_to_cached_token(monkeypatch):
+def test_get_aliyun_nls_token_refresh_falls_back_to_cached_token(monkeypatch) -> None:
     monkeypatch.setenv("REDIS_KEY_PREFIX", "test:aliyun:nls-token:fallback:")
     monkeypatch.delenv("ALIYUN_TTS_TOKEN", raising=False)
     monkeypatch.setenv("ALIYUN_AK_ID", "my_access_key_id")
@@ -108,7 +108,7 @@ def test_get_aliyun_nls_token_refresh_falls_back_to_cached_token(monkeypatch):
     assert captured["calls"] == 1
 
 
-def test_aliyun_provider_is_configured_with_access_keys(monkeypatch):
+def test_aliyun_provider_is_configured_with_access_keys(monkeypatch) -> None:
     monkeypatch.setenv("ALIYUN_TTS_APPKEY", "appkey")
     monkeypatch.delenv("ALIYUN_TTS_TOKEN", raising=False)
     monkeypatch.setenv("ALIYUN_AK_ID", "ak")
@@ -118,7 +118,7 @@ def test_aliyun_provider_is_configured_with_access_keys(monkeypatch):
     assert provider.is_configured() is True
 
 
-def test_aliyun_provider_synthesize_uses_dynamic_token(monkeypatch):
+def test_aliyun_provider_synthesize_uses_dynamic_token(monkeypatch) -> None:
     monkeypatch.setenv("ALIYUN_TTS_APPKEY", "appkey")
     monkeypatch.setenv("ALIYUN_TTS_REGION", "shanghai")
     monkeypatch.delenv("ALIYUN_TTS_TOKEN", raising=False)

--- a/src/api/tests/service/tts/test_audio_utils.py
+++ b/src/api/tests/service/tts/test_audio_utils.py
@@ -70,7 +70,9 @@ class _RecordingAudioSegment:
         return _FakeSegment(int(segment_io.getvalue().decode("utf-8")))
 
 
-def test_try_get_audio_duration_ms_decodes_with_the_requested_format(monkeypatch):
+def test_try_get_audio_duration_ms_decodes_with_the_requested_format(
+    monkeypatch,
+) -> None:
     _RecordingAudioSegment.from_file_formats.clear()
     monkeypatch.setattr(
         audio_utils, "AudioSegment", _RecordingAudioSegment, raising=False
@@ -81,7 +83,7 @@ def test_try_get_audio_duration_ms_decodes_with_the_requested_format(monkeypatch
     assert _RecordingAudioSegment.from_file_formats == ["wav"]
 
 
-def test_get_audio_duration_ms_estimates_when_decoding_fails(monkeypatch):
+def test_get_audio_duration_ms_estimates_when_decoding_fails(monkeypatch) -> None:
     monkeypatch.setattr(
         audio_utils, "AudioSegment", _PartiallyBrokenAudioSegment, raising=False
     )
@@ -92,7 +94,7 @@ def test_get_audio_duration_ms_estimates_when_decoding_fails(monkeypatch):
     )
 
 
-def test_concat_audio_mp3_does_not_crossfade_by_default(monkeypatch):
+def test_concat_audio_mp3_does_not_crossfade_by_default(monkeypatch) -> None:
     _FakeSegment.append_crossfades.clear()
     monkeypatch.setattr(audio_utils, "AudioSegment", _FakeAudioSegment, raising=False)
     monkeypatch.setattr(audio_utils, "PYDUB_AVAILABLE", True)
@@ -103,7 +105,9 @@ def test_concat_audio_mp3_does_not_crossfade_by_default(monkeypatch):
     assert output == b"duration=182"
 
 
-def test_concat_audio_mp3_caps_explicit_crossfade_for_short_segments(monkeypatch):
+def test_concat_audio_mp3_caps_explicit_crossfade_for_short_segments(
+    monkeypatch,
+) -> None:
     _FakeSegment.append_crossfades.clear()
     monkeypatch.setattr(audio_utils, "AudioSegment", _FakeAudioSegment, raising=False)
     monkeypatch.setattr(audio_utils, "PYDUB_AVAILABLE", True)
@@ -114,7 +118,7 @@ def test_concat_audio_mp3_caps_explicit_crossfade_for_short_segments(monkeypatch
     assert output == b"duration=130"
 
 
-def test_concat_audio_mp3_raises_on_partial_decode_failure(monkeypatch):
+def test_concat_audio_mp3_raises_on_partial_decode_failure(monkeypatch) -> None:
     monkeypatch.setattr(
         audio_utils, "AudioSegment", _PartiallyBrokenAudioSegment, raising=False
     )
@@ -126,7 +130,7 @@ def test_concat_audio_mp3_raises_on_partial_decode_failure(monkeypatch):
 
 def test_concat_audio_best_effort_reexports_decodable_segments_on_partial_failure(
     monkeypatch,
-):
+) -> None:
     monkeypatch.setattr(
         audio_utils, "AudioSegment", _PartiallyBrokenAudioSegment, raising=False
     )
@@ -137,7 +141,7 @@ def test_concat_audio_best_effort_reexports_decodable_segments_on_partial_failur
     assert output == b"duration=180"
 
 
-def test_concat_audio_best_effort_drops_undecodable_single_segment(monkeypatch):
+def test_concat_audio_best_effort_drops_undecodable_single_segment(monkeypatch) -> None:
     monkeypatch.setattr(
         audio_utils, "AudioSegment", _PartiallyBrokenAudioSegment, raising=False
     )
@@ -148,7 +152,9 @@ def test_concat_audio_best_effort_drops_undecodable_single_segment(monkeypatch):
     assert output == b""
 
 
-def test_concat_audio_best_effort_drops_undecodable_multiple_segments(monkeypatch):
+def test_concat_audio_best_effort_drops_undecodable_multiple_segments(
+    monkeypatch,
+) -> None:
     monkeypatch.setattr(
         audio_utils, "AudioSegment", _PartiallyBrokenAudioSegment, raising=False
     )
@@ -161,7 +167,7 @@ def test_concat_audio_best_effort_drops_undecodable_multiple_segments(monkeypatc
 
 def test_export_audio_range_does_not_return_invalid_bytes_after_decode_failure(
     monkeypatch,
-):
+) -> None:
     monkeypatch.setattr(
         audio_utils, "AudioSegment", _PartiallyBrokenAudioSegment, raising=False
     )

--- a/src/api/tests/service/tts/test_av_speakable_segmentation.py
+++ b/src/api/tests/service/tts/test_av_speakable_segmentation.py
@@ -8,7 +8,7 @@ def _require_app(app):
         pytest.skip("App fixture disabled")
 
 
-def test_split_av_speakable_segments_splits_svg_blocks(app):
+def test_split_av_speakable_segments_splits_svg_blocks(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -24,7 +24,7 @@ def test_split_av_speakable_segments_splits_svg_blocks(app):
     assert split_av_speakable_segments(text) == ["Before.", "After."]
 
 
-def test_split_av_speakable_segments_splits_multiple_svg_blocks(app):
+def test_split_av_speakable_segments_splits_multiple_svg_blocks(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -34,7 +34,7 @@ def test_split_av_speakable_segments_splits_multiple_svg_blocks(app):
     assert split_av_speakable_segments(text) == ["A.", "B.", "C."]
 
 
-def test_split_av_speakable_segments_splits_img_tag(app):
+def test_split_av_speakable_segments_splits_img_tag(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -43,7 +43,9 @@ def test_split_av_speakable_segments_splits_img_tag(app):
     assert split_av_speakable_segments(text) == ["Hello", "world."]
 
 
-def test_split_av_speakable_segments_keeps_markdown_headers_in_speakable_text(app):
+def test_split_av_speakable_segments_keeps_markdown_headers_in_speakable_text(
+    app,
+) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -52,7 +54,7 @@ def test_split_av_speakable_segments_keeps_markdown_headers_in_speakable_text(ap
     assert split_av_speakable_segments(text) == [text]
 
 
-def test_split_av_speakable_segments_splits_markdown_image(app):
+def test_split_av_speakable_segments_splits_markdown_image(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -61,7 +63,7 @@ def test_split_av_speakable_segments_splits_markdown_image(app):
     assert split_av_speakable_segments(text) == ["Hello", "world."]
 
 
-def test_split_av_speakable_segments_treats_fenced_code_as_boundary(app):
+def test_split_av_speakable_segments_treats_fenced_code_as_boundary(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -71,7 +73,7 @@ def test_split_av_speakable_segments_treats_fenced_code_as_boundary(app):
     assert split_av_speakable_segments(text) == ["Before.", "After."]
 
 
-def test_split_av_speakable_segments_splits_markdown_table(app):
+def test_split_av_speakable_segments_splits_markdown_table(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -81,7 +83,7 @@ def test_split_av_speakable_segments_splits_markdown_table(app):
     assert split_av_speakable_segments(text) == ["Before.", "After."]
 
 
-def test_split_av_speakable_segments_splits_html_table(app):
+def test_split_av_speakable_segments_splits_html_table(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -90,7 +92,7 @@ def test_split_av_speakable_segments_splits_html_table(app):
     assert split_av_speakable_segments(text) == ["Before.", "After."]
 
 
-def test_split_av_speakable_segments_splits_video_tag(app):
+def test_split_av_speakable_segments_splits_video_tag(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -99,7 +101,7 @@ def test_split_av_speakable_segments_splits_video_tag(app):
     assert split_av_speakable_segments(text) == ["Before.", "After."]
 
 
-def test_split_av_speakable_segments_splits_iframe_tag(app):
+def test_split_av_speakable_segments_splits_iframe_tag(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -108,7 +110,9 @@ def test_split_av_speakable_segments_splits_iframe_tag(app):
     assert split_av_speakable_segments(text) == ["Before.", "After."]
 
 
-def test_split_av_speakable_segments_splits_iframe_wrapped_by_fixed_markers(app):
+def test_split_av_speakable_segments_splits_iframe_wrapped_by_fixed_markers(
+    app,
+) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -122,7 +126,7 @@ def test_split_av_speakable_segments_splits_iframe_wrapped_by_fixed_markers(app)
     assert split_av_speakable_segments(text) == ["Hello.", "After."]
 
 
-def test_split_av_speakable_segments_splits_sandbox_html_block(app):
+def test_split_av_speakable_segments_splits_sandbox_html_block(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -131,7 +135,7 @@ def test_split_av_speakable_segments_splits_sandbox_html_block(app):
     assert split_av_speakable_segments(text) == ["Before.", "After."]
 
 
-def test_split_av_speakable_segments_does_not_narrate_sandbox_html_block(app):
+def test_split_av_speakable_segments_does_not_narrate_sandbox_html_block(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -140,7 +144,9 @@ def test_split_av_speakable_segments_does_not_narrate_sandbox_html_block(app):
     assert split_av_speakable_segments(text) == ["Before.", "After."]
 
 
-def test_split_av_speakable_segments_returns_single_segment_when_no_boundaries(app):
+def test_split_av_speakable_segments_returns_single_segment_when_no_boundaries(
+    app,
+) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import split_av_speakable_segments
@@ -148,7 +154,7 @@ def test_split_av_speakable_segments_returns_single_segment_when_no_boundaries(a
     assert split_av_speakable_segments("Hello.") == ["Hello."]
 
 
-def test_build_av_segmentation_contract_contains_boundaries_and_positions(app):
+def test_build_av_segmentation_contract_contains_boundaries_and_positions(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts.pipeline import build_av_segmentation_contract

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -33,7 +33,7 @@ def _ignore_saved_audio_record(record: object, commit: object = None) -> None:
     del record, commit
 
 
-def test_minimax_http_streaming_parses_audio_and_final_subtitles(monkeypatch):
+def test_minimax_http_streaming_parses_audio_and_final_subtitles(monkeypatch) -> None:
     from flaskr.api.tts.base import AudioSettings, VoiceSettings
     from flaskr.api.tts.minimax_provider import MinimaxTTSProvider
 
@@ -133,7 +133,7 @@ def test_minimax_http_streaming_parses_audio_and_final_subtitles(monkeypatch):
     }
 
 
-def test_minimax_synthesize_splits_word_count_and_usage_characters(monkeypatch):
+def test_minimax_synthesize_splits_word_count_and_usage_characters(monkeypatch) -> None:
     from flaskr.api.tts.base import AudioSettings, VoiceSettings
     from flaskr.api.tts.minimax_provider import MinimaxTTSProvider
 
@@ -182,7 +182,7 @@ def test_minimax_synthesize_splits_word_count_and_usage_characters(monkeypatch):
     assert post_calls[0][0].endswith("GroupId=test-group")
 
 
-def test_minimax_http_streaming_raises_on_business_error(monkeypatch):
+def test_minimax_http_streaming_raises_on_business_error(monkeypatch) -> None:
     from flaskr.api.tts.minimax_provider import MinimaxTTSProvider
 
     monkeypatch.setattr(
@@ -217,7 +217,7 @@ def test_minimax_http_streaming_raises_on_business_error(monkeypatch):
 
 def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
     monkeypatch,
-):
+) -> None:
     from flaskr.service.learn.learn_dtos import GeneratedType
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
@@ -356,7 +356,7 @@ def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
 
 def test_streaming_tts_minimax_http_stream_falls_back_for_partial_subtitles(
     monkeypatch,
-):
+) -> None:
     from flaskr.service.learn.learn_dtos import GeneratedType
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
@@ -474,7 +474,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_for_partial_subtitles(
 
 def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
     monkeypatch,
-):
+) -> None:
     from flaskr.service.learn.learn_dtos import GeneratedType
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
@@ -598,7 +598,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
 
 def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitles(
     monkeypatch,
-):
+) -> None:
     from flaskr.service.learn.learn_dtos import GeneratedType
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
@@ -724,7 +724,7 @@ def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitle
 
 def test_streaming_tts_minimax_http_stream_does_not_emit_audio_past_subtitles(
     monkeypatch,
-):
+) -> None:
     from flaskr.service.learn.learn_dtos import GeneratedType
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
@@ -862,7 +862,7 @@ def test_streaming_tts_minimax_http_stream_does_not_emit_audio_past_subtitles(
 
 def test_streaming_tts_minimax_http_stream_offsets_live_cues_by_emitted_audio(
     monkeypatch,
-):
+) -> None:
     from flaskr.service.learn.learn_dtos import GeneratedType
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
@@ -1020,7 +1020,7 @@ def test_streaming_tts_minimax_http_stream_offsets_live_cues_by_emitted_audio(
 
 def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_stretch(
     monkeypatch,
-):
+) -> None:
     from flaskr.service.learn.learn_dtos import GeneratedType
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
@@ -1157,7 +1157,7 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
 
 def test_streaming_tts_minimax_http_stream_keeps_provider_middle_cue_timing(
     monkeypatch,
-):
+) -> None:
     from flaskr.service.learn.learn_dtos import GeneratedType
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
@@ -1318,7 +1318,7 @@ def test_streaming_tts_minimax_http_stream_keeps_provider_middle_cue_timing(
 
 def test_streaming_tts_minimax_http_stream_freezes_emitted_prefix_for_same_count_provider_cues(
     monkeypatch,
-):
+) -> None:
     from flaskr.service.learn.learn_dtos import GeneratedType
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 

--- a/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
+++ b/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
@@ -64,7 +64,7 @@ def _seed_clone(
         db.session.commit()
 
 
-def test_built_in_voice_is_always_allowed(app):
+def test_built_in_voice_is_always_allowed(app) -> None:
     _prepare_tables(app)
     with app.app_context():
         # No clone rows, unknown owner: a built-in voice must still pass.
@@ -73,7 +73,7 @@ def test_built_in_voice_is_always_allowed(app):
         )
 
 
-def test_ready_clone_owned_by_requester_is_allowed(app):
+def test_ready_clone_owned_by_requester_is_allowed(app) -> None:
     _prepare_tables(app)
     _seed_clone(
         app,
@@ -90,7 +90,7 @@ def test_ready_clone_owned_by_requester_is_allowed(app):
         )
 
 
-def test_ready_clone_owned_by_another_user_is_rejected(app):
+def test_ready_clone_owned_by_another_user_is_rejected(app) -> None:
     _prepare_tables(app)
     _seed_clone(
         app,
@@ -108,7 +108,7 @@ def test_ready_clone_owned_by_another_user_is_rejected(app):
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
-def test_isolation_when_same_voice_id_has_different_owners(app):
+def test_isolation_when_same_voice_id_has_different_owners(app) -> None:
     """Two clones share the same voice_id but differ by owner: the requester only matches their own row, never the foreign one."""
     _prepare_tables(app)
     _seed_clone(
@@ -142,7 +142,7 @@ def test_isolation_when_same_voice_id_has_different_owners(app):
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
-def test_custom_voice_with_empty_owner_is_rejected(app):
+def test_custom_voice_with_empty_owner_is_rejected(app) -> None:
     """An empty owner must not bypass owner scoping and match any ready clone."""
     _prepare_tables(app)
     _seed_clone(
@@ -161,7 +161,7 @@ def test_custom_voice_with_empty_owner_is_rejected(app):
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
-def test_failed_clone_is_rejected(app):
+def test_failed_clone_is_rejected(app) -> None:
     _prepare_tables(app)
     _seed_clone(
         app,
@@ -179,7 +179,7 @@ def test_failed_clone_is_rejected(app):
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
-def test_deleted_clone_is_rejected(app):
+def test_deleted_clone_is_rejected(app) -> None:
     """A ready, owned clone that has been soft-deleted is rejected like an unknown voice."""
     _prepare_tables(app)
     _seed_clone(
@@ -199,7 +199,7 @@ def test_deleted_clone_is_rejected(app):
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
-def test_unknown_custom_voice_is_rejected(app):
+def test_unknown_custom_voice_is_rejected(app) -> None:
     _prepare_tables(app)
     with app.app_context(), pytest.raises(AppError) as exc_info:
         assert_preview_cloned_voice_available(
@@ -211,7 +211,7 @@ def test_unknown_custom_voice_is_rejected(app):
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
-def test_empty_voice_id_is_rejected(app):
+def test_empty_voice_id_is_rejected(app) -> None:
     _prepare_tables(app)
     with app.app_context(), pytest.raises(AppError) as exc_info:
         assert_preview_cloned_voice_available(
@@ -220,7 +220,7 @@ def test_empty_voice_id_is_rejected(app):
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
-def test_volcengine_ready_clone_owned_by_requester_is_allowed(app):
+def test_volcengine_ready_clone_owned_by_requester_is_allowed(app) -> None:
     _prepare_tables(app)
     _seed_clone(
         app,
@@ -238,7 +238,7 @@ def test_volcengine_ready_clone_owned_by_requester_is_allowed(app):
         )
 
 
-def test_volcengine_ready_clone_of_another_owner_is_rejected(app):
+def test_volcengine_ready_clone_of_another_owner_is_rejected(app) -> None:
     _prepare_tables(app)
     _seed_clone(
         app,
@@ -257,7 +257,7 @@ def test_volcengine_ready_clone_of_another_owner_is_rejected(app):
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
-def test_volcengine_clone_row_does_not_leak_to_minimax_provider(app):
+def test_volcengine_clone_row_does_not_leak_to_minimax_provider(app) -> None:
     """A ready volcengine row must not authorize the same id under minimax."""
     _prepare_tables(app)
     _seed_clone(

--- a/src/api/tests/service/tts/test_minimax_rpm_limit.py
+++ b/src/api/tests/service/tts/test_minimax_rpm_limit.py
@@ -11,19 +11,19 @@ def _set_config(monkeypatch, mapping):
     )
 
 
-def test_resolve_rpm_turbo_tier_default(monkeypatch):
+def test_resolve_rpm_turbo_tier_default(monkeypatch) -> None:
     _set_config(monkeypatch, {})
     assert minimax_provider._resolve_minimax_rpm_limit("speech-2.8-turbo") == 200
     assert minimax_provider._resolve_minimax_rpm_limit("speech-01-turbo") == 200
 
 
-def test_resolve_rpm_hd_tier_default(monkeypatch):
+def test_resolve_rpm_hd_tier_default(monkeypatch) -> None:
     _set_config(monkeypatch, {})
     assert minimax_provider._resolve_minimax_rpm_limit("speech-2.8-hd") == 20
     assert minimax_provider._resolve_minimax_rpm_limit("speech-02-hd") == 20
 
 
-def test_resolve_rpm_json_override_takes_precedence(monkeypatch):
+def test_resolve_rpm_json_override_takes_precedence(monkeypatch) -> None:
     _set_config(monkeypatch, {"MINIMAX_TTS_RPM_LIMITS": '{"speech-2.8-hd": 15}'})
     # Explicit override wins over the tier default.
     assert minimax_provider._resolve_minimax_rpm_limit("speech-2.8-hd") == 15
@@ -31,18 +31,18 @@ def test_resolve_rpm_json_override_takes_precedence(monkeypatch):
     assert minimax_provider._resolve_minimax_rpm_limit("speech-2.8-turbo") == 200
 
 
-def test_resolve_rpm_invalid_override_json_is_ignored(monkeypatch):
+def test_resolve_rpm_invalid_override_json_is_ignored(monkeypatch) -> None:
     _set_config(monkeypatch, {"MINIMAX_TTS_RPM_LIMITS": "not-json"})
     assert minimax_provider._resolve_minimax_rpm_limit("speech-2.8-turbo") == 200
 
 
-def test_resolve_rpm_unknown_model_falls_back_to_global(monkeypatch):
+def test_resolve_rpm_unknown_model_falls_back_to_global(monkeypatch) -> None:
     _set_config(monkeypatch, {"MINIMAX_TTS_RPM_LIMIT": 42})
     # No tier suffix and no override -> global fallback.
     assert minimax_provider._resolve_minimax_rpm_limit("some-future-model") == 42
 
 
-def test_resolve_rpm_unknown_model_without_global_disables_gating(monkeypatch):
+def test_resolve_rpm_unknown_model_without_global_disables_gating(monkeypatch) -> None:
     _set_config(monkeypatch, {})
     # Global default is 0 which disables gating for unknown models.
     assert minimax_provider._resolve_minimax_rpm_limit("some-future-model") == 0

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 
 import pytest
 from flask import Flask
@@ -27,6 +27,9 @@ from flaskr.service.metering.consts import BILL_USAGE_SCENE_PREVIEW, BILL_USAGE_
 from flaskr.service.metering.models import BillUsageRecord
 from flaskr.service.shifu.models import DraftShifu
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 def _enqueue_clone(app: object, *, voice_bid: str) -> bool:
     del app, voice_bid
@@ -44,7 +47,7 @@ def _normalize_audio(data: bytes, filename: str, purpose: str) -> SimpleNamespac
 
 
 @pytest.fixture
-def minimax_clone_app(monkeypatch):
+def minimax_clone_app(monkeypatch) -> Iterator[Flask]:
     app = Flask(__name__)
     app.testing = True
     app.config.update(
@@ -499,7 +502,9 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
         assert read_calls[0] == (source_object_key, "resource-bucket")
 
 
-def test_execute_clone_processing_uses_row_values_inside_app_context(monkeypatch):
+def test_execute_clone_processing_uses_row_values_inside_app_context(
+    monkeypatch,
+) -> None:
     from flaskr.service.tts import minimax_voice_clone
 
     in_context = False

--- a/src/api/tests/service/tts/test_provider_error_responses.py
+++ b/src/api/tests/service/tts/test_provider_error_responses.py
@@ -23,7 +23,7 @@ class _Response:
 
 
 @pytest.fixture
-def baidu(monkeypatch):
+def baidu(monkeypatch) -> BaiduTTSProvider:
     monkeypatch.setattr(baidu_mod, "_get_access_token", lambda *_args: "token")
     provider = BaiduTTSProvider()
     monkeypatch.setattr(provider, "_get_credentials", lambda: ("key", "secret"))
@@ -31,14 +31,14 @@ def baidu(monkeypatch):
 
 
 @pytest.fixture
-def aliyun(monkeypatch):
+def aliyun(monkeypatch) -> AliyunTTSProvider:
     monkeypatch.setattr(aliyun_mod, "get_aliyun_nls_token", lambda: "token")
     provider = AliyunTTSProvider()
     monkeypatch.setattr(provider, "_get_settings", lambda: ("appkey", "shanghai"))
     return provider
 
 
-def test_baidu_reports_the_json_error_payload(baidu, monkeypatch):
+def test_baidu_reports_the_json_error_payload(baidu, monkeypatch) -> None:
     monkeypatch.setattr(
         requests,
         "post",
@@ -49,7 +49,7 @@ def test_baidu_reports_the_json_error_payload(baidu, monkeypatch):
         baidu.synthesize("hello")
 
 
-def test_baidu_reports_the_raw_body_when_json_is_malformed(baidu, monkeypatch):
+def test_baidu_reports_the_raw_body_when_json_is_malformed(baidu, monkeypatch) -> None:
     monkeypatch.setattr(
         requests,
         "post",
@@ -60,7 +60,7 @@ def test_baidu_reports_the_raw_body_when_json_is_malformed(baidu, monkeypatch):
         baidu.synthesize("hello")
 
 
-def test_aliyun_reports_the_json_error_payload(aliyun, monkeypatch):
+def test_aliyun_reports_the_json_error_payload(aliyun, monkeypatch) -> None:
     monkeypatch.setattr(
         requests,
         "post",
@@ -77,7 +77,9 @@ def test_aliyun_reports_the_json_error_payload(aliyun, monkeypatch):
         aliyun.synthesize("hello")
 
 
-def test_aliyun_reports_the_raw_body_when_json_is_malformed(aliyun, monkeypatch):
+def test_aliyun_reports_the_raw_body_when_json_is_malformed(
+    aliyun, monkeypatch
+) -> None:
     monkeypatch.setattr(
         requests,
         "post",

--- a/src/api/tests/service/tts/test_streaming_tts_av_contract.py
+++ b/src/api/tests/service/tts/test_streaming_tts_av_contract.py
@@ -8,7 +8,9 @@ def _require_app(app):
         pytest.skip("App fixture disabled")
 
 
-def test_av_streaming_tts_processor_emits_av_contract_in_events(app, monkeypatch):
+def test_av_streaming_tts_processor_emits_av_contract_in_events(
+    app, monkeypatch
+) -> None:
     _require_app(app)
 
     from flaskr.service.learn.learn_dtos import (
@@ -90,7 +92,9 @@ def test_av_streaming_tts_processor_emits_av_contract_in_events(app, monkeypatch
     assert [item["position"] for item in first_contract["speakable_segments"]] == [0, 1]
 
 
-def test_av_streaming_tts_processor_skips_chunked_markdown_image(app, monkeypatch):
+def test_av_streaming_tts_processor_skips_chunked_markdown_image(
+    app, monkeypatch
+) -> None:
     _require_app(app)
 
     from flaskr.service.tts.streaming_tts import AVStreamingTTSProcessor
@@ -146,7 +150,9 @@ def test_av_streaming_tts_processor_skips_chunked_markdown_image(app, monkeypatc
     assert "![" not in joined
 
 
-def test_av_streaming_tts_processor_skips_chunked_html_img_tag(app, monkeypatch):
+def test_av_streaming_tts_processor_skips_chunked_html_img_tag(
+    app, monkeypatch
+) -> None:
     _require_app(app)
 
     from flaskr.service.tts.streaming_tts import AVStreamingTTSProcessor
@@ -203,7 +209,7 @@ def test_av_streaming_tts_processor_skips_chunked_html_img_tag(app, monkeypatch)
 
 def test_av_streaming_tts_processor_does_not_split_markdown_h2_after_svg(
     app, monkeypatch
-):
+) -> None:
     _require_app(app)
 
     from flaskr.service.tts.streaming_tts import AVStreamingTTSProcessor
@@ -269,7 +275,7 @@ def test_av_streaming_tts_processor_does_not_split_markdown_h2_after_svg(
 
 def test_av_streaming_tts_processor_advances_position_when_segment_has_no_audio(
     app, monkeypatch
-):
+) -> None:
     _require_app(app)
 
     from flaskr.service.learn.learn_dtos import (
@@ -336,7 +342,9 @@ def test_av_streaming_tts_processor_advances_position_when_segment_has_no_audio(
     assert audio_complete[0].content.position == 1
 
 
-def test_av_streaming_tts_processor_never_emits_new_slide_event(app, monkeypatch):
+def test_av_streaming_tts_processor_never_emits_new_slide_event(
+    app, monkeypatch
+) -> None:
     _require_app(app)
 
     from flaskr.service.learn.learn_dtos import (
@@ -401,7 +409,7 @@ def test_av_streaming_tts_processor_never_emits_new_slide_event(app, monkeypatch
 
 def test_av_streaming_tts_processor_updates_next_element_index_from_contract(
     app, monkeypatch
-):
+) -> None:
     _require_app(app)
 
     from flaskr.service.learn.listen_slide_builder import VisualSegment
@@ -458,7 +466,7 @@ def test_av_streaming_tts_processor_updates_next_element_index_from_contract(
 
 def test_av_streaming_tts_processor_releases_sentence_before_long_list_tail(
     app, monkeypatch
-):
+) -> None:
     _require_app(app)
 
     from flaskr.service.tts.streaming_tts import AVStreamingTTSProcessor

--- a/src/api/tests/service/tts/test_streaming_tts_empty_audio_retry.py
+++ b/src/api/tests/service/tts/test_streaming_tts_empty_audio_retry.py
@@ -8,23 +8,23 @@ from flaskr.service.tts.streaming_tts import _is_retryable_empty_audio_error
     "provider",
     ["", "tencent", "tencent_texttovoice", "volcengine"],
 )
-def test_empty_audio_is_retryable_for_all_tts_providers(provider):
+def test_empty_audio_is_retryable_for_all_tts_providers(provider) -> None:
     error = ValueError(f"No audio data received from provider {provider or 'auto'}")
     assert _is_retryable_empty_audio_error(error, provider) is True
 
 
-def test_empty_audio_retry_matches_tencent_texttovoice_error_message():
+def test_empty_audio_retry_matches_tencent_texttovoice_error_message() -> None:
     # The exact message raised by tencent_texttovoice_provider must keep
     # matching the retry detector's substring.
     error = ValueError("No audio data received from Tencent TextToVoice")
     assert _is_retryable_empty_audio_error(error, "tencent_texttovoice") is True
 
 
-def test_non_empty_audio_errors_are_not_retryable():
+def test_non_empty_audio_errors_are_not_retryable() -> None:
     error = ValueError("Tencent TextToVoice error AuthFailure: bad secret")
     assert _is_retryable_empty_audio_error(error, "tencent_texttovoice") is False
 
 
-def test_unknown_provider_is_not_retryable():
+def test_unknown_provider_is_not_retryable() -> None:
     error = ValueError("No audio data received")
     assert _is_retryable_empty_audio_error(error, "some_future_provider") is False

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -14,14 +14,14 @@ from flaskr.service.tts.streaming_tts import StreamingTTSProcessor, TTSSegment
 
 
 @pytest.fixture
-def mock_app():
+def mock_app() -> MagicMock:
     """Create a mock Flask app."""
     app = MagicMock()
     app.config = {}
     return app
 
 
-def create_test_processor(mock_app, **kwargs: object):
+def create_test_processor(mock_app, **kwargs: object) -> StreamingTTSProcessor:
     """Create a StreamingTTSProcessor with test defaults."""
     defaults = {
         "app": mock_app,
@@ -43,7 +43,7 @@ class TestFinalizeSegmentation:
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_process_chunk_submits_only_after_sentence_boundary(
         self, mock_is_configured, mock_executor, mock_app
-    ):
+    ) -> None:
         """Test stream-time submission waits for a full sentence ending."""
         mock_is_configured.return_value = True
 
@@ -75,7 +75,7 @@ class TestFinalizeSegmentation:
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_submit_remaining_text_in_segments_splits_at_sentence_boundaries(
         self, mock_is_configured, mock_executor, mock_app
-    ):
+    ) -> None:
         """Test that remaining text is split at sentence boundaries."""
         mock_is_configured.return_value = True
 
@@ -119,7 +119,7 @@ class TestFinalizeSegmentation:
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_submit_remaining_text_does_not_split_by_char_count_without_sentence(
         self, mock_is_configured, mock_executor, mock_app
-    ):
+    ) -> None:
         """Test that text without sentence boundaries is submitted as one segment."""
         mock_is_configured.return_value = True
 
@@ -155,7 +155,7 @@ class TestFinalizeSegmentation:
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_submit_remaining_text_handles_short_text(
         self, mock_is_configured, mock_executor, mock_app
-    ):
+    ) -> None:
         """Test handling of very short remaining text."""
         mock_is_configured.return_value = True
 
@@ -190,7 +190,7 @@ class TestFinalizeSegmentation:
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_submit_remaining_text_handles_empty_string(
         self, mock_is_configured, mock_executor, mock_app
-    ):
+    ) -> None:
         """Test handling of empty remaining text."""
         mock_is_configured.return_value = True
 
@@ -206,7 +206,7 @@ class TestFinalizeSegmentation:
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_submit_remaining_text_handles_whitespace_only(
         self, mock_is_configured, mock_executor, mock_app
-    ):
+    ) -> None:
         """Test handling of whitespace-only remaining text."""
         mock_is_configured.return_value = True
 
@@ -222,7 +222,7 @@ class TestFinalizeSegmentation:
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_submit_remaining_text_logs_segment_info(
         self, mock_is_configured, mock_executor, mock_app, caplog
-    ):
+    ) -> None:
         """Test that segment submission is properly logged."""
         mock_is_configured.return_value = True
 
@@ -260,7 +260,7 @@ class TestStreamingSynthesisRetries:
         mock_record_usage,
         mock_sleep,
         mock_app,
-    ):
+    ) -> None:
         mock_is_configured.return_value = True
         mock_synthesize_text.side_effect = [
             ValueError("No audio data received from Tencent TTS"),
@@ -307,7 +307,7 @@ class TestStreamingSynthesisRetries:
         mock_sleep,
         mock_logger,
         mock_app,
-    ):
+    ) -> None:
         mock_is_configured.return_value = True
         mock_synthesize_text.side_effect = ValueError(
             "No audio data received from Tencent TTS"
@@ -355,7 +355,7 @@ class TestStreamingSynthesisRetries:
         mock_logger,
         mock_app,
         tts_provider,
-    ):
+    ) -> None:
         mock_is_configured.return_value = True
         app_context = MagicMock()
         app_context.__enter__.return_value = None
@@ -394,7 +394,7 @@ class TestStreamingSynthesisRetries:
         mock_minimax_provider,
         mock_logger,
         mock_app,
-    ):
+    ) -> None:
         mock_is_configured.return_value = True
         processor = create_test_processor(mock_app, tts_provider="minimax")
 
@@ -424,7 +424,7 @@ class TestStreamingSynthesisRetries:
         mock_synthesize_text,
         mock_logger,
         mock_app,
-    ):
+    ) -> None:
         mock_is_configured.return_value = True
         processor = create_test_processor(mock_app, tts_provider="volcengine")
 
@@ -456,7 +456,7 @@ class TestStreamingSynthesisRetries:
         mock_record_usage,
         mock_sleep,
         mock_app,
-    ):
+    ) -> None:
         mock_is_configured.return_value = True
         mock_synthesize_text.side_effect = [
             ValueError("No audio data received"),
@@ -515,7 +515,7 @@ class TestStreamingSynthesisRetries:
         mock_record_aggregate_usage,
         mock_save_audio_record,
         mock_app,
-    ):
+    ) -> None:
         mock_is_configured.return_value = True
         mock_synthesize_text.return_value = TTSResult(
             audio_data=b"provider-audio",
@@ -592,7 +592,7 @@ class TestStreamingSynthesisRetries:
         mock_save_audio_record,
         mock_sleep,
         mock_app,
-    ):
+    ) -> None:
         mock_is_configured.return_value = True
         mock_synthesize_text.side_effect = [
             ValueError("No audio data received"),
@@ -641,7 +641,7 @@ class TestOffsetDriftRegression:
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_bold_spanning_chunks_no_text_loss(
         self, mock_is_configured, mock_executor, mock_app
-    ):
+    ) -> None:
         """Bold markers completing across chunks must not cause text loss.
 
         Regression: when **bold** spans the processed/unprocessed boundary,
@@ -688,7 +688,7 @@ class TestOffsetDriftRegression:
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     def test_link_spanning_chunks_no_text_loss(
         self, mock_is_configured, mock_executor, mock_app
-    ):
+    ) -> None:
         """Links completing across chunks must not lose surrounding text."""
         mock_is_configured.return_value = True
 
@@ -731,7 +731,7 @@ class TestFinalizeDelayManagement:
         mock_synthesize_text,
         mock_record_segment_usage,
         mock_app,
-    ):
+    ) -> None:
         mock_is_configured.return_value = True
         mock_synthesize_text.return_value = TTSResult(
             audio_data=b"fake_audio_data",
@@ -778,7 +778,7 @@ class TestFinalizeDelayManagement:
     @patch("flaskr.service.tts.streaming_tts.time.sleep")
     def test_yield_ready_segments_adds_delay_between_segments(
         self, mock_sleep, mock_is_configured, mock_executor, mock_app
-    ):
+    ) -> None:
         """Test that _yield_ready_segments adds delay between segment yields."""
         _ = mock_executor
         mock_is_configured.return_value = True

--- a/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
+++ b/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
@@ -30,7 +30,7 @@ _TENCENT_MESSAGE = (
         ("No audio data received", False),
     ],
 )
-def test_rate_limit_detector(message, expected):
+def test_rate_limit_detector(message, expected) -> None:
     assert _is_retryable_rate_limit_error(ValueError(message)) is expected
 
 
@@ -61,7 +61,7 @@ def _run_retry(monkeypatch, outcomes, segment_index=0):
     return result, calls, sleeps
 
 
-def test_throttled_segment_retries_until_success(monkeypatch):
+def test_throttled_segment_retries_until_success(monkeypatch) -> None:
     success = types.SimpleNamespace(audio_data=b"ok")
     result, calls, sleeps = _run_retry(
         monkeypatch,
@@ -75,7 +75,7 @@ def test_throttled_segment_retries_until_success(monkeypatch):
     assert sleeps[1] > sleeps[0] > 0
 
 
-def test_throttled_segment_gives_up_after_max_attempts(monkeypatch):
+def test_throttled_segment_gives_up_after_max_attempts(monkeypatch) -> None:
     with pytest.raises(ValueError, match="LimitExceeded"):
         _run_retry(
             monkeypatch,
@@ -83,7 +83,7 @@ def test_throttled_segment_gives_up_after_max_attempts(monkeypatch):
         )
 
 
-def test_stagger_gives_concurrent_segments_distinct_delays(monkeypatch):
+def test_stagger_gives_concurrent_segments_distinct_delays(monkeypatch) -> None:
     from flaskr.service.tts.streaming_tts import _RATE_LIMIT_RETRY_STAGGER_SLOTS
 
     success = types.SimpleNamespace(audio_data=b"ok")
@@ -102,7 +102,7 @@ def test_stagger_gives_concurrent_segments_distinct_delays(monkeypatch):
     assert len(set(delays)) == _RATE_LIMIT_RETRY_STAGGER_SLOTS
 
 
-def test_non_retryable_error_still_raises_immediately(monkeypatch):
+def test_non_retryable_error_still_raises_immediately(monkeypatch) -> None:
     with pytest.raises(ValueError, match="AuthFailure"):
         _run_retry(
             monkeypatch,

--- a/src/api/tests/service/tts/test_streaming_tts_subtitles.py
+++ b/src/api/tests/service/tts/test_streaming_tts_subtitles.py
@@ -27,7 +27,7 @@ class TestStreamingTtsSubtitles:
         with cls.app.app_context():
             dao.db.create_all()
 
-    def test_streaming_tts_processor_persists_subtitle_cues(self, monkeypatch):
+    def test_streaming_tts_processor_persists_subtitle_cues(self, monkeypatch) -> None:
         from types import SimpleNamespace
 
         from flaskr.dao import db

--- a/src/api/tests/service/tts/test_tencent_provider.py
+++ b/src/api/tests/service/tts/test_tencent_provider.py
@@ -82,7 +82,7 @@ def _patch_tencent_config(monkeypatch, tencent_provider):
     )
 
 
-def test_tencent_sse_tc3_headers_sign_exact_request_payload():
+def test_tencent_sse_tc3_headers_sign_exact_request_payload() -> None:
     from flaskr.api.tts.tencent_provider import (
         build_tencent_tc3_headers,
         encode_tencent_sse_payload,
@@ -124,7 +124,7 @@ def test_tencent_sse_tc3_headers_sign_exact_request_payload():
     )
 
 
-def test_tencent_provider_config_validation_and_explicit_only(monkeypatch):
+def test_tencent_provider_config_validation_and_explicit_only(monkeypatch) -> None:
     import flaskr.api.tts as tts_api
     from flaskr.api.tts import tencent_provider
     from flaskr.common.config import ENV_VARS
@@ -186,7 +186,7 @@ def test_tencent_provider_config_validation_and_explicit_only(monkeypatch):
 
 def test_tencent_provider_stream_synthesize_parses_sse_audio_and_alignments(
     monkeypatch,
-):
+) -> None:
     from flaskr.api.tts import tencent_provider
     from flaskr.api.tts.base import AudioSettings, VoiceSettings
 
@@ -270,7 +270,7 @@ def test_tencent_provider_stream_synthesize_parses_sse_audio_and_alignments(
 
 def test_tencent_provider_synthesize_collects_audio_and_sentence_subtitles(
     monkeypatch,
-):
+) -> None:
     from flaskr.api.tts import tencent_provider
     from flaskr.api.tts.base import AudioSettings, VoiceSettings
 
@@ -365,7 +365,7 @@ def test_tencent_provider_synthesize_collects_audio_and_sentence_subtitles(
     assert [cue["text"] for cue in result.subtitle_cues] == ["你好。", "世界！"]
 
 
-def test_tencent_provider_raises_sanitized_error_on_sse_error(monkeypatch):
+def test_tencent_provider_raises_sanitized_error_on_sse_error(monkeypatch) -> None:
     from flaskr.api.tts import tencent_provider
 
     _patch_tencent_config(monkeypatch, tencent_provider)

--- a/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
+++ b/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
@@ -72,7 +72,7 @@ class _FakeResponse:
         return self._body
 
 
-def test_tc3_headers_sign_exact_request_payload():
+def test_tc3_headers_sign_exact_request_payload() -> None:
     from flaskr.api.tts.tencent_texttovoice_provider import (
         build_texttovoice_tc3_headers,
     )
@@ -108,7 +108,7 @@ def test_tc3_headers_sign_exact_request_payload():
     )
 
 
-def test_provider_config_exposes_two_model_tiers_with_tagged_voices():
+def test_provider_config_exposes_two_model_tiers_with_tagged_voices() -> None:
     from flaskr.api.tts.tencent_texttovoice_provider import (
         TencentTextToVoiceProvider,
     )
@@ -130,7 +130,7 @@ def test_provider_config_exposes_two_model_tiers_with_tagged_voices():
     assert all(v["value"][:3] in {"501", "601"} for v in large_voices)
 
 
-def test_resolve_sample_rate_by_voice_tier_and_model_fallback():
+def test_resolve_sample_rate_by_voice_tier_and_model_fallback() -> None:
     from flaskr.api.tts.tencent_texttovoice_provider import _resolve_sample_rate
 
     assert _resolve_sample_rate("101001", "") == 16000
@@ -141,7 +141,7 @@ def test_resolve_sample_rate_by_voice_tier_and_model_fallback():
     assert _resolve_sample_rate("999999", "") == 16000
 
 
-def test_split_text_weighted_limits():
+def test_split_text_weighted_limits() -> None:
     from flaskr.api.tts.tencent_texttovoice_provider import (
         _SEGMENT_WEIGHT_LIMIT,
         _split_text,
@@ -169,7 +169,7 @@ def test_split_text_weighted_limits():
     assert _split_text("   ") == []
 
 
-def test_synthesize_builds_payload_and_concatenates_segments(monkeypatch):
+def test_synthesize_builds_payload_and_concatenates_segments(monkeypatch) -> None:
     from flaskr.api.tts import tencent_texttovoice_provider as module
 
     _patch_credentials(monkeypatch)
@@ -226,7 +226,7 @@ def test_synthesize_builds_payload_and_concatenates_segments(monkeypatch):
     assert result.usage_characters == len(text)
 
 
-def test_synthesize_raises_on_api_error_with_code(monkeypatch):
+def test_synthesize_raises_on_api_error_with_code(monkeypatch) -> None:
     from flaskr.api.tts import tencent_texttovoice_provider as module
 
     _patch_credentials(monkeypatch)
@@ -256,7 +256,7 @@ def test_synthesize_raises_on_api_error_with_code(monkeypatch):
     assert "req-err" in str(exc_info.value)
 
 
-def test_synthesize_raises_on_empty_audio(monkeypatch):
+def test_synthesize_raises_on_empty_audio(monkeypatch) -> None:
     from flaskr.api.tts import tencent_texttovoice_provider as module
 
     _patch_credentials(monkeypatch)
@@ -279,7 +279,7 @@ def test_synthesize_raises_on_empty_audio(monkeypatch):
     assert "No audio data received from Tencent TextToVoice" in str(exc_info.value)
 
 
-def test_synthesize_rejects_non_numeric_voice_id(monkeypatch):
+def test_synthesize_rejects_non_numeric_voice_id(monkeypatch) -> None:
     from flaskr.api.tts import tencent_texttovoice_provider as module
 
     _patch_credentials(monkeypatch)
@@ -294,7 +294,7 @@ def test_synthesize_rejects_non_numeric_voice_id(monkeypatch):
     assert "Invalid Tencent TextToVoice voice id" in str(exc_info.value)
 
 
-def test_validation_requires_model_and_tier_consistency():
+def test_validation_requires_model_and_tier_consistency() -> None:
     from flaskr.service.common.models import AppError
     from flaskr.service.tts.validation import validate_tts_settings_strict
 

--- a/src/api/tests/service/tts/test_tts_config_options.py
+++ b/src/api/tests/service/tts/test_tts_config_options.py
@@ -40,7 +40,7 @@ class _FakeBaiduProvider:
 
 def test_tts_config_model_options_follow_allowlist_and_localized_names(
     monkeypatch,
-):
+) -> None:
     import flaskr.api.tts as tts_api
     from flaskr.i18n import clear_language, set_language
 
@@ -119,7 +119,7 @@ def _chars_per_token_config(value: str):
     return _get_config
 
 
-def test_tts_credit_multiplier_uses_shared_llm_anchor(monkeypatch):
+def test_tts_credit_multiplier_uses_shared_llm_anchor(monkeypatch) -> None:
     import flaskr.api.tts as tts_api
     from flaskr.service.billing.consts import BILLING_METRIC_TTS_OUTPUT_CHARS
     from flaskr.service.metering.consts import BILL_USAGE_TYPE_TTS
@@ -158,7 +158,7 @@ def test_tts_credit_multiplier_uses_shared_llm_anchor(monkeypatch):
     ) in captured
 
 
-def test_tts_credit_multiplier_scales_with_chars_per_token(monkeypatch):
+def test_tts_credit_multiplier_scales_with_chars_per_token(monkeypatch) -> None:
     import flaskr.api.tts as tts_api
     from flaskr.service.billing.consts import BILLING_METRIC_TTS_OUTPUT_CHARS
     from flaskr.service.metering.consts import BILL_USAGE_TYPE_TTS
@@ -192,7 +192,7 @@ def test_tts_credit_multiplier_scales_with_chars_per_token(monkeypatch):
     )
 
 
-def test_tts_credit_multiplier_none_when_tts_rate_missing(monkeypatch):
+def test_tts_credit_multiplier_none_when_tts_rate_missing(monkeypatch) -> None:
     import flaskr.api.tts as tts_api
 
     def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
@@ -211,7 +211,7 @@ def test_tts_credit_multiplier_none_when_tts_rate_missing(monkeypatch):
     assert tts_api._resolve_credit_multiplier_label("unknown", "missing") is None
 
 
-def test_tts_credit_multiplier_none_when_conversion_unset(monkeypatch):
+def test_tts_credit_multiplier_none_when_conversion_unset(monkeypatch) -> None:
     import flaskr.api.tts as tts_api
 
     def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
@@ -231,7 +231,7 @@ def test_tts_credit_multiplier_none_when_conversion_unset(monkeypatch):
     assert tts_api._resolve_credit_multiplier_label("tencent", "") is None
 
 
-def test_tts_display_name_prefers_request_language(monkeypatch):
+def test_tts_display_name_prefers_request_language(monkeypatch) -> None:
     import flaskr.api.tts as tts_api
     from flaskr.i18n import clear_language
 
@@ -262,7 +262,7 @@ def test_tts_display_name_prefers_request_language(monkeypatch):
         clear_language()
 
 
-def test_tts_display_name_normalizes_config_keys(monkeypatch):
+def test_tts_display_name_normalizes_config_keys(monkeypatch) -> None:
     import flaskr.api.tts as tts_api
     from flaskr.i18n import clear_language
 
@@ -298,7 +298,7 @@ def test_tts_display_name_normalizes_config_keys(monkeypatch):
         clear_language()
 
 
-def test_parse_tts_display_names_accepts_preparsed_dict(monkeypatch):
+def test_parse_tts_display_names_accepts_preparsed_dict(monkeypatch) -> None:
     import flaskr.api.tts as tts_api
 
     # A programmatic/unit-test config may hand back an already-parsed dict; the
@@ -317,7 +317,7 @@ def test_parse_tts_display_names_accepts_preparsed_dict(monkeypatch):
     assert display_names == {"minimax/speech-01-turbo": {"en-US": "Flagship Voice"}}
 
 
-def test_usage_rate_unit_cost_uses_utc_settlement(monkeypatch):
+def test_usage_rate_unit_cost_uses_utc_settlement(monkeypatch) -> None:
     from datetime import datetime
 
     import flaskr.api.tts as tts_api
@@ -349,7 +349,7 @@ def test_usage_rate_unit_cost_uses_utc_settlement(monkeypatch):
     assert captured["settlement_at"] == utc_sentinel
 
 
-def test_tts_config_three_tier_allowlist_orders_and_localizes(monkeypatch):
+def test_tts_config_three_tier_allowlist_orders_and_localizes(monkeypatch) -> None:
     """The local three-tier lineup: tencent premium first, then tencent large-model (configured default), then volcengine seed-tts-2.0, with zh display names.
 
     The default marker must not reorder the allowlist.
@@ -439,7 +439,7 @@ def _patch_two_provider_registry(monkeypatch, tts_api):
     )
 
 
-def test_tts_default_model_marks_provider_only_option(monkeypatch):
+def test_tts_default_model_marks_provider_only_option(monkeypatch) -> None:
     import flaskr.api.tts as tts_api
 
     _patch_two_provider_registry(monkeypatch, tts_api)
@@ -456,7 +456,7 @@ def test_tts_default_model_marks_provider_only_option(monkeypatch):
     ]
 
 
-def test_tts_default_model_applies_without_allowlist(monkeypatch):
+def test_tts_default_model_applies_without_allowlist(monkeypatch) -> None:
     import flaskr.api.tts as tts_api
 
     _patch_two_provider_registry(monkeypatch, tts_api)
@@ -474,7 +474,7 @@ def test_tts_default_model_applies_without_allowlist(monkeypatch):
     ]
 
 
-def test_tts_default_model_invalid_format_falls_back(monkeypatch, caplog):
+def test_tts_default_model_invalid_format_falls_back(monkeypatch, caplog) -> None:
     import logging
 
     import flaskr.api.tts as tts_api
@@ -490,7 +490,7 @@ def test_tts_default_model_invalid_format_falls_back(monkeypatch, caplog):
     assert "Ignoring invalid TTS_DEFAULT_MODEL" in caplog.text
 
 
-def test_tts_default_model_outside_allowlist_falls_back(monkeypatch, caplog):
+def test_tts_default_model_outside_allowlist_falls_back(monkeypatch, caplog) -> None:
     import logging
 
     import flaskr.api.tts as tts_api
@@ -508,7 +508,7 @@ def test_tts_default_model_outside_allowlist_falls_back(monkeypatch, caplog):
     assert "TTS_DEFAULT_MODEL not in available model options" in caplog.text
 
 
-def test_tts_default_model_unset_leaves_all_options_non_default(monkeypatch):
+def test_tts_default_model_unset_leaves_all_options_non_default(monkeypatch) -> None:
     import flaskr.api.tts as tts_api
 
     _patch_two_provider_registry(monkeypatch, tts_api)

--- a/src/api/tests/service/tts/test_tts_executor_fork_isolation.py
+++ b/src/api/tests/service/tts/test_tts_executor_fork_isolation.py
@@ -13,7 +13,7 @@ import inspect
 from flaskr.service.tts import streaming_tts
 
 
-def test_module_does_not_create_an_executor_at_import_time():
+def test_module_does_not_create_an_executor_at_import_time() -> None:
     # The import-time instance is the fork-inheritance hazard; only the
     # lazy accessor may create one.
     module_ast = ast.parse(inspect.getsource(streaming_tts))
@@ -31,7 +31,7 @@ def test_module_does_not_create_an_executor_at_import_time():
                 raise AssertionError(message)
 
 
-def test_executor_is_cached_within_one_process(monkeypatch):
+def test_executor_is_cached_within_one_process(monkeypatch) -> None:
     monkeypatch.setattr(streaming_tts._tts_executor_state, "executor", None)
     monkeypatch.setattr(streaming_tts._tts_executor_state, "pid", None)
 
@@ -42,7 +42,7 @@ def test_executor_is_cached_within_one_process(monkeypatch):
     first.shutdown(wait=False)
 
 
-def test_directly_injected_executor_is_honored(monkeypatch):
+def test_directly_injected_executor_is_honored(monkeypatch) -> None:
     # Existing tests patch the registry executor with a mock and leave the pid
     # unset; the accessor must return the injection instead of clobbering
     # it with a real executor.
@@ -53,7 +53,7 @@ def test_directly_injected_executor_is_honored(monkeypatch):
     assert streaming_tts._get_tts_executor() is sentinel
 
 
-def test_executor_is_rebuilt_after_fork(monkeypatch):
+def test_executor_is_rebuilt_after_fork(monkeypatch) -> None:
     monkeypatch.setattr(streaming_tts._tts_executor_state, "executor", None)
     monkeypatch.setattr(streaming_tts._tts_executor_state, "pid", None)
 

--- a/src/api/tests/service/tts/test_tts_rpm_gate.py
+++ b/src/api/tests/service/tts/test_tts_rpm_gate.py
@@ -57,7 +57,7 @@ def _reset_gate_state():
     rpm_gate._FALLBACK_WARNING_KEYS.clear()
 
 
-def test_rpm_gate_smooths_same_provider_and_api_key(monkeypatch):
+def test_rpm_gate_smooths_same_provider_and_api_key(monkeypatch) -> None:
     fake_redis = _FakeRedis()
     monkeypatch.setattr(rpm_gate, "_get_redis_client", lambda: fake_redis)
     now_fn, sleep_fn = _clock()
@@ -83,7 +83,7 @@ def test_rpm_gate_smooths_same_provider_and_api_key(monkeypatch):
     assert second.waited_seconds == pytest.approx(1.0)
 
 
-def test_rpm_gate_uses_independent_queues_for_different_api_keys(monkeypatch):
+def test_rpm_gate_uses_independent_queues_for_different_api_keys(monkeypatch) -> None:
     fake_redis = _FakeRedis()
     monkeypatch.setattr(rpm_gate, "_get_redis_client", lambda: fake_redis)
     now_fn, sleep_fn = _clock()
@@ -109,7 +109,7 @@ def test_rpm_gate_uses_independent_queues_for_different_api_keys(monkeypatch):
     assert second.waited_seconds == 0
 
 
-def test_rpm_gate_uses_independent_queues_for_different_models(monkeypatch):
+def test_rpm_gate_uses_independent_queues_for_different_models(monkeypatch) -> None:
     fake_redis = _FakeRedis()
     monkeypatch.setattr(rpm_gate, "_get_redis_client", lambda: fake_redis)
     now_fn, sleep_fn = _clock()
@@ -138,7 +138,7 @@ def test_rpm_gate_uses_independent_queues_for_different_models(monkeypatch):
     assert second.waited_seconds == 0
 
 
-def test_rpm_gate_smooths_same_model(monkeypatch):
+def test_rpm_gate_smooths_same_model(monkeypatch) -> None:
     fake_redis = _FakeRedis()
     monkeypatch.setattr(rpm_gate, "_get_redis_client", lambda: fake_redis)
     now_fn, sleep_fn = _clock()
@@ -166,7 +166,7 @@ def test_rpm_gate_smooths_same_model(monkeypatch):
     assert second.waited_seconds == pytest.approx(1.0)
 
 
-def test_rpm_gate_times_out_when_queue_exceeds_max_wait(monkeypatch):
+def test_rpm_gate_times_out_when_queue_exceeds_max_wait(monkeypatch) -> None:
     fake_redis = _FakeRedis()
     monkeypatch.setattr(rpm_gate, "_get_redis_client", lambda: fake_redis)
     now_fn, sleep_fn = _clock()
@@ -191,7 +191,9 @@ def test_rpm_gate_times_out_when_queue_exceeds_max_wait(monkeypatch):
         )
 
 
-def test_rpm_gate_falls_back_to_process_local_when_redis_unavailable(monkeypatch):
+def test_rpm_gate_falls_back_to_process_local_when_redis_unavailable(
+    monkeypatch,
+) -> None:
     monkeypatch.setattr(
         rpm_gate,
         "_get_redis_client",

--- a/src/api/tests/service/tts/test_tts_text_preprocess.py
+++ b/src/api/tests/service/tts/test_tts_text_preprocess.py
@@ -8,7 +8,7 @@ def _require_app(app):
         pytest.skip("App fixture disabled")
 
 
-def test_preprocess_for_tts_removes_complete_svg(app):
+def test_preprocess_for_tts_removes_complete_svg(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -28,7 +28,7 @@ def test_preprocess_for_tts_removes_complete_svg(app):
     assert "http://www.w3.org" not in cleaned
 
 
-def test_preprocess_for_tts_strips_incomplete_svg_tail(app):
+def test_preprocess_for_tts_strips_incomplete_svg_tail(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -41,7 +41,7 @@ def test_preprocess_for_tts_strips_incomplete_svg_tail(app):
     assert "http://www.w3.org" not in cleaned
 
 
-def test_preprocess_for_tts_strips_incomplete_fenced_code(app):
+def test_preprocess_for_tts_strips_incomplete_fenced_code(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -52,7 +52,7 @@ def test_preprocess_for_tts_strips_incomplete_fenced_code(app):
     assert cleaned == "Hello."
 
 
-def test_preprocess_for_tts_strips_escaped_html_tags(app):
+def test_preprocess_for_tts_strips_escaped_html_tags(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -65,7 +65,7 @@ def test_preprocess_for_tts_strips_escaped_html_tags(app):
     assert "<p>" not in cleaned
 
 
-def test_preprocess_for_tts_strips_double_escaped_html_tags(app):
+def test_preprocess_for_tts_strips_double_escaped_html_tags(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -78,7 +78,7 @@ def test_preprocess_for_tts_strips_double_escaped_html_tags(app):
     assert "&lt;" not in cleaned
 
 
-def test_preprocess_for_tts_strips_incomplete_html_tag_tail(app):
+def test_preprocess_for_tts_strips_incomplete_html_tag_tail(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -89,7 +89,7 @@ def test_preprocess_for_tts_strips_incomplete_html_tag_tail(app):
     assert cleaned == "Before."
 
 
-def test_preprocess_for_tts_keeps_non_tag_angle_brackets(app):
+def test_preprocess_for_tts_keeps_non_tag_angle_brackets(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -100,7 +100,7 @@ def test_preprocess_for_tts_keeps_non_tag_angle_brackets(app):
     assert cleaned == "I love you < 3."
 
 
-def test_preprocess_for_tts_strips_incomplete_markdown_image_tail(app):
+def test_preprocess_for_tts_strips_incomplete_markdown_image_tail(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -113,7 +113,7 @@ def test_preprocess_for_tts_strips_incomplete_markdown_image_tail(app):
     assert "![" not in cleaned
 
 
-def test_preprocess_for_tts_strips_stray_svg_text_elements(app):
+def test_preprocess_for_tts_strips_stray_svg_text_elements(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -125,7 +125,9 @@ def test_preprocess_for_tts_strips_stray_svg_text_elements(app):
     assert "Hello" not in cleaned
 
 
-def test_streaming_tts_processor_skips_svg_and_keeps_following_text(app, monkeypatch):
+def test_streaming_tts_processor_skips_svg_and_keeps_following_text(
+    app, monkeypatch
+) -> None:
     _require_app(app)
 
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
@@ -172,7 +174,7 @@ def test_streaming_tts_processor_skips_svg_and_keeps_following_text(app, monkeyp
     assert all("http://www.w3.org" not in t for t in captured)
 
 
-def test_streaming_tts_processor_skips_chunked_markdown_image(app, monkeypatch):
+def test_streaming_tts_processor_skips_chunked_markdown_image(app, monkeypatch) -> None:
     _require_app(app)
 
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
@@ -216,7 +218,7 @@ def test_streaming_tts_processor_skips_chunked_markdown_image(app, monkeypatch):
     assert all("![" not in t for t in captured)
 
 
-def test_preprocess_for_tts_removes_interaction_block(app):
+def test_preprocess_for_tts_removes_interaction_block(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -235,7 +237,7 @@ def test_preprocess_for_tts_removes_interaction_block(app):
     assert "几乎空白" not in cleaned
 
 
-def test_preprocess_for_tts_removes_interaction_block_with_variable(app):
+def test_preprocess_for_tts_removes_interaction_block_with_variable(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -249,7 +251,7 @@ def test_preprocess_for_tts_removes_interaction_block_with_variable(app):
     assert "概念清楚了" not in cleaned
 
 
-def test_preprocess_for_tts_removes_interaction_block_variants(app):
+def test_preprocess_for_tts_removes_interaction_block_variants(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -270,7 +272,7 @@ def test_preprocess_for_tts_removes_interaction_block_variants(app):
             assert fragment not in cleaned
 
 
-def test_preprocess_for_tts_strips_incomplete_interaction_tail(app):
+def test_preprocess_for_tts_strips_incomplete_interaction_tail(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -284,7 +286,7 @@ def test_preprocess_for_tts_strips_incomplete_interaction_tail(app):
     assert "概念还含糊" not in cleaned
 
 
-def test_preprocess_for_tts_removes_unresolved_variable_placeholders(app):
+def test_preprocess_for_tts_removes_unresolved_variable_placeholders(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -298,7 +300,7 @@ def test_preprocess_for_tts_removes_unresolved_variable_placeholders(app):
     assert "preserved" not in cleaned
 
 
-def test_preprocess_for_tts_keeps_regular_markdown_links(app):
+def test_preprocess_for_tts_keeps_regular_markdown_links(app) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts
@@ -311,7 +313,9 @@ def test_preprocess_for_tts_keeps_regular_markdown_links(app):
     assert "example.com" not in cleaned
 
 
-def test_preprocess_for_tts_keeps_markdown_link_directly_after_question_mark(app):
+def test_preprocess_for_tts_keeps_markdown_link_directly_after_question_mark(
+    app,
+) -> None:
     _require_app(app)
 
     from flaskr.service.tts import preprocess_for_tts

--- a/src/api/tests/service/tts/test_tts_validation_cloned_voice.py
+++ b/src/api/tests/service/tts/test_tts_validation_cloned_voice.py
@@ -78,7 +78,7 @@ def _validate(provider: str, model: str, voice_id: str):
     )
 
 
-def test_volcengine_registered_clone_keeps_teacher_selected_model(app):
+def test_volcengine_registered_clone_keeps_teacher_selected_model(app) -> None:
     """A registered cloned voice validates under the teacher's normal model.
 
     For example, seed-tts-2.0 remains the model; the clone resource id is inferred inside the
@@ -92,7 +92,7 @@ def test_volcengine_registered_clone_keeps_teacher_selected_model(app):
     assert validated.model == "seed-tts-2.0"
 
 
-def test_volcengine_clone_with_unlisted_model_is_rejected(app):
+def test_volcengine_clone_with_unlisted_model_is_rejected(app) -> None:
     _prepare_tables(app)
     _seed_ready_clone(app, provider="volcengine", voice_id="S_xxxxxxxxxx")
     with app.app_context(), pytest.raises(AppError) as exc_info:
@@ -100,21 +100,21 @@ def test_volcengine_clone_with_unlisted_model_is_rejected(app):
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
-def test_volcengine_unregistered_clone_is_rejected(app):
+def test_volcengine_unregistered_clone_is_rejected(app) -> None:
     _prepare_tables(app)
     with app.app_context(), pytest.raises(AppError) as exc_info:
         _validate("volcengine", "seed-tts-2.0", "S_xxxxxxxxxxxx")
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
-def test_volcengine_bad_shape_custom_voice_is_rejected(app):
+def test_volcengine_bad_shape_custom_voice_is_rejected(app) -> None:
     _prepare_tables(app)
     with app.app_context(), pytest.raises(AppError) as exc_info:
         _validate("volcengine", "seed-tts-2.0", "AiShifu_not_a_speaker")
     assert exc_info.value.code == ERROR_CODE["server.common.paramsError"]
 
 
-def test_minimax_format_bypass_does_not_require_db_row(app):
+def test_minimax_format_bypass_does_not_require_db_row(app) -> None:
     """Regression: the historical MiniMax bypass stays format-only (no DB row needed), so stale-but-well-formed ids keep passing strict validation."""
     _prepare_tables(app)
     with app.app_context():

--- a/src/api/tests/service/tts/test_volcengine_http_provider.py
+++ b/src/api/tests/service/tts/test_volcengine_http_provider.py
@@ -13,7 +13,7 @@ from flaskr.service.tts.pipeline import split_text_for_tts
 from flaskr.service.tts.validation import validate_tts_settings_strict
 
 
-def test_volcengine_http_synthesize_success(monkeypatch):
+def test_volcengine_http_synthesize_success(monkeypatch) -> None:
     monkeypatch.setenv("VOLCENGINE_TTS_APP_KEY", "test-app")
     monkeypatch.setenv("VOLCENGINE_TTS_ACCESS_KEY", "test-token")
     monkeypatch.setenv("VOLCENGINE_TTS_CLUSTER_ID", "volcano_tts")
@@ -77,7 +77,9 @@ def test_volcengine_http_synthesize_success(monkeypatch):
     assert captured["json"]["audio"]["emotion"] == "happy"
 
 
-def test_volcengine_http_legacy_resource_id_overrides_default_cluster(monkeypatch):
+def test_volcengine_http_legacy_resource_id_overrides_default_cluster(
+    monkeypatch,
+) -> None:
     """Ensure old VOLCENGINE_TTS_RESOURCE_ID still works when new cluster var is unset."""
     monkeypatch.setenv("VOLCENGINE_TTS_APP_KEY", "test-app")
     monkeypatch.setenv("VOLCENGINE_TTS_ACCESS_KEY", "test-token")
@@ -122,14 +124,14 @@ def test_volcengine_http_legacy_resource_id_overrides_default_cluster(monkeypatc
     assert captured["json"]["app"]["cluster"] == "legacy_cluster"
 
 
-def test_volcengine_http_provider_config_omits_models(monkeypatch):
+def test_volcengine_http_provider_config_omits_models(monkeypatch) -> None:
     monkeypatch.setenv("VOLCENGINE_TTS_CLUSTER_ID", "custom_cluster")
     provider = VolcengineHttpTTSProvider()
     config = provider.get_provider_config().to_dict()
     assert "models" not in config
 
 
-def test_split_text_for_tts_volcengine_http_byte_limit():
+def test_split_text_for_tts_volcengine_http_byte_limit() -> None:
     text = "é" * 600
     segments = split_text_for_tts(
         text, provider_name="volcengine_http", max_segment_chars=2000
@@ -138,7 +140,7 @@ def test_split_text_for_tts_volcengine_http_byte_limit():
     assert all(len(segment.encode("utf-8")) <= 1024 for segment in segments)
 
 
-def test_validate_tts_settings_strict_volcengine_http(monkeypatch):
+def test_validate_tts_settings_strict_volcengine_http(monkeypatch) -> None:
     monkeypatch.setenv("VOLCENGINE_TTS_CLUSTER_ID", "volcano_tts")
     settings = validate_tts_settings_strict(
         provider="volcengine_http",

--- a/src/api/tests/service/tts/test_volcengine_ws_provider.py
+++ b/src/api/tests/service/tts/test_volcengine_ws_provider.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 from flaskr.api.tts import volcengine_provider
 
 
-def test_volcengine_ws_get_credentials_prefers_volcengine_tts_keys(monkeypatch):
+def test_volcengine_ws_get_credentials_prefers_volcengine_tts_keys(monkeypatch) -> None:
     monkeypatch.setenv("VOLCENGINE_TTS_APP_KEY", "test-app")
     monkeypatch.setenv("VOLCENGINE_TTS_ACCESS_KEY", "test-access")
     monkeypatch.setenv("ARK_ACCESS_KEY_ID", "legacy-app")
@@ -20,7 +20,7 @@ def test_volcengine_ws_get_credentials_prefers_volcengine_tts_keys(monkeypatch):
     assert resource_id == "seed-tts-2.0"
 
 
-def test_volcengine_ws_get_credentials_falls_back_to_ark_keys(monkeypatch):
+def test_volcengine_ws_get_credentials_falls_back_to_ark_keys(monkeypatch) -> None:
     monkeypatch.delenv("VOLCENGINE_TTS_APP_KEY", raising=False)
     monkeypatch.delenv("VOLCENGINE_TTS_ACCESS_KEY", raising=False)
     monkeypatch.setenv("ARK_ACCESS_KEY_ID", "legacy-app")
@@ -34,7 +34,7 @@ def test_volcengine_ws_get_credentials_falls_back_to_ark_keys(monkeypatch):
     assert resource_id == "seed-tts-1.0"
 
 
-def test_volcengine_ws_is_configured_uses_volcengine_tts_keys(monkeypatch):
+def test_volcengine_ws_is_configured_uses_volcengine_tts_keys(monkeypatch) -> None:
     monkeypatch.setenv("VOLCENGINE_TTS_APP_KEY", "test-app")
     monkeypatch.setenv("VOLCENGINE_TTS_ACCESS_KEY", "test-access")
     monkeypatch.delenv("ARK_ACCESS_KEY_ID", raising=False)
@@ -45,7 +45,9 @@ def test_volcengine_ws_is_configured_uses_volcengine_tts_keys(monkeypatch):
     assert provider.is_configured() is True
 
 
-def test_volcengine_ws_waits_for_session_started_before_task_request(monkeypatch):
+def test_volcengine_ws_waits_for_session_started_before_task_request(
+    monkeypatch,
+) -> None:
     monkeypatch.setenv("VOLCENGINE_TTS_APP_KEY", "test-app")
     monkeypatch.setenv("VOLCENGINE_TTS_ACCESS_KEY", "test-access")
     monkeypatch.setattr(volcengine_provider, "WEBSOCKET_AVAILABLE", True)

--- a/src/api/tests/service/user/test_captcha_routes.py
+++ b/src/api/tests/service/user/test_captcha_routes.py
@@ -42,7 +42,7 @@ def _get_ticket(client, app):
     return body["data"]["captcha_ticket"]
 
 
-def test_get_captcha_returns_image_payload(test_client, app):
+def test_get_captcha_returns_image_payload(test_client, app) -> None:
     captcha = _get_captcha(test_client, app)
 
     assert captcha["captcha_id"]
@@ -54,7 +54,7 @@ def test_get_captcha_returns_image_payload(test_client, app):
     assert captcha["expires_in"] == app.config["CAPTCHA_EXPIRE_TIME"]
 
 
-def test_captcha_verify_rejects_wrong_code(test_client, app):
+def test_captcha_verify_rejects_wrong_code(test_client, app) -> None:
     captcha = _get_captcha(test_client, app)
 
     response, body = _post_json(
@@ -70,7 +70,7 @@ def test_captcha_verify_rejects_wrong_code(test_client, app):
     assert body["code"] == 1009
 
 
-def test_captcha_verify_localizes_wrong_code_message(test_client, app):
+def test_captcha_verify_localizes_wrong_code_message(test_client, app) -> None:
     captcha = _get_captcha(test_client, app)
 
     response = test_client.post(
@@ -91,7 +91,7 @@ def test_captcha_verify_localizes_wrong_code_message(test_client, app):
     assert body["message"] == "图形验证码错误"
 
 
-def test_captcha_verify_deletes_after_attempt_limit(test_client, app):
+def test_captcha_verify_deletes_after_attempt_limit(test_client, app) -> None:
     original_attempts = app.config.get("CAPTCHA_MAX_VERIFY_ATTEMPTS")
     app.config["CAPTCHA_MAX_VERIFY_ATTEMPTS"] = 1
     try:
@@ -122,7 +122,7 @@ def test_captcha_verify_deletes_after_attempt_limit(test_client, app):
         app.config["CAPTCHA_MAX_VERIFY_ATTEMPTS"] = original_attempts
 
 
-def test_send_sms_code_requires_captcha_ticket(test_client, app):
+def test_send_sms_code_requires_captcha_ticket(test_client, app) -> None:
     _ = app
     response, body = _post_json(
         test_client,
@@ -134,7 +134,7 @@ def test_send_sms_code_requires_captcha_ticket(test_client, app):
     assert body["code"] == 1009
 
 
-def test_send_sms_code_swagger_parameters_stay_valid_yaml(app):
+def test_send_sms_code_swagger_parameters_stay_valid_yaml(app) -> None:
     view = app.view_functions["send_sms_code_api"]
 
     _summary, _description, specification = parse_docstring(
@@ -150,7 +150,9 @@ def test_send_sms_code_swagger_parameters_stay_valid_yaml(app):
     ]
 
 
-def test_send_sms_code_localizes_missing_captcha_ticket_message(test_client, app):
+def test_send_sms_code_localizes_missing_captcha_ticket_message(
+    test_client, app
+) -> None:
     _ = app
     response, body = _post_json(
         test_client,
@@ -163,7 +165,7 @@ def test_send_sms_code_localizes_missing_captcha_ticket_message(test_client, app
     assert body["message"] == "图形验证码错误"
 
 
-def test_send_sms_code_consumes_ticket_once(test_client, app, monkeypatch):
+def test_send_sms_code_consumes_ticket_once(test_client, app, monkeypatch) -> None:
     import flaskr.service.user.utils as user_utils
 
     monkeypatch.setattr(
@@ -199,7 +201,7 @@ def test_send_sms_code_consumes_ticket_once(test_client, app, monkeypatch):
 
 def test_console_send_sms_code_does_not_require_captcha_ticket(
     test_client, monkeypatch
-):
+) -> None:
     import flaskr.service.user.utils as user_utils
 
     monkeypatch.setattr(
@@ -219,7 +221,9 @@ def test_console_send_sms_code_does_not_require_captcha_ticket(
     assert body["data"]["expire_in"] > 0
 
 
-def test_console_send_sms_code_normalizes_cn_prefix(test_client, app, monkeypatch):
+def test_console_send_sms_code_normalizes_cn_prefix(
+    test_client, app, monkeypatch
+) -> None:
     import flaskr.service.user.utils as user_utils
     from flaskr.service.user.models import UserVerifyCode
 

--- a/src/api/tests/service/user/test_demo_course_permissions.py
+++ b/src/api/tests/service/user/test_demo_course_permissions.py
@@ -32,7 +32,7 @@ def _seed_published_shifu(shifu_bid: str) -> None:
     )
 
 
-def test_ensure_demo_course_permissions_creates_view_auth(app, monkeypatch):
+def test_ensure_demo_course_permissions_creates_view_auth(app, monkeypatch) -> None:
     demo_bid = uuid.uuid4().hex[:32]
     user_id = uuid.uuid4().hex[:32]
 
@@ -67,7 +67,7 @@ def test_ensure_demo_course_permissions_creates_view_auth(app, monkeypatch):
 
 def test_ensure_demo_course_permissions_keeps_existing_higher_permission(
     app, monkeypatch
-):
+) -> None:
     demo_bid = uuid.uuid4().hex[:32]
     user_id = uuid.uuid4().hex[:32]
     edit_auth = json.dumps(["edit"])
@@ -111,7 +111,7 @@ def test_ensure_demo_course_permissions_keeps_existing_higher_permission(
             db.session.commit()
 
 
-def test_ensure_demo_course_permissions_fills_empty_auth_type(app, monkeypatch):
+def test_ensure_demo_course_permissions_fills_empty_auth_type(app, monkeypatch) -> None:
     demo_bid = uuid.uuid4().hex[:32]
     user_id = uuid.uuid4().hex[:32]
 
@@ -154,7 +154,9 @@ def test_ensure_demo_course_permissions_fills_empty_auth_type(app, monkeypatch):
             db.session.commit()
 
 
-def test_ensure_demo_course_permissions_skips_missing_demo_courses(app, monkeypatch):
+def test_ensure_demo_course_permissions_skips_missing_demo_courses(
+    app, monkeypatch
+) -> None:
     demo_bid = uuid.uuid4().hex[:32]
     user_id = uuid.uuid4().hex[:32]
 
@@ -181,7 +183,7 @@ def test_ensure_demo_course_permissions_skips_missing_demo_courses(app, monkeypa
             db.session.commit()
 
 
-def test_ensure_demo_course_permissions_uses_explicit_demo_ids(app):
+def test_ensure_demo_course_permissions_uses_explicit_demo_ids(app) -> None:
     demo_bid = uuid.uuid4().hex[:32]
     user_id = uuid.uuid4().hex[:32]
 
@@ -209,7 +211,9 @@ def test_ensure_demo_course_permissions_uses_explicit_demo_ids(app):
             db.session.commit()
 
 
-def test_ensure_demo_course_permissions_skips_empty_explicit_demo_ids(app, monkeypatch):
+def test_ensure_demo_course_permissions_skips_empty_explicit_demo_ids(
+    app, monkeypatch
+) -> None:
     demo_bid = uuid.uuid4().hex[:32]
     user_id = uuid.uuid4().hex[:32]
 

--- a/src/api/tests/service/user/test_google_auth.py
+++ b/src/api/tests/service/user/test_google_auth.py
@@ -1,6 +1,7 @@
 """Verify Google sign-in preserves account trust and paid state."""
 
 import uuid
+from collections.abc import Iterator
 
 import flaskr.common.config as common_config
 import pytest
@@ -29,7 +30,7 @@ def _reset_config_cache(*keys: str) -> None:
 
 
 @pytest.fixture(autouse=True)
-def clear_google_public_url_config_cache():
+def clear_google_public_url_config_cache() -> Iterator[None]:
     _reset_config_cache("HOST_URL")
     yield
     _reset_config_cache("HOST_URL")
@@ -92,7 +93,7 @@ def _run_google_callback(app, monkeypatch, profile, *, fetch_token_error=None):
 
 def test_google_unverified_email_does_not_consume_first_account_bootstrap(
     app, monkeypatch
-):
+) -> None:
     first_email = f"{uuid.uuid4().hex[:10]}@example.com"
     second_email = f"{uuid.uuid4().hex[:10]}@example.com"
 
@@ -145,7 +146,7 @@ def test_google_unverified_email_does_not_consume_first_account_bootstrap(
             _reset_user_auth_tables()
 
 
-def test_google_verified_login_does_not_downgrade_paid_user(app, monkeypatch):
+def test_google_verified_login_does_not_downgrade_paid_user(app, monkeypatch) -> None:
     email = f"{uuid.uuid4().hex[:10]}@example.com"
 
     with app.app_context():
@@ -186,7 +187,7 @@ def test_google_verified_login_does_not_downgrade_paid_user(app, monkeypatch):
 def test_google_existing_account_keeps_pre_profile_display_name_behavior(
     app,
     monkeypatch,
-):
+) -> None:
     email = f"{uuid.uuid4().hex[:10]}@example.com"
 
     with app.app_context():
@@ -248,7 +249,7 @@ def test_google_existing_account_keeps_pre_profile_display_name_behavior(
             _reset_user_auth_tables()
 
 
-def test_google_oauth_token_fetch_failure_propagates(app, monkeypatch):
+def test_google_oauth_token_fetch_failure_propagates(app, monkeypatch) -> None:
     with app.app_context():
         _reset_user_auth_tables()
         try:

--- a/src/api/tests/service/user/test_import_user_command.py
+++ b/src/api/tests/service/user/test_import_user_command.py
@@ -21,7 +21,7 @@ def test_import_user_keeps_pre_profile_nickname_behavior(
     app,
     monkeypatch,
     canonical_source,
-):
+) -> None:
     import_user_module = import_module("flaskr.command.import_user")
 
     monkeypatch.setattr(
@@ -91,7 +91,7 @@ def test_import_user_keeps_pre_profile_nickname_behavior(
 def test_import_user_does_not_consult_profile_state_before_nickname_defaults(
     app,
     monkeypatch,
-):
+) -> None:
     import_user_module = import_module("flaskr.command.import_user")
 
     monkeypatch.setattr(

--- a/src/api/tests/service/user/test_learner_profile_optimizer.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer.py
@@ -86,7 +86,7 @@ def _install_trace_spies(monkeypatch, captured: dict) -> None:
 
 def test_optimize_returns_reviewable_draft_without_changing_business_state(
     app, monkeypatch
-):
+) -> None:
     user_bid = "profile-optimize-success"
     source = (
         "我在上海做办公室工作，大学学的是工商管理，之前没学过编程。"
@@ -165,7 +165,7 @@ def test_optimize_returns_reviewable_draft_without_changing_business_state(
 )
 def test_optimize_returns_model_text_without_quality_postprocessing(
     app, monkeypatch, case_suffix, optimized
-):
+) -> None:
     user_bid = f"profile-optimize-low-quality-{case_suffix}"
     source = "我在教育行业工作，希望表达简洁准确。"
     captured: dict = {}
@@ -200,7 +200,7 @@ def test_optimize_returns_model_text_without_quality_postprocessing(
 )
 def test_optimizer_uses_the_current_users_system_language(
     app, monkeypatch, language, expected_output_language
-):
+) -> None:
     user_bid = f"profile-optimize-language-{language}"
     captured: dict = {}
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
@@ -225,7 +225,7 @@ def test_optimizer_uses_the_current_users_system_language(
     assert "Put each category on a separate line" in system_prompt
 
 
-def test_optimizer_prompt_targets_the_downstream_learner_context_contract():
+def test_optimizer_prompt_targets_the_downstream_learner_context_contract() -> None:
     optimization_prompt = optimizer.load_prompt_template(
         "learner_profile_optimizer"
     ).strip()
@@ -281,7 +281,7 @@ def test_optimizer_prompt_targets_the_downstream_learner_context_contract():
     assert "Translate every foreign-language word or phrase" not in optimization_prompt
 
 
-def test_named_style_input_uses_the_full_optimizer_prompt(app, monkeypatch):
+def test_named_style_input_uses_the_full_optimizer_prompt(app, monkeypatch) -> None:
     captured: dict = {}
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
     monkeypatch.setattr(
@@ -306,7 +306,7 @@ def test_named_style_input_uses_the_full_optimizer_prompt(app, monkeypatch):
 
 def test_optimize_rejects_moderation_without_calling_llm_or_changing_state(
     app, monkeypatch
-):
+) -> None:
     user_bid = "profile-optimize-rejected"
     invoked = False
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: False)
@@ -335,7 +335,9 @@ def test_optimize_rejects_moderation_without_calling_llm_or_changing_state(
     assert after == before
 
 
-def test_optimize_provider_unavailable_moderation_still_allows_llm(app, monkeypatch):
+def test_optimize_provider_unavailable_moderation_still_allows_llm(
+    app, monkeypatch
+) -> None:
     user_bid = "profile-optimize-moderation-unavailable"
     source = "Provider unavailable source profile"
     captured: dict = {}
@@ -379,7 +381,7 @@ def test_optimize_provider_unavailable_moderation_still_allows_llm(app, monkeypa
 
 def test_optimize_missing_default_model_does_not_call_llm_or_change_state(
     app, monkeypatch
-):
+) -> None:
     user_bid = "profile-optimize-missing-model"
     invoked = False
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
@@ -416,7 +418,7 @@ def test_optimize_missing_default_model_does_not_call_llm_or_change_state(
 )
 def test_optimize_rejects_empty_model_output_without_changing_state(
     app, monkeypatch, case_suffix, raw_output
-):
+) -> None:
     user_bid = f"profile-optimize-empty-{case_suffix}"
     captured: dict = {}
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
@@ -445,7 +447,9 @@ def test_optimize_rejects_empty_model_output_without_changing_state(
     assert captured["trace_finalize"]["root_span"] is not None
 
 
-def test_optimize_timeout_finalizes_trace_without_changing_state(app, monkeypatch):
+def test_optimize_timeout_finalizes_trace_without_changing_state(
+    app, monkeypatch
+) -> None:
     user_bid = "profile-optimize-timeout"
     captured: dict = {}
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
@@ -476,7 +480,7 @@ def test_optimize_timeout_finalizes_trace_without_changing_state(app, monkeypatc
     assert captured["trace_finalize"]["root_span"] is not None
 
 
-def test_optimize_reports_a_wrapped_timeout_as_timeout(app, monkeypatch):
+def test_optimize_reports_a_wrapped_timeout_as_timeout(app, monkeypatch) -> None:
     user_bid = "profile-optimize-wrapped-timeout"
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
@@ -516,7 +520,7 @@ def test_optimize_reports_a_wrapped_timeout_as_timeout(app, monkeypatch):
 )
 def test_optimize_reports_runtime_failure_reason_without_changing_state(
     app, monkeypatch, provider_error, expected_code, expected_message
-):
+) -> None:
     user_bid = f"profile-optimize-runtime-error-{expected_code}"
     captured: dict = {}
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
@@ -547,7 +551,7 @@ def test_optimize_reports_runtime_failure_reason_without_changing_state(
 
 def test_optimize_reports_moderation_failure_reason_without_calling_llm(
     app, monkeypatch
-):
+) -> None:
     invoked = False
 
     def failed_moderation(*_args: object):
@@ -577,7 +581,7 @@ def test_optimize_reports_moderation_failure_reason_without_calling_llm(
 @pytest.mark.parametrize("learner_profile", ["", "   ", "x" * 1001])
 def test_optimize_rejects_invalid_input_before_moderation(
     app, monkeypatch, learner_profile
-):
+) -> None:
     moderated = False
 
     def unexpected_moderation(*_args: object):

--- a/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Never
+
 import pytest
 from flaskr import dao
 from flaskr.service.common.models import AppError
 from flaskr.service.profile import learner_profile_optimizer_admission as admission
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class FakeRedis:
@@ -16,7 +21,7 @@ class FakeRedis:
         self.in_flight_tokens: dict[str, str] = {}
         self.acquire_ttls: list[int] = []
 
-    def eval(self, script, numkeys, *args: object):
+    def eval(self, script, numkeys, *args: object) -> int:
         assert numkeys == 1
         key = str(args[0])
         token = str(args[1])
@@ -40,13 +45,13 @@ class FakeRedis:
 class ExplodingRedis:
     """Simulate a Redis failure for tests."""
 
-    def eval(self, *_args: object, **_kwargs: object):
+    def eval(self, *_args: object, **_kwargs: object) -> Never:
         message = "redis unavailable"
         raise RuntimeError(message)
 
 
 @pytest.fixture(autouse=True)
-def reset_local_admission_state():
+def reset_local_admission_state() -> Iterator[None]:
     with admission._local_lock:
         admission._local_in_flight_state.clear()
     yield
@@ -67,7 +72,7 @@ def _assert_admission_denied(app, *, user_id: str) -> None:
     assert raised.value.code == 1023
 
 
-def test_admission_allows_only_one_in_flight_request_per_user(app, monkeypatch):
+def test_admission_allows_only_one_in_flight_request_per_user(app, monkeypatch) -> None:
     fake_redis = FakeRedis()
     monkeypatch.setattr(dao._redis_state, "client", fake_redis)
 
@@ -86,7 +91,7 @@ def test_admission_allows_only_one_in_flight_request_per_user(app, monkeypatch):
     assert fake_redis.acquire_ttls == [admission.IN_FLIGHT_TTL_SECONDS] * 3
 
 
-def test_admission_does_not_group_different_users(app, monkeypatch):
+def test_admission_does_not_group_different_users(app, monkeypatch) -> None:
     fake_redis = FakeRedis()
     monkeypatch.setattr(dao._redis_state, "client", fake_redis)
 
@@ -97,7 +102,7 @@ def test_admission_does_not_group_different_users(app, monkeypatch):
         pass
 
 
-def test_admission_releases_slot_after_request_error(app, monkeypatch):
+def test_admission_releases_slot_after_request_error(app, monkeypatch) -> Never:
     fake_redis = FakeRedis()
     monkeypatch.setattr(dao._redis_state, "client", fake_redis)
 
@@ -118,7 +123,9 @@ def test_admission_releases_slot_after_request_error(app, monkeypatch):
         pass
 
 
-def test_expired_lease_release_cannot_remove_replacement_redis_slot(app, monkeypatch):
+def test_expired_lease_release_cannot_remove_replacement_redis_slot(
+    app, monkeypatch
+) -> None:
     fake_redis = FakeRedis()
     monkeypatch.setattr(dao._redis_state, "client", fake_redis)
 
@@ -134,7 +141,7 @@ def test_expired_lease_release_cannot_remove_replacement_redis_slot(app, monkeyp
 
 def test_configured_redis_failure_denies_request_without_logging_identity(
     app, monkeypatch, caplog
-):
+) -> None:
     sentinel_identity = "SENSITIVE_ADMISSION_IDENTITY"
     monkeypatch.setattr(dao._redis_state, "client", ExplodingRedis())
 
@@ -148,7 +155,7 @@ def test_configured_redis_failure_denies_request_without_logging_identity(
     assert sentinel_identity not in caplog.text
 
 
-def test_missing_redis_uses_process_local_user_slot(app, monkeypatch):
+def test_missing_redis_uses_process_local_user_slot(app, monkeypatch) -> None:
     monkeypatch.setattr(dao._redis_state, "client", None)
 
     with admission.learner_profile_optimization_admission(

--- a/src/api/tests/service/user/test_learner_profile_service.py
+++ b/src/api/tests/service/user/test_learner_profile_service.py
@@ -107,7 +107,7 @@ def _track_profile_lock_reads(monkeypatch) -> list[tuple[str, str, bool, bool]]:
     return read_order
 
 
-def test_repository_aggregate_exposes_learner_profile(app):
+def test_repository_aggregate_exposes_learner_profile(app) -> None:
     with app.app_context():
         _create_user("profile-aggregate", learner_profile="偏好图表和简洁表达")
         aggregate = load_user_aggregate("profile-aggregate")
@@ -117,7 +117,9 @@ def test_repository_aggregate_exposes_learner_profile(app):
     _assert_orm_utc(aggregate.learner_profile_updated_at, PROFILE_UPDATED_AT)
 
 
-def test_empty_profile_prefill_uses_canonical_nickname_and_latest_legacy_values(app):
+def test_empty_profile_prefill_uses_canonical_nickname_and_latest_legacy_values(
+    app,
+) -> None:
     from flaskr.service.profile.learner_profile import get_learner_profile
 
     with app.app_context():
@@ -193,7 +195,7 @@ def test_legacy_nickname_account_identifier_filter_is_exact(
     legacy_nickname,
     suffix,
     expected_nickname,
-):
+) -> None:
     from flaskr.service.profile.learner_profile import get_learner_profile
 
     with app.app_context():
@@ -225,7 +227,7 @@ def test_identifier_shaped_canonical_nickname_for_different_value_is_prefilled(
     identifier,
     nickname,
     suffix,
-):
+) -> None:
     from flaskr.service.profile.learner_profile import get_learner_profile
 
     with app.app_context():
@@ -250,7 +252,7 @@ def test_credential_identifier_filter_is_exact(
     nickname,
     suffix,
     expected_nickname,
-):
+) -> None:
     from flaskr.service.profile.learner_profile import get_learner_profile
 
     with app.app_context():
@@ -274,7 +276,7 @@ def test_credential_identifier_filter_is_exact(
     assert loaded["nickname"] == (nickname if expected_nickname else "")
 
 
-def test_identifier_fallback_prefers_explicit_legacy_nickname(app):
+def test_identifier_fallback_prefers_explicit_legacy_nickname(app) -> None:
     from flaskr.service.profile.learner_profile import get_learner_profile
 
     with app.app_context():
@@ -294,7 +296,7 @@ def test_identifier_fallback_prefers_explicit_legacy_nickname(app):
     assert loaded["legacy_profile_values"]["sys_user_nickname"] == "小林"
 
 
-def test_identifier_fallback_does_not_revive_cleared_legacy_nickname(app):
+def test_identifier_fallback_does_not_revive_cleared_legacy_nickname(app) -> None:
     from flaskr.service.profile.learner_profile import get_learner_profile
 
     with app.app_context():
@@ -319,7 +321,7 @@ def test_identifier_fallback_does_not_revive_cleared_legacy_nickname(app):
     assert "sys_user_nickname" not in loaded["legacy_profile_values"]
 
 
-def test_user_bid_fallback_is_not_profile_prefill_after_identifier_changes(app):
+def test_user_bid_fallback_is_not_profile_prefill_after_identifier_changes(app) -> None:
     from flaskr.service.profile.learner_profile import get_learner_profile
 
     with app.app_context():
@@ -336,7 +338,7 @@ def test_user_bid_fallback_is_not_profile_prefill_after_identifier_changes(app):
     assert "sys_user_nickname" not in loaded["legacy_profile_values"]
 
 
-def test_empty_legacy_values_do_not_revive_older_prefill_values(app):
+def test_empty_legacy_values_do_not_revive_older_prefill_values(app) -> None:
     from flaskr.service.profile.learner_profile import get_learner_profile
 
     with app.app_context():
@@ -367,7 +369,7 @@ def test_empty_legacy_values_do_not_revive_older_prefill_values(app):
     assert loaded["legacy_profile_values"] == {}
 
 
-def test_canonical_profile_does_not_expose_legacy_prefill_values(app):
+def test_canonical_profile_does_not_expose_legacy_prefill_values(app) -> None:
     from flaskr.service.profile.learner_profile import get_learner_profile
 
     with app.app_context():
@@ -387,7 +389,7 @@ def test_canonical_profile_does_not_expose_legacy_prefill_values(app):
     assert loaded["legacy_profile_values"] == {}
 
 
-def test_replace_and_clear_learner_profile(app, monkeypatch):
+def test_replace_and_clear_learner_profile(app, monkeypatch) -> None:
     from flaskr.service.profile.learner_profile import (
         clear_learner_profile,
         get_learner_profile,
@@ -436,7 +438,9 @@ def test_replace_and_clear_learner_profile(app, monkeypatch):
     "value",
     [None, 1, "🙂" * 1001],
 )
-def test_replace_rejects_invalid_profile_without_overwriting(app, monkeypatch, value):
+def test_replace_rejects_invalid_profile_without_overwriting(
+    app, monkeypatch, value
+) -> None:
     from flaskr.service.profile.learner_profile import (
         get_learner_profile,
         replace_learner_profile,
@@ -457,7 +461,7 @@ def test_replace_rejects_invalid_profile_without_overwriting(app, monkeypatch, v
     assert loaded["learner_profile"] == "existing profile"
 
 
-def test_replace_accepts_exactly_1000_unicode_code_points(app, monkeypatch):
+def test_replace_accepts_exactly_1000_unicode_code_points(app, monkeypatch) -> None:
     from flaskr.service.profile.learner_profile import replace_learner_profile
 
     _allow_profile_safety(monkeypatch)
@@ -472,7 +476,7 @@ def test_replace_accepts_exactly_1000_unicode_code_points(app, monkeypatch):
     assert len(result["learner_profile"]) == 1000
 
 
-def test_replace_atomically_saves_explicit_nickname(app, monkeypatch):
+def test_replace_atomically_saves_explicit_nickname(app, monkeypatch) -> None:
     from flaskr.service.profile.learner_profile import replace_learner_profile
 
     _allow_profile_safety(monkeypatch)
@@ -492,7 +496,7 @@ def test_replace_atomically_saves_explicit_nickname(app, monkeypatch):
     assert stored.nickname == "小雨"
 
 
-def test_replace_without_nickname_preserves_display_name(app, monkeypatch):
+def test_replace_without_nickname_preserves_display_name(app, monkeypatch) -> None:
     from flaskr.service.profile.learner_profile import replace_learner_profile
 
     _allow_profile_safety(monkeypatch)
@@ -509,7 +513,7 @@ def test_replace_without_nickname_preserves_display_name(app, monkeypatch):
     assert stored.nickname == "Test learner"
 
 
-def test_replace_explicit_empty_nickname_clears_display_name(app, monkeypatch):
+def test_replace_explicit_empty_nickname_clears_display_name(app, monkeypatch) -> None:
     from flaskr.service.profile.learner_profile import replace_learner_profile
 
     checked = _allow_profile_safety(monkeypatch)
@@ -531,7 +535,9 @@ def test_replace_explicit_empty_nickname_clears_display_name(app, monkeypatch):
     assert checked == []
 
 
-def test_replace_empty_profile_can_save_nickname_and_handled_state(app, monkeypatch):
+def test_replace_empty_profile_can_save_nickname_and_handled_state(
+    app, monkeypatch
+) -> None:
     from flaskr.service.profile.learner_profile import replace_learner_profile
 
     checked = _allow_profile_safety(monkeypatch)
@@ -556,7 +562,7 @@ def test_replace_empty_profile_can_save_nickname_and_handled_state(app, monkeypa
 @pytest.mark.parametrize("nickname", [1, "🙂" * 65])
 def test_replace_rejects_invalid_nickname_without_overwriting(
     app, monkeypatch, nickname
-):
+) -> None:
     from flaskr.service.profile.learner_profile import replace_learner_profile
 
     _allow_profile_safety(monkeypatch)
@@ -576,7 +582,7 @@ def test_replace_rejects_invalid_nickname_without_overwriting(
     assert stored.nickname == "Test learner"
 
 
-def test_safety_rejection_preserves_existing_profile(app, monkeypatch):
+def test_safety_rejection_preserves_existing_profile(app, monkeypatch) -> None:
     from flaskr.service.profile.learner_profile import (
         get_learner_profile,
         replace_learner_profile,
@@ -612,7 +618,7 @@ def test_safety_rejection_preserves_existing_profile(app, monkeypatch):
 )
 def test_profile_moderation_allows_every_non_reject_result(
     app, monkeypatch, check_result
-):
+) -> None:
     from flaskr.api.check.dto import CheckResultDTO
     from flaskr.service.profile.learner_profile import (
         get_learner_profile,
@@ -648,7 +654,7 @@ def test_profile_moderation_allows_every_non_reject_result(
     assert state is not None
 
 
-def test_profile_moderation_rejects_only_explicit_reject(app, monkeypatch):
+def test_profile_moderation_rejects_only_explicit_reject(app, monkeypatch) -> None:
     from flaskr.api.check.dto import CheckResultDTO
     from flaskr.service.profile.learner_profile import (
         get_learner_profile,
@@ -686,7 +692,9 @@ def test_profile_moderation_rejects_only_explicit_reject(app, monkeypatch):
     assert state is None
 
 
-def test_nickname_rejection_rolls_back_profile_nickname_and_state(app, monkeypatch):
+def test_nickname_rejection_rolls_back_profile_nickname_and_state(
+    app, monkeypatch
+) -> None:
     from flaskr.service.profile.learner_profile import (
         get_learner_profile,
         replace_learner_profile,
@@ -724,7 +732,7 @@ def test_nickname_rejection_rolls_back_profile_nickname_and_state(app, monkeypat
     assert state is None
 
 
-def test_profile_moderation_allows_save_when_provider_is_unavailable(app):
+def test_profile_moderation_allows_save_when_provider_is_unavailable(app) -> None:
     from flaskr.service.profile.learner_profile import (
         get_learner_profile,
         replace_learner_profile,
@@ -750,7 +758,9 @@ def test_profile_moderation_allows_save_when_provider_is_unavailable(app):
     assert state is not None
 
 
-def test_profile_safety_audit_records_text_and_provider_response(app, monkeypatch):
+def test_profile_safety_audit_records_text_and_provider_response(
+    app, monkeypatch
+) -> None:
     from flaskr.api.check.dto import CHECK_RESULT_PASS, CheckResultDTO
     from flaskr.service.check_risk.models import RiskControlResult
     from flaskr.service.profile.learner_profile import replace_learner_profile
@@ -793,7 +803,9 @@ def test_profile_safety_audit_records_text_and_provider_response(app, monkeypatc
     )
 
 
-def test_legacy_status_hides_for_canonical_profile_or_fixed_v2_state(app, monkeypatch):
+def test_legacy_status_hides_for_canonical_profile_or_fixed_v2_state(
+    app, monkeypatch
+) -> None:
     from flaskr.service.profile import onboarding as onboarding_module
     from flaskr.service.profile.learner_profile import (
         PROFILE_ONBOARDING_SCENE_KEY,
@@ -844,7 +856,9 @@ def test_legacy_status_hides_for_canonical_profile_or_fixed_v2_state(app, monkey
     }
 
 
-def test_complete_atomically_writes_profile_and_fixed_v2_state(app, monkeypatch):
+def test_complete_atomically_writes_profile_and_fixed_v2_state(
+    app, monkeypatch
+) -> None:
     from flaskr.service.profile.learner_profile import (
         PROFILE_ONBOARDING_SCENE_KEY,
         PROFILE_ONBOARDING_VERSION,
@@ -901,7 +915,7 @@ def test_save_moderates_only_changed_nonempty_fields(
     learner_profile,
     nickname,
     expected_checked,
-):
+) -> None:
     from flaskr.service.profile.learner_profile import save_learner_profile
 
     checked = _allow_profile_safety(monkeypatch)
@@ -924,7 +938,7 @@ def test_save_moderates_only_changed_nonempty_fields(
     assert checked == [(user_bid, value) for value in expected_checked]
 
 
-def test_save_locks_user_then_state_before_writing_profile(app, monkeypatch):
+def test_save_locks_user_then_state_before_writing_profile(app, monkeypatch) -> None:
     from flaskr.service.profile.learner_profile import save_learner_profile
 
     with app.app_context():
@@ -966,7 +980,7 @@ def test_save_locks_user_then_state_before_writing_profile(app, monkeypatch):
     assert result["learner_profile"] == "Please call me Locked Learner."
 
 
-def test_save_moderates_once_when_state_creation_retries(app, monkeypatch):
+def test_save_moderates_once_when_state_creation_retries(app, monkeypatch) -> None:
     from flaskr.service.profile import learner_profile
 
     moderation_calls: list[str] = []
@@ -1007,7 +1021,7 @@ def test_save_moderates_once_when_state_creation_retries(app, monkeypatch):
     assert result["learner_profile"] == "Please call me Retry Learner."
 
 
-def test_clear_locks_user_then_state_before_clearing_profile(app, monkeypatch):
+def test_clear_locks_user_then_state_before_clearing_profile(app, monkeypatch) -> None:
     from flaskr.service.profile.learner_profile import clear_learner_profile
 
     with app.app_context():
@@ -1029,7 +1043,9 @@ def test_clear_locks_user_then_state_before_clearing_profile(app, monkeypatch):
     assert result["learner_profile"] == ""
 
 
-def test_complete_preserves_legacy_variable_values_for_old_courses(app, monkeypatch):
+def test_complete_preserves_legacy_variable_values_for_old_courses(
+    app, monkeypatch
+) -> None:
     from flaskr.service.profile.learner_profile import save_learner_profile
 
     _allow_profile_safety(monkeypatch)
@@ -1088,7 +1104,7 @@ def test_complete_preserves_legacy_variable_values_for_old_courses(app, monkeypa
     }
 
 
-def test_clear_profile_keeps_v2_completed_and_returns_legacy_prefill(app):
+def test_clear_profile_keeps_v2_completed_and_returns_legacy_prefill(app) -> None:
     from flaskr.service.profile.learner_profile import (
         PROFILE_ONBOARDING_SCENE_KEY,
         PROFILE_ONBOARDING_VERSION,
@@ -1156,7 +1172,9 @@ def test_clear_profile_keeps_v2_completed_and_returns_legacy_prefill(app):
     }
 
 
-def test_empty_profile_save_returns_legacy_prefill_on_next_get(app, monkeypatch):
+def test_empty_profile_save_returns_legacy_prefill_on_next_get(
+    app, monkeypatch
+) -> None:
     from flaskr.service.profile.learner_profile import (
         PROFILE_ONBOARDING_SCENE_KEY,
         PROFILE_ONBOARDING_VERSION,
@@ -1210,7 +1228,9 @@ def test_empty_profile_save_returns_legacy_prefill_on_next_get(app, monkeypatch)
     assert checked == []
 
 
-def test_repeated_completion_preserves_profile_and_state_timestamps(app, monkeypatch):
+def test_repeated_completion_preserves_profile_and_state_timestamps(
+    app, monkeypatch
+) -> None:
     from flaskr.service.profile.learner_profile import save_learner_profile
 
     _allow_profile_safety(monkeypatch)
@@ -1233,7 +1253,7 @@ def test_repeated_completion_preserves_profile_and_state_timestamps(app, monkeyp
     assert second["completed_at"] == first["completed_at"]
 
 
-def test_complete_rolls_back_profile_and_state_together(app, monkeypatch):
+def test_complete_rolls_back_profile_and_state_together(app, monkeypatch) -> None:
     from flaskr.service.profile.learner_profile import (
         PROFILE_ONBOARDING_SCENE_KEY,
         save_learner_profile,
@@ -1278,7 +1298,7 @@ def test_complete_rolls_back_profile_and_state_together(app, monkeypatch):
     assert legacy_background.deleted == 0
 
 
-def test_clear_rolls_back_profile_and_state_together(app, monkeypatch):
+def test_clear_rolls_back_profile_and_state_together(app, monkeypatch) -> None:
     from flaskr.service.profile.learner_profile import (
         PROFILE_ONBOARDING_SCENE_KEY,
         clear_learner_profile,

--- a/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
+++ b/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
@@ -130,7 +130,7 @@ def test_merge_helper_transfers_profile_and_handled_state(
     source_profile,
     status,
     trigger_source,
-):
+) -> None:
     monkeypatch.setattr(
         "flaskr.service.profile.learner_profile.check_text_content",
         lambda *_args, **_kwargs: pytest.fail("sign-in merge must not re-moderate"),
@@ -180,7 +180,7 @@ def test_merge_helper_transfers_profile_and_handled_state(
         _assert_orm_utc(target_state.completed_at, PROFILE_UPDATED_AT)
 
 
-def test_merge_helper_preserves_target_profile_and_state(app):
+def test_merge_helper_preserves_target_profile_and_state(app) -> None:
     with app.app_context():
         source = _create_user(
             identify=uuid.uuid4().hex,
@@ -219,7 +219,9 @@ def test_merge_helper_preserves_target_profile_and_state(app):
         assert target_state.trigger_source == "settings"
 
 
-def test_merge_helper_replaces_account_identifier_fallback_with_guest_nickname(app):
+def test_merge_helper_replaces_account_identifier_fallback_with_guest_nickname(
+    app,
+) -> None:
     with app.app_context():
         source = _create_user(
             identify=uuid.uuid4().hex,
@@ -247,7 +249,9 @@ def test_merge_helper_replaces_account_identifier_fallback_with_guest_nickname(a
         assert stored_target.nickname == "Guest nickname"
 
 
-def test_merge_helper_keeps_target_identifier_fallback_without_guest_nickname(app):
+def test_merge_helper_keeps_target_identifier_fallback_without_guest_nickname(
+    app,
+) -> None:
     with app.app_context():
         source_identify = uuid.uuid4().hex
         source = _create_user(
@@ -279,7 +283,7 @@ def test_merge_helper_keeps_target_identifier_fallback_without_guest_nickname(ap
         assert target_state.status == "completed"
 
 
-def test_merge_helper_does_not_restore_a_profile_the_target_cleared(app):
+def test_merge_helper_does_not_restore_a_profile_the_target_cleared(app) -> None:
     with app.app_context():
         source = _create_user(
             identify=uuid.uuid4().hex,
@@ -320,7 +324,7 @@ def test_merge_helper_does_not_restore_a_profile_the_target_cleared(app):
 def test_merge_helper_never_copies_from_a_source_with_account_identifier(
     app,
     source_identify,
-):
+) -> None:
     with app.app_context():
         source = _create_user(
             identify=source_identify,
@@ -352,7 +356,7 @@ def test_merge_helper_never_copies_from_a_source_with_account_identifier(
 def test_merge_helper_never_copies_from_non_guest_random_identifier(
     app,
     source_state,
-):
+) -> None:
     with app.app_context():
         source = _create_user(
             identify=uuid.uuid4().hex,
@@ -377,7 +381,7 @@ def test_merge_helper_never_copies_from_non_guest_random_identifier(
         assert load_learner_profile_state(target.user_bid) is None
 
 
-def test_merge_helper_allows_numeric_uuid_guest_identifier(app):
+def test_merge_helper_allows_numeric_uuid_guest_identifier(app) -> None:
     with app.app_context():
         numeric_uuid = uuid.UUID("12345678-9012-4567-8901-234567890123").hex
         assert len(numeric_uuid) == 32
@@ -410,7 +414,7 @@ def test_merge_helper_allows_numeric_uuid_guest_identifier(app):
         assert target_state.trigger_source == "settings"
 
 
-def test_merge_helper_allows_unregistered_guest_with_wechat_credential(app):
+def test_merge_helper_allows_unregistered_guest_with_wechat_credential(app) -> None:
     with app.app_context():
         source = _create_user(
             identify=uuid.uuid4().hex,
@@ -451,7 +455,7 @@ def test_merge_helper_allows_unregistered_guest_with_wechat_credential(app):
 def test_merge_helper_allows_unregistered_guest_with_unverified_account_credential(
     app,
     provider_name,
-):
+) -> None:
     with app.app_context():
         source = _create_user(
             identify=uuid.uuid4().hex,
@@ -512,7 +516,7 @@ def test_merge_helper_allows_unregistered_guest_with_unverified_account_credenti
 def test_merge_helper_rejects_unregistered_source_with_verified_account_credential(
     app,
     provider_name,
-):
+) -> None:
     with app.app_context():
         source = _create_user(
             identify=uuid.uuid4().hex,
@@ -561,7 +565,7 @@ def test_merge_helper_rejects_unregistered_source_with_verified_account_credenti
         assert load_learner_profile_state(target.user_bid) is None
 
 
-def test_merge_helper_rolls_back_with_sign_in_transaction(app):
+def test_merge_helper_rolls_back_with_sign_in_transaction(app) -> None:
     with app.app_context():
         source = _create_user(
             identify=uuid.uuid4().hex,
@@ -597,7 +601,9 @@ def test_merge_helper_rolls_back_with_sign_in_transaction(app):
         assert load_learner_profile_state(target.user_bid) is None
 
 
-def test_merge_helper_locks_target_then_source_profile_snapshots(app, monkeypatch):
+def test_merge_helper_locks_target_then_source_profile_snapshots(
+    app, monkeypatch
+) -> None:
     with app.app_context():
         source = _create_user(
             identify=uuid.uuid4().hex,
@@ -655,7 +661,7 @@ def test_merge_helper_locks_target_then_source_profile_snapshots(app, monkeypatc
         assert load_learner_profile_state(target.user_bid) is not None
 
 
-def test_merge_helper_refreshes_a_stale_source_identity_map(app):
+def test_merge_helper_refreshes_a_stale_source_identity_map(app) -> None:
     with app.app_context():
         source = _create_user(
             identify=uuid.uuid4().hex,
@@ -691,7 +697,9 @@ def test_merge_helper_refreshes_a_stale_source_identity_map(app):
         assert stored_target.nickname == "新名字"
 
 
-def test_phone_sign_in_merges_profile_without_course_id(app, monkeypatch, caplog):
+def test_phone_sign_in_merges_profile_without_course_id(
+    app, monkeypatch, caplog
+) -> None:
     from flaskr.service.user import phone_flow
 
     caplog.set_level(logging.INFO)
@@ -740,7 +748,9 @@ def test_phone_sign_in_merges_profile_without_course_id(app, monkeypatch, caplog
         assert "phone merge sentinel" not in caplog.text
 
 
-def test_email_sign_in_transfers_cleared_state_without_course_id(app, monkeypatch):
+def test_email_sign_in_transfers_cleared_state_without_course_id(
+    app, monkeypatch
+) -> None:
     from flaskr.service.user import email_flow
 
     monkeypatch.setattr(email_flow, "redis", _FakeRedis())
@@ -774,7 +784,7 @@ def test_legacy_profile_migration_preserves_target_nickname(
     app,
     monkeypatch,
     sign_in_method,
-):
+) -> None:
     from flaskr.service.user import email_flow, phone_flow
 
     flow = phone_flow if sign_in_method == "phone" else email_flow
@@ -837,7 +847,7 @@ def test_legacy_profile_migration_transfers_guest_nickname_when_target_has_none(
     monkeypatch,
     sign_in_method,
     target_nickname_kind,
-):
+) -> None:
     from flaskr.service.user import email_flow, phone_flow
 
     flow = phone_flow if sign_in_method == "phone" else email_flow
@@ -889,7 +899,7 @@ def test_legacy_profile_migration_transfers_guest_nickname_when_target_has_none(
         assert token.userInfo.name == "Guest nickname"
 
 
-def test_google_sign_in_merges_profile_and_skipped_state(app, monkeypatch):
+def test_google_sign_in_merges_profile_and_skipped_state(app, monkeypatch) -> None:
     import flaskr.service.user.auth.providers.google as google_provider
     from flaskr.service.user import phone_flow
 
@@ -959,7 +969,9 @@ def test_google_sign_in_merges_profile_and_skipped_state(app, monkeypatch):
         assert UserInfo.query.filter_by(user_bid=source.user_bid).one() is not None
 
 
-def test_google_sign_in_keeps_pre_profile_display_name_behavior(app, monkeypatch):
+def test_google_sign_in_keeps_pre_profile_display_name_behavior(
+    app, monkeypatch
+) -> None:
     import flaskr.service.user.auth.providers.google as google_provider
     from flaskr.service.user import phone_flow
 

--- a/src/api/tests/service/user/test_legacy_learner_profile_compatibility.py
+++ b/src/api/tests/service/user/test_legacy_learner_profile_compatibility.py
@@ -69,7 +69,7 @@ def test_legacy_nickname_writers_keep_pre_profile_mapping_behavior(
     app,
     monkeypatch,
     writer,
-):
+) -> None:
     monkeypatch.setattr(
         "flaskr.service.profile.funcs.get_profile_item_definition_list",
         lambda *_args, **_kwargs: [],
@@ -143,7 +143,9 @@ def test_legacy_nickname_writers_keep_pre_profile_mapping_behavior(
         assert stored_user.nickname == "After"
 
 
-def test_completed_v2_state_preserves_legacy_profile_read_write_paths(app, monkeypatch):
+def test_completed_v2_state_preserves_legacy_profile_read_write_paths(
+    app, monkeypatch
+) -> None:
     definitions = [
         SimpleNamespace(
             profile_key="sys_user_background", profile_id="background-variable"
@@ -196,7 +198,7 @@ def test_completed_v2_state_preserves_legacy_profile_read_write_paths(app, monke
         assert profiles["sys_user_style"] == "another style"
 
 
-def test_skipped_v2_state_preserves_legacy_profile_behavior(app, monkeypatch):
+def test_skipped_v2_state_preserves_legacy_profile_behavior(app, monkeypatch) -> None:
     monkeypatch.setattr(
         "flaskr.service.profile.funcs.get_profile_item_definition_list",
         lambda *_args, **_kwargs: [],
@@ -223,7 +225,7 @@ def test_skipped_v2_state_preserves_legacy_profile_behavior(app, monkeypatch):
 def test_legacy_nickname_writers_still_update_user_and_runtime_nickname(
     app,
     monkeypatch,
-):
+) -> None:
     definitions = [
         SimpleNamespace(
             profile_key="sys_user_nickname",
@@ -308,7 +310,7 @@ def test_legacy_nickname_writers_still_update_user_and_runtime_nickname(
 def test_explicit_nickname_uses_existing_runtime_precedence_without_rewriting_legacy_rows(
     app,
     monkeypatch,
-):
+) -> None:
     monkeypatch.setattr(
         "flaskr.service.profile.learner_profile.check_text_content",
         lambda *_args, **_kwargs: True,

--- a/src/api/tests/service/user/test_migrate_user_study_record.py
+++ b/src/api/tests/service/user/test_migrate_user_study_record.py
@@ -37,7 +37,7 @@ def _add_progress_with_block(shifu_bid: str, user_bid: str, suffix: str) -> None
     db.session.commit()
 
 
-def test_migrate_user_study_record_moves_records_and_blocks(app):
+def test_migrate_user_study_record_moves_records_and_blocks(app) -> None:
     shifu_bid = "shifu-migrate"
     with app.app_context():
         LearnGeneratedBlock.query.delete()
@@ -94,7 +94,7 @@ def test_migrate_user_study_record_moves_records_and_blocks(app):
         assert untouched_block.user_bid == "tmp-user"
 
 
-def test_migrate_user_study_record_skips_outlines_already_present(app):
+def test_migrate_user_study_record_skips_outlines_already_present(app) -> None:
     shifu_bid = "shifu-migrate-dup"
     with app.app_context():
         LearnGeneratedBlock.query.delete()

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -39,7 +39,7 @@ def _create_user(
     return user
 
 
-def test_serialize_datetime_emits_explicit_utc_suffix():
+def test_serialize_datetime_emits_explicit_utc_suffix() -> None:
     assert _serialize_datetime(None) is None
     assert _serialize_datetime(datetime(2026, 6, 17, 12, 5, 0)) == (
         "2026-06-17T12:05:00Z"
@@ -54,7 +54,7 @@ def test_serialize_datetime_emits_explicit_utc_suffix():
 
 def test_onboarding_status_returns_eligible_creator_scene_state(
     app, test_client, monkeypatch
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
     now = datetime(2026, 6, 17, 12, 0, 0)
 
@@ -120,7 +120,7 @@ def test_onboarding_status_returns_eligible_creator_scene_state(
 
 def test_onboarding_status_allows_operator_creator_when_new_creator_gate_matches(
     app, test_client, monkeypatch
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
     with app.app_context():
         _create_user(
@@ -161,7 +161,7 @@ def test_onboarding_status_allows_operator_creator_when_new_creator_gate_matches
 
 def test_onboarding_status_treats_old_user_newly_activated_as_existing_rollout(
     app, test_client, monkeypatch
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
     created_at = datetime(2026, 6, 1, 12, 0, 0)
     creator_activated_at = datetime(2026, 6, 12, 9, 30, 0)
@@ -203,7 +203,7 @@ def test_onboarding_status_treats_old_user_newly_activated_as_existing_rollout(
 
 def test_onboarding_status_includes_existing_creator_rollout_segment(
     app, test_client, monkeypatch
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
     created_at = datetime(2026, 5, 1, 12, 0, 0)
 
@@ -245,7 +245,7 @@ def test_onboarding_status_includes_existing_creator_rollout_segment(
 
 def test_onboarding_status_excludes_existing_creator_before_rollout_switch(
     app, test_client, monkeypatch
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
 
     with app.app_context():
@@ -286,7 +286,7 @@ def test_onboarding_status_excludes_existing_creator_before_rollout_switch(
 
 def test_onboarding_status_uses_conservative_fallback_when_new_creator_gate_missing(
     app, test_client, monkeypatch
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
 
     with app.app_context():
@@ -331,7 +331,7 @@ def test_onboarding_status_uses_conservative_fallback_when_new_creator_gate_miss
 
 def test_onboarding_status_stays_ineligible_when_all_rollout_gates_missing(
     app, test_client, monkeypatch
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
 
     with app.app_context():
@@ -366,7 +366,7 @@ def test_onboarding_status_stays_ineligible_when_all_rollout_gates_missing(
     assert payload["data"]["user_segment"] == "ineligible"
 
 
-def test_complete_onboarding_scene_is_idempotent(app, test_client, monkeypatch):
+def test_complete_onboarding_scene_is_idempotent(app, test_client, monkeypatch) -> None:
     user_bid = uuid.uuid4().hex[:32]
     with app.app_context():
         _create_user(user_bid=user_bid, created_at=datetime(2026, 6, 17, 12, 0, 0))
@@ -414,7 +414,9 @@ def test_complete_onboarding_scene_is_idempotent(app, test_client, monkeypatch):
         assert len(rows) == 1
 
 
-def test_complete_onboarding_scene_records_skipped(app, test_client, monkeypatch):
+def test_complete_onboarding_scene_records_skipped(
+    app, test_client, monkeypatch
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
     with app.app_context():
         _create_user(user_bid=user_bid, created_at=datetime(2026, 6, 17, 12, 0, 0))
@@ -457,7 +459,7 @@ def test_complete_onboarding_scene_records_skipped(app, test_client, monkeypatch
 
 def test_complete_onboarding_scene_rejects_invalid_status(
     app, test_client, monkeypatch
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
     with app.app_context():
         _create_user(user_bid=user_bid, created_at=datetime(2026, 6, 17, 12, 0, 0))
@@ -496,7 +498,7 @@ def test_complete_onboarding_scene_rejects_invalid_status(
 
 def test_complete_course_editor_onboarding_accepts_direct_editor_entry(
     app, test_client, monkeypatch
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
     with app.app_context():
         _create_user(user_bid=user_bid, created_at=datetime(2026, 6, 17, 12, 0, 0))
@@ -537,7 +539,7 @@ def test_complete_course_editor_onboarding_accepts_direct_editor_entry(
 
 def test_complete_course_editor_onboarding_accepts_skills_create(
     app, test_client, monkeypatch
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
     with app.app_context():
         _create_user(user_bid=user_bid, created_at=datetime(2026, 6, 17, 12, 0, 0))
@@ -578,7 +580,7 @@ def test_complete_course_editor_onboarding_accepts_skills_create(
 
 def test_complete_onboarding_scene_handles_integrity_error(
     app, test_client, monkeypatch
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
     completed_at = datetime(2026, 6, 17, 12, 5, 0)
 
@@ -639,7 +641,7 @@ def test_complete_onboarding_scene_handles_integrity_error(
 
 def test_complete_onboarding_scene_rejects_ineligible_user(
     app, test_client, monkeypatch
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
     with app.app_context():
         _create_user(
@@ -672,7 +674,7 @@ def test_complete_onboarding_scene_rejects_ineligible_user(
 
 def test_complete_onboarding_scene_handles_non_object_payload(
     app, test_client, monkeypatch
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
     with app.app_context():
         _create_user(user_bid=user_bid, created_at=datetime(2026, 6, 17, 12, 0, 0))

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -46,7 +46,7 @@ def _post_json(
     return resp, json.loads(resp.data)
 
 
-def test_reset_password_does_not_create_new_user(test_client, app):
+def test_reset_password_does_not_create_new_user(test_client, app) -> None:
     from flaskr.service.user.models import UserInfo as UserEntity
 
     phone = "15500009999"
@@ -72,7 +72,7 @@ def test_reset_password_does_not_create_new_user(test_client, app):
         assert UserEntity.query.filter_by(user_identify=phone).count() == 0
 
 
-def test_set_password_requires_login_and_verification_code(test_client, app):
+def test_set_password_requires_login_and_verification_code(test_client, app) -> None:
     from flaskr.service.user import phone_flow
 
     phone = "15500001111"
@@ -116,7 +116,7 @@ def test_set_password_requires_login_and_verification_code(test_client, app):
     assert body2["code"] == 1017  # server.user.passwordAlreadySet
 
 
-def test_password_login_after_setting_password(test_client, app):
+def test_password_login_after_setting_password(test_client, app) -> None:
     from flaskr.service.user import phone_flow
 
     phone = "15500002222"
@@ -451,7 +451,9 @@ def test_password_reset_clears_identifier_failure_limit(
     assert login_body["code"] == 0
 
 
-def test_password_login_merges_authenticated_guest_learner_profile(test_client, app):
+def test_password_login_merges_authenticated_guest_learner_profile(
+    test_client, app
+) -> None:
     from flaskr.dao import db
     from flaskr.service.profile.learner_profile import (
         PROFILE_ONBOARDING_SCENE_KEY,
@@ -578,7 +580,9 @@ def test_password_login_merges_authenticated_guest_learner_profile(test_client, 
         assert target_state.trigger_source == "settings"
 
 
-def test_password_login_never_merges_from_a_registered_account(test_client, app):
+def test_password_login_never_merges_from_a_registered_account(
+    test_client, app
+) -> None:
     from flaskr.dao import db
     from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserInfo
@@ -627,7 +631,9 @@ def test_password_login_never_merges_from_a_registered_account(test_client, app)
         assert stored_target.nickname == "Existing target"
 
 
-def test_password_login_ignores_invalid_and_expired_optional_tokens(test_client, app):
+def test_password_login_ignores_invalid_and_expired_optional_tokens(
+    test_client, app
+) -> None:
     from flaskr.dao import db
     from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserInfo
@@ -687,7 +693,7 @@ def test_password_login_ignores_invalid_and_expired_optional_tokens(test_client,
         assert stored_target.nickname == "Stable target"
 
 
-def test_sms_login_route_logs_in_with_phone_code(test_client):
+def test_sms_login_route_logs_in_with_phone_code(test_client) -> None:
     phone = "15500003333"
 
     resp, body = _post_json(
@@ -707,7 +713,9 @@ def test_sms_login_route_logs_in_with_phone_code(test_client):
     assert body["data"]["userInfo"]["mobile"] == phone
 
 
-def test_sms_login_route_does_not_rebind_authenticated_account_phone(test_client, app):
+def test_sms_login_route_does_not_rebind_authenticated_account_phone(
+    test_client, app
+) -> None:
     from flaskr.service.user import phone_flow
     from flaskr.service.user.models import AuthCredential
     from flaskr.service.user.models import UserInfo as UserEntity
@@ -753,7 +761,7 @@ def test_sms_login_route_does_not_rebind_authenticated_account_phone(test_client
         ]
 
 
-def test_sms_login_route_normalizes_cn_prefix(test_client, app):
+def test_sms_login_route_normalizes_cn_prefix(test_client, app) -> None:
     from flaskr.service.user.models import AuthCredential
     from flaskr.service.user.models import UserInfo as UserEntity
 
@@ -786,7 +794,7 @@ def test_sms_login_route_normalizes_cn_prefix(test_client, app):
         assert credential is not None
 
 
-def test_sms_login_referral_metadata_helper_hashes_client_context():
+def test_sms_login_referral_metadata_helper_hashes_client_context() -> None:
     from flaskr.service.referral.service import extract_referral_post_auth_fields
 
     fields = extract_referral_post_auth_fields(

--- a/src/api/tests/service/user/test_profile_onboarding.py
+++ b/src/api/tests/service/user/test_profile_onboarding.py
@@ -1,5 +1,6 @@
 """Verify profile onboarding behavior."""
 
+from collections.abc import Iterator
 from contextlib import contextmanager
 from types import SimpleNamespace
 
@@ -11,7 +12,7 @@ from flaskr.service.user.repository import create_user_entity
 
 
 @contextmanager
-def nullcontext_admission(*_args: object, **_kwargs: object):
+def nullcontext_admission(*_args: object, **_kwargs: object) -> Iterator[None]:
     yield
 
 
@@ -25,7 +26,7 @@ def _create_user(user_bid: str = "user-onboarding") -> None:
     db.session.commit()
 
 
-def test_profile_onboarding_config_roundtrip(app, monkeypatch):
+def test_profile_onboarding_config_roundtrip(app, monkeypatch) -> None:
     from flaskr.service.common import profile_onboarding as module
 
     saved_payloads = []
@@ -69,7 +70,7 @@ def test_profile_onboarding_config_roundtrip(app, monkeypatch):
     assert saved_payloads[0][1] == "operator-1"
 
 
-def test_profile_onboarding_config_rejects_non_whitelisted_variable(app):
+def test_profile_onboarding_config_rejects_non_whitelisted_variable(app) -> None:
     from flaskr.service.common.profile_onboarding import (
         update_profile_onboarding_config,
     )
@@ -85,7 +86,7 @@ def test_profile_onboarding_config_rejects_non_whitelisted_variable(app):
         )
 
 
-def test_profile_onboarding_status_hides_after_skip(app):
+def test_profile_onboarding_status_hides_after_skip(app) -> None:
     from flaskr.service.profile.onboarding import (
         PROFILE_ONBOARDING_STATE_KEY,
         complete_profile_onboarding,
@@ -115,7 +116,9 @@ def test_profile_onboarding_status_hides_after_skip(app):
     assert status["should_show"] is False
 
 
-def test_profile_onboarding_complete_writes_allowed_system_profiles(app, monkeypatch):
+def test_profile_onboarding_complete_writes_allowed_system_profiles(
+    app, monkeypatch
+) -> None:
     from flaskr.service.profile.onboarding import complete_profile_onboarding
 
     checked_text = []
@@ -156,7 +159,7 @@ def test_profile_onboarding_complete_writes_allowed_system_profiles(app, monkeyp
     ]
 
 
-def test_profile_onboarding_routes_delegate(monkeypatch, test_client):
+def test_profile_onboarding_routes_delegate(monkeypatch, test_client) -> None:
     dummy_user = SimpleNamespace(
         user_id="user-onboarding",
         language="zh-CN",
@@ -223,7 +226,7 @@ def test_profile_onboarding_routes_delegate(monkeypatch, test_client):
     }
 
 
-def test_learner_profile_routes_delegate(monkeypatch, test_client):
+def test_learner_profile_routes_delegate(monkeypatch, test_client) -> None:
     dummy_user = SimpleNamespace(user_id="learner-profile-user", language="zh-CN")
     monkeypatch.setattr(
         "flaskr.route.user.validate_user",
@@ -298,7 +301,7 @@ def test_learner_profile_routes_delegate(monkeypatch, test_client):
 )
 def test_learner_profile_update_rejects_invalid_shapes(
     monkeypatch, test_client, payload
-):
+) -> None:
     dummy_user = SimpleNamespace(user_id="learner-profile-user", language="zh-CN")
     monkeypatch.setattr(
         "flaskr.route.user.validate_user",
@@ -312,7 +315,9 @@ def test_learner_profile_update_rejects_invalid_shapes(
     assert response.get_json(force=True)["code"] != 0
 
 
-def test_learner_profile_update_omits_optional_nickname(monkeypatch, test_client):
+def test_learner_profile_update_omits_optional_nickname(
+    monkeypatch, test_client
+) -> None:
     dummy_user = SimpleNamespace(user_id="learner-profile-user", language="zh-CN")
     monkeypatch.setattr(
         "flaskr.route.user.validate_user",
@@ -343,7 +348,7 @@ def test_learner_profile_update_omits_optional_nickname(monkeypatch, test_client
 
 def test_learner_profile_optimize_route_delegates_without_persistence(
     monkeypatch, test_client
-):
+) -> None:
     dummy_user = SimpleNamespace(user_id="learner-profile-user", language="zh-CN")
     monkeypatch.setattr(
         "flaskr.route.user.validate_user",
@@ -393,7 +398,7 @@ def test_learner_profile_optimize_route_delegates_without_persistence(
 )
 def test_learner_profile_optimize_route_rejects_invalid_shapes(
     monkeypatch, test_client, payload
-):
+) -> None:
     dummy_user = SimpleNamespace(user_id="learner-profile-user", language="zh-CN")
     monkeypatch.setattr(
         "flaskr.route.user.validate_user",

--- a/src/api/tests/service/user/test_repository.py
+++ b/src/api/tests/service/user/test_repository.py
@@ -1,6 +1,7 @@
 """Verify user aggregates resolve active and legacy credentials."""
 
 import uuid
+from collections.abc import Iterator
 from datetime import datetime
 
 import pytest
@@ -26,7 +27,7 @@ from flaskr.util.datetime import now_utc
 
 
 @pytest.fixture
-def app():
+def app() -> Iterator[Flask]:
     app = Flask(__name__)
     app.config.update(
         SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
@@ -120,7 +121,7 @@ def _create_user(
     return entity
 
 
-def test_load_user_aggregate_returns_expected_data(app, user_bid):
+def test_load_user_aggregate_returns_expected_data(app, user_bid) -> None:
     email = f"{uuid.uuid4().hex[:12]}@example.com"
     with app.app_context():
         _create_user(user_bid, email, is_operator=True)
@@ -145,7 +146,7 @@ def test_load_user_aggregate_returns_expected_data(app, user_bid):
             db.session.commit()
 
 
-def test_load_user_aggregate_by_identifier_uses_credentials(app, user_bid):
+def test_load_user_aggregate_by_identifier_uses_credentials(app, user_bid) -> None:
     email = f"{uuid.uuid4().hex[:12]}@example.com"
     with app.app_context():
         _create_user(user_bid, email)
@@ -160,7 +161,9 @@ def test_load_user_aggregate_by_identifier_uses_credentials(app, user_bid):
             db.session.commit()
 
 
-def test_load_user_aggregate_by_identifier_ignores_soft_deleted_direct_match(app):
+def test_load_user_aggregate_by_identifier_ignores_soft_deleted_direct_match(
+    app,
+) -> None:
     email = f"{uuid.uuid4().hex[:12]}@example.com"
     deleted_user_bid = uuid.uuid4().hex[:32]
     active_user_bid = uuid.uuid4().hex[:32]
@@ -198,7 +201,7 @@ def test_load_user_aggregate_by_identifier_ignores_soft_deleted_direct_match(app
 
 def test_load_user_aggregate_by_identifier_finds_legacy_prefixed_phone_credential(
     app,
-):
+) -> None:
     phone = "15500008888"
     user_bid = uuid.uuid4().hex[:32]
     with app.app_context():
@@ -226,7 +229,7 @@ def test_load_user_aggregate_by_identifier_finds_legacy_prefixed_phone_credentia
             db.session.commit()
 
 
-def test_upsert_user_entity_creates_and_updates_records(app):
+def test_upsert_user_entity_creates_and_updates_records(app) -> None:
     email = f"{uuid.uuid4().hex[:12]}@example.com"
     user_bid = uuid.uuid4().hex[:32]
     with app.app_context():
@@ -251,7 +254,9 @@ def test_upsert_user_entity_creates_and_updates_records(app):
             db.session.commit()
 
 
-def test_get_first_verified_credential_created_at_prefers_earliest_verified(app):
+def test_get_first_verified_credential_created_at_prefers_earliest_verified(
+    app,
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
     with app.app_context():
         create_user_entity(
@@ -294,7 +299,7 @@ def test_get_first_verified_credential_created_at_prefers_earliest_verified(app)
 
 def test_get_first_verified_credential_created_at_returns_none_without_verified(
     app,
-):
+) -> None:
     user_bid = uuid.uuid4().hex[:32]
     with app.app_context():
         create_user_entity(

--- a/src/api/tests/service/user/test_require_tmp_route.py
+++ b/src/api/tests/service/user/test_require_tmp_route.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 
 
-def test_require_tmp_passes_payload_source_to_temp_user(test_client, monkeypatch):
+def test_require_tmp_passes_payload_source_to_temp_user(
+    test_client, monkeypatch
+) -> None:
     import flaskr.route.user as user_route
 
     calls: list[dict[str, str | None]] = []

--- a/src/api/tests/service/user/test_trial_credit_bootstrap.py
+++ b/src/api/tests/service/user/test_trial_credit_bootstrap.py
@@ -6,6 +6,7 @@ import importlib
 import json
 import uuid
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import pytest
 from flask import Flask
@@ -38,6 +39,9 @@ from flaskr.service.user.utils import generate_token
 from tests.common.fixtures.bill_products import build_bill_products
 from tests.common.fixtures.fake_redis import FakeRedis
 
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient
+
 
 def _load_user_route_handlers():
     common_module = importlib.import_module("flaskr.route.common")
@@ -58,7 +62,7 @@ def _post_json(client, path: str, payload: dict, headers: dict | None = None):
 
 
 @pytest.fixture
-def user_trial_client(monkeypatch, tmp_path):
+def user_trial_client(monkeypatch, tmp_path) -> FlaskClient:
     import flaskr.service.billing.auth_hooks as _billing_auth_hooks  # noqa: F401
     import flaskr.service.user.utils as user_utils
     from flaskr.service.user import email_flow, phone_flow
@@ -172,7 +176,7 @@ def _assert_trial_bootstrapped(user_bid: str) -> None:
 
 def test_sms_login_admin_login_bootstraps_trial_once(
     user_trial_client,
-):
+) -> None:
     app = user_trial_client.application
     app.config["ADMIN_LOGIN_GRANT_CREATOR_WITH_DEMO"] = True
     phone = f"155{uuid.uuid4().int % 100000000:08d}"
@@ -214,7 +218,7 @@ def test_sms_login_admin_login_bootstraps_trial_once(
 
 def test_ensure_admin_creator_bootstraps_trial_for_existing_user_once(
     user_trial_client,
-):
+) -> None:
     app = user_trial_client.application
     app.config["ADMIN_LOGIN_GRANT_CREATOR_WITH_DEMO"] = True
     email = f"{uuid.uuid4().hex[:10]}@example.com"
@@ -255,7 +259,7 @@ def test_ensure_admin_creator_bootstraps_trial_for_existing_user_once(
 
 def test_password_login_existing_creator_does_not_bootstrap_trial_again(
     user_trial_client,
-):
+) -> None:
     app = user_trial_client.application
     email = f"{uuid.uuid4().hex[:10]}@example.com"
     password = "Abcd1234"
@@ -305,7 +309,7 @@ def test_password_login_existing_creator_does_not_bootstrap_trial_again(
 
 def test_password_login_non_creator_does_not_grant_trial(
     user_trial_client,
-):
+) -> None:
     app = user_trial_client.application
     email = f"{uuid.uuid4().hex[:10]}@example.com"
     password = "Abcd1234"
@@ -351,7 +355,7 @@ def test_password_login_non_creator_does_not_grant_trial(
 
 def test_post_auth_extension_failures_do_not_block_trial_bootstrap(
     user_trial_client,
-):
+) -> None:
     app = user_trial_client.application
     app.config["ADMIN_LOGIN_GRANT_CREATOR_WITH_DEMO"] = True
     email = f"{uuid.uuid4().hex[:10]}@example.com"

--- a/src/api/tests/service/user/test_user_identify.py
+++ b/src/api/tests/service/user/test_user_identify.py
@@ -52,7 +52,9 @@ def _reset_shifu_tables() -> None:
     db.session.commit()
 
 
-def test_phone_flow_marks_temp_phone_claim_as_created_new_user(tmp_path, monkeypatch):
+def test_phone_flow_marks_temp_phone_claim_as_created_new_user(
+    tmp_path, monkeypatch
+) -> None:
     from flask import Flask
     from flaskr import dao
     from flaskr.service.user import phone_flow
@@ -126,7 +128,7 @@ def test_phone_flow_marks_temp_phone_claim_as_created_new_user(tmp_path, monkeyp
         assert credential is not None
 
 
-def test_phone_flow_sets_user_identify(app):
+def test_phone_flow_sets_user_identify(app) -> None:
     from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserInfo as UserEntity
 
@@ -155,7 +157,7 @@ def test_phone_flow_sets_user_identify(app):
             _reset_user_auth_tables()
 
 
-def test_email_flow_sets_user_identify(app):
+def test_email_flow_sets_user_identify(app) -> None:
     from flaskr.service.user import email_flow
     from flaskr.service.user.models import UserInfo as UserEntity
 
@@ -178,7 +180,7 @@ def test_email_flow_sets_user_identify(app):
             _reset_user_auth_tables()
 
 
-def test_send_email_code_stores_lowercase_identifier(app, monkeypatch):
+def test_send_email_code_stores_lowercase_identifier(app, monkeypatch) -> None:
     import flaskr.service.user.utils as user_utils
     from flaskr.dao import db
     from flaskr.service.user.models import UserVerifyCode
@@ -247,7 +249,7 @@ def test_send_email_code_stores_lowercase_identifier(app, monkeypatch):
             db.session.commit()
 
 
-def test_phone_flow_verifies_code_from_db_when_cache_missing(app):
+def test_phone_flow_verifies_code_from_db_when_cache_missing(app) -> None:
     from flaskr.dao import db
     from flaskr.service.user import phone_flow
     from flaskr.service.user.models import UserVerifyCode
@@ -281,7 +283,7 @@ def test_phone_flow_verifies_code_from_db_when_cache_missing(app):
         assert updated.verify_code_used == 1
 
 
-def test_phone_flow_normalizes_cn_prefix_when_verifying_db_code(app):
+def test_phone_flow_normalizes_cn_prefix_when_verifying_db_code(app) -> None:
     from flaskr.dao import db
     from flaskr.service.user import phone_flow
     from flaskr.service.user.models import AuthCredential, UserVerifyCode
@@ -329,7 +331,7 @@ def test_phone_flow_normalizes_cn_prefix_when_verifying_db_code(app):
             _reset_user_auth_tables()
 
 
-def test_phone_flow_accepts_prefixed_pending_db_code(app):
+def test_phone_flow_accepts_prefixed_pending_db_code(app) -> None:
     from flaskr.dao import db
     from flaskr.service.user import phone_flow
     from flaskr.service.user.models import AuthCredential, UserVerifyCode
@@ -377,7 +379,7 @@ def test_phone_flow_accepts_prefixed_pending_db_code(app):
             _reset_user_auth_tables()
 
 
-def test_consume_verification_code_accepts_prefixed_pending_cache_key(app):
+def test_consume_verification_code_accepts_prefixed_pending_cache_key(app) -> None:
     from flaskr.dao import db
     from flaskr.service.user import verification_codes
     from flaskr.service.user.models import UserVerifyCode
@@ -415,7 +417,7 @@ def test_consume_verification_code_accepts_prefixed_pending_cache_key(app):
             db.session.commit()
 
 
-def test_phone_flow_bootstrap_sets_draft_owner_for_published_demo(app):
+def test_phone_flow_bootstrap_sets_draft_owner_for_published_demo(app) -> None:
     from flaskr.dao import db
     from flaskr.service.shifu.models import DraftShifu, PublishedShifu
     from flaskr.service.user import phone_flow
@@ -466,7 +468,7 @@ def test_phone_flow_bootstrap_sets_draft_owner_for_published_demo(app):
             _reset_user_auth_tables()
 
 
-def test_email_flow_verifies_code_from_db_when_cache_missing(app):
+def test_email_flow_verifies_code_from_db_when_cache_missing(app) -> None:
     from flaskr.dao import db
     from flaskr.service.user import email_flow
     from flaskr.service.user.models import UserVerifyCode

--- a/src/api/tests/service/user/test_user_repository.py
+++ b/src/api/tests/service/user/test_user_repository.py
@@ -1,7 +1,11 @@
 """transactional_session termination-classification behavior."""
 
+from typing import Never
 
-def test_transactional_session_classifies_before_savepoint_rollback(app, monkeypatch):
+
+def test_transactional_session_classifies_before_savepoint_rollback(
+    app, monkeypatch
+) -> Never:
     """Abnormal terminations must invalidate WITHOUT any savepoint rollback reaching the wire; ordinary errors keep the legacy full-rollback path."""
     _ = app
     import flaskr.service.user.repository as repo_module

--- a/src/api/tests/service/user/test_utils.py
+++ b/src/api/tests/service/user/test_utils.py
@@ -13,19 +13,19 @@ from flaskr.service.user.utils import (
 )
 
 
-def test_get_user_language_supports_language_attribute():
+def test_get_user_language_supports_language_attribute() -> None:
     user = SimpleNamespace(language="zh-CN")
 
     assert get_user_language(user) == "zh-CN"
 
 
-def test_get_user_language_supports_user_language_attribute():
+def test_get_user_language_supports_user_language_attribute() -> None:
     user = SimpleNamespace(user_language="en_US")
 
     assert get_user_language(user) == "en-US"
 
 
-def test_admin_login_auto_grant_keeps_operator_unchanged(app):
+def test_admin_login_auto_grant_keeps_operator_unchanged(app) -> None:
     user_bid = uuid.uuid4().hex[:32]
 
     with app.app_context():

--- a/src/api/tests/service/user/test_validate_user.py
+++ b/src/api/tests/service/user/test_validate_user.py
@@ -7,7 +7,9 @@ from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.user.common import validate_user
 
 
-def test_validate_user_maps_invalid_algorithm_token_to_user_not_found(monkeypatch):
+def test_validate_user_maps_invalid_algorithm_token_to_user_not_found(
+    monkeypatch,
+) -> None:
     app = Flask("validate-user-invalid-algorithm-tests")
     app.config["SECRET_KEY"] = "test-secret"
     app.config["ENVERIMENT"] = "prod"

--- a/src/api/tests/service/user/test_verification_code_errors.py
+++ b/src/api/tests/service/user/test_verification_code_errors.py
@@ -7,7 +7,9 @@ from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.user.verification_codes import consume_verification_code
 
 
-def test_consume_verification_code_rejects_missing_identifier_as_param_error(app):
+def test_consume_verification_code_rejects_missing_identifier_as_param_error(
+    app,
+) -> None:
     with pytest.raises(AppError) as exc_info:
         consume_verification_code(app, identifier="", code="1234")
 
@@ -15,7 +17,7 @@ def test_consume_verification_code_rejects_missing_identifier_as_param_error(app
     assert "identifier" in exc_info.value.message
 
 
-def test_consume_verification_code_rejects_missing_code_as_param_error(app):
+def test_consume_verification_code_rejects_missing_code_as_param_error(app) -> None:
     with pytest.raises(AppError) as exc_info:
         consume_verification_code(app, identifier="user@example.com", code="")
 
@@ -23,7 +25,9 @@ def test_consume_verification_code_rejects_missing_code_as_param_error(app):
     assert "code" in exc_info.value.message
 
 
-def test_consume_verification_code_rejects_empty_normalized_phone_as_param_error(app):
+def test_consume_verification_code_rejects_empty_normalized_phone_as_param_error(
+    app,
+) -> None:
     with pytest.raises(AppError) as exc_info:
         consume_verification_code(app, identifier="+86", code="1234")
 

--- a/src/api/tests/test_app.py
+++ b/src/api/tests/test_app.py
@@ -1,7 +1,7 @@
 """Verify application factory ownership and reuse."""
 
 
-def test_create_app_reuses_the_owned_application(app):
+def test_create_app_reuses_the_owned_application(app) -> None:
     from app import create_app
 
     assert create_app() is app

--- a/src/api/tests/test_chapter.py
+++ b/src/api/tests/test_chapter.py
@@ -6,7 +6,7 @@ from flaskr.service.shifu.shifu_history_manager import HistoryItem
 from flaskr.service.shifu.shifu_struct_manager import get_shifu_outline_tree
 
 
-def test_get_shifu_outline_tree_preview(app):
+def test_get_shifu_outline_tree_preview(app) -> None:
     with app.app_context():
         shifu = DraftShifu(shifu_bid="shifu-1", title="Shifu", created_user_bid="u1")
         db.session.add(shifu)

--- a/src/api/tests/test_discount.py
+++ b/src/api/tests/test_discount.py
@@ -33,31 +33,31 @@ def _make_usage(user_id: str, coupon_bid: str) -> CouponUsage:
     return usage
 
 
-def test_get_course_id_from_filter_handles_invalid_json():
+def test_get_course_id_from_filter_handles_invalid_json() -> None:
     coupon = Coupon()
     coupon.filter = "not-json"
     assert _get_course_id_from_filter(coupon) is None
 
 
-def test_coupon_matches_course_when_filter_missing():
+def test_coupon_matches_course_when_filter_missing() -> None:
     coupon = _make_coupon(None)
     assert _coupon_matches_course(coupon, "course-1") is True
 
 
-def test_coupon_matches_course_when_filter_matches():
+def test_coupon_matches_course_when_filter_matches() -> None:
     coupon = _make_coupon("course-1")
     assert _coupon_matches_course(coupon, "course-1") is True
     assert _coupon_matches_course(coupon, "course-2") is False
 
 
-def test_coupon_matches_course_returns_false_for_inactive_coupon():
+def test_coupon_matches_course_returns_false_for_inactive_coupon() -> None:
     coupon = _make_coupon("course-1")
     coupon.status = 0
 
     assert _coupon_matches_course(coupon, "course-1") is False
 
 
-def test_coupon_matches_course_returns_true_for_legacy_inactive_coupon():
+def test_coupon_matches_course_returns_true_for_legacy_inactive_coupon() -> None:
     coupon = _make_coupon("course-1")
     coupon.status = 0
     coupon.created_user_bid = ""
@@ -66,14 +66,14 @@ def test_coupon_matches_course_returns_true_for_legacy_inactive_coupon():
     assert _coupon_matches_course(coupon, "course-1") is True
 
 
-def test_coupon_matches_course_returns_false_for_deleted_coupon():
+def test_coupon_matches_course_returns_false_for_deleted_coupon() -> None:
     coupon = _make_coupon("course-1")
     coupon.deleted = 1
 
     assert _coupon_matches_course(coupon, "course-1") is False
 
 
-def test_pick_coupon_candidate_prefers_user_usage():
+def test_pick_coupon_candidate_prefers_user_usage() -> None:
     coupon = _make_coupon("course-1")
     usage = _make_usage("user-1", coupon.coupon_bid)
     other_usage = _make_usage("user-2", coupon.coupon_bid)
@@ -91,7 +91,7 @@ def test_pick_coupon_candidate_prefers_user_usage():
     assert has_candidate is True
 
 
-def test_pick_coupon_candidate_falls_back_to_code_coupon():
+def test_pick_coupon_candidate_falls_back_to_code_coupon() -> None:
     coupon = _make_coupon("course-1")
     usage_result, coupon_result, has_candidate = _pick_coupon_candidate(
         [],
@@ -106,7 +106,7 @@ def test_pick_coupon_candidate_falls_back_to_code_coupon():
     assert has_candidate is True
 
 
-def test_pick_coupon_candidate_skips_batch_code_for_single_use_coupon():
+def test_pick_coupon_candidate_skips_batch_code_for_single_use_coupon() -> None:
     coupon = _make_coupon("course-1")
     coupon.usage_type = COUPON_APPLY_TYPE_SPECIFIC
 

--- a/src/api/tests/test_edun.py
+++ b/src/api/tests/test_edun.py
@@ -5,7 +5,7 @@ from typing import Self
 import pytest
 
 
-def test_check_text_returns_unconfigured_for_yidun(app):
+def test_check_text_returns_unconfigured_for_yidun(app) -> None:
     from flaskr.api.check import CHECK_RESULT_UNCONF, check_text
 
     with app.app_context():
@@ -15,7 +15,7 @@ def test_check_text_returns_unconfigured_for_yidun(app):
         assert result.provider == "yidun"
 
 
-def test_yidun_check_uses_configured_timeout(app, monkeypatch):
+def test_yidun_check_uses_configured_timeout(app, monkeypatch) -> None:
     from flaskr.api.check import CHECK_RESULT_PASS
     from flaskr.api.check import yidun as yidun_module
 
@@ -48,7 +48,7 @@ def test_yidun_check_uses_configured_timeout(app, monkeypatch):
     assert captured["timeout"] == 3
 
 
-def test_ilivedata_send_wraps_oserror_as_urlerror(monkeypatch):
+def test_ilivedata_send_wraps_oserror_as_urlerror(monkeypatch) -> None:
     from urllib.error import URLError
 
     from flaskr.api.check import ilivedata as ilivedata_module
@@ -63,7 +63,7 @@ def test_ilivedata_send_wraps_oserror_as_urlerror(monkeypatch):
         ilivedata_module.send("{}", b"sig", "2026-07-11T00:00:00Z", "pid", timeout=5)
 
 
-def test_ilivedata_check_uses_configured_timeout(app, monkeypatch):
+def test_ilivedata_check_uses_configured_timeout(app, monkeypatch) -> None:
     from flaskr.api.check import CHECK_RESULT_PASS
     from flaskr.api.check import ilivedata as ilivedata_module
 

--- a/src/api/tests/test_feishu.py
+++ b/src/api/tests/test_feishu.py
@@ -3,7 +3,7 @@
 from types import SimpleNamespace
 
 
-def test_send_order_feishu_formats_notification(app, monkeypatch):
+def test_send_order_feishu_formats_notification(app, monkeypatch) -> None:
     from flaskr.service.order import funs as order_funs
 
     price_item = SimpleNamespace(

--- a/src/api/tests/test_fix_discount.py
+++ b/src/api/tests/test_fix_discount.py
@@ -17,7 +17,7 @@ from flaskr.service.promo.models import Coupon, CouponUsage
 from flaskr.util.datetime import now_utc
 
 
-def test_use_coupon_code_applies_discount(app, monkeypatch):
+def test_use_coupon_code_applies_discount(app, monkeypatch) -> None:
     order_bid = "order-fix-discount-1"
     course_bid = "course-fix-discount-1"
     user_bid = "user-fix-discount-1"
@@ -76,7 +76,9 @@ def test_use_coupon_code_applies_discount(app, monkeypatch):
     assert sent["code"] == coupon_code
 
 
-def test_use_specific_all_courses_coupon_keeps_unbound_usage_course(app, monkeypatch):
+def test_use_specific_all_courses_coupon_keeps_unbound_usage_course(
+    app, monkeypatch
+) -> None:
     order_bid = "order-fix-discount-2"
     course_bid = "course-fix-discount-2"
     user_bid = "user-fix-discount-2"
@@ -146,7 +148,7 @@ def test_use_specific_all_courses_coupon_keeps_unbound_usage_course(app, monkeyp
         assert updated_coupon.used_count == 1
 
 
-def test_use_coupon_code_accepts_legacy_coupon_status(app, monkeypatch):
+def test_use_coupon_code_accepts_legacy_coupon_status(app, monkeypatch) -> None:
     order_bid = "order-fix-discount-legacy"
     course_bid = "course-fix-discount-legacy"
     user_bid = "user-fix-discount-legacy"
@@ -201,7 +203,7 @@ def test_use_coupon_code_accepts_legacy_coupon_status(app, monkeypatch):
         assert updated_coupon.used_count == 1
 
 
-def test_use_coupon_code_accepts_coupon_expiring_soon_in_utc(app, monkeypatch):
+def test_use_coupon_code_accepts_coupon_expiring_soon_in_utc(app, monkeypatch) -> None:
     # Regression: the validity window is stored and compared as naive UTC.
     # A localized (UTC+8) reading of `end` used to reject coupons that expire
     # within the next eight hours as already expired.
@@ -247,7 +249,9 @@ def test_use_coupon_code_accepts_coupon_expiring_soon_in_utc(app, monkeypatch):
     assert result.order_id == order_bid
 
 
-def test_use_coupon_code_rejects_coupon_not_yet_started_in_utc(app, monkeypatch):
+def test_use_coupon_code_rejects_coupon_not_yet_started_in_utc(
+    app, monkeypatch
+) -> None:
     # Regression: a localized (UTC+8) reading of `start` used to open the
     # redemption window eight hours before the stored UTC start time.
     order_bid = "order-fix-discount-utc-2"

--- a/src/api/tests/test_fmt_prompt.py
+++ b/src/api/tests/test_fmt_prompt.py
@@ -1,7 +1,7 @@
 """Verify prompt variables resolve without mutating learner profiles."""
 
 
-def test_fmt_prompt_replaces_known_variables(app, monkeypatch):
+def test_fmt_prompt_replaces_known_variables(app, monkeypatch) -> None:
     from flaskr.service.learn import utils_v2
 
     monkeypatch.setattr(
@@ -16,7 +16,7 @@ def test_fmt_prompt_replaces_known_variables(app, monkeypatch):
         assert fmt_prompt == "Hello, Alice!"
 
 
-def test_fmt_prompt_keeps_unknown_variables(app, monkeypatch):
+def test_fmt_prompt_keeps_unknown_variables(app, monkeypatch) -> None:
     from flaskr.service.learn import utils_v2
 
     monkeypatch.setattr(
@@ -31,7 +31,7 @@ def test_fmt_prompt_keeps_unknown_variables(app, monkeypatch):
         assert fmt_prompt == "Hello, {unknown}!"
 
 
-def test_fmt_prompt_uses_input_when_template_empty(app, monkeypatch):
+def test_fmt_prompt_uses_input_when_template_empty(app, monkeypatch) -> None:
     from flaskr.service.learn import utils_v2
 
     monkeypatch.setattr(
@@ -49,7 +49,7 @@ def test_fmt_prompt_uses_input_when_template_empty(app, monkeypatch):
 
 def test_fmt_prompt_prefers_request_overrides_without_mutating_profiles(
     app, monkeypatch
-):
+) -> None:
     from flaskr.service.learn import utils_v2
 
     stored_profiles = {

--- a/src/api/tests/test_fmt_prompt_new.py
+++ b/src/api/tests/test_fmt_prompt_new.py
@@ -1,7 +1,7 @@
 """Verify double-brace prompt variables and invalid names."""
 
 
-def test_fmt_prompt_replaces_double_braces(app, monkeypatch):
+def test_fmt_prompt_replaces_double_braces(app, monkeypatch) -> None:
     from flaskr.service.learn import utils_v2
 
     monkeypatch.setattr(
@@ -16,7 +16,7 @@ def test_fmt_prompt_replaces_double_braces(app, monkeypatch):
         assert fmt_prompt == "Hello, Alice!"
 
 
-def test_fmt_prompt_ignores_invalid_variable_names(app, monkeypatch):
+def test_fmt_prompt_ignores_invalid_variable_names(app, monkeypatch) -> None:
     from flaskr.service.learn import utils_v2
 
     monkeypatch.setattr(

--- a/src/api/tests/test_gunicorn_worker_patch_guard.py
+++ b/src/api/tests/test_gunicorn_worker_patch_guard.py
@@ -23,7 +23,7 @@ def _load_detector():
     return namespace["_gevent_worker_requested"]
 
 
-def test_worker_class_detection():
+def test_worker_class_detection() -> None:
     detect = _load_detector()
 
     assert detect(["gunicorn", "-k", "gevent", "app:app"]) is True
@@ -57,7 +57,7 @@ def test_worker_class_detection():
     assert detect(["gunicorn", "app:app"]) is False
 
 
-def test_observer_skips_unpatched_processes(monkeypatch):
+def test_observer_skips_unpatched_processes(monkeypatch) -> None:
     from flaskr.common.gevent_hub_observer import install_hub_error_observer
     from gevent import monkey
 

--- a/src/api/tests/test_langfuse.py
+++ b/src/api/tests/test_langfuse.py
@@ -20,18 +20,18 @@ TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 class CoerceTraceIdTests(unittest.TestCase):
     """Verify coerce trace ID behavior."""
 
-    def test_passes_through_valid_w3c_trace_id(self):
+    def test_passes_through_valid_w3c_trace_id(self) -> None:
         valid = "0123456789abcdef0123456789abcdef"
         assert coerce_langfuse_trace_id(valid) == valid
 
-    def test_maps_arbitrary_ids_deterministically(self):
+    def test_maps_arbitrary_ids_deterministically(self) -> None:
         first = coerce_langfuse_trace_id("my-request-id")
         second = coerce_langfuse_trace_id("my-request-id")
         assert first == second
         assert re.search(TRACE_ID_RE, first)
         assert first != coerce_langfuse_trace_id("other-request-id")
 
-    def test_generates_random_id_when_seed_missing(self):
+    def test_generates_random_id_when_seed_missing(self) -> None:
         generated = coerce_langfuse_trace_id(None)
         assert re.search(TRACE_ID_RE, generated)
 
@@ -39,12 +39,12 @@ class CoerceTraceIdTests(unittest.TestCase):
 class RequestTraceIdTests(unittest.TestCase):
     """Verify request trace ID behavior."""
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         for attr in ("request_id",):
             if hasattr(thread_local, attr):
                 delattr(thread_local, attr)
 
-    def test_prefers_thread_local_request_id(self):
+    def test_prefers_thread_local_request_id(self) -> None:
         app = Flask("langfuse-thread-local")
         thread_local.request_id = "thread-local-request-id"
 
@@ -53,7 +53,7 @@ class RequestTraceIdTests(unittest.TestCase):
                 "thread-local-request-id"
             )
 
-    def test_falls_back_to_request_header(self):
+    def test_falls_back_to_request_header(self) -> None:
         if hasattr(thread_local, "request_id"):
             delattr(thread_local, "request_id")
         fake_request = types.SimpleNamespace(
@@ -68,7 +68,7 @@ class RequestTraceIdTests(unittest.TestCase):
         finally:
             get_request_trace_id.__globals__["request"] = original_request
 
-    def test_uses_generated_uuid_when_request_id_is_missing(self):
+    def test_uses_generated_uuid_when_request_id_is_missing(self) -> None:
         fake_uuid = types.SimpleNamespace(hex="0123456789abcdef0123456789abcdef")
 
         with patch("flaskr.api.langfuse.uuid.uuid4", return_value=fake_uuid):
@@ -78,23 +78,23 @@ class RequestTraceIdTests(unittest.TestCase):
 class ResolveLangfuseTraceIdTests(unittest.TestCase):
     """Verify resolve langfuse trace ID behavior."""
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         for attr in ("request_id",):
             if hasattr(thread_local, attr):
                 delattr(thread_local, attr)
 
-    def test_prefers_explicit_string_trace_id(self):
+    def test_prefers_explicit_string_trace_id(self) -> None:
         observation = types.SimpleNamespace(trace_id="observation-trace-id")
         assert (
             resolve_langfuse_trace_id(observation, "explicit-trace-id")
             == "explicit-trace-id"
         )
 
-    def test_falls_back_to_observation_string_trace_id(self):
+    def test_falls_back_to_observation_string_trace_id(self) -> None:
         observation = types.SimpleNamespace(trace_id="observation-trace-id")
         assert resolve_langfuse_trace_id(observation) == "observation-trace-id"
 
-    def test_ignores_non_string_trace_id_from_mock_client(self):
+    def test_ignores_non_string_trace_id_from_mock_client(self) -> None:
         # When Langfuse is disabled, observations are MockClient instances whose
         # __getattr__ returns a bound method for any attribute, including
         # ``trace_id``. That object must never be used as the trace id.
@@ -104,7 +104,7 @@ class ResolveLangfuseTraceIdTests(unittest.TestCase):
             "request-trace-id"
         )
 
-    def test_ignores_empty_string_trace_ids(self):
+    def test_ignores_empty_string_trace_ids(self) -> None:
         thread_local.request_id = "request-trace-id"
         observation = types.SimpleNamespace(trace_id="")
 

--- a/src/api/tests/test_langfuse_preload_deferral.py
+++ b/src/api/tests/test_langfuse_preload_deferral.py
@@ -33,7 +33,7 @@ def _configure(app, monkeypatch):
     )
 
 
-def test_preload_master_defers_real_client(app, monkeypatch):
+def test_preload_master_defers_real_client(app, monkeypatch) -> None:
     _configure(app, monkeypatch)
     monkeypatch.setattr(langfuse_module, "Langfuse", _RecordingLangfuse)
     monkeypatch.setattr(_RecordingLangfuse, "instances", [])
@@ -45,7 +45,7 @@ def test_preload_master_defers_real_client(app, monkeypatch):
     assert isinstance(langfuse_module.get_langfuse_client(), MockClient)
 
 
-def test_worker_builds_real_client_after_flag_cleared(app, monkeypatch):
+def test_worker_builds_real_client_after_flag_cleared(app, monkeypatch) -> None:
     _configure(app, monkeypatch)
     monkeypatch.setattr(langfuse_module, "Langfuse", _RecordingLangfuse)
     monkeypatch.setattr(_RecordingLangfuse, "instances", [])

--- a/src/api/tests/test_learn_api.py
+++ b/src/api/tests/test_learn_api.py
@@ -17,7 +17,7 @@ from flaskr.service.shifu.models import (
 from flaskr.service.shifu.shifu_history_manager import HistoryItem
 
 
-def test_get_shifu_info_returns_dto(app):
+def test_get_shifu_info_returns_dto(app) -> None:
     with app.app_context():
         shifu = PublishedShifu(
             shifu_bid="shifu-learn-1",
@@ -41,7 +41,7 @@ def test_get_shifu_info_returns_dto(app):
     assert dto.__json__()["default_listen_mode_enabled"] is True
 
 
-def test_get_shifu_info_preview_mode_uses_draft_tts_flag(app):
+def test_get_shifu_info_preview_mode_uses_draft_tts_flag(app) -> None:
     with app.app_context():
         draft = DraftShifu(
             shifu_bid="shifu-learn-tts",
@@ -75,7 +75,7 @@ def test_get_shifu_info_preview_mode_uses_draft_tts_flag(app):
     assert live_dto.default_listen_mode_enabled is False
 
 
-def test_get_outline_item_tree_preview_mode(app):
+def test_get_outline_item_tree_preview_mode(app) -> None:
     with app.app_context():
         outline = DraftOutlineItem(
             outline_item_bid="outline-learn-1",
@@ -116,7 +116,9 @@ def test_get_outline_item_tree_preview_mode(app):
     assert result.outline_items[0].has_content_update_for_current_user is False
 
 
-def test_get_outline_item_tree_marks_published_lesson_updates_for_current_user(app):
+def test_get_outline_item_tree_marks_published_lesson_updates_for_current_user(
+    app,
+) -> None:
     with app.app_context():
         chapter = PublishedOutlineItem(
             outline_item_bid="chapter-learn-1",
@@ -199,7 +201,9 @@ def test_get_outline_item_tree_marks_published_lesson_updates_for_current_user(a
     )
 
 
-def test_get_outline_item_tree_keeps_update_notice_hidden_for_not_started_lessons(app):
+def test_get_outline_item_tree_keeps_update_notice_hidden_for_not_started_lessons(
+    app,
+) -> None:
     with app.app_context():
         lesson = PublishedOutlineItem(
             outline_item_bid="lesson-learn-not-started-1",
@@ -265,7 +269,7 @@ def test_get_outline_item_tree_keeps_update_notice_hidden_for_not_started_lesson
     assert result.outline_items[0].has_content_update_for_current_user is False
 
 
-def test_get_outline_item_tree_uses_normalized_published_effective_time(app):
+def test_get_outline_item_tree_uses_normalized_published_effective_time(app) -> None:
     with app.app_context():
         lesson = PublishedOutlineItem(
             outline_item_bid="lesson-learn-published-timezone-1",
@@ -327,7 +331,9 @@ def test_get_outline_item_tree_uses_normalized_published_effective_time(app):
     assert result.outline_items[0].has_content_update_for_current_user is True
 
 
-def test_get_outline_item_tree_ignores_published_copy_created_at_for_updates(app):
+def test_get_outline_item_tree_ignores_published_copy_created_at_for_updates(
+    app,
+) -> None:
     with app.app_context():
         lesson = PublishedOutlineItem(
             outline_item_bid="lesson-learn-published-copy-created-1",

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -122,14 +122,14 @@ class DummySpan:
         self.trace_id = trace_id
         self.id = span_id
 
-    def generation(self, **kwargs: object):
+    def generation(self, **kwargs: object) -> "DummySpan":
         self.generation_args = kwargs
         return self
 
-    def end(self, **kwargs: object):
+    def end(self, **kwargs: object) -> None:
         self.end_args = kwargs
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.update_args = kwargs
 
 
@@ -161,10 +161,10 @@ class FakeModelsResponse:
         """Initialize the fake models response test double."""
         self.payload = payload
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         return None
 
-    def json(self):
+    def json(self) -> dict[str, object]:
         return self.payload
 
 
@@ -251,7 +251,9 @@ def _configure_model_list(monkeypatch):
     )
 
 
-def test_get_current_models_adds_output_token_credit_multiplier(monkeypatch, app):
+def test_get_current_models_adds_output_token_credit_multiplier(
+    monkeypatch, app
+) -> None:
     _configure_model_list(monkeypatch)
     with app.app_context():
         db.session.query(CreditUsageRate).delete()
@@ -327,7 +329,7 @@ def test_get_current_models_adds_output_token_credit_multiplier(monkeypatch, app
     )
 
 
-def test_get_current_models_uses_fixed_credit_1x_anchor(monkeypatch, app):
+def test_get_current_models_uses_fixed_credit_1x_anchor(monkeypatch, app) -> None:
     _configure_model_list(monkeypatch)
     with app.app_context():
         db.session.query(CreditUsageRate).delete()
@@ -374,7 +376,7 @@ def test_get_current_models_uses_fixed_credit_1x_anchor(monkeypatch, app):
 
 def test_get_current_models_hides_multiplier_when_credit_1x_anchor_missing(
     monkeypatch, app
-):
+) -> None:
     _configure_model_list(monkeypatch)
     missing_anchor_config = {
         "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
@@ -414,7 +416,9 @@ def test_get_current_models_hides_multiplier_when_credit_1x_anchor_missing(
     assert all(item.get("credit_multiplier_label") is None for item in models)
 
 
-def test_get_current_models_keeps_list_when_credit_rate_lookup_fails(monkeypatch, app):
+def test_get_current_models_keeps_list_when_credit_rate_lookup_fails(
+    monkeypatch, app
+) -> None:
     _configure_model_list(monkeypatch)
 
     def raise_lookup(_app):
@@ -433,7 +437,7 @@ def test_get_current_models_keeps_list_when_credit_rate_lookup_fails(monkeypatch
     assert all(item["credit_multiplier"] is None for item in models)
 
 
-def test_deepseek_model_loader_lists_models(monkeypatch):
+def test_deepseek_model_loader_lists_models(monkeypatch) -> None:
     captured = {}
 
     def fake_get(url, headers=None, timeout=None):
@@ -470,7 +474,7 @@ def test_deepseek_model_loader_lists_models(monkeypatch):
     assert captured["timeout"] == 20
 
 
-def test_deepseek_model_loader_falls_back_when_list_models_fails(monkeypatch):
+def test_deepseek_model_loader_falls_back_when_list_models_fails(monkeypatch) -> None:
     def fake_get(*args: object, **kwargs: object):
         _ = args, kwargs
         message = "network unavailable"
@@ -493,7 +497,7 @@ def test_deepseek_model_loader_falls_back_when_list_models_fails(monkeypatch):
     assert models == llm.DEEPSEEK_FALLBACK_MODELS
 
 
-def test_qwen_prefixed_model_routes_without_fetched_alias(monkeypatch, app):
+def test_qwen_prefixed_model_routes_without_fetched_alias(monkeypatch, app) -> None:
     captured = {}
 
     def fake_completion(model, *args: object, **kwargs: object):
@@ -549,7 +553,7 @@ def test_qwen_prefixed_model_routes_without_fetched_alias(monkeypatch, app):
     assert captured["kwargs"]["max_tokens"] == 393216
 
 
-def test_load_and_register_model_max_output_tokens(monkeypatch):
+def test_load_and_register_model_max_output_tokens(monkeypatch) -> None:
     configured = {
         "qwen/deepseek-v4-flash": 393216,
         "ark/doubao-seed-2-0-lite-260428": 131072,
@@ -579,7 +583,7 @@ def test_load_and_register_model_max_output_tokens(monkeypatch):
     }
 
 
-def test_load_model_max_output_tokens_ignores_invalid_config(monkeypatch):
+def test_load_model_max_output_tokens_ignores_invalid_config(monkeypatch) -> None:
     monkeypatch.setattr(
         llm,
         "get_config",
@@ -597,7 +601,9 @@ def test_load_model_max_output_tokens_ignores_invalid_config(monkeypatch):
     assert llm._load_and_register_model_max_output_tokens() == {}
 
 
-def test_stream_litellm_completion_falls_back_to_litellm_limit(monkeypatch, app):
+def test_stream_litellm_completion_falls_back_to_litellm_limit(
+    monkeypatch, app
+) -> None:
     captured = {}
     monkeypatch.setattr(llm, "MODEL_MAX_OUTPUT_TOKENS", {})
     monkeypatch.setattr(llm.litellm, "get_max_tokens", lambda _model: 8192)
@@ -630,7 +636,7 @@ def test_stream_litellm_completion_applies_configured_limit_as_ceiling(
     app,
     requested_max_tokens,
     expected_max_tokens,
-):
+) -> None:
     captured = {}
     monkeypatch.setattr(
         llm,
@@ -660,7 +666,7 @@ def test_stream_litellm_completion_applies_configured_limit_as_ceiling(
     assert captured["max_tokens"] == expected_max_tokens
 
 
-def test_stream_litellm_completion_omits_unknown_limit(monkeypatch, app):
+def test_stream_litellm_completion_omits_unknown_limit(monkeypatch, app) -> None:
     captured = {}
 
     def raise_unknown(_model):
@@ -689,7 +695,7 @@ def test_stream_litellm_completion_omits_unknown_limit(monkeypatch, app):
     assert "max_tokens" not in captured
 
 
-def test_qwen_provider_config_keeps_prefix_fallback():
+def test_qwen_provider_config_keeps_prefix_fallback() -> None:
     qwen_config = next(
         config for config in llm.LITELLM_PROVIDER_CONFIGS if config.key == "qwen"
     )
@@ -712,7 +718,7 @@ def test_qwen_provider_config_keeps_prefix_fallback():
 def test_provider_configs_use_expected_litellm_adapters(
     provider_key,
     expected_litellm_provider,
-):
+) -> None:
     provider_config = next(
         config for config in llm.LITELLM_PROVIDER_CONFIGS if config.key == provider_key
     )
@@ -757,7 +763,7 @@ def test_openai_params_use_litellm_reasoning_capabilities(
     model_info,
     expected_effort,
     expected_temperature,
-):
+) -> None:
     captured = {}
 
     def fake_get_model_info(*, model, custom_llm_provider):
@@ -779,7 +785,9 @@ def test_openai_params_use_litellm_reasoning_capabilities(
     }
 
 
-def test_openai_params_fall_back_to_existing_policy_for_unknown_model(monkeypatch):
+def test_openai_params_fall_back_to_existing_policy_for_unknown_model(
+    monkeypatch,
+) -> None:
     def raise_unknown(*args: object, **kwargs: object):
         _ = args, kwargs
         message = "unknown model"
@@ -793,7 +801,9 @@ def test_openai_params_fall_back_to_existing_policy_for_unknown_model(monkeypatc
     }
 
 
-def test_openai_params_fall_back_when_capability_metadata_is_partial(monkeypatch):
+def test_openai_params_fall_back_when_capability_metadata_is_partial(
+    monkeypatch,
+) -> None:
     monkeypatch.setattr(
         llm.litellm,
         "get_model_info",
@@ -810,7 +820,7 @@ def test_openai_params_fall_back_when_capability_metadata_is_partial(monkeypatch
     "model_id",
     ["glm-4.5", "glm-4.6-air", "glm-4.7-flash", "glm-5.2"],
 )
-def test_glm_params_disable_thinking_for_supported_models(model_id):
+def test_glm_params_disable_thinking_for_supported_models(model_id) -> None:
     params = llm._reload_glm_params(model_id, 0.4)
 
     assert params == {
@@ -820,7 +830,7 @@ def test_glm_params_disable_thinking_for_supported_models(model_id):
     }
 
 
-def test_glm_params_leave_legacy_models_unchanged():
+def test_glm_params_leave_legacy_models_unchanged() -> None:
     params = llm._reload_glm_params("glm-4-plus", 0.4)
 
     assert params == {
@@ -829,7 +839,7 @@ def test_glm_params_leave_legacy_models_unchanged():
     }
 
 
-def test_provider_specific_thinking_params_remain_compatible():
+def test_provider_specific_thinking_params_remain_compatible() -> None:
     assert llm._reload_qwen_params("qwen-max", 0.4)["extra_body"] == {
         "enable_thinking": False
     }
@@ -844,7 +854,7 @@ def test_provider_specific_thinking_params_remain_compatible():
     ]
 
 
-def test_provider_thinking_policy_removes_caller_conflicts():
+def test_provider_thinking_policy_removes_caller_conflicts() -> None:
     kwargs = {
         "reasoning_effort": "high",
         "thinking": {"type": "enabled"},
@@ -879,7 +889,7 @@ def test_gemini_thinking_policy_removes_nested_caller_override(
     generation_config_key,
     thinking_config_key,
     top_k_key,
-):
+) -> None:
     kwargs = {
         "extra_body": {
             generation_config_key: {
@@ -909,7 +919,7 @@ def test_gemini_thinking_policy_removes_nested_caller_override(
 @pytest.mark.parametrize("generation_config_key", llm._GEMINI_GENERATION_CONFIG_KEYS)
 def test_gemini_thinking_policy_removes_invalid_native_config(
     generation_config_key,
-):
+) -> None:
     kwargs = {
         "extra_body": {
             generation_config_key: None,
@@ -925,7 +935,7 @@ def test_gemini_thinking_policy_removes_invalid_native_config(
     assert kwargs["extra_body"] == {"custom_field": "keep"}
 
 
-def test_gemini_thinking_policy_normalizes_generation_config_aliases():
+def test_gemini_thinking_policy_normalizes_generation_config_aliases() -> None:
     kwargs = {
         "extra_body": {
             "generation_config": {
@@ -952,7 +962,7 @@ def test_gemini_thinking_policy_normalizes_generation_config_aliases():
     }
 
 
-def test_provider_thinking_policy_preserves_caller_extra_body_fields():
+def test_provider_thinking_policy_preserves_caller_extra_body_fields() -> None:
     kwargs = {
         "extra_body": {
             "enable_thinking": True,
@@ -993,7 +1003,7 @@ def _installed_litellm_version() -> str | None:
         "install requirements.txt to run it"
     ),
 )
-def test_litellm_195_native_adapter_contracts():
+def test_litellm_195_native_adapter_contracts() -> None:
     script = textwrap.dedent(
         """
         import importlib.metadata
@@ -1246,7 +1256,7 @@ def test_litellm_195_native_adapter_contracts():
     }
 
 
-def test_chat_llm_disables_deepseek_thinking(monkeypatch, app):
+def test_chat_llm_disables_deepseek_thinking(monkeypatch, app) -> None:
     captured_kwargs = {}
 
     def fake_completion(*args: object, **kwargs: object):
@@ -1299,7 +1309,7 @@ def test_chat_llm_disables_deepseek_thinking(monkeypatch, app):
     assert captured_kwargs["kwargs"]["extra_body"] == {"custom_field": "keep"}
 
 
-def test_gemini_3_params_use_none_with_explicit_allowlist():
+def test_gemini_3_params_use_none_with_explicit_allowlist() -> None:
     params = llm._reload_gemini_params("gemini-3.1-flash-lite", 0.3)
 
     assert params == {
@@ -1309,14 +1319,14 @@ def test_gemini_3_params_use_none_with_explicit_allowlist():
     }
 
 
-def test_gemini_25_pro_params_use_lowest_supported_reasoning():
+def test_gemini_25_pro_params_use_lowest_supported_reasoning() -> None:
     params = llm._reload_gemini_params("gemini-2.5-pro", 0.3)
 
     assert params["allowed_openai_params"] == ["reasoning_effort"]
     assert params["reasoning_effort"] == "minimal"
 
 
-def test_invoke_llm_uses_actual_model_for_provider_params(monkeypatch, app):
+def test_invoke_llm_uses_actual_model_for_provider_params(monkeypatch, app) -> None:
     captured = {}
 
     def reload_params(model_id, temperature):
@@ -1368,7 +1378,9 @@ def test_invoke_llm_uses_actual_model_for_provider_params(monkeypatch, app):
     assert captured["completion_kwargs"]["temperature"] == 0.4
 
 
-def test_chat_llm_ends_partial_response_on_repeated_stream_chunk(monkeypatch, app):
+def test_chat_llm_ends_partial_response_on_repeated_stream_chunk(
+    monkeypatch, app
+) -> None:
     class RepeatedChunkError(Exception):
         __module__ = "litellm.exceptions"
 
@@ -1405,7 +1417,7 @@ def test_chat_llm_ends_partial_response_on_repeated_stream_chunk(monkeypatch, ap
     assert [resp.result for resp in responses] == ["你好"]
 
 
-def test_chat_llm_streams(monkeypatch, app):
+def test_chat_llm_streams(monkeypatch, app) -> None:
     captured_kwargs = {}
     captured_usage = {}
 
@@ -1478,7 +1490,7 @@ def test_chat_llm_streams(monkeypatch, app):
 @pytest.mark.parametrize("llm_method", ["invoke_llm", "chat_llm"])
 def test_llm_sends_reasoning_output_to_langfuse_without_streaming_it(
     monkeypatch, app, llm_method
-):
+) -> None:
     def fake_completion(*args: object, **kwargs: object):
         _ = args, kwargs
         return iter(
@@ -1531,7 +1543,7 @@ def test_llm_sends_reasoning_output_to_langfuse_without_streaming_it(
     }
 
 
-def test_langfuse_reasoning_output_keeps_empty_content_key():
+def test_langfuse_reasoning_output_keeps_empty_content_key() -> None:
     assert llm._build_langfuse_llm_output("", "Think carefully.") == {
         "content": "",
         "reasoning_content": "Think carefully.",
@@ -1574,11 +1586,13 @@ def test_langfuse_reasoning_output_keeps_empty_content_key():
         ),
     ],
 )
-def test_extract_reasoning_delta_supports_litellm_fallback_fields(delta, expected):
+def test_extract_reasoning_delta_supports_litellm_fallback_fields(
+    delta, expected
+) -> None:
     assert llm._extract_reasoning_delta(delta) == expected
 
 
-def test_chat_llm_falls_back_to_request_trace_id(monkeypatch, app):
+def test_chat_llm_falls_back_to_request_trace_id(monkeypatch, app) -> None:
     def fake_completion(*args: object, **kwargs: object):
         _ = args, kwargs
         return iter([FakeResponse("chunk-1", content="Hi", finish_reason="stop")])
@@ -1693,7 +1707,7 @@ def _collect_retry_stream(app):
 )
 def test_stream_retries_connection_error_before_first_content(
     monkeypatch, app, error_type
-):
+) -> None:
     _patch_retryable_stream_errors(monkeypatch)
     calls = _patch_scripted_streams(
         monkeypatch,
@@ -1709,7 +1723,7 @@ def test_stream_retries_connection_error_before_first_content(
     assert calls["count"] == 2
 
 
-def test_stream_retry_discards_reasoning_from_failed_attempt(monkeypatch, app):
+def test_stream_retry_discards_reasoning_from_failed_attempt(monkeypatch, app) -> None:
     _patch_retryable_stream_errors(monkeypatch)
     calls = _patch_scripted_streams(
         monkeypatch,
@@ -1736,7 +1750,7 @@ def test_stream_retry_discards_reasoning_from_failed_attempt(monkeypatch, app):
     assert calls["count"] == 2
 
 
-def test_stream_error_after_content_is_not_retried(monkeypatch, app):
+def test_stream_error_after_content_is_not_retried(monkeypatch, app) -> None:
     _patch_retryable_stream_errors(monkeypatch)
     calls = _patch_scripted_streams(
         monkeypatch,
@@ -1749,7 +1763,7 @@ def test_stream_error_after_content_is_not_retried(monkeypatch, app):
     assert calls["count"] == 1
 
 
-def test_stream_retry_attempts_are_bounded(monkeypatch, app):
+def test_stream_retry_attempts_are_bounded(monkeypatch, app) -> None:
     _patch_retryable_stream_errors(monkeypatch)
     calls = _patch_scripted_streams(
         monkeypatch,
@@ -1765,7 +1779,7 @@ def test_stream_retry_attempts_are_bounded(monkeypatch, app):
     assert calls["count"] == 2
 
 
-def test_stream_non_retryable_error_raises_immediately(monkeypatch, app):
+def test_stream_non_retryable_error_raises_immediately(monkeypatch, app) -> None:
     _patch_retryable_stream_errors(monkeypatch)
     calls = _patch_scripted_streams(monkeypatch, [[ValueError("business error")]])
 
@@ -1775,7 +1789,7 @@ def test_stream_non_retryable_error_raises_immediately(monkeypatch, app):
     assert calls["count"] == 1
 
 
-def test_stream_retry_noop_when_exception_types_unavailable(monkeypatch, app):
+def test_stream_retry_noop_when_exception_types_unavailable(monkeypatch, app) -> None:
     """The litellm test stub has no exceptions submodule; the wrapper must degrade to raising instead of crashing on type resolution."""
     monkeypatch.delattr(llm.litellm, "exceptions", raising=False)
     calls = _patch_scripted_streams(

--- a/src/api/tests/test_mdflow_adapter.py
+++ b/src/api/tests/test_mdflow_adapter.py
@@ -24,7 +24,7 @@ from flaskr.service.user.models import UserInfo
 from flaskr.util.datetime import now_utc
 
 
-def test_parse_shifu_mdflow_returns_variables(app):
+def test_parse_shifu_mdflow_returns_variables(app) -> None:
     with app.app_context():
         outline = DraftOutlineItem(
             outline_item_bid="outline-mdflow-1",
@@ -81,7 +81,7 @@ def _add_outline_version(
         return int(item.id)
 
 
-def test_get_shifu_mdflow_history_includes_baseline_and_masks_user(app):
+def test_get_shifu_mdflow_history_includes_baseline_and_masks_user(app) -> None:
     shifu_bid = "shifu-mdflow-history-1"
     outline_bid = "outline-mdflow-history-1"
     user_1 = "user-mdflow-history-1"
@@ -124,7 +124,7 @@ def test_get_shifu_mdflow_history_includes_baseline_and_masks_user(app):
     assert [item["version_id"] for item in limited["items"]] == [id_5, id_3]
 
 
-def test_get_shifu_mdflow_history_version_detail_returns_content_and_user(app):
+def test_get_shifu_mdflow_history_version_detail_returns_content_and_user(app) -> None:
     shifu_bid = "shifu-mdflow-history-detail-1"
     outline_bid = "outline-mdflow-history-detail-1"
     user_bid = "user-mdflow-history-detail-1"
@@ -157,7 +157,7 @@ def test_get_shifu_mdflow_history_version_detail_returns_content_and_user(app):
     assert isinstance(detail["updated_at"], datetime)
 
 
-def test_get_shifu_mdflow_history_version_detail_raises_not_found(app):
+def test_get_shifu_mdflow_history_version_detail_raises_not_found(app) -> None:
     with pytest.raises(AppError):
         get_shifu_mdflow_history_version_detail(
             app,
@@ -167,7 +167,7 @@ def test_get_shifu_mdflow_history_version_detail_raises_not_found(app):
         )
 
 
-def test_save_shifu_mdflow_rejects_outline_from_other_shifu(app):
+def test_save_shifu_mdflow_rejects_outline_from_other_shifu(app) -> None:
     _add_outline_version(
         app,
         "shifu-idor-owner",
@@ -187,7 +187,7 @@ def test_save_shifu_mdflow_rejects_outline_from_other_shifu(app):
         )
 
 
-def test_draft_meta_revision_stays_stable_for_metadata_only_updates(app):
+def test_draft_meta_revision_stays_stable_for_metadata_only_updates(app) -> None:
     shifu_bid = "shifu-mdflow-meta-1"
     outline_bid = "outline-mdflow-meta-1"
 
@@ -223,7 +223,7 @@ def test_draft_meta_revision_stays_stable_for_metadata_only_updates(app):
     assert meta["updated_user"]["user_bid"] == "user-meta-1"
 
 
-def test_save_shifu_mdflow_conflicts_when_outline_deleted(app):
+def test_save_shifu_mdflow_conflicts_when_outline_deleted(app) -> None:
     shifu_bid = "shifu-mdflow-delete-1"
     outline_bid = "outline-mdflow-delete-1"
     active_revision = _add_outline_version(
@@ -263,7 +263,7 @@ def test_save_shifu_mdflow_conflicts_when_outline_deleted(app):
     assert result["meta"]["revision"] == deleted_revision
 
 
-def test_save_shifu_mdflow_normalizes_none_content(app, monkeypatch):
+def test_save_shifu_mdflow_normalizes_none_content(app, monkeypatch) -> None:
     shifu_bid = "shifu-mdflow-none-content-1"
     outline_bid = "outline-mdflow-none-content-1"
 
@@ -307,7 +307,9 @@ def test_save_shifu_mdflow_normalizes_none_content(app, monkeypatch):
     assert get_shifu_mdflow(app, shifu_bid, outline_bid) == ""
 
 
-def test_save_shifu_mdflow_returns_outline_revision_not_history_log(app, monkeypatch):
+def test_save_shifu_mdflow_returns_outline_revision_not_history_log(
+    app, monkeypatch
+) -> None:
     shifu_bid = "shifu-mdflow-revision-1"
     outline_bid = "outline-mdflow-revision-1"
 
@@ -351,7 +353,9 @@ def test_save_shifu_mdflow_returns_outline_revision_not_history_log(app, monkeyp
     assert result["new_revision"] != 999999
 
 
-def test_save_shifu_mdflow_serializes_with_outline_structure_writes(app, monkeypatch):
+def test_save_shifu_mdflow_serializes_with_outline_structure_writes(
+    app, monkeypatch
+) -> None:
     shifu_bid = "shifu-mdflow-structure-lock-1"
     outline_bid = "outline-mdflow-structure-lock-1"
     lock_calls = []
@@ -433,7 +437,9 @@ def test_save_shifu_mdflow_serializes_with_outline_structure_writes(app, monkeyp
     assert latest.position == "0101"
 
 
-def test_save_shifu_mdflow_rereads_outline_after_risk_control_commit(app, monkeypatch):
+def test_save_shifu_mdflow_rereads_outline_after_risk_control_commit(
+    app, monkeypatch
+) -> None:
     shifu_bid = "shifu-mdflow-risk-commit-1"
     outline_bid = "outline-mdflow-risk-commit-1"
 
@@ -511,7 +517,7 @@ def test_save_shifu_mdflow_rereads_outline_after_risk_control_commit(app, monkey
     assert latest.position == "0101"
 
 
-def test_cleanup_outline_history_preserves_content_anchor_revision(app):
+def test_cleanup_outline_history_preserves_content_anchor_revision(app) -> None:
     shifu_bid = "shifu-mdflow-cleanup-1"
     outline_bid = "outline-mdflow-cleanup-1"
 
@@ -548,7 +554,7 @@ def test_cleanup_outline_history_preserves_content_anchor_revision(app):
     assert get_shifu_draft_revision(app, shifu_bid, outline_bid) == anchor_revision
 
 
-def test_restore_shifu_mdflow_history_restores_content(app, monkeypatch):
+def test_restore_shifu_mdflow_history_restores_content(app, monkeypatch) -> None:
     shifu_bid = "shifu-mdflow-restore-1"
     outline_bid = "outline-mdflow-restore-1"
 
@@ -605,7 +611,7 @@ def test_restore_shifu_mdflow_history_restores_content(app, monkeypatch):
         assert latest.content == "Old"
 
 
-def test_restore_shifu_mdflow_history_passes_base_revision(app, monkeypatch):
+def test_restore_shifu_mdflow_history_passes_base_revision(app, monkeypatch) -> None:
     shifu_bid = "shifu-mdflow-restore-2"
     outline_bid = "outline-mdflow-restore-2"
 
@@ -644,7 +650,7 @@ def test_restore_shifu_mdflow_history_passes_base_revision(app, monkeypatch):
     assert result["conflict"] is True
 
 
-def test_restore_shifu_mdflow_history_deleted_outline_returns_deleted_flag(app):
+def test_restore_shifu_mdflow_history_deleted_outline_returns_deleted_flag(app) -> None:
     shifu_bid = "shifu-mdflow-restore-deleted-1"
     outline_bid = "outline-mdflow-restore-deleted-1"
     user_bid = "user-restore-deleted-1"

--- a/src/api/tests/test_openai.py
+++ b/src/api/tests/test_openai.py
@@ -95,14 +95,14 @@ class DummySpan:
         self.trace_id = trace_id
         self.id = span_id
 
-    def generation(self, **kwargs: object):
+    def generation(self, **kwargs: object) -> "DummySpan":
         self.generation_args = kwargs
         return self
 
-    def end(self, **kwargs: object):
+    def end(self, **kwargs: object) -> None:
         self.end_args = kwargs
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updated = kwargs
 
 
@@ -127,7 +127,7 @@ class FakeUsage:
         self.total_tokens = total_tokens
 
 
-def test_invoke_llm_streams_via_litellm(monkeypatch, app):
+def test_invoke_llm_streams_via_litellm(monkeypatch, app) -> None:
     captured_kwargs = {}
 
     def fake_completion(*args: object, **kwargs: object):

--- a/src/api/tests/test_order.py
+++ b/src/api/tests/test_order.py
@@ -41,7 +41,7 @@ def _query_promo_applications(items: list[object]) -> object:
     return query
 
 
-def test_init_buy_record_creates_order(app, monkeypatch):
+def test_init_buy_record_creates_order(app, monkeypatch) -> None:
     from flaskr.service.order import funs as order_funs
 
     monkeypatch.setattr(order_funs, "get_shifu_creator_bid", lambda _app, _bid: "u1")
@@ -70,7 +70,9 @@ def test_init_buy_record_creates_order(app, monkeypatch):
         db.session.commit()
 
 
-def test_init_buy_record_refreshes_existing_unpaid_order_promotions(app, monkeypatch):
+def test_init_buy_record_refreshes_existing_unpaid_order_promotions(
+    app, monkeypatch
+) -> None:
     from flaskr.service.order import funs as order_funs
 
     monkeypatch.setattr(order_funs, "get_shifu_creator_bid", lambda _app, _bid: "u1")
@@ -129,7 +131,7 @@ def test_init_buy_record_refreshes_existing_unpaid_order_promotions(app, monkeyp
         db.session.commit()
 
 
-def test_init_buy_record_reactivates_voided_promo_redemption(app, monkeypatch):
+def test_init_buy_record_reactivates_voided_promo_redemption(app, monkeypatch) -> None:
     from flaskr.service.order import funs as order_funs
 
     monkeypatch.setattr(order_funs, "get_shifu_creator_bid", lambda _app, _bid: "u1")
@@ -197,7 +199,7 @@ def test_init_buy_record_reactivates_voided_promo_redemption(app, monkeypatch):
         db.session.commit()
 
 
-def test_init_buy_record_applies_legacy_campaign(app, monkeypatch):
+def test_init_buy_record_applies_legacy_campaign(app, monkeypatch) -> None:
     from flaskr.service.order import funs as order_funs
 
     monkeypatch.setattr(order_funs, "get_shifu_creator_bid", lambda _app, _bid: "u1")
@@ -245,7 +247,7 @@ def test_init_buy_record_applies_legacy_campaign(app, monkeypatch):
 
 def test_query_promo_campaign_applications_keeps_legacy_campaign_when_recalculating(
     app,
-):
+) -> None:
     from flaskr.service.promo.funcs import query_promo_campaign_applications
 
     now = now_utc()
@@ -290,7 +292,9 @@ def test_query_promo_campaign_applications_keeps_legacy_campaign_when_recalculat
     assert result[0].promo_bid == "promo-legacy-runtime-2"
 
 
-def test_init_buy_record_refresh_keeps_existing_coupon_discount(app, monkeypatch):
+def test_init_buy_record_refresh_keeps_existing_coupon_discount(
+    app, monkeypatch
+) -> None:
     from flaskr.service.order import funs as order_funs
 
     monkeypatch.setattr(order_funs, "get_shifu_creator_bid", lambda _app, _bid: "u1")

--- a/src/api/tests/test_phone_numbers.py
+++ b/src/api/tests/test_phone_numbers.py
@@ -6,16 +6,16 @@ from flaskr.service.common.phone_numbers import (
 )
 
 
-def test_normalize_phone_identifier_strips_cn_prefix():
+def test_normalize_phone_identifier_strips_cn_prefix() -> None:
     assert normalize_phone_identifier("+8613800000000") == "13800000000"
 
 
-def test_is_valid_sms_mobile_accepts_cn_mobile():
+def test_is_valid_sms_mobile_accepts_cn_mobile() -> None:
     assert is_valid_sms_mobile("13800000000") is True
     assert is_valid_sms_mobile("+8613800000000") is True
 
 
-def test_is_valid_sms_mobile_rejects_invalid_mobile():
+def test_is_valid_sms_mobile_rejects_invalid_mobile() -> None:
     assert is_valid_sms_mobile("186380295265") is False
     assert is_valid_sms_mobile("23800000000") is False
     assert is_valid_sms_mobile("") is False

--- a/src/api/tests/test_pingpp.py
+++ b/src/api/tests/test_pingpp.py
@@ -3,7 +3,7 @@
 from flaskr.service.order.payment_providers.base import PaymentCreationResult
 
 
-def test_init_pingxx_uses_provider(app, monkeypatch):
+def test_init_pingxx_uses_provider(app, monkeypatch) -> None:
     from flaskr.service.order import pingxx_order
 
     class FakeProvider:
@@ -22,7 +22,7 @@ def test_init_pingxx_uses_provider(app, monkeypatch):
     assert provider.called is True
 
 
-def test_create_pingxx_order_builds_request(app, monkeypatch):
+def test_create_pingxx_order_builds_request(app, monkeypatch) -> None:
     from flaskr.service.order import pingxx_order
 
     captured = {}

--- a/src/api/tests/test_profile.py
+++ b/src/api/tests/test_profile.py
@@ -8,7 +8,7 @@ from flaskr.service.profile.profile_manage import (
 )
 
 
-def test_add_profile_item_quick_creates_definition(app):
+def test_add_profile_item_quick_creates_definition(app) -> None:
     with app.app_context():
         definition = add_profile_item_quick(
             app,
@@ -22,7 +22,7 @@ def test_add_profile_item_quick_creates_definition(app):
         assert any(item.profile_key == "favorite_color" for item in definitions)
 
 
-def test_hide_unused_profile_items_no_unused(monkeypatch):
+def test_hide_unused_profile_items_no_unused(monkeypatch) -> None:
     calls = []
 
     def fake_get_unused(app, parent_id):
@@ -49,7 +49,7 @@ def test_hide_unused_profile_items_no_unused(monkeypatch):
     assert ("defs", "shifu_bid") in calls
 
 
-def test_hide_unused_profile_items_updates_hidden(monkeypatch):
+def test_hide_unused_profile_items_updates_hidden(monkeypatch) -> None:
     calls = []
 
     def fake_get_unused(app, parent_id):

--- a/src/api/tests/test_query_order.py
+++ b/src/api/tests/test_query_order.py
@@ -22,7 +22,7 @@ def _query_promo_applications(items: list[object]) -> object:
     return query
 
 
-def test_query_buy_record_returns_dto(app):
+def test_query_buy_record_returns_dto(app) -> None:
     with app.app_context():
         order = Order(
             order_bid="order-query-1",
@@ -41,7 +41,9 @@ def test_query_buy_record_returns_dto(app):
     assert result.course_id == "shifu-query-1"
 
 
-def test_query_buy_record_keeps_stored_discount_for_unpaid_order(app, monkeypatch):
+def test_query_buy_record_keeps_stored_discount_for_unpaid_order(
+    app, monkeypatch
+) -> None:
     from flaskr.service.order import funs as order_funs
 
     with app.app_context():
@@ -82,7 +84,9 @@ def test_query_buy_record_keeps_stored_discount_for_unpaid_order(app, monkeypatc
             db.session.commit()
 
 
-def test_query_buy_record_uses_coupon_name_and_code_in_price_item(app, monkeypatch):
+def test_query_buy_record_uses_coupon_name_and_code_in_price_item(
+    app, monkeypatch
+) -> None:
     from flaskr.service.order import funs as order_funs
 
     with app.app_context():
@@ -144,7 +148,7 @@ def test_query_buy_record_uses_coupon_name_and_code_in_price_item(app, monkeypat
 
 def test_query_buy_record_does_not_supplement_voided_campaign_redemption(
     app, monkeypatch
-):
+) -> None:
     from flaskr.service.order import funs as order_funs
     from flaskr.service.promo.consts import (
         PROMO_CAMPAIGN_APPLICATION_STATUS_VOIDED,

--- a/src/api/tests/test_redislock.py
+++ b/src/api/tests/test_redislock.py
@@ -1,7 +1,7 @@
 """Verify Redis-guarded work runs only with a configured client."""
 
 
-def test_run_with_redis_executes_once(app, monkeypatch):
+def test_run_with_redis_executes_once(app, monkeypatch) -> None:
     from flaskr import dao
 
     from tests.common.fixtures.fake_redis import FakeRedis
@@ -16,7 +16,7 @@ def test_run_with_redis_executes_once(app, monkeypatch):
     assert result == 2
 
 
-def test_run_with_redis_skips_when_client_is_unconfigured(app, monkeypatch):
+def test_run_with_redis_skips_when_client_is_unconfigured(app, monkeypatch) -> None:
     from flaskr import dao
 
     monkeypatch.setattr(dao._redis_state, "client", None)

--- a/src/api/tests/test_retry_on_deadlock.py
+++ b/src/api/tests/test_retry_on_deadlock.py
@@ -18,7 +18,7 @@ def _operational_error(errno):
     return OperationalError("SELECT 1", {}, _FakeOrigError(errno, "boom"))
 
 
-def test_retries_deadlock_then_succeeds():
+def test_retries_deadlock_then_succeeds() -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
@@ -32,7 +32,7 @@ def test_retries_deadlock_then_succeeds():
     assert calls["n"] == 3
 
 
-def test_retries_lock_wait_timeout():
+def test_retries_lock_wait_timeout() -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=2, backoff_seconds=0)
@@ -46,7 +46,7 @@ def test_retries_lock_wait_timeout():
     assert calls["n"] == 2
 
 
-def test_reraises_after_exhausting_attempts():
+def test_reraises_after_exhausting_attempts() -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
@@ -59,7 +59,7 @@ def test_reraises_after_exhausting_attempts():
     assert calls["n"] == 3
 
 
-def test_does_not_retry_non_retryable_operational_error():
+def test_does_not_retry_non_retryable_operational_error() -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
@@ -72,7 +72,7 @@ def test_does_not_retry_non_retryable_operational_error():
     assert calls["n"] == 1
 
 
-def test_rolls_back_session_on_every_caught_error(monkeypatch):
+def test_rolls_back_session_on_every_caught_error(monkeypatch) -> None:
     """Session must be rolled back on each catch, including retries and the final failed attempt, so the broken session is not reused later."""
     fake_db = MagicMock()
     monkeypatch.setattr(dao, "db", fake_db)
@@ -87,7 +87,7 @@ def test_rolls_back_session_on_every_caught_error(monkeypatch):
     assert fake_db.session.rollback.call_count == 3
 
 
-def test_rolls_back_session_on_non_retryable_error(monkeypatch):
+def test_rolls_back_session_on_non_retryable_error(monkeypatch) -> None:
     fake_db = MagicMock()
     monkeypatch.setattr(dao, "db", fake_db)
 
@@ -100,7 +100,7 @@ def test_rolls_back_session_on_non_retryable_error(monkeypatch):
     assert fake_db.session.rollback.call_count == 1
 
 
-def test_protocol_interrupt_invalidates_and_does_not_retry(monkeypatch):
+def test_protocol_interrupt_invalidates_and_does_not_retry(monkeypatch) -> None:
     from flaskr import dao
 
     invalidations = []
@@ -123,7 +123,7 @@ def test_protocol_interrupt_invalidates_and_does_not_retry(monkeypatch):
     assert invalidations == ["retry_on_deadlock protocol interrupt"]
 
 
-def test_rollback_db_failure_escalates_and_stops_retrying(monkeypatch):
+def test_rollback_db_failure_escalates_and_stops_retrying(monkeypatch) -> None:
     from flaskr import dao
 
     invalidations = []

--- a/src/api/tests/test_shifu_funcs.py
+++ b/src/api/tests/test_shifu_funcs.py
@@ -3,7 +3,7 @@
 from flaskr.service.shifu import shifu_publish_funcs
 
 
-def test_run_summary_with_error_handling_logs_and_continues(app, monkeypatch):
+def test_run_summary_with_error_handling_logs_and_continues(app, monkeypatch) -> None:
     called = {"apply": False, "summary": False}
 
     def fake_apply(_snapshot):

--- a/src/api/tests/test_shifu_upload_file.py
+++ b/src/api/tests/test_shifu_upload_file.py
@@ -7,7 +7,9 @@ from flaskr.service.resource.models import Resource
 from flaskr.service.shifu import funcs
 
 
-def test_upload_file_creates_resource_when_resource_id_is_missing(app, monkeypatch):
+def test_upload_file_creates_resource_when_resource_id_is_missing(
+    app, monkeypatch
+) -> None:
     class DummyFile:
         filename = "avatar.png"
 

--- a/src/api/tests/test_shifu_utils.py
+++ b/src/api/tests/test_shifu_utils.py
@@ -11,7 +11,7 @@ from flaskr.service.shifu.utils import (
 )
 
 
-def test_resource_url_helpers(app):
+def test_resource_url_helpers(app) -> None:
     with app.app_context():
         res = Resource(
             resource_id="res-1",
@@ -35,7 +35,7 @@ def test_resource_url_helpers(app):
         assert parse_shifu_res_bid("https://example.com/path/res-1") == "res-1"
 
 
-def test_get_shifu_creator_bid_prefers_draft(app):
+def test_get_shifu_creator_bid_prefers_draft(app) -> None:
     with app.app_context():
         draft = DraftShifu(
             shifu_bid="shifu-1",

--- a/src/api/tests/test_sms_aliyun.py
+++ b/src/api/tests/test_sms_aliyun.py
@@ -6,7 +6,7 @@ from flask import Flask
 from flaskr.api.sms import aliyun
 
 
-def test_query_sms_template_list_caps_page_size_at_provider_limit(monkeypatch):
+def test_query_sms_template_list_caps_page_size_at_provider_limit(monkeypatch) -> None:
     captured = {}
 
     class FakeClient:

--- a/src/api/tests/test_study_record.py
+++ b/src/api/tests/test_study_record.py
@@ -7,7 +7,7 @@ from flaskr.service.order.consts import LEARN_STATUS_IN_PROGRESS
 from flaskr.service.shifu.consts import BLOCK_TYPE_CONTENT_VALUE
 
 
-def test_get_learn_record_returns_blocks(app):
+def test_get_learn_record_returns_blocks(app) -> None:
     with app.app_context():
         # Other test modules (e.g. the mdflow backfill tests) commit rows for
         # the same shifu-1/outline-1/user-1 bids into the shared SQLite

--- a/src/api/tests/test_sudy.py
+++ b/src/api/tests/test_sudy.py
@@ -3,7 +3,7 @@
 from flaskr.service.learn.learn_funcs import get_learn_record
 
 
-def test_get_learn_record_empty_when_no_progress(app):
+def test_get_learn_record_empty_when_no_progress(app) -> None:
     record = get_learn_record(
         app, "shifu-empty", "outline-empty", "user-empty", preview_mode=False
     )

--- a/src/api/tests/test_uow.py
+++ b/src/api/tests/test_uow.py
@@ -1,9 +1,11 @@
 """unit_of_work termination-classification behavior."""
 
+from typing import Never
+
 import pytest
 
 
-def test_unit_of_work_invalidates_on_base_exception(app, monkeypatch):
+def test_unit_of_work_invalidates_on_base_exception(app, monkeypatch) -> Never:
     from flaskr import dao
     from flaskr.dao.uow import unit_of_work
 
@@ -23,7 +25,7 @@ def test_unit_of_work_invalidates_on_base_exception(app, monkeypatch):
     assert invalidations == ["unit_of_work interrupt"]
 
 
-def test_unit_of_work_classifies_desync_exceptions(app, monkeypatch):
+def test_unit_of_work_classifies_desync_exceptions(app, monkeypatch) -> Never:
     from flaskr import dao
     from flaskr.dao.uow import unit_of_work
 

--- a/src/api/tests/test_user.py
+++ b/src/api/tests/test_user.py
@@ -11,7 +11,7 @@ from flaskr.service.user.repository import (
 )
 
 
-def test_get_user_profiles_uses_user_fallbacks(app):
+def test_get_user_profiles_uses_user_fallbacks(app) -> None:
     with app.app_context():
         user = UserInfo(
             user_bid="user-profile-1",
@@ -27,7 +27,7 @@ def test_get_user_profiles_uses_user_fallbacks(app):
         assert profiles["sys_user_nickname"] == "Tester"
 
 
-def test_get_user_profiles_prefers_user_entity_for_mapped_system_keys(app):
+def test_get_user_profiles_prefers_user_entity_for_mapped_system_keys(app) -> None:
     with app.app_context():
         user = UserInfo(
             user_bid="user-profile-2",
@@ -83,7 +83,7 @@ def test_get_user_profiles_prefers_user_entity_for_mapped_system_keys(app):
         assert profiles["sys_user_language"] == "en-US"
 
 
-def test_update_user_info_updates_both_name_and_language_profiles(app):
+def test_update_user_info_updates_both_name_and_language_profiles(app) -> None:
     with app.app_context():
         user = UserInfo(
             user_bid="user-profile-3",

--- a/src/api/tests/test_wx_pub_order.py
+++ b/src/api/tests/test_wx_pub_order.py
@@ -9,7 +9,7 @@ from flaskr.service.order.funs import BuyRecordDTO, generate_charge
 from flaskr.service.order.models import Order
 
 
-def test_generate_charge_uses_pingxx_channel(app, monkeypatch):
+def test_generate_charge_uses_pingxx_channel(app, monkeypatch) -> None:
     from flaskr.service.order import funs as order_funs
 
     order_bid = "order-wx-pub-1"


### PR DESCRIPTION
## Summary
- enable ANN201 and add observable return contracts to 2,184 public production, contributor-tool, and test callables across 331 Python files
- use concrete DTO, model, collection, Flask, iterator, fixture, and callable types; reserve `object` for genuinely heterogeneous SDK, ORM, and decorator boundaries without introducing new `Any` returns
- retain one exact exception for 102 immutable applied Alembic `upgrade` / `downgrade` hooks, with no migration-version file changes
- document the project contract for future public return annotations, runtime consumers, type-only imports, and migration history

## Verification
- reversible AST audit: 2,184 added return annotations and 133 annotation-only import aliases; all 331 executable ASTs match the D103 parent after removing the type scaffolding
- full backend suite: 3,032 passed, 17 skipped
- applied migration-version diff is empty; Python compileall passes
- translation validation, repository harness, architecture boundaries, pinned Ruff 0.16.3 development-tool check, and all pre-commit hooks passed

## Ruff impact
- configured ANN201 and repository Ruff checks pass
- stable ALL census: 22,963 -> 20,845; ANN201 falls from 2,286 configured findings to zero
- isolated ALL census: 36,993 -> 34,977; exactly 102 immutable migration hooks remain visible without project configuration
- formatter-owned COM812 rises by 165 and E501 by three as concrete return types expand signatures; both remain explicitly excluded formatter conflicts, and no enforced rule gains debt

## Stack
- base: #2614 (`sunner/ruff-d103`)
- this PR contains only the ANN201 rule unit

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->