### PR TITLE
chore: annotate private return contracts

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -579,6 +579,22 @@ annotations and type-import scaffolding. Applied Alembic revisions are
 immutable and keep their conventional unannotated `upgrade` / `downgrade`
 hooks; new and otherwise mutable public functions must be annotated.
 
+For `ANN202`, apply the same observable-contract standard to private functions
+and methods: private visibility does not make an uncertain return type
+acceptable. Route-local view functions use Flask's `ResponseReturnValue`;
+generators and yielding fixtures use `Iterator[T]` or `AsyncIterator[T]`; and
+private adapters, query builders, serializers, and state helpers use the
+concrete stable type their callers observe. Reserve `object` for genuinely
+dynamic SDK, ORM, decorator, and test-double boundaries, and never introduce
+`Any` merely to move the finding to `ANN401`. Inspect local and forward types
+before importing them: use `TYPE_CHECKING` imports or quoted annotations when
+runtime evaluation would otherwise introduce a cycle or an unavailable name.
+Treat Ruff's unsafe fix only as an inventory starting point, then review every
+non-`None` inference and prove executable AST equality without the annotations
+and type-import scaffolding. Applied Alembic revisions are immutable, including
+private migration helpers; keep only the exact migration-history exception and
+annotate every new or otherwise mutable private callable.
+
 For `FIX002`, do not make an unresolved task invisible by renaming `TODO`,
 adding `noqa`, or turning the same promise into an untracked prose comment.
 Complete the work when it is part of the current change. When it genuinely

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -783,6 +783,38 @@ plan's progress update for that rule.
   harness, architecture boundary ratchet, configured Ruff and format, pinned
   Ruff 0.16.3 development-tool validation, and every repository pre-commit
   hook across all files.
+- [x] 2026-08-21 16:00 CST: Ready ANN201 PR
+  [#2615](https://github.com/ai-shifu/ai-shifu/pull/2615) passed every GitHub
+  check, including the 3,032-test backend job and runtime harness. Selected
+  ANN202 next because it extends the same reviewed return-contract policy to
+  private callables without changing executable behavior.
+- [x] 2026-08-21 16:28 CST: Enabled ANN202 across every mutable private
+  callable. Ruff supplied 413 retained fixes after restoring its one edit to
+  applied migration history; 1,096 manually reviewed boundaries received
+  concrete route, iterator, DTO, model, collection, protocol, or deliberately
+  heterogeneous `object` contracts. No new return annotation uses `Any`.
+- [x] 2026-08-21 16:28 CST: Retained one exact migration-history exception for
+  the private `_set_server_default` helper and made no change under
+  `src/api/migrations/versions/`. A semantic audit found exactly 1,509 added
+  return annotations and 186 annotation-only import aliases across 276
+  annotated Python files. After removing that type scaffolding and normalizing
+  four expected source-signature literals in one additional contract test, all
+  277 changed Python files have identical executable ASTs. Configured ANN202
+  and repository Ruff pass.
+- [x] 2026-08-21 16:28 CST: The stable census falls from 20,845 to 19,430:
+  configured ANN202 falls from 1,510 findings to zero, while formatter-owned
+  COM812 rises by 94 and E501 by one because concrete return types expand
+  signatures. The isolated census falls from 34,977 to 33,563 and exposes
+  exactly the one immutable migration helper; no enforced rule gains debt.
+- [x] 2026-08-21 16:32 CST: Updated one source-contract test to recognize the
+  new `ResponseReturnValue` route-local signatures; its three focused tests
+  pass. The complete backend suite passes 3,032 tests with 17 skips and 733
+  existing warnings.
+- [x] 2026-08-21 16:34 CST: Regenerated collaboration mirrors and repository
+  knowledge, then passed translation validation, the repository harness,
+  architecture boundary ratchet, configured Ruff and format, pinned Ruff
+  0.16.3 development-tool validation, and every repository pre-commit hook
+  across all files.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -1012,6 +1044,16 @@ plan's progress update for that rule.
   exception. Prove the final edit preserves executable ASTs after removing
   annotations and type-only import scaffolding, then run the complete backend
   suite to catch runtime annotation and import consumers.
+- 2026-08-21: ANN202 follows the same observable-contract policy for private
+  callables; private visibility is not permission to use an uncertain type.
+  Route-local views use `ResponseReturnValue`, generators and yielding fixtures
+  use iterator protocols, and private adapters or query builders use concrete
+  stable types. Reserve `object` for dynamic SDK, ORM, decorator, and test-
+  double boundaries, never use `Any` to move debt to ANN401, and audit local or
+  forward types for runtime annotation evaluation. Applied migration helpers
+  remain an exact immutable-history exception. Review Ruff's unsafe fix,
+  preserve executable AST equality after removing annotation scaffolding, and
+  run the complete backend suite for import and annotation consumers.
 
 ## Outcomes & Retrospective
 
@@ -1308,6 +1350,22 @@ isolated census falls to 34,977 with exactly the 102 documented hooks exposed.
 The complete backend suite passes 3,032 tests with 17 skips, and all repository
 harness, architecture, Ruff, format, development-tool, and pre-commit gates
 pass.
+
+The ANN202 stage extends that contract to all 1,509 mutable private production,
+tool, and test callables across 276 Python files. Concrete return, route,
+generator, fixture, protocol, and model types are preferred; only genuinely
+dynamic SDK, ORM, decorator, and test-double boundaries use `object`, and no
+new `Any` return is introduced. The exact applied-migration exception retains
+one immutable private helper without editing migration history. A semantic
+audit strips the new return annotations and 186 type-only import aliases and
+normalizes four expected signature literals in one source-contract test, then
+matches all 277 changed Python-file ASTs to the ANN201 parent. Configured
+ANN202 falls from 1,510 findings to zero, the stable census falls to 19,430,
+and the isolated census falls to 33,563 with exactly the documented migration
+helper exposed. The synchronized source-contract test passes three focused
+tests, and the complete backend suite passes 3,032 tests with 17 skips.
+Generated collaboration guidance, repository knowledge, translation,
+architecture, Ruff, format, development-tool, and pre-commit gates all pass.
 
 ## Context and Orientation
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,7 +15,7 @@
 #   below, so the rationale survives the next Ruff upgrade.
 #
 # Deliberately not selected:
-# - ANN (except ANN002/ANN003/ANN201/ANN204/ANN205/ANN206, see `select`) / SLF001 /
+# - ANN (except ANN002/ANN003/ANN201/ANN202/ANN204/ANN205/ANN206, see `select`) / SLF001 /
 #   PLC0415 / PLR2004
 #   (and D1xx, see the ignore block): thousands of violations each; enforcing
 #   them is a codebase-wide project, not a lint config change.
@@ -191,6 +191,7 @@ select = [
     "ANN002",  # missing type for *args
     "ANN003",  # missing type for **kwargs
     "ANN201",  # missing return type on a public function or method
+    "ANN202",  # missing return type on a private function or method
     "ANN204",  # missing return type on a special method
     "ANN205",  # missing return type on a staticmethod
     "ANN206",  # missing return type on a classmethod
@@ -272,6 +273,8 @@ runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 # Applied revision hooks are immutable public functions. New revisions inherit
 # Alembic's `upgrade` / `downgrade` contract instead of rewriting history.
 "src/api/migrations/versions/**" = ["ANN201"]
+# This applied revision's private server-default helper is also immutable.
+"src/api/migrations/versions/f6b2a4d8c9e0_remove_legacy_timestamp_server_defaults.py" = ["ANN202"]
 # This applied no-op revision keeps a legacy `NOTE:` section in its module
 # docstring. Migration history is immutable, so D405 is scoped to this file.
 "src/api/migrations/versions/a4d68cce5ce6_add_demo_shifu.py" = ["D405"]

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -45,7 +45,7 @@ def load_json(path: Path) -> dict:
 def flatten_translation(data, namespace: str) -> dict[str, str]:
     """Flatten nested translation JSON to dot-separated keys."""
 
-    def _flatten(obj, prefix: str):
+    def _flatten(obj, prefix: str) -> dict[str, str]:
         items: dict[str, str] = {}
         if isinstance(obj, dict):
             # __flat__ allows specifying exact keys without additional nesting

--- a/scripts/update_i18n.py
+++ b/scripts/update_i18n.py
@@ -33,7 +33,7 @@ def load_json(path: Path) -> object:
 def flatten_translation(data, namespace: str) -> dict[str, str]:
     """Flatten translation."""
 
-    def _flatten(obj, prefix: str, acc: dict[str, str]):
+    def _flatten(obj, prefix: str, acc: dict[str, str]) -> None:
         if isinstance(obj, dict):
             flat_section = obj.get("__flat__")
             if isinstance(flat_section, dict):

--- a/src/api/flaskr/api/check/__init__.py
+++ b/src/api/flaskr/api/check/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 
-def check_text(app: Flask, data_id: str, text: str, user_id: str):
+def check_text(app: Flask, data_id: str, text: str, user_id: str) -> CheckResultDTO:
     check_provider = app.config.get("CHECK_PROVIDER")
     if check_provider == "ilivedata":
         return ilivedata_check(app, data_id, text, user_id)

--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -63,7 +63,7 @@ class MockClient:
     def __getattr__(self, name) -> Any:
         """Return a no-op callable for any Langfuse operation."""
 
-        def method(*args: object, **kwargs: object):
+        def method(*args: object, **kwargs: object) -> MockClient:
             _ = (args, kwargs)
             return self
 

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 import time
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Iterator
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from decimal import ROUND_CEILING, Decimal, InvalidOperation
@@ -62,7 +62,7 @@ _original_asyncio_run = asyncio.run
 _background_asyncio_tasks: set[asyncio.Task] = set()
 
 
-def _safe_asyncio_run(coro, *args: object, **kwargs: object):
+def _safe_asyncio_run(coro, *args: object, **kwargs: object) -> object:
     try:
         return _original_asyncio_run(coro, *args, **kwargs)
     except RuntimeError as exc:
@@ -446,7 +446,7 @@ def _stream_litellm_completion(
     messages: list,
     params: dict,
     kwargs: dict,
-):
+) -> object:
     try:
         # Routed ids are the application-level identity. LiteLLM completion uses
         # the stripped provider model id, which can collide across routes (for
@@ -517,7 +517,7 @@ def _iter_stream_with_precontent_retry(
     messages: list,
     params: dict,
     kwargs: dict,
-):
+) -> Iterator[object]:
     """Yield litellm stream chunks, re-issuing the request when the stream dies on a connection-level error before any content token arrived.
 
     The built-in openai/litellm retries only cover request setup; an

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -14,6 +14,7 @@ The provider can be selected per-Shifu configuration.
 import contextlib
 import json
 import logging
+from collections.abc import Iterator
 from decimal import Decimal, InvalidOperation
 
 from flask import has_request_context, request
@@ -119,7 +120,9 @@ def _resolve_provider_name(provider_name: str = "") -> str:
     return normalized or _auto_detect_provider_name()
 
 
-def _iter_provider_classes(*, include_explicit_only: bool = True):
+def _iter_provider_classes(
+    *, include_explicit_only: bool = True
+) -> Iterator[tuple[str, type[BaseTTSProvider]]]:
     provider_priority = (
         _PROVIDER_PRIORITY if include_explicit_only else _AUTO_DETECT_PROVIDER_PRIORITY
     )
@@ -297,7 +300,7 @@ def _parse_tts_display_names() -> dict:
     return normalized
 
 
-def _iter_tts_display_language_candidates():
+def _iter_tts_display_language_candidates() -> Iterator[str]:
     if has_request_context():
         for value in (
             request.args.get("language"),

--- a/src/api/flaskr/api/tts/volcengine_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_provider.py
@@ -508,7 +508,7 @@ class VolcengineTTSProvider(BaseTTSProvider):
 
         protocol = VolcengineProtocol()
 
-        def on_message(ws, message):
+        def on_message(ws, message) -> None:
             _ = ws
             nonlocal error_message, total_duration_ms
 
@@ -592,7 +592,7 @@ class VolcengineTTSProvider(BaseTTSProvider):
                 session_started.set()
                 session_finished.set()
 
-        def on_error(ws, error):
+        def on_error(ws, error) -> None:
             _ = ws
             nonlocal error_message
             error_message = str(error)
@@ -601,13 +601,13 @@ class VolcengineTTSProvider(BaseTTSProvider):
             session_started.set()
             session_finished.set()
 
-        def on_close(ws, close_status_code, close_msg):
+        def on_close(ws, close_status_code, close_msg) -> None:
             _ = ws
             logger.debug("WebSocket closed: %s - %s", close_status_code, close_msg)
             connection_established.set()
             session_finished.set()
 
-        def on_open(ws):
+        def on_open(ws) -> None:
             logger.debug("WebSocket opened, sending StartConnection")
             # Send StartConnection
             ws.send(

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -36,7 +36,7 @@ def enable_commands(app: Flask) -> None:
     """Register the application's command-line commands."""
 
     @app.cli.group()
-    def console():
+    def console() -> None:
         """AI Shifu Console management commands."""
 
     register_billing_commands(console)
@@ -47,7 +47,7 @@ def enable_commands(app: Flask) -> None:
     @click.argument("course_id")
     @click.argument("discount_code")
     @click.argument("user_nick_name")
-    def import_user_command(mobile, course_id, discount_code, user_nick_name):
+    def import_user_command(mobile, course_id, discount_code, user_nick_name) -> None:
         """Import user and enable course."""
         import_user(app, mobile, course_id, discount_code, user_nick_name)
 
@@ -63,7 +63,9 @@ def enable_commands(app: Flask) -> None:
         is_flag=True,
         help="Show what would be migrated without actually doing it",
     )
-    def migrate_command(batch_size, max_workers, force_full, output_file, dry_run):
+    def migrate_command(
+        batch_size, max_workers, force_full, output_file, dry_run
+    ) -> None:
         """Run unified legacy data migration."""
         setup_migration_logging()
         logger = logging.getLogger(__name__)
@@ -182,7 +184,7 @@ def enable_commands(app: Flask) -> None:
             raise click.ClickException(error_message)
 
     @console.command(name="verify")
-    def verify_command():
+    def verify_command() -> None:
         """Verify data consistency between old and new tables."""
         setup_migration_logging()
         logger = logging.getLogger(__name__)
@@ -238,7 +240,7 @@ def enable_commands(app: Flask) -> None:
                 migration_task.close()
 
     @console.command(name="status")
-    def status_command():
+    def status_command() -> None:
         """Show migration status and table counts."""
         setup_migration_logging()
         logger = logging.getLogger(__name__)
@@ -325,7 +327,7 @@ def enable_commands(app: Flask) -> None:
     @console.command(name="export_shifu")
     @click.argument("shifu_id")
     @click.argument("file_path")
-    def export_shifu_command(shifu_id, file_path):
+    def export_shifu_command(shifu_id, file_path) -> None:
         """Export a shifu to a JSON file.
 
         Args:
@@ -363,7 +365,7 @@ def enable_commands(app: Flask) -> None:
     @click.option(
         "--user-id", required=True, help="User ID for creating/updating the shifu"
     )
-    def import_shifu_command(file_path, shifu_id, user_id):
+    def import_shifu_command(file_path, shifu_id, user_id) -> None:
         """Import a shifu from a JSON file.
 
         Args:
@@ -417,7 +419,7 @@ def enable_commands(app: Flask) -> None:
             raise click.ClickException(message) from e
 
     @console.command(name="update_demo_shifu")
-    def update_demo_shifu_command():
+    def update_demo_shifu_command() -> None:
         """Update demo shifu."""
         app.logger.info("Updating demo shifu...")
         update_demo_shifu(app)

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -881,7 +881,7 @@ class UnifiedMigrationTask:
             logger.warning("Error getting last synced ID: %s", e)
             return 0
 
-    def _update_sync_time(self, sync_type: str, sync_time: datetime):
+    def _update_sync_time(self, sync_type: str, sync_time: datetime) -> None:
         """Update sync time in log table."""
         session = self.SessionClass()
         try:
@@ -891,7 +891,7 @@ class UnifiedMigrationTask:
 
     def _update_sync_time_with_session(
         self, session, sync_type: str, sync_time: datetime
-    ):
+    ) -> None:
         """Update sync time in log table using provided session."""
         try:
             self._ensure_sync_log_table_with_session(session)
@@ -908,7 +908,7 @@ class UnifiedMigrationTask:
 
     def _update_last_synced_id_with_session(
         self, session, sync_type: str, last_synced_id: int
-    ):
+    ) -> None:
         """Update last synced ID in log table using provided session."""
         try:
             self._ensure_sync_log_table_with_session(session)
@@ -923,7 +923,7 @@ class UnifiedMigrationTask:
         except Exception as e:
             logger.warning("Error updating last synced ID: %s", e)
 
-    def _ensure_sync_log_table(self):
+    def _ensure_sync_log_table(self) -> None:
         """Ensure sync log table exists."""
         session = self.SessionClass()
         try:
@@ -931,7 +931,7 @@ class UnifiedMigrationTask:
         finally:
             session.close()
 
-    def _ensure_sync_log_table_with_session(self, session):
+    def _ensure_sync_log_table_with_session(self, session) -> None:
         """Ensure sync log table exists using provided session."""
         try:
             session.execute(

--- a/src/api/flaskr/command/update_shifu_demo.py
+++ b/src/api/flaskr/command/update_shifu_demo.py
@@ -98,7 +98,7 @@ def _process_demo_shifu(
     return shifu_bid
 
 
-def _ensure_creator_permissions(app: Flask, shifu_bid: str):
+def _ensure_creator_permissions(app: Flask, shifu_bid: str) -> None:
     """Ensure all creator users have permissions for the given shifu.
 
     Args:

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -82,7 +82,7 @@ class CacheUnavailableError(RuntimeError):
 
 
 class _DynamicRedisCacheProvider:
-    def _client(self):
+    def _client(self) -> CacheProvider:
         try:
             from flaskr.dao import get_redis_client
         except Exception as exc:  # pragma: no cover - defensive
@@ -95,10 +95,12 @@ class _DynamicRedisCacheProvider:
             raise CacheUnavailableError(message)
         return redis_client
 
-    def get(self, key: str):
+    def get(self, key: str) -> bytes | None:
         return self._client().get(key)
 
-    def getex(self, key: str, ex: int | None = None, px: int | None = None):
+    def getex(
+        self, key: str, ex: int | None = None, px: int | None = None
+    ) -> bytes | None:
         return self._client().getex(key, ex=ex, px=px)
 
     def set(
@@ -111,19 +113,19 @@ class _DynamicRedisCacheProvider:
         xx: bool = False,
         *args: object,
         **kwargs: object,
-    ):
+    ) -> bool:
         if ex is None and args:
             ex = args[0]
             args = ()
         return self._client().set(key, value, ex=ex, px=px, nx=nx, xx=xx, **kwargs)
 
-    def setex(self, key: str, time_in_seconds: int, value: Any):
+    def setex(self, key: str, time_in_seconds: int, value: Any) -> bool:
         return self._client().setex(key, time_in_seconds, value)
 
     def delete(self, *keys: str) -> int:
         return int(self._client().delete(*keys))
 
-    def incr(self, key: str, amount: int = 1):
+    def incr(self, key: str, amount: int = 1) -> int:
         return self._client().incr(key, amount)
 
     def ttl(self, key: str) -> int:
@@ -134,7 +136,7 @@ class _DynamicRedisCacheProvider:
         key: str,
         timeout: int | None = None,
         blocking_timeout: int | None = None,
-    ):
+    ) -> CacheLock:
         return self._client().lock(
             key, timeout=timeout, blocking_timeout=blocking_timeout
         )
@@ -151,7 +153,9 @@ class _InMemoryLock:
         self._lock = lock
         self._held = False
 
-    def acquire(self, blocking: bool = True, blocking_timeout: int | None = None):
+    def acquire(
+        self, blocking: bool = True, blocking_timeout: int | None = None
+    ) -> bool:
         if not blocking:
             acquired = self._lock.acquire(blocking=False)
         elif blocking_timeout is None:
@@ -316,7 +320,7 @@ class FallbackCacheProvider:
         self._primary = primary
         self._fallback = fallback
 
-    def _call(self, method: str, *args: object, **kwargs: object):
+    def _call(self, method: str, *args: object, **kwargs: object) -> object:
         primary_fn = getattr(self._primary, method)
         fallback_fn = getattr(self._fallback, method)
         try:

--- a/src/api/flaskr/common/celery_app.py
+++ b/src/api/flaskr/common/celery_app.py
@@ -203,7 +203,7 @@ def _resolve_billing_crontab(
     flask_app: Flask,
     config_key: str,
     default_expression: str,
-):
+) -> crontab:
     # Raw env fallback for Flask apps not backed by the registry Config; the
     # BILLING_*_CRON keys are declared in flaskr/common/config.py.
     raw_expression = str(
@@ -226,7 +226,7 @@ def _resolve_billing_crontab(
     return fallback_schedule
 
 
-def _parse_crontab_expression(expression: str):
+def _parse_crontab_expression(expression: str) -> crontab | None:
     normalized_expression = " ".join(str(expression or "").split())
     parts = normalized_expression.split(" ")
     if len(parts) != 5 or any(not part for part in parts):

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1983,7 +1983,7 @@ class EnhancedConfig:
         """Interpolate environment variables in format ${VAR_NAME}."""
         pattern = re.compile(r"\$\{([^}]+)\}")
 
-        def replacer(match):
+        def replacer(match) -> str:
             var_name = match.group(1)
             return os.environ.get(var_name, match.group(0))
 

--- a/src/api/flaskr/common/gevent_hub_observer.py
+++ b/src/api/flaskr/common/gevent_hub_observer.py
@@ -55,7 +55,7 @@ def install_hub_error_observer(logger, hub=None) -> bool:
 
     original_handle_error = hub.handle_error
 
-    def handle_error(context, exc_type, value, tb):
+    def handle_error(context, exc_type, value, tb) -> object:
         # Log BEFORE delegating: the original handler may re-raise for
         # system errors. Nothing in here may raise or block - a failure in
         # the error path would take down the hub itself.

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -13,7 +13,7 @@ from typing import Any
 import colorlog
 import pytz
 import requests
-from flask import Flask, request
+from flask import Flask, Response, request
 
 from .observability import current_trace_ids
 from .request_context import thread_local
@@ -168,7 +168,7 @@ def init_log(app: Flask) -> Flask:
     """Configure request-aware application logging."""
 
     @app.before_request
-    def setup_logging():
+    def setup_logging() -> None:
         request_id = request.headers.get("X-Request-ID", uuid.uuid4().hex)
         thread_local.request_id = request_id
         thread_local.url = request.path
@@ -202,7 +202,7 @@ def init_log(app: Flask) -> Flask:
             app.logger.info("Request method: %s", request.method)
 
     @app.after_request
-    def after_request(response):
+    def after_request(response) -> Response:
         try:
             _update_request_timing(response.status_code)
             if response.headers.get(
@@ -211,7 +211,7 @@ def init_log(app: Flask) -> Flask:
                 app.logger.info("Response: <SSE streaming response>")
 
                 @response.call_on_close
-                def log_sse_end():
+                def log_sse_end() -> None:
                     app.logger.info("SSE Response: <streaming ended>")
 
                 return response

--- a/src/api/flaskr/common/observability.py
+++ b/src/api/flaskr/common/observability.py
@@ -84,7 +84,7 @@ def init_observability(app: Flask) -> Flask:
         tracer = None
 
     @app.before_request
-    def _start_request_observability():
+    def _start_request_observability() -> None:
         request_id = request.headers.get("X-Request-ID", "") or getattr(
             thread_local, "request_id", ""
         )
@@ -114,7 +114,7 @@ def init_observability(app: Flask) -> Flask:
         set_thread_local_trace_ids()
 
     @app.after_request
-    def _finalize_request_observability(response):
+    def _finalize_request_observability(response) -> Response:
         duration_ms = _record_request_metrics(response.status_code)
         span = getattr(g, "_ai_shifu_observability_span", None)
         if span is not None:
@@ -136,7 +136,7 @@ def init_observability(app: Flask) -> Flask:
         return response
 
     @app.teardown_request
-    def _teardown_request_observability(error: Exception | None):
+    def _teardown_request_observability(error: Exception | None) -> None:
         if error is None:
             return
         span = getattr(g, "_ai_shifu_observability_span", None)
@@ -145,11 +145,11 @@ def init_observability(app: Flask) -> Flask:
             span.set_status(Status(StatusCode.ERROR, str(error)))
 
     @app.route(metrics_path, methods=["GET"])
-    def metrics_handler():
+    def metrics_handler() -> Response:
         return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
 
     @app.route(health_path, methods=["GET"])
-    def observability_health_handler():
+    def observability_health_handler() -> Response:
         return jsonify(
             {
                 "ok": True,

--- a/src/api/flaskr/common/shifu_context.py
+++ b/src/api/flaskr/common/shifu_context.py
@@ -173,7 +173,7 @@ def with_shifu_context(
 
     def decorator(func: Callable) -> Callable:
         @wraps(func)
-        def wrapper(*args: object, **kwargs: object):
+        def wrapper(*args: object, **kwargs: object) -> object:
             try:
                 from flask import current_app, request
             except Exception:

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -125,7 +125,7 @@ def _socket_has_unread_data(dbapi_connection, timeout: float = 0) -> bool:
 _CHECKIN_PROBE_GRACE_SECONDS = 0.002
 
 
-def _server_thread_id(dbapi_connection):
+def _server_thread_id(dbapi_connection) -> int | None:
     """Best-effort MySQL server-side connection id for log correlation."""
     try:
         return dbapi_connection.thread_id()
@@ -133,7 +133,7 @@ def _server_thread_id(dbapi_connection):
         return None
 
 
-def _pool_diagnostics_logger():
+def _pool_diagnostics_logger() -> logging.Logger:
     """Log through the app logger when available.
 
     The app logger carries the RequestFormatter (request-id / trace context)
@@ -152,7 +152,9 @@ def _pool_diagnostics_logger():
 
 
 @event.listens_for(sa_pool.Pool, "checkin")
-def _invalidate_desynced_connection_on_checkin(dbapi_connection, connection_record):
+def _invalidate_desynced_connection_on_checkin(
+    dbapi_connection, connection_record
+) -> None:
     if dbapi_connection is None:
         return
     if _socket_has_unread_data(dbapi_connection, timeout=_CHECKIN_PROBE_GRACE_SECONDS):
@@ -176,7 +178,7 @@ def _invalidate_desynced_connection_on_checkin(dbapi_connection, connection_reco
 @event.listens_for(sa_pool.Pool, "checkout")
 def _reject_desynced_connection_on_checkout(
     dbapi_connection, connection_record, connection_proxy
-):
+) -> None:
     _ = connection_proxy
     if _socket_has_unread_data(dbapi_connection):
         _pool_diagnostics_logger().warning(
@@ -260,7 +262,7 @@ def _statement_journal(connection) -> collections.deque:
 @event.listens_for(Engine, "before_cursor_execute")
 def _intercept_desync_before_execute(
     conn, cursor, statement, parameters, context, executemany
-):
+) -> None:
     _ = (cursor, parameters, context, executemany)
     dbapi_connection = getattr(conn.connection, "dbapi_connection", None)
     if dbapi_connection is None:
@@ -292,7 +294,7 @@ def _intercept_desync_before_execute(
 @event.listens_for(Engine, "after_cursor_execute")
 def _journal_statement_after_execute(
     conn, cursor, statement, parameters, context, executemany
-):
+) -> None:
     _ = (parameters, context, executemany)
     with contextlib.suppress(Exception):
         _statement_journal(conn).append(
@@ -311,7 +313,7 @@ MYSQL_DEADLOCK_ERRNO = 1213
 MYSQL_LOCK_WAIT_TIMEOUT_ERRNO = 1205
 
 
-def _operational_errno(exc: OperationalError):
+def _operational_errno(exc: OperationalError) -> int | None:
     orig = getattr(exc, "orig", None)
     args = getattr(orig, "args", None)
     return args[0] if args else None
@@ -509,9 +511,9 @@ def retry_on_deadlock(
     that connection.
     """
 
-    def decorator(func):
+    def decorator(func) -> Callable[..., object]:
         @functools.wraps(func)
-        def wrapper(*args: object, **kwargs: object):
+        def wrapper(*args: object, **kwargs: object) -> object:
             attempt = 0
             while True:
                 try:
@@ -618,18 +620,18 @@ def init_db(app: Flask) -> None:
     # REVERSE registration order, so registering AFTER db.init_app makes
     # this run BEFORE the extension's session removal.
     @app.teardown_appcontext
-    def _invalidate_session_on_interrupted_teardown(exc):
+    def _invalidate_session_on_interrupted_teardown(exc) -> None:
         if exc is not None and is_abnormal_stream_termination(exc):
             invalidate_session(source="appcontext teardown interrupt")
 
     # Enable formatted SQL output in the development environment
     if app.debug:
 
-        def setup_sql_logging():
+        def setup_sql_logging() -> None:
             @event.listens_for(db.engine, "before_cursor_execute")
             def before_cursor_execute(
                 conn, cursor, statement, parameters, context, executemany
-            ):
+            ) -> None:
                 _ = (conn, cursor, context, executemany)
                 stack = traceback.extract_stack()
                 project_root = str((Path(__file__).parent / "../../../").resolve())

--- a/src/api/flaskr/framework/plugin/base.py
+++ b/src/api/flaskr/framework/plugin/base.py
@@ -16,7 +16,7 @@ class BasePlugin:
         if self.migration_dir:
             self._run_migrations()
 
-    def _run_migrations(self):
+    def _run_migrations(self) -> None:
         """Run the plugin migrations."""
         from alembic import command
         from alembic.config import Config

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -2,6 +2,7 @@
 
 import shutil
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 
 import click
@@ -21,12 +22,12 @@ def enable_plugins(app: Flask) -> None:
         raise RuntimeError(message)
 
     @app.cli.group()
-    def plugin():
+    def plugin() -> None:
         """Plugin management commands."""
 
     @plugin.command(name="add")
     @click.argument("repo_url")
-    def add(repo_url):
+    def add(repo_url) -> None:
         """Add a plugin by cloning the repository."""
         repo_name = repo_url.split("/")[-1].replace(".git", "")
         dest_dir = str(Path("flaskr") / "plugins" / repo_name)
@@ -41,7 +42,7 @@ def enable_plugins(app: Flask) -> None:
 
     @plugin.command(name="delete")
     @click.argument("repo_name")
-    def delete(repo_name):
+    def delete(repo_name) -> None:
         """Delete a plugin by its repository name."""
         dest_dir = str(Path("flaskr") / "plugins" / repo_name)
         if not Path(dest_dir).exists():
@@ -49,7 +50,7 @@ def enable_plugins(app: Flask) -> None:
         shutil.rmtree(dest_dir)
 
     @plugin.command(name="list")
-    def list_plugins():
+    def list_plugins() -> None:
         """List all plugins."""
         plugins_dir = str(Path("flaskr") / "plugins")
         plugins = [path.name for path in Path(plugins_dir).iterdir() if path.is_dir()]
@@ -57,7 +58,7 @@ def enable_plugins(app: Flask) -> None:
             if plugin == "__pycache__":
                 continue
 
-    def get_plugin_migrations():
+    def get_plugin_migrations() -> list[object]:
         """Get plugin migrations."""
         plugins = []
         app.logger.info(
@@ -72,7 +73,7 @@ def enable_plugins(app: Flask) -> None:
         return plugins
 
     @plugin.group(name="db")
-    def plugin_db():
+    def plugin_db() -> None:
         """Manage the plugin database."""
 
     def get_version_table_name(plugin_name: str) -> str:
@@ -94,10 +95,10 @@ def enable_plugins(app: Flask) -> None:
 
         return alembic_cfg
 
-    def get_plugin_include_object(plugin_name: str):
+    def get_plugin_include_object(plugin_name: str) -> Callable[..., object]:
         """Generate plugin model filter function."""
 
-        def include_object(db_object, name, type_, reflected, compare_to):
+        def include_object(db_object, name, type_, reflected, compare_to) -> bool:
             _ = (name, reflected, compare_to)
             if type_ == "table":
                 return db_object.__module__.startswith(f"flaskr.plugins.{plugin_name}")
@@ -108,7 +109,7 @@ def enable_plugins(app: Flask) -> None:
     @plugin_db.command(name="upgrade")
     @click.argument("plugin_name", required=False)
     @with_appcontext
-    def upgrade(plugin_name):
+    def upgrade(plugin_name) -> None:
         """Upgrade the plugin database to the latest version."""
         plugins = get_plugin_migrations()
 
@@ -125,7 +126,7 @@ def enable_plugins(app: Flask) -> None:
     @plugin_db.command(name="history")
     @click.argument("plugin_name")
     @with_appcontext
-    def history(plugin_name):
+    def history(plugin_name) -> None:
         """View the migration history of the plugin."""
         plugins = get_plugin_migrations()
         for plugin in plugins:
@@ -141,7 +142,7 @@ def enable_plugins(app: Flask) -> None:
     @plugin_db.command(name="migrate")
     @click.argument("plugin_name")
     @with_appcontext
-    def migrate(plugin_name):
+    def migrate(plugin_name) -> None:
         """Migrate the plugin database to the latest version."""
         plugins = get_plugin_migrations()
         for plugin in plugins:

--- a/src/api/flaskr/framework/plugin/hot_reload.py
+++ b/src/api/flaskr/framework/plugin/hot_reload.py
@@ -48,7 +48,7 @@ class PluginHotReloader:
         except Exception:
             self.app.logger.exception("Hot reload plugin failed: %s", plugin_path)
 
-    def _unload_plugin(self, plugin_path: str):
+    def _unload_plugin(self, plugin_path: str) -> None:
         """Unload a plugin and clean up its resources.
 
         Args:
@@ -97,7 +97,7 @@ class PluginHotReloader:
         except Exception:
             self.app.logger.exception("Failed to unload plugin %s", plugin_path)
 
-    def _register_plugin(self, module):
+    def _register_plugin(self, module) -> None:
         """Register a newly loaded plugin.
 
         Args:

--- a/src/api/flaskr/framework/plugin/inject.py
+++ b/src/api/flaskr/framework/plugin/inject.py
@@ -9,7 +9,7 @@ def inject(func) -> Callable[..., object]:
     """Inject a plugin callback at the requested extension point."""
 
     @wraps(func)
-    def wrapper(*args: object, **kwargs: object):
+    def wrapper(*args: object, **kwargs: object) -> object:
         app = kwargs.get("app")
         if app:
             with app.app_context():

--- a/src/api/flaskr/framework/plugin/load_plugin.py
+++ b/src/api/flaskr/framework/plugin/load_plugin.py
@@ -25,7 +25,7 @@ def load_plugins_from_dir(
     plugins = []
     app.logger.info("load modules from: %s", plugins_dir)
 
-    def load_from_directory(directory, plugin_manager: PluginManager = None):
+    def load_from_directory(directory, plugin_manager: PluginManager = None) -> None:
         files = [path.name for path in Path(directory).iterdir()]
         plugin_obj = None
         if SRC_DIR in files:

--- a/src/api/flaskr/framework/plugin/plugin_manager.py
+++ b/src/api/flaskr/framework/plugin/plugin_manager.py
@@ -140,7 +140,7 @@ def disable_plugin_manager(app: Flask) -> Flask:
 def extension(target_func_name) -> Callable[..., object]:
     """Decorate a function with registered extension callbacks."""
 
-    def decorator(func):
+    def decorator(func) -> Callable[..., object]:
         manager = get_plugin_manager()
         if manager is None:
             message = "Plugin manager is not enabled"
@@ -154,7 +154,7 @@ def extension(target_func_name) -> Callable[..., object]:
 def extensible_generic_register(func_name) -> Callable[..., object]:
     """Register a generic extension point."""
 
-    def decorator(func):
+    def decorator(func) -> Callable[..., object]:
         manager = get_plugin_manager()
         if manager is None:
             message = "Plugin manager is not enabled"
@@ -170,7 +170,7 @@ def extensible(func) -> Callable[..., object]:
     """Decorate a function as an extension point."""
 
     @wraps(func)
-    def wrapper(*args: object, **kwargs: object):
+    def wrapper(*args: object, **kwargs: object) -> object:
         result = func(*args, **kwargs)
         manager = get_plugin_manager()
         if manager is None:
@@ -192,7 +192,7 @@ def extensible_generic(func) -> Callable[..., object]:
         pass
 
     @wraps(func)
-    def wrapper(*args: object, **kwargs: object):
+    def wrapper(*args: object, **kwargs: object) -> Iterator[object]:
         result = func(*args, **kwargs)
         if result:
             yield from result

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -43,7 +43,7 @@ def _shared_json_root() -> Path:
     return Path(__file__).resolve().parents[2] / "i18n"
 
 
-def _flatten_dict(data, prefix: str = ""):
+def _flatten_dict(data, prefix: str = "") -> dict[str, object]:
     if not isinstance(data, dict):
         key = prefix or ""
         return {key: data} if key else {}
@@ -59,14 +59,14 @@ def _flatten_dict(data, prefix: str = ""):
     return flattened
 
 
-def _store_translation(lang: str, key: str, value):
+def _store_translation(lang: str, key: str, value) -> None:
     if value is None:
         return
     _translations[lang][key] = value
     _translations[lang][key.upper()] = value
 
 
-def _load_json_translations(app: Flask, root: Path):
+def _load_json_translations(app: Flask, root: Path) -> None:
     if not root.exists():
         app.logger.debug("i18n JSON directory not found: %s", root)
         return
@@ -148,7 +148,7 @@ def _load_json_translations(app: Flask, root: Path):
                     _store_translation(lang, key, value)
 
 
-def _validate_json_translations(root: Path):
+def _validate_json_translations(root: Path) -> None:
     if not root.exists():
         message = f"Missing shared i18n directory at '{root}'. Run the migration checklist to generate JSON translations."
         raise FileNotFoundError(message)
@@ -216,7 +216,7 @@ def _validate_json_translations(root: Path):
         raise RuntimeError(details)
 
 
-def _load_python_translations(app: Flask, translations_dir: Path):
+def _load_python_translations(app: Flask, translations_dir: Path) -> None:
     if not translations_dir.exists():
         return
 
@@ -282,11 +282,11 @@ def translate_for_language(text: str, language: str | None = None) -> str:
     )
 
 
-def _(text: str):
+def _(text: str) -> str:
     return translate_for_language(text)
 
 
-def get_current_language():
+def get_current_language() -> str:
     return getattr(_thread_local, "language", "en-US")
 
 

--- a/src/api/flaskr/route/callback.py
+++ b/src/api/flaskr/route/callback.py
@@ -1,6 +1,7 @@
 """Expose callback HTTP routes."""
 
-from flask import Flask, jsonify, make_response, request
+from flask import Flask, Response, jsonify, make_response, request
+from flask.typing import ResponseReturnValue
 
 from flaskr.service.billing.customization import (
     build_provider_config_overrides,
@@ -28,7 +29,9 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route("/api/order/webhooks/<provider_name>/<callback_token>", methods=["POST"])
     @bypass_token_validation
-    def scoped_payment_webhook(provider_name: str, callback_token: str):
+    def scoped_payment_webhook(
+        provider_name: str, callback_token: str
+    ) -> ResponseReturnValue:
         context = resolve_provider_credential_context(
             app,
             provider=provider_name,
@@ -87,7 +90,7 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
     # pingxx支付回调
     @app.route(path_prefix + "/pingxx-callback", methods=["POST"])
     @bypass_token_validation
-    def pingxx_callback():
+    def pingxx_callback() -> ResponseReturnValue:
         body = request.get_json()
         app.logger.info("pingxx-callback: %s", body)
         event_type = body.get("type", "")
@@ -107,7 +110,7 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/alipay-notify", methods=["POST"])
     @bypass_token_validation
-    def alipay_notify():
+    def alipay_notify() -> ResponseReturnValue:
         form_payload = request.form.to_dict(flat=True)
         app.logger.info("alipay-notify: %s", form_payload)
         provider = get_payment_provider("alipay")
@@ -144,7 +147,7 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/wechatpay-notify", methods=["POST"])
     @bypass_token_validation
-    def wechatpay_notify():
+    def wechatpay_notify() -> ResponseReturnValue:
         raw_body = request.get_data() or b""
         app.logger.info("wechatpay-notify: %s", raw_body)
         provider = get_payment_provider("wechatpay")
@@ -183,7 +186,7 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
     return app
 
 
-def _plain_text_response(value: str):
+def _plain_text_response(value: str) -> Response:
     response = make_response(value)
     response.mimetype = "text/plain"
     return response

--- a/src/api/flaskr/route/common.py
+++ b/src/api/flaskr/route/common.py
@@ -7,7 +7,7 @@ import traceback
 from collections.abc import Callable
 from functools import wraps
 
-from flask import Flask, jsonify, request
+from flask import Flask, Response, jsonify, request
 from werkzeug.exceptions import HTTPException
 
 from flaskr.common.shifu_context import clear_shifu_context
@@ -66,7 +66,7 @@ def bypass_token_validation(func) -> Callable[..., object]:
     by_pass_login_func.append(func.__name__)
 
     @wraps(func)
-    def wrapper(*args: object, **kwargs: object):
+    def wrapper(*args: object, **kwargs: object) -> object:
         return func(*args, **kwargs)
 
     return wrapper
@@ -76,20 +76,20 @@ def register_common_handler(app: Flask) -> Flask:
     """Register the common routes on the Flask application."""
 
     @app.errorhandler(AppError)
-    def handle_invalid_usage(error: AppError):
+    def handle_invalid_usage(error: AppError) -> Response:
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response
 
     @app.errorhandler(HTTPException)
-    def handle_invalid_http(error: HTTPException):
+    def handle_invalid_http(error: HTTPException) -> Response:
         app.logger.info(error)
         response = jsonify({"code": error.code, "message": error.description})
         response.status_code = 200
         return response
 
     @app.errorhandler(Exception)
-    def handle_invalid_exception(error: Exception):
+    def handle_invalid_exception(error: Exception) -> Response:
         del error
         app.logger.error(traceback.format_exc())
         language = _extract_request_language()
@@ -100,7 +100,7 @@ def register_common_handler(app: Flask) -> Flask:
         return response
 
     @app.teardown_request
-    def teardown_shifu_context(exception):
+    def teardown_shifu_context(exception) -> None:
         # Ensure shifu context does not leak between requests on the same worker thread
         del exception
         clear_shifu_context()

--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -1,6 +1,7 @@
 """Expose config HTTP routes."""
 
 from flask import Flask, request
+from flask.typing import ResponseReturnValue
 
 from flaskr.common.config import ENV_VARS
 from flaskr.common.public_urls import build_google_oauth_callback_url
@@ -41,7 +42,7 @@ def _to_bool(value, default=False) -> bool:
     return default
 
 
-def _to_list(value, default=None):
+def _to_list(value, default=None) -> list[object]:
     default = default or []
     if value is None:
         return default
@@ -75,7 +76,7 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/runtime-config", methods=["GET"])
     @bypass_token_validation
     @with_shifu_context()
-    def get_runtime_config():
+    def get_runtime_config() -> ResponseReturnValue:
         # An explicit creator_bid lets surfaces without a shifu in the path
         # (e.g. the /admin backend) fetch a creator's branding. Falls back to
         # the shifu-context creator when absent, so existing callers are

--- a/src/api/flaskr/route/creator_analytics.py
+++ b/src/api/flaskr/route/creator_analytics.py
@@ -2,18 +2,23 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from flask import Flask, request
 
 from flaskr.route.common import make_common_response
 from flaskr.service.creator_analytics.credit_detail import run as run_credit_detail
 from flaskr.service.creator_analytics.funcs import run_dsl
 
+if TYPE_CHECKING:
+    from flask.typing import ResponseReturnValue
+
 
 def register_creator_analytics_handler(app: Flask, path_prefix: str) -> Flask:
     """Register the creator analytics routes on the Flask application."""
 
     @app.route(path_prefix + "/query", methods=["POST"])
-    def creator_analytics_query():
+    def creator_analytics_query() -> ResponseReturnValue:
         """Run a creator-analytics DSL query.
 
         ---
@@ -89,7 +94,7 @@ def register_creator_analytics_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(result)
 
     @app.route(path_prefix + "/credit-detail", methods=["POST"])
-    def creator_analytics_credit_detail():
+    def creator_analytics_credit_detail() -> ResponseReturnValue:
         """Fetch joined credit consumption detail for one shifu.
 
         Server-side joins ``bill_usage`` and ``credit_ledger_entries`` on

--- a/src/api/flaskr/route/dicts.py
+++ b/src/api/flaskr/route/dicts.py
@@ -1,6 +1,7 @@
 """Expose dicts HTTP routes."""
 
 from flask import Flask
+from flask.typing import ResponseReturnValue
 
 from flaskr.api.llm import get_current_models
 from flaskr.service.common.dicts import get_all_dicts
@@ -13,7 +14,7 @@ def register_dict_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/dicts", methods=["GET"])
     @bypass_token_validation
-    def get_dicts():
+    def get_dicts() -> ResponseReturnValue:
         """Get all dictionaries.
 
         ---
@@ -24,7 +25,7 @@ def register_dict_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/models", methods=["GET"])
     @bypass_token_validation
-    def get_models():
+    def get_models() -> ResponseReturnValue:
         """Get all models.
 
         ---

--- a/src/api/flaskr/route/open_api.py
+++ b/src/api/flaskr/route/open_api.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from functools import wraps
 
 from flask import Flask, request
+from flask.typing import ResponseReturnValue
 
 from flaskr.route.common import bypass_token_validation, make_common_response
 from flaskr.service.common.models import raise_error, raise_param_error
@@ -20,7 +21,7 @@ def require_api_key(f) -> Callable[..., object]:
     """Authenticate Open API requests via X-User-Uid + X-Api-Key headers."""
 
     @wraps(f)
-    def wrapper(*args: object, **kwargs: object):
+    def wrapper(*args: object, **kwargs: object) -> object:
         user_uid = request.headers.get("X-User-Uid", "").strip()
         api_key = request.headers.get("X-Api-Key", "").strip()
 
@@ -39,7 +40,7 @@ def require_api_key(f) -> Callable[..., object]:
     return wrapper
 
 
-def _extract_params():
+def _extract_params() -> tuple[str, str, str]:
     """Extract and validate common request parameters."""
     payload = request.get_json(silent=True) or request.form.to_dict() or {}
     shifu_bid = str(payload.get("shifu_bid", "")).strip()
@@ -62,7 +63,7 @@ def register_open_api_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/order/query", methods=["POST"])
     @bypass_token_validation
     @require_api_key
-    def open_api_order_query():
+    def open_api_order_query() -> ResponseReturnValue:
         shifu_bid, user_identify, user_identify_type = _extract_params()
         owner_bid = request.open_api_user_bid
         result = open_api_query_order(
@@ -73,7 +74,7 @@ def register_open_api_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/order/grant", methods=["POST"])
     @bypass_token_validation
     @require_api_key
-    def open_api_order_grant():
+    def open_api_order_grant() -> ResponseReturnValue:
         shifu_bid, user_identify, user_identify_type = _extract_params()
         owner_bid = request.open_api_user_bid
         result = open_api_grant_order(
@@ -84,7 +85,7 @@ def register_open_api_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/order/revoke", methods=["POST"])
     @bypass_token_validation
     @require_api_key
-    def open_api_order_revoke():
+    def open_api_order_revoke() -> ResponseReturnValue:
         shifu_bid, user_identify, user_identify_type = _extract_params()
         owner_bid = request.open_api_user_bid
         result = open_api_revoke_order(

--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime
 
 from flask import Flask, request
+from flask.typing import ResponseReturnValue
 
 from flaskr.common.shifu_context import with_shifu_context
 from flaskr.route.common import make_common_response
@@ -45,7 +46,7 @@ from flaskr.util.datetime import parse_naive_utc
 def register_order_handler(app: Flask, path_prefix: str) -> Flask:
     """Register the order routes on the Flask application."""
 
-    def _require_creator():
+    def _require_creator() -> None:
         if not request.user.is_creator:
             raise_error("server.shifu.noPermission")
 
@@ -92,7 +93,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
             parsed = parsed.astimezone(UTC).replace(tzinfo=None)
         return parsed
 
-    def _parse_admin_pagination():
+    def _parse_admin_pagination() -> tuple[int, int]:
         page_index = request.args.get("page_index", 1)
         page_size = request.args.get("page_size", 20)
         try:
@@ -128,7 +129,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return None
 
     @app.route(path_prefix + "/reqiure-to-pay", methods=["POST"])
-    def reqiure_to_pay():
+    def reqiure_to_pay() -> ResponseReturnValue:
         """Request payment.
 
         ---
@@ -183,7 +184,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/init-order", methods=["POST"])
     @with_shifu_context()
-    def init_order():
+    def init_order() -> ResponseReturnValue:
         """Initialize an order.
 
         ---
@@ -221,7 +222,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(init_buy_record(app, user_id, course_id))
 
     @app.route(path_prefix + "/query-order", methods=["POST"])
-    def query_order():
+    def query_order() -> ResponseReturnValue:
         """Query an order.
 
         ---
@@ -258,7 +259,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(query_buy_record(app, order_id))
 
     @app.route(path_prefix + "/apply-discount", methods=["POST"])
-    def apply_discount():
+    def apply_discount() -> ResponseReturnValue:
         """Apply a discount code.
 
         ---
@@ -305,7 +306,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/payment-detail", methods=["POST"])
-    def payment_detail():
+    def payment_detail() -> ResponseReturnValue:
         """Query payment details.
 
         ---
@@ -341,7 +342,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(get_payment_details(app, order_id))
 
     @app.route(path_prefix + "/stripe/sync", methods=["POST"])
-    def stripe_sync():
+    def stripe_sync() -> ResponseReturnValue:
         """Sync the Stripe payment status.
 
         ---
@@ -380,7 +381,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/payment/sync", methods=["POST"])
-    def payment_sync():
+    def payment_sync() -> ResponseReturnValue:
         """Sync the payment status.
 
         ---
@@ -418,7 +419,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/stripe/webhook", methods=["POST"])
-    def stripe_webhook():
+    def stripe_webhook() -> ResponseReturnValue:
         """Stripe webhook placeholder.
 
         ---
@@ -435,7 +436,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return app.response_class(body, status=status_code, mimetype="application/json")
 
     @app.route(path_prefix + "/admin/orders", methods=["GET"])
-    def admin_order_list():
+    def admin_order_list() -> ResponseReturnValue:
         """Admin order list.
 
         ---
@@ -513,7 +514,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/admin/orders/shifus", methods=["GET"])
-    def admin_order_shifu_list():
+    def admin_order_shifu_list() -> ResponseReturnValue:
         """List created shifus for order admin filters.
 
         ---
@@ -593,7 +594,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/admin/orders/import-activation", methods=["POST"])
-    def admin_import_activation():
+    def admin_import_activation() -> ResponseReturnValue:
         """Admin import activation order.
 
         ---
@@ -711,7 +712,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/admin/orders/redemption-codes", methods=["GET"])
-    def admin_creator_redemption_code_list():
+    def admin_creator_redemption_code_list() -> ResponseReturnValue:
         """List course redemption code batches created by the current creator."""
         _require_creator()
         page_index, page_size = _parse_admin_pagination()
@@ -742,7 +743,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/admin/orders/redemption-codes", methods=["POST"])
-    def admin_create_creator_redemption_code():
+    def admin_create_creator_redemption_code() -> ResponseReturnValue:
         """Create a course redemption code for the current creator's published course."""
         _require_creator()
         payload = _parse_required_json_payload()
@@ -754,7 +755,9 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>/usages",
         methods=["GET"],
     )
-    def admin_creator_redemption_code_usage_list(coupon_bid: str):
+    def admin_creator_redemption_code_usage_list(
+        coupon_bid: str,
+    ) -> ResponseReturnValue:
         """List usage records for a course redemption code owned by the current creator."""
         _require_creator()
         page_index, page_size = _parse_admin_pagination()
@@ -773,7 +776,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>/codes",
         methods=["GET"],
     )
-    def admin_creator_redemption_code_code_list(coupon_bid: str):
+    def admin_creator_redemption_code_code_list(coupon_bid: str) -> ResponseReturnValue:
         """List generated sub-codes for a course redemption code owned by the current creator."""
         _require_creator()
         page_index, page_size = _parse_admin_pagination()
@@ -791,7 +794,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>",
         methods=["GET"],
     )
-    def admin_creator_redemption_code_detail(coupon_bid: str):
+    def admin_creator_redemption_code_detail(coupon_bid: str) -> ResponseReturnValue:
         """Get detail for a course redemption code owned by the current creator."""
         _require_creator()
         return make_common_response(
@@ -804,7 +807,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>",
         methods=["POST"],
     )
-    def admin_update_creator_redemption_code(coupon_bid: str):
+    def admin_update_creator_redemption_code(coupon_bid: str) -> ResponseReturnValue:
         """Update a course redemption code owned by the current creator."""
         _require_creator()
         payload = _parse_required_json_payload()
@@ -818,7 +821,9 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>/status",
         methods=["POST"],
     )
-    def admin_update_creator_redemption_code_status(coupon_bid: str):
+    def admin_update_creator_redemption_code_status(
+        coupon_bid: str,
+    ) -> ResponseReturnValue:
         """Update status for a course redemption code owned by the current creator."""
         _require_creator()
         payload = _parse_required_json_payload()
@@ -832,7 +837,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response({"enabled": bool(result.get("enabled"))})
 
     @app.route(path_prefix + "/admin/orders/<order_bid>", methods=["GET"])
-    def admin_order_detail(order_bid: str):
+    def admin_order_detail(order_bid: str) -> ResponseReturnValue:
         """Admin order detail.
 
         ---

--- a/src/api/flaskr/route/storage.py
+++ b/src/api/flaskr/route/storage.py
@@ -13,6 +13,8 @@ from flaskr.service.common.storage import get_local_storage_path
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from flask.typing import ResponseReturnValue
+
 
 def _guess_mimetype(path: Path) -> str:
     guessed, _encoding = mimetypes.guess_type(path.name)
@@ -46,7 +48,7 @@ def register_storage_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/storage/<profile>/<path:object_key>", methods=["GET"])
     @bypass_token_validation
-    def serve_local_storage(profile: str, object_key: str):
+    def serve_local_storage(profile: str, object_key: str) -> ResponseReturnValue:
         try:
             file_path = get_local_storage_path(profile, object_key)
         except ValueError:

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -4,7 +4,8 @@ import contextlib
 from collections.abc import Callable
 from functools import wraps
 
-from flask import Flask, current_app, make_response, request
+from flask import Flask, Response, current_app, make_response, request
+from flask.typing import ResponseReturnValue
 
 from flaskr.common.public_urls import resolve_request_origin
 from flaskr.common.shifu_context import with_shifu_context
@@ -47,7 +48,7 @@ from flaskr.service.user.captcha import (
 )
 from flaskr.service.user.common import update_user_info, validate_user
 from flaskr.service.user.consts import CREDENTIAL_STATE_VERIFIED
-from flaskr.service.user.models import AuthCredential
+from flaskr.service.user.models import AuthCredential, UserInfo
 from flaskr.service.user.onboarding import (
     ONBOARDING_VERSION,
     build_onboarding_status,
@@ -200,7 +201,7 @@ def optional_token_validation(f) -> Callable[..., object]:
     """Allow a route to accept an optional authentication token."""
 
     @wraps(f)
-    def decorated_function(*args: object, **kwargs: object):
+    def decorated_function(*args: object, **kwargs: object) -> object:
         token = request.cookies.get("token", None)
         if not token:
             token = request.args.get("token", None)
@@ -219,7 +220,7 @@ def optional_token_validation(f) -> Callable[..., object]:
     return decorated_function
 
 
-def _best_effort_password_login_user(app: Flask):
+def _best_effort_password_login_user(app: Flask) -> UserInfo | None:
     """Resolve the explicitly authenticated guest without blocking login."""
     token = request.headers.get("Token", None)
     if not token:
@@ -235,7 +236,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     """Register the user routes on the Flask application."""
 
     @app.before_request
-    def before_request():
+    def before_request() -> None:
         if request.path.startswith("/internal/"):
             return
         if (
@@ -264,7 +265,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         request.user = user
 
     @app.route(path_prefix + "/info", methods=["GET"])
-    def info():
+    def info() -> ResponseReturnValue:
         """Get user information.
 
         ---
@@ -289,7 +290,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(request.user)
 
     @app.route(path_prefix + "/ensure_admin_creator", methods=["POST"])
-    def ensure_admin_creator():
+    def ensure_admin_creator() -> ResponseReturnValue:
         """Ensure admin creator permissions for the current user.
 
         ---
@@ -321,7 +322,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response({"granted": True})
 
     @app.route(path_prefix + "/onboarding/status", methods=["GET"])
-    def onboarding_status():
+    def onboarding_status() -> ResponseReturnValue:
         return make_common_response(
             build_onboarding_status(
                 app,
@@ -331,7 +332,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/onboarding/complete", methods=["POST"])
-    def complete_onboarding():
+    def complete_onboarding() -> ResponseReturnValue:
         payload = request.get_json(silent=True)
         if not isinstance(payload, dict):
             payload = {}
@@ -347,7 +348,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/update_info", methods=["POST"])
-    def update_info():
+    def update_info() -> ResponseReturnValue:
         """Update user information.
 
         ---
@@ -401,7 +402,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/profile-onboarding", methods=["GET"])
-    def profile_onboarding_status_api():
+    def profile_onboarding_status_api() -> ResponseReturnValue:
         """Get platform-level profile onboarding state for current user.
 
         ---
@@ -416,7 +417,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/profile-onboarding/complete", methods=["POST"])
-    def complete_profile_onboarding_api():
+    def complete_profile_onboarding_api() -> ResponseReturnValue:
         """Complete or skip platform-level profile onboarding.
 
         ---
@@ -439,12 +440,12 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(result)
 
     @app.route(path_prefix + "/learner-profile", methods=["GET"])
-    def learner_profile_api():
+    def learner_profile_api() -> ResponseReturnValue:
         """Return the current user's canonical learning profile."""
         return make_common_response(get_learner_profile(user_id=request.user.user_id))
 
     @app.route(path_prefix + "/learner-profile", methods=["PUT"])
-    def update_learner_profile_api():
+    def update_learner_profile_api() -> ResponseReturnValue:
         """Replace the current user's canonical learning profile."""
         payload = _request_json_object("learner_profile")
         _reject_unknown_fields(
@@ -468,12 +469,12 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/learner-profile", methods=["DELETE"])
-    def clear_learner_profile_api():
+    def clear_learner_profile_api() -> ResponseReturnValue:
         """Clear the profile while keeping profile-v2 handled."""
         return make_common_response(clear_learner_profile(user_id=request.user.user_id))
 
     @app.route(path_prefix + "/learner-profile/optimize", methods=["POST"])
-    def optimize_learner_profile_api():
+    def optimize_learner_profile_api() -> ResponseReturnValue:
         """Return an LLM-optimized draft without saving profile state."""
         payload = _request_json_object("learner_profile")
         _reject_unknown_fields(
@@ -499,7 +500,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/require_tmp", methods=["POST"])
     @bypass_token_validation
     @with_shifu_context()
-    def require_tmp():
+    def require_tmp() -> ResponseReturnValue:
         """Temp login user.
 
         ---
@@ -562,7 +563,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/captcha", methods=["GET"])
     @bypass_token_validation
-    def captcha_api():
+    def captcha_api() -> ResponseReturnValue:
         """Create image captcha.
 
         ---
@@ -574,7 +575,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/captcha/verify", methods=["POST"])
     @bypass_token_validation
-    def captcha_verify_api():
+    def captcha_verify_api() -> ResponseReturnValue:
         """Verify image captcha and return one-time ticket.
 
         ---
@@ -599,7 +600,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/send_sms_code", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation
-    def send_sms_code_api():
+    def send_sms_code_api() -> ResponseReturnValue:
         """Send SMS Captcha.
 
         ---
@@ -664,7 +665,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/console_send_sms_code", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation
-    def console_send_sms_code_api():
+    def console_send_sms_code_api() -> ResponseReturnValue:
         """Send SMS verification code for console clients without image captcha.
 
         ---
@@ -688,7 +689,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/send_email_code", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation
-    def send_email_code_api():
+    def send_email_code_api() -> ResponseReturnValue:
         """Send email verification code.
 
         ---
@@ -712,7 +713,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
         return make_common_response(send_email_code(app, email, client_ip, language))
 
-    def _handle_sms_login():
+    def _handle_sms_login() -> Response:
         with app.app_context():
             payload = request.get_json(silent=True)
             payload = payload if isinstance(payload, dict) else {}
@@ -771,7 +772,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/login_sms", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation
-    def login_sms_api():
+    def login_sms_api() -> ResponseReturnValue:
         """Login through SMS verification code for web clients.
 
         ---
@@ -781,7 +782,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         return _handle_sms_login()
 
     @app.route(path_prefix + "/get_profile", methods=["GET"])
-    def get_profile():
+    def get_profile() -> ResponseReturnValue:
         """Get user profile.
 
         ---
@@ -818,7 +819,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/update_profile", methods=["POST"])
-    def update_profile():
+    def update_profile() -> ResponseReturnValue:
         """Update user profile.
 
         ---
@@ -880,7 +881,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             return make_common_response(ret.__json__())
 
     @app.route(path_prefix + "/upload_avatar", methods=["POST"])
-    def upload_avatar():
+    def upload_avatar() -> ResponseReturnValue:
         """Upload avatar.
 
         ---
@@ -918,7 +919,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/update_openid", methods=["POST"])
     @with_shifu_context()
-    def update_wechat_openid():
+    def update_wechat_openid() -> ResponseReturnValue:
         """Update Wechat OpenID.
 
         ---
@@ -963,7 +964,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/submit-feedback", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation
-    def sumbit_feedback_api():
+    def sumbit_feedback_api() -> ResponseReturnValue:
         """Submit feedback.
 
         ---
@@ -1013,7 +1014,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/oauth/google", methods=["GET"])
     @bypass_token_validation
     @optional_token_validation
-    def google_oauth_start():
+    def google_oauth_start() -> ResponseReturnValue:
         provider = get_provider("google")
         metadata = {}
         redirect_uri = request.args.get("redirect_uri")
@@ -1044,7 +1045,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/oauth/google/callback-origin", methods=["GET"])
     @bypass_token_validation
-    def google_oauth_callback_origin():
+    def google_oauth_callback_origin() -> ResponseReturnValue:
         """Resolve which domain a pending Google login should return to.
 
         Every domain shares one Google callback, so the page that receives it
@@ -1061,7 +1062,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/oauth/google/callback", methods=["GET"])
     @bypass_token_validation
     @optional_token_validation
-    def google_oauth_callback():
+    def google_oauth_callback() -> ResponseReturnValue:
         provider = get_provider("google")
         current_user = getattr(request, "user", None)
         current_user_id = None
@@ -1100,7 +1101,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/login_password", methods=["POST"])
     @bypass_token_validation
-    def login_password():
+    def login_password() -> ResponseReturnValue:
         """Login with password.
 
         ---
@@ -1159,7 +1160,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(auth_result.token)
 
     @app.route(path_prefix + "/set_password", methods=["POST"])
-    def set_password():
+    def set_password() -> ResponseReturnValue:
         """Set password for logged-in user (first time only).
 
         ---
@@ -1242,7 +1243,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response({"success": True})
 
     @app.route(path_prefix + "/change_password", methods=["POST"])
-    def change_password():
+    def change_password() -> ResponseReturnValue:
         """Change password for logged-in user (requires old password).
 
         ---
@@ -1277,7 +1278,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/reset_password", methods=["POST"])
     @bypass_token_validation
-    def reset_password():
+    def reset_password() -> ResponseReturnValue:
         """Reset password via verification code.
 
         ---
@@ -1350,7 +1351,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     # health check
     @app.route("/health", methods=["GET"])
     @bypass_token_validation
-    def health():
+    def health() -> ResponseReturnValue:
         app.logger.info("health")
         return make_common_response("ok")
 

--- a/src/api/flaskr/service/billing/campaigns.py
+++ b/src/api/flaskr/service/billing/campaigns.py
@@ -36,6 +36,7 @@ from .consts import (
 )
 from .dtos import (
     AdminBillingCampaignDetailDTO,
+    AdminBillingCampaignDTO,
     AdminBillingCampaignProductOptionsDTO,
     AdminBillingCampaignsPageDTO,
 )
@@ -1110,7 +1111,7 @@ def _serialize_admin_campaign_row(
     product_types: list[str],
     bindings: list[BillingCampaignProduct],
     hit_order_count: int,
-):
+) -> AdminBillingCampaignDTO:
     campaign_rule_snapshot = _resolve_campaign_rule_snapshot_from_bindings(
         row,
         bindings=bindings,

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -352,7 +352,7 @@ def register_billing_commands(console) -> None:
     """Register offline billing maintenance commands under ``flask console``."""
 
     @console.group(name="billing")
-    def billing_group():
+    def billing_group() -> None:
         """Billing maintenance commands for offline repair and replay."""
 
     @billing_group.command(name="seed-bootstrap-data")

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -67,6 +67,7 @@ from .primitives import to_decimal as _to_decimal
 
 if TYPE_CHECKING:
     from flask import Flask
+    from sqlalchemy.sql.elements import ColumnElement
 
 TASK_NAME = "billing.send_credit_notification"
 SOURCE_TYPE_LEDGER = "ledger"
@@ -3103,7 +3104,7 @@ def _is_notification_not_sent_status(status: str) -> bool:
     )
 
 
-def _notification_not_sent_condition():
+def _notification_not_sent_condition() -> ColumnElement[bool]:
     return or_(
         NotificationRecord.status.like("skipped%"),
         NotificationRecord.status == CREDIT_NOTIFICATION_STATUS_SUPPRESSED_DUPLICATE,
@@ -3140,7 +3141,9 @@ def _resolve_notification_skip_reason(status: str, error_code: str = "") -> str:
     return ""
 
 
-def _notification_delivery_status_condition(delivery_status: str):
+def _notification_delivery_status_condition(
+    delivery_status: str,
+) -> ColumnElement[bool] | None:
     if delivery_status == CREDIT_NOTIFICATION_STATUS_PENDING:
         return NotificationRecord.status == CREDIT_NOTIFICATION_STATUS_PENDING
     if delivery_status == CREDIT_NOTIFICATION_STATUS_SENT:
@@ -3152,7 +3155,7 @@ def _notification_delivery_status_condition(delivery_status: str):
     return None
 
 
-def _notification_skip_reason_condition(skip_reason: str):
+def _notification_skip_reason_condition(skip_reason: str) -> ColumnElement[bool] | None:
     contact_condition = (
         NotificationRecord.status == CREDIT_NOTIFICATION_STATUS_SKIPPED_NO_MOBILE
     )

--- a/src/api/flaskr/service/billing/customization.py
+++ b/src/api/flaskr/service/billing/customization.py
@@ -39,6 +39,8 @@ from .entitlements import (
 from .primitives import normalize_bid
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from werkzeug.datastructures import FileStorage
 
 BRANDING_KEY = "CUSTOMIZATION.BRANDING"
@@ -1310,7 +1312,7 @@ def _save_logo_image(image: Image.Image, *, suffix: str) -> bytes:
     return output.getvalue()
 
 
-def _saas_funcs(*, required: bool = True):
+def _saas_funcs(*, required: bool = True) -> ModuleType | None:
     try:
         module = import_module(
             "flaskr.plugins.ai_shifu_saas_plugin.src.service.config.funcs"
@@ -1335,7 +1337,7 @@ def _saas_funcs(*, required: bool = True):
     return module
 
 
-def _saas_model():
+def _saas_model() -> type[object]:
     return import_module(
         "flaskr.plugins.ai_shifu_saas_plugin.src.service.config.models"
     ).SaasUserConfig

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -188,7 +188,7 @@ _ADMIN_BILLING_FOCUS_ATTENTION_REASON_ORDER = (
 )
 
 
-def _filter_out_reserved_credit_grant_ledgers(query):
+def _filter_out_reserved_credit_grant_ledgers(query) -> object:
     bucket_credit_state_expr = db.func.lower(
         db.func.trim(
             db.func.coalesce(
@@ -493,7 +493,7 @@ def _load_credit_order_product_map(
 def _load_credit_order_grant_map(
     app: Flask,
     order_bids: list[str],
-):
+) -> dict[object, object]:
     normalized_order_bids = [_normalize_bid(bid) for bid in order_bids if bid]
     if not normalized_order_bids:
         return {}

--- a/src/api/flaskr/service/billing/referral_plan_rewards.py
+++ b/src/api/flaskr/service/billing/referral_plan_rewards.py
@@ -13,7 +13,11 @@ from flaskr.util.datetime import now_utc
 from flaskr.util.uuid import generate_id
 
 if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
     from datetime import datetime
+    from types import ModuleType
+
+    from .models import BillingSubscription
 
 _MANUAL_PROVIDER_NAME = "manual"
 _CHECKOUT_TYPE = "referral_invitation_reward"
@@ -70,7 +74,7 @@ class _NullContext:
         return False
 
 
-def _with_app_context(app: Flask):
+def _with_app_context(app: Flask) -> AbstractContextManager[object]:
     return _NullContext() if has_app_context() else app.app_context()
 
 
@@ -82,19 +86,19 @@ def _normalize_bid(value: object) -> str:
     return str(value or "").strip()
 
 
-def _billing_consts():
+def _billing_consts() -> ModuleType:
     from . import consts
 
     return consts
 
 
-def _billing_models():
+def _billing_models() -> ModuleType:
     from . import models
 
     return models
 
 
-def _load_reward_product(product_code: str):
+def _load_reward_product(product_code: str) -> object:
     consts = _billing_consts()
     models = _billing_models()
     return (
@@ -109,7 +113,7 @@ def _load_reward_product(product_code: str):
     )
 
 
-def _load_product_by_bid(product_bid: str):
+def _load_product_by_bid(product_bid: str) -> object:
     consts = _billing_consts()
     models = _billing_models()
     return (
@@ -166,7 +170,9 @@ def _load_existing_order(
     )
 
 
-def _load_primary_active_subscription(creator_bid: str, *, as_of: datetime):
+def _load_primary_active_subscription(
+    creator_bid: str, *, as_of: datetime
+) -> BillingSubscription | None:
     from .queries import load_primary_active_subscription
 
     return load_primary_active_subscription(creator_bid, as_of=as_of)
@@ -176,7 +182,7 @@ def _calculate_self_managed_billing_cycle_end(
     product,
     *,
     cycle_start_at: datetime,
-):
+) -> datetime | None:
     from .queries import calculate_self_managed_billing_cycle_end
 
     return calculate_self_managed_billing_cycle_end(
@@ -189,7 +195,7 @@ def _calculate_self_managed_billing_cycle_end_after_boundary(
     product,
     *,
     cycle_boundary_at: datetime,
-):
+) -> datetime | None:
     from .queries import calculate_self_managed_billing_cycle_end_after_boundary
 
     return calculate_self_managed_billing_cycle_end_after_boundary(

--- a/src/api/flaskr/service/billing/routes.py
+++ b/src/api/flaskr/service/billing/routes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from flask import Flask, request
 from flaskr.dao.uow import unit_of_work
 from flaskr.framework.plugin.inject import inject
@@ -69,6 +71,9 @@ from flaskr.service.billing.trials import acknowledge_trial_welcome_dialog
 from flaskr.service.common.models import raise_error, raise_param_error
 
 from .primitives import is_billing_enabled
+
+if TYPE_CHECKING:
+    from flask.typing import ResponseReturnValue
 
 # Compatibility aliases keep existing route tests patchable while the concrete
 # user-service access lives behind billing-owned adapter functions.
@@ -162,17 +167,17 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     admin_path_prefix = "/api/admin/billing"
 
     @app.route(path_prefix, methods=["GET"])
-    def billing_bootstrap_api():
+    def billing_bootstrap_api() -> ResponseReturnValue:
         _require_billing_access(app)
         return make_common_response(build_billing_route_bootstrap(path_prefix))
 
     @app.route(path_prefix + "/catalog", methods=["GET"])
-    def billing_catalog_api():
+    def billing_catalog_api() -> ResponseReturnValue:
         _require_billing_access(app)
         return make_common_response(build_billing_catalog(app))
 
     @app.route(path_prefix + "/overview", methods=["GET"])
-    def billing_overview_api():
+    def billing_overview_api() -> ResponseReturnValue:
         _require_billing_access(app)
         return make_common_response(
             build_billing_overview(
@@ -182,7 +187,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/trial-offer/welcome/ack", methods=["POST"])
-    def billing_trial_offer_welcome_ack_api():
+    def billing_trial_offer_welcome_ack_api() -> ResponseReturnValue:
         _require_billing_access(app)
         return make_common_response(
             acknowledge_trial_welcome_dialog(
@@ -192,7 +197,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/wallet-buckets", methods=["GET"])
-    def billing_wallet_buckets_api():
+    def billing_wallet_buckets_api() -> ResponseReturnValue:
         _require_billing_access(app)
         return make_common_response(
             build_billing_wallet_buckets(
@@ -202,7 +207,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/ledger", methods=["GET"])
-    def billing_ledger_api():
+    def billing_ledger_api() -> ResponseReturnValue:
         _require_billing_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -215,7 +220,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/orders/<bill_order_bid>/sync", methods=["POST"])
-    def billing_order_sync_api(bill_order_bid: str):
+    def billing_order_sync_api(bill_order_bid: str) -> ResponseReturnValue:
         _require_billing_access(app)
         return make_common_response(
             sync_billing_order(
@@ -227,7 +232,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/orders/<bill_order_bid>/checkout", methods=["POST"])
-    def billing_order_checkout_api(bill_order_bid: str):
+    def billing_order_checkout_api(bill_order_bid: str) -> ResponseReturnValue:
         _require_billing_access(app)
         return make_common_response(
             create_billing_order_checkout(
@@ -239,7 +244,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/orders/<bill_order_bid>/refund", methods=["POST"])
-    def billing_order_refund_api(bill_order_bid: str):
+    def billing_order_refund_api(bill_order_bid: str) -> ResponseReturnValue:
         _require_billing_access(app)
         return make_common_response(
             refund_billing_order(
@@ -251,7 +256,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/subscriptions/checkout", methods=["POST"])
-    def billing_subscription_checkout_api():
+    def billing_subscription_checkout_api() -> ResponseReturnValue:
         _require_billing_access(app)
         return make_common_response(
             create_billing_subscription_checkout(
@@ -262,7 +267,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/subscriptions/cancel", methods=["POST"])
-    def billing_subscription_cancel_api():
+    def billing_subscription_cancel_api() -> ResponseReturnValue:
         _require_billing_access(app)
         return make_common_response(
             cancel_billing_subscription(
@@ -273,7 +278,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/subscriptions/resume", methods=["POST"])
-    def billing_subscription_resume_api():
+    def billing_subscription_resume_api() -> ResponseReturnValue:
         _require_billing_access(app)
         return make_common_response(
             resume_billing_subscription(
@@ -284,7 +289,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/topups/checkout", methods=["POST"])
-    def billing_topup_checkout_api():
+    def billing_topup_checkout_api() -> ResponseReturnValue:
         _require_billing_access(app)
         return make_common_response(
             create_billing_topup_checkout(
@@ -295,14 +300,14 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/customization", methods=["GET"])
-    def billing_customization_api():
+    def billing_customization_api() -> ResponseReturnValue:
         _require_billing_access(app)
         return make_common_response(
             build_creator_customization(app, _get_creator_bid())
         )
 
     @app.route(path_prefix + "/customization/branding", methods=["PUT"])
-    def billing_customization_branding_api():
+    def billing_customization_branding_api() -> ResponseReturnValue:
         _require_customization_access(app)
         return make_common_response(
             save_creator_branding(
@@ -311,7 +316,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/customization/branding/logo", methods=["POST"])
-    def billing_customization_branding_logo_api():
+    def billing_customization_branding_logo_api() -> ResponseReturnValue:
         _require_customization_access(app)
         file = request.files.get("file")
         if file is None:
@@ -326,7 +331,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/customization/domains", methods=["POST"])
-    def billing_customization_domain_create_api():
+    def billing_customization_domain_create_api() -> ResponseReturnValue:
         _require_customization_access(app)
         payload = dict(request.get_json(silent=True) or {})
         payload["action"] = "bind"
@@ -338,7 +343,9 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         path_prefix + "/customization/domains/<domain_binding_bid>/verify",
         methods=["POST"],
     )
-    def billing_customization_domain_verify_api(domain_binding_bid: str):
+    def billing_customization_domain_verify_api(
+        domain_binding_bid: str,
+    ) -> ResponseReturnValue:
         _require_customization_access(app)
         payload = dict(request.get_json(silent=True) or {})
         payload.update(action="verify", domain_binding_bid=domain_binding_bid)
@@ -350,7 +357,9 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         path_prefix + "/customization/domains/<domain_binding_bid>",
         methods=["DELETE"],
     )
-    def billing_customization_domain_disable_api(domain_binding_bid: str):
+    def billing_customization_domain_disable_api(
+        domain_binding_bid: str,
+    ) -> ResponseReturnValue:
         _require_customization_access(app)
         return make_common_response(
             manage_creator_domain_binding(
@@ -361,7 +370,9 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/customization/integrations/<provider>", methods=["PUT"])
-    def billing_customization_integration_save_api(provider: str):
+    def billing_customization_integration_save_api(
+        provider: str,
+    ) -> ResponseReturnValue:
         _require_customization_access(app)
         return make_common_response(
             save_creator_integration(
@@ -376,7 +387,9 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         path_prefix + "/customization/integrations/<provider>/verify",
         methods=["POST"],
     )
-    def billing_customization_integration_verify_api(provider: str):
+    def billing_customization_integration_verify_api(
+        provider: str,
+    ) -> ResponseReturnValue:
         _require_customization_access(app)
         payload = request.get_json(silent=True) or {}
         return make_common_response(
@@ -391,14 +404,16 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     @app.route(
         path_prefix + "/customization/integrations/<provider>", methods=["DELETE"]
     )
-    def billing_customization_integration_disable_api(provider: str):
+    def billing_customization_integration_disable_api(
+        provider: str,
+    ) -> ResponseReturnValue:
         _require_customization_access(app)
         return make_common_response(
             disable_creator_integration(app, _get_creator_bid(), provider)
         )
 
     @app.route(admin_path_prefix + "/subscriptions", methods=["GET"])
-    def admin_bill_subscriptions_api():
+    def admin_bill_subscriptions_api() -> ResponseReturnValue:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -414,7 +429,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/entitlements", methods=["GET"])
-    def admin_bill_entitlements_api():
+    def admin_bill_entitlements_api() -> ResponseReturnValue:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -428,7 +443,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/entitlements/grants", methods=["POST"])
-    def admin_bill_entitlement_grant_api():
+    def admin_bill_entitlement_grant_api() -> ResponseReturnValue:
         _require_billing_operator_access(app)
         payload = request.get_json(silent=True) or {}
         allowed_fields = {
@@ -486,7 +501,9 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         return make_common_response(response_payload)
 
     @app.route(admin_path_prefix + "/entitlements/<creator_bid>", methods=["POST"])
-    def admin_bill_entitlement_grant_legacy_api(creator_bid: str):
+    def admin_bill_entitlement_grant_legacy_api(
+        creator_bid: str,
+    ) -> ResponseReturnValue:
         _require_billing_operator_access(app)
         payload = request.get_json(silent=True) or {}
         allowed_fields = {
@@ -509,12 +526,12 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         return make_common_response(serialize_creator_entitlements(state))
 
     @app.route(admin_path_prefix + "/ops-state", methods=["GET"])
-    def admin_billing_ops_state_api():
+    def admin_billing_ops_state_api() -> ResponseReturnValue:
         _require_billing_operator_access(app)
         return make_common_response(build_admin_billing_ops_state(app))
 
     @app.route(admin_path_prefix + "/ops-state/config-status", methods=["POST"])
-    def admin_billing_config_status_api():
+    def admin_billing_config_status_api() -> ResponseReturnValue:
         _require_billing_operator_access(app)
         payload = request.get_json(silent=True) or {}
         return make_common_response(
@@ -526,7 +543,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/customization/<creator_bid>", methods=["GET"])
-    def admin_billing_customization_api(creator_bid: str):
+    def admin_billing_customization_api(creator_bid: str) -> ResponseReturnValue:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             build_creator_customization(
@@ -540,7 +557,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/customization-draft", methods=["GET"])
-    def admin_billing_customization_draft_api():
+    def admin_billing_customization_draft_api() -> ResponseReturnValue:
         _require_billing_customization_operator_access(app)
         creator_bid = str(request.args.get("creator_bid") or "").strip()
         creator_mobile = str(request.args.get("creator_mobile") or "").strip()
@@ -553,7 +570,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/customization-draft", methods=["PUT"])
-    def admin_billing_customization_draft_save_api():
+    def admin_billing_customization_draft_save_api() -> ResponseReturnValue:
         _require_billing_customization_operator_access(app)
         payload = dict(request.get_json(silent=True) or {})
         return make_common_response(
@@ -566,7 +583,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/customization-draft", methods=["DELETE"])
-    def admin_billing_customization_draft_delete_api():
+    def admin_billing_customization_draft_delete_api() -> ResponseReturnValue:
         _require_billing_customization_operator_access(app)
         creator_bid = str(request.args.get("creator_bid") or "").strip()
         creator_mobile = str(request.args.get("creator_mobile") or "").strip()
@@ -581,7 +598,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         admin_path_prefix + "/customization-draft/branding/logo",
         methods=["POST"],
     )
-    def admin_billing_customization_draft_logo_api():
+    def admin_billing_customization_draft_logo_api() -> ResponseReturnValue:
         _require_billing_customization_operator_access(app)
         file = request.files.get("file")
         if file is None:
@@ -600,7 +617,9 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         admin_path_prefix + "/customization/<creator_bid>/branding",
         methods=["PUT"],
     )
-    def admin_billing_customization_branding_api(creator_bid: str):
+    def admin_billing_customization_branding_api(
+        creator_bid: str,
+    ) -> ResponseReturnValue:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             save_creator_branding(
@@ -618,7 +637,9 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         admin_path_prefix + "/customization/<creator_bid>/branding/logo",
         methods=["POST"],
     )
-    def admin_billing_customization_branding_logo_api(creator_bid: str):
+    def admin_billing_customization_branding_logo_api(
+        creator_bid: str,
+    ) -> ResponseReturnValue:
         _require_billing_customization_operator_access(app)
         file = request.files.get("file")
         if file is None:
@@ -640,7 +661,9 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         admin_path_prefix + "/customization/<creator_bid>/domains",
         methods=["POST"],
     )
-    def admin_billing_customization_domain_create_api(creator_bid: str):
+    def admin_billing_customization_domain_create_api(
+        creator_bid: str,
+    ) -> ResponseReturnValue:
         _require_billing_customization_operator_access(app)
         payload = dict(request.get_json(silent=True) or {})
         payload["action"] = "bind"
@@ -662,7 +685,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_domain_verify_api(
         creator_bid: str, domain_binding_bid: str
-    ):
+    ) -> ResponseReturnValue:
         _require_billing_customization_operator_access(app)
         payload = dict(request.get_json(silent=True) or {})
         payload.update(action="verify", domain_binding_bid=domain_binding_bid)
@@ -683,7 +706,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_domain_disable_api(
         creator_bid: str, domain_binding_bid: str
-    ):
+    ) -> ResponseReturnValue:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             manage_creator_domain_binding(
@@ -702,7 +725,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_integration_save_api(
         creator_bid: str, provider: str
-    ):
+    ) -> ResponseReturnValue:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             save_creator_integration(
@@ -724,7 +747,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_integration_verify_api(
         creator_bid: str, provider: str
-    ):
+    ) -> ResponseReturnValue:
         _require_billing_customization_operator_access(app)
         payload = request.get_json(silent=True) or {}
         return make_common_response(
@@ -745,7 +768,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_integration_disable_api(
         creator_bid: str, provider: str
-    ):
+    ) -> ResponseReturnValue:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             disable_creator_integration(
@@ -759,7 +782,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/reports/usage-daily", methods=["GET"])
-    def admin_billing_daily_usage_reports_api():
+    def admin_billing_daily_usage_reports_api() -> ResponseReturnValue:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -774,7 +797,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/reports/focus-teachers", methods=["GET"])
-    def admin_billing_focus_teachers_reports_api():
+    def admin_billing_focus_teachers_reports_api() -> ResponseReturnValue:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -786,7 +809,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/reports/ledger-daily", methods=["GET"])
-    def admin_billing_daily_ledger_reports_api():
+    def admin_billing_daily_ledger_reports_api() -> ResponseReturnValue:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -801,7 +824,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/ledger/adjust", methods=["POST"])
-    def admin_billing_ledger_adjust_api():
+    def admin_billing_ledger_adjust_api() -> ResponseReturnValue:
         _require_billing_operator_access(app)
         payload = request.get_json(silent=True) or {}
         target_creator_bid = _resolve_existing_admin_billing_target_user_bid(
@@ -817,12 +840,12 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/products/options", methods=["GET"])
-    def admin_billing_campaign_product_options_api():
+    def admin_billing_campaign_product_options_api() -> ResponseReturnValue:
         _require_billing_operator_access(app)
         return make_common_response(build_admin_billing_campaign_product_options(app))
 
     @app.route(admin_path_prefix + "/campaigns", methods=["GET"])
-    def admin_billing_campaigns_api():
+    def admin_billing_campaigns_api() -> ResponseReturnValue:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -840,7 +863,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/campaigns", methods=["POST"])
-    def admin_billing_campaign_create_api():
+    def admin_billing_campaign_create_api() -> ResponseReturnValue:
         _require_billing_operator_access(app)
         return make_common_response(
             create_admin_billing_campaign(
@@ -851,7 +874,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/campaigns/<campaign_bid>", methods=["GET"])
-    def admin_billing_campaign_detail_api(campaign_bid: str):
+    def admin_billing_campaign_detail_api(campaign_bid: str) -> ResponseReturnValue:
         _require_billing_operator_access(app)
         return make_common_response(
             build_admin_billing_campaign_detail(
@@ -861,7 +884,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/campaigns/<campaign_bid>", methods=["POST"])
-    def admin_billing_campaign_update_api(campaign_bid: str):
+    def admin_billing_campaign_update_api(campaign_bid: str) -> ResponseReturnValue:
         _require_billing_operator_access(app)
         return make_common_response(
             update_admin_billing_campaign(
@@ -873,7 +896,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/campaigns/<campaign_bid>/status", methods=["POST"])
-    def admin_billing_campaign_status_api(campaign_bid: str):
+    def admin_billing_campaign_status_api(campaign_bid: str) -> ResponseReturnValue:
         _require_billing_operator_access(app)
         return make_common_response(
             update_admin_billing_campaign_status(

--- a/src/api/flaskr/service/billing/settlement.py
+++ b/src/api/flaskr/service/billing/settlement.py
@@ -45,6 +45,7 @@ from .wallets import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from datetime import datetime
 
     from flask import Flask
@@ -558,7 +559,9 @@ def backfill_bill_usage_settlement(
 
 
 @contextmanager
-def _usage_settlement_lock(app: Flask, *, creator_bid: str, usage_bid: str):
+def _usage_settlement_lock(
+    app: Flask, *, creator_bid: str, usage_bid: str
+) -> Iterator[None]:
     normalized_creator_bid = str(creator_bid or "").strip()
     normalized_usage_bid = str(usage_bid or "").strip()
     lock_scope = normalized_creator_bid or f"usage:{normalized_usage_bid}"

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -13,7 +13,11 @@ from flaskr.service.config import get_config
 from flaskr.util.datetime import now_utc
 from sqlalchemy import and_, or_
 
-from .checkout import reconcile_billing_provider_reference, sync_billing_order
+from .checkout import (
+    ProviderReferenceReconcileResult,
+    reconcile_billing_provider_reference,
+    sync_billing_order,
+)
 from .consts import (
     BILL_CONFIG_KEY_RENEWAL_TASK_CONFIG,
     BILLING_ORDER_STATUS_PENDING,
@@ -66,6 +70,8 @@ from .wallets import expire_credit_wallet_buckets
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from flask import Flask
+
 try:  # pragma: no cover - exercised indirectly when Celery is installed
     from celery import shared_task
 except ImportError:  # pragma: no cover - local fallback for non-Celery test envs
@@ -95,7 +101,7 @@ class CreditNotificationRetryableError(RuntimeError):
     """Raised when the credit notification worker should use Celery autoretry."""
 
 
-def _create_task_app():
+def _create_task_app() -> Flask:
     os.environ.setdefault("SKIP_APP_AUTOCREATE", "1")
     from app import create_app
 
@@ -299,7 +305,7 @@ def _run_reconcile_provider_reference(
     provider_reference_id: str = "",
     bill_order_bid: str = "",
     session_id: str = "",
-):
+) -> ProviderReferenceReconcileResult:
     normalized_creator_bid = _normalize_bid(creator_bid)
     normalized_payment_provider = _normalize_bid(payment_provider)
     normalized_provider_reference_id = _normalize_bid(provider_reference_id)

--- a/src/api/flaskr/service/billing/trials.py
+++ b/src/api/flaskr/service/billing/trials.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from contextlib import nullcontext
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
@@ -61,7 +61,7 @@ _ACTIVE_SUBSCRIPTION_STATUSES = (
 _TRIAL_WELCOME_ACK_KEY = "welcome_trial_dialog_acknowledged_at"
 
 
-def _maybe_app_context(app: Flask):
+def _maybe_app_context(app: Flask) -> AbstractContextManager[object]:
     return nullcontext() if has_app_context() else app.app_context()
 
 

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -274,7 +274,7 @@ def _parse_int(raw: Any, field_name: str, *, default: int) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _join_conditions():
+def _join_conditions() -> str:
     """Build the bill_usage x credit_ledger_entries ON clause.
 
     ``source_type = USAGE`` is part of the JOIN (not the WHERE) so the
@@ -296,7 +296,7 @@ def _join_conditions():
     )
 
 
-def _where_clauses(params: _Params):
+def _where_clauses(params: _Params) -> list[bool]:
     """Build the WHERE predicates shared by detail + summary queries."""
     bu = BillUsageRecord.__table__
     clauses = [bu.c.shifu_bid == bindparam("__shifu_bid", value=params.shifu_bid)]

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from flask import Flask
+    from sqlalchemy.sql.elements import ColumnElement
 
 
 @dataclass(frozen=True)
@@ -145,7 +146,7 @@ def _dashboard_learner_keyword_matches(
 def _build_dashboard_learner_keyword_filter(
     user_bid_column,
     keyword: str,
-):
+) -> ColumnElement[bool] | None:
     normalized_keyword = _normalize_dashboard_identifier(keyword).strip()
     if not normalized_keyword:
         return None
@@ -278,7 +279,7 @@ def _build_course_outline_context_map(
     return context_map
 
 
-def _build_course_follow_up_base_subquery(shifu_bid: str):
+def _build_course_follow_up_base_subquery(shifu_bid: str) -> object:
     return (
         db.session.query(
             LearnGeneratedBlock.id.label("id"),
@@ -312,7 +313,7 @@ def _build_course_follow_up_base_subquery(shifu_bid: str):
 def _build_follow_up_user_keyword_filter(
     user_bid_column,
     keyword: str,
-):
+) -> ColumnElement[bool] | None:
     normalized = _normalize_dashboard_identifier(keyword)
     if not normalized:
         return None

--- a/src/api/flaskr/service/dashboard/routes.py
+++ b/src/api/flaskr/service/dashboard/routes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from flask import Flask, request
 from flaskr.framework.plugin.inject import inject
 from flaskr.route.common import make_common_response
@@ -14,6 +16,9 @@ from flaskr.service.dashboard.funcs import (
     build_dashboard_course_ratings,
     build_dashboard_entry,
 )
+
+if TYPE_CHECKING:
+    from flask.typing import ResponseReturnValue
 
 
 def _get_timezone_name() -> str | None:
@@ -43,7 +48,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
     app.logger.info("register dashboard routes %s", path_prefix)
 
     @app.route(path_prefix + "/entry", methods=["GET"])
-    def dashboard_entry_api():
+    def dashboard_entry_api() -> ResponseReturnValue:
         user_id = request.user.user_id
         page_index, page_size = _get_pagination_args()
         timezone_name = _get_timezone_name()
@@ -61,7 +66,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
         )
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/detail", methods=["GET"])
-    def dashboard_course_detail_api(shifu_bid: str):
+    def dashboard_course_detail_api(shifu_bid: str) -> ResponseReturnValue:
         user_id = request.user.user_id
         return make_common_response(
             build_dashboard_course_detail(
@@ -73,7 +78,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
         )
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/learners", methods=["GET"])
-    def dashboard_course_learners_api(shifu_bid: str):
+    def dashboard_course_learners_api(shifu_bid: str) -> ResponseReturnValue:
         user_id = request.user.user_id
         page_index, page_size = _get_pagination_args()
         return make_common_response(
@@ -92,7 +97,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
         )
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/follow-ups", methods=["GET"])
-    def dashboard_course_follow_ups_api(shifu_bid: str):
+    def dashboard_course_follow_ups_api(shifu_bid: str) -> ResponseReturnValue:
         user_id = request.user.user_id
         page_index, page_size = _get_pagination_args()
         return make_common_response(
@@ -113,7 +118,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
         )
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/ratings", methods=["GET"])
-    def dashboard_course_ratings_api(shifu_bid: str):
+    def dashboard_course_ratings_api(shifu_bid: str) -> ResponseReturnValue:
         user_id = request.user.user_id
         page_index, page_size = _get_pagination_args()
         return make_common_response(
@@ -140,7 +145,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
     def dashboard_course_follow_up_detail_api(
         shifu_bid: str,
         generated_block_bid: str,
-    ):
+    ) -> ResponseReturnValue:
         user_id = request.user.user_id
         return make_common_response(
             build_dashboard_course_follow_up_detail(

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -10,7 +10,7 @@ from collections.abc import Callable, Generator, Iterable, Iterator
 from dataclasses import dataclass, replace
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from flask import Flask
 from flaskr.api.langfuse import (
@@ -131,6 +131,9 @@ from markdown_flow import (
     replace_variables_in_text,
 )
 from markdown_flow.llm import LLMResult
+
+if TYPE_CHECKING:
+    from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
 context_local = threading.local()
 
@@ -1750,7 +1753,7 @@ class RunScriptContextV2:
         position: int = 0,
         stream_element_number: int | None = None,
         stream_element_type: str | None = None,
-    ):
+    ) -> "StreamingTTSProcessor | None":
         """Create StreamingTTSProcessor if TTS is configured, else return None."""
         try:
             from flaskr.common.config import get_config
@@ -3361,7 +3364,7 @@ class RunScriptContextV2:
         def _switch_tts_processor(
             stream_element_type: str | None = None,
             stream_element_number: int | None = None,
-        ):
+        ) -> None:
             nonlocal \
                 tts_processor, \
                 tts_enabled, \
@@ -3395,7 +3398,7 @@ class RunScriptContextV2:
             chunk_content: str,
             stream_element_type: str | None = None,
             stream_element_number: int | None = None,
-        ):
+        ) -> Iterator[RunMarkdownFlowDTO]:
             nonlocal \
                 generated_content, \
                 tts_processor, \
@@ -3448,7 +3451,7 @@ class RunScriptContextV2:
             )
             _disable_all_tts()
 
-        def _drain_current_tts_ready_events():
+        def _drain_current_tts_ready_events() -> Iterator[RunMarkdownFlowDTO]:
             if not tts_processor:
                 return
             if not hasattr(tts_processor, "drain_ready_segments"):
@@ -3458,7 +3461,7 @@ class RunScriptContextV2:
             except Exception as exc:
                 _handle_current_tts_drain_error(exc)
 
-        def _drain_tts_ready_events():
+        def _drain_tts_ready_events() -> Iterator[RunMarkdownFlowDTO]:
             yield from tts_finalize_drainer.drain()
             yield from _drain_current_tts_ready_events()
             yield from tts_finalize_drainer.drain()

--- a/src/api/flaskr/service/learn/handle_input_ask.py
+++ b/src/api/flaskr/service/learn/handle_input_ask.py
@@ -1,6 +1,6 @@
 """Handle learner follow-up questions and streamed answers."""
 
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 from typing import Any
 
 from flask import Flask
@@ -65,7 +65,7 @@ stream_ask_provider_response = None
 chat_llm = None
 
 
-def _is_valid_asks(asks):
+def _is_valid_asks(asks) -> bool:
     """Check if asks list has at least one complete student+teacher pair."""
     if not asks or not isinstance(asks, list):
         return False
@@ -74,7 +74,9 @@ def _is_valid_asks(asks):
     return has_student and has_teacher
 
 
-def _load_legacy_ask_context(anchor_element, ask_element, ask_max_history_len):
+def _load_legacy_ask_context(
+    anchor_element, ask_element, ask_max_history_len
+) -> list[dict[str, str]] | None:
     if anchor_element is None or ask_element is None:
         return None
 
@@ -104,7 +106,9 @@ def _load_legacy_ask_context(anchor_element, ask_element, ask_max_history_len):
     return messages
 
 
-def _load_ask_context(anchor_element, follow_up_elements, ask_max_history_len):
+def _load_ask_context(
+    anchor_element, follow_up_elements, ask_max_history_len
+) -> list[dict[str, str]] | None:
     """Load ask context from ask/answer sidecar elements first."""
     if anchor_element is None or not follow_up_elements:
         return None
@@ -157,7 +161,7 @@ def _create_ask_block(
     user_bid,
     input_text,
     last_position,
-):
+) -> LearnGeneratedBlock:
     ask_block = init_generated_block(
         app,
         shifu_bid=outline_item_info.shifu_bid,
@@ -183,7 +187,7 @@ def _create_answer_block(
     user_bid,
     response_text,
     last_position,
-):
+) -> LearnGeneratedBlock:
     answer_block = init_generated_block(
         app,
         shifu_bid=outline_item_info.shifu_bid,
@@ -215,7 +219,7 @@ def _run_guardrail(
     usage_context,
     chapter_title,
     ask_scene,
-):
+) -> list[str]:
     check_text_func = globals().get("check_text_with_llm_response")
     llm_settings_cls = globals().get("LLMSettings")
     if check_text_func is None or llm_settings_cls is None:
@@ -594,7 +598,7 @@ def handle_input_ask(
         apply_knowledge_to_messages,
     )
 
-    def _chat_llm_stream(stream_messages: list[dict[str, Any]]):
+    def _chat_llm_stream(stream_messages: list[dict[str, Any]]) -> Iterator[object]:
         return chat_llm_func(
             app,
             user_info.user_id,

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -386,7 +386,9 @@ def get_outline_item_tree(
                     progress_record
                 )
 
-        def build_outline_item_tree(item: HistoryItem):
+        def build_outline_item_tree(
+            item: HistoryItem,
+        ) -> LearnOutlineItemInfoDTO | None:
             outline_item: DraftOutlineItem | PublishedOutlineItem = next(
                 (i for i in outline_items_dbs if i.id == item.id), None
             )
@@ -814,7 +816,7 @@ def _resolve_shifu_tts_settings(
     *,
     shifu_bid: str,
     preview_mode: bool,
-):
+) -> tuple[object, object, object, object]:
     shifu_model = DraftShifu if preview_mode else PublishedShifu
     shifu = (
         shifu_model.query.filter(
@@ -871,7 +873,7 @@ def _yield_tts_segments(
     tts_model: str,
     voice_settings,
     audio_settings,
-):
+) -> Iterator[tuple[str, str, int, object, int, int, int]]:
     provider_name = (provider or "").strip().lower()
     if not provider_name:
         error_message = "TTS provider is required"
@@ -1002,7 +1004,7 @@ def _yield_with_tts_error_mapping(
     *,
     unknown_error_log: str,
     body,
-):
+) -> Iterator[RunMarkdownFlowDTO]:
     try:
         yield from body()
     except ValueError as exc:
@@ -1151,7 +1153,7 @@ def _yield_tts_synthesis(
     outline_bid: str,
     unknown_error_log: str,
     body,
-):
+) -> Iterator[RunMarkdownFlowDTO]:
     """Run a TTS synthesis body under a per-(user, outline) concurrency slot.
 
     Cache-hit paths never reach here, so they do not consume a slot. When the
@@ -1194,7 +1196,7 @@ def _record_stream_segment_usage(
     parent_usage_bid: str,
     segment_index: int,
     usage_metadata: dict,
-):
+) -> None:
     segment_length = len(segment_text or "")
     output_chars = resolve_tts_billable_chars(segment_text, usage_characters)
     record_tts_usage(
@@ -1231,7 +1233,7 @@ def _record_stream_summary_usage(
     duration_ms: int,
     segment_count: int,
     usage_metadata: dict,
-):
+) -> None:
     raw_length = len(raw_text or "")
     cleaned_length = len(cleaned_text or "")
     output_chars = total_output_chars or cleaned_length
@@ -1446,7 +1448,7 @@ def _yield_stream_tts_audio_segments(
     stats: dict,
     position: int | None = None,
     av_contract: dict | None = None,
-):
+) -> Iterator[RunMarkdownFlowDTO]:
     for (
         index,
         audio_data,
@@ -1521,7 +1523,7 @@ def _yield_run_tts_audio_events(
     position: int | None = None,
     stream_element_number: int | None = None,
     stream_element_type: str | None = None,
-):
+) -> Iterator[RunMarkdownFlowDTO]:
     from flaskr.common.config import get_config
 
     max_segment_chars = get_config("TTS_MAX_SEGMENT_CHARS") or 300
@@ -1596,7 +1598,7 @@ def stream_generated_block_audio(
             )
         )
 
-        def _resolve_existing_single_block_audio():
+        def _resolve_existing_single_block_audio() -> object:
             existing_audios = (
                 LearnGeneratedAudio.query.filter(
                     LearnGeneratedAudio.generated_block_bid == generated_block_bid,
@@ -1623,7 +1625,9 @@ def stream_generated_block_audio(
                 None,
             )
 
-        def _yield_existing_single_block_audio(existing_audio: LearnGeneratedAudio):
+        def _yield_existing_single_block_audio(
+            existing_audio: LearnGeneratedAudio,
+        ) -> Iterator[RunMarkdownFlowDTO]:
             yield _build_audio_complete_message(
                 outline_bid=generated_block.outline_item_bid or "",
                 generated_block_bid=generated_block_bid,
@@ -1639,7 +1643,7 @@ def stream_generated_block_audio(
                 yield from _yield_existing_single_block_audio(existing_audio)
                 return
 
-        def _yield_single_block_audio():
+        def _yield_single_block_audio() -> Iterator[RunMarkdownFlowDTO]:
             cleaned_text = preprocess_for_tts(raw_text)
             if not cleaned_text or len(cleaned_text.strip()) < 2:
                 raise_error_with_args(
@@ -1647,7 +1651,7 @@ def stream_generated_block_audio(
                     param_message="No speakable text available for TTS synthesis",
                 )
 
-            def _generate_single_audio():
+            def _generate_single_audio() -> Iterator[RunMarkdownFlowDTO]:
                 yield from _yield_run_tts_audio_events(
                     app=app,
                     text=raw_text,
@@ -1668,7 +1672,7 @@ def stream_generated_block_audio(
                 body=_generate_single_audio,
             )
 
-        def _yield_preview_single_block_audio():
+        def _yield_preview_single_block_audio() -> Iterator[RunMarkdownFlowDTO]:
             cleaned_text = preprocess_for_tts(raw_text)
             if not cleaned_text or len(cleaned_text.strip()) < 2:
                 raise_error_with_args(
@@ -1695,7 +1699,7 @@ def stream_generated_block_audio(
             audio_parts: list[bytes] = []
             subtitle_cues: list[dict] = []
 
-            def _generate_preview_audio():
+            def _generate_preview_audio() -> Iterator[RunMarkdownFlowDTO]:
                 yield from _yield_stream_tts_audio_segments(
                     app=app,
                     text=raw_text,
@@ -1808,7 +1812,7 @@ def stream_generated_block_audio(
                     )
                     return
 
-                def _generate_legacy_audio():
+                def _generate_legacy_audio() -> Iterator[RunMarkdownFlowDTO]:
                     yield from _yield_run_tts_audio_events(
                         app=app,
                         text=raw_text,
@@ -1901,7 +1905,7 @@ def stream_generated_block_audio(
                 )
                 return
 
-            def _generate_av_audio():
+            def _generate_av_audio() -> Iterator[RunMarkdownFlowDTO]:
                 for position, element in enumerate(speakable_elements):
                     speakable_text = str(element.content_text or "")
                     # Skip before the cache lookup so historical records for
@@ -2001,7 +2005,7 @@ def stream_preview_tts_audio(
         audio_parts: list[bytes] = []
         subtitle_cues: list[dict] = []
 
-        def _generate_preview_audio():
+        def _generate_preview_audio() -> Iterator[RunMarkdownFlowDTO]:
             yield from _yield_stream_tts_audio_segments(
                 app=app,
                 text=text or "",

--- a/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
+++ b/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
@@ -96,6 +96,7 @@ from flaskr.service.shifu.consts import (
 
 if TYPE_CHECKING:
     from flask import Flask
+    from flaskr.service.learn.listen_elements import ListenElementRunAdapter
 
 SUPPORTED_BLOCK_TYPES = {
     BLOCK_TYPE_MDCONTENT_VALUE,
@@ -256,7 +257,7 @@ def _make_adapter(
     outline_bid: str,
     user_bid: str,
     run_session_bid: str,
-):
+) -> ListenElementRunAdapter:
     from flaskr.service.learn.listen_elements import ListenElementRunAdapter
 
     return ListenElementRunAdapter(
@@ -271,7 +272,7 @@ def _make_adapter(
 def _iter_active_group_rows(
     progress_record_bid: str,
     generated_block_bid: str,
-):
+) -> object:
     return LearnGeneratedElement.query.filter(
         LearnGeneratedElement.progress_record_bid == progress_record_bid,
         LearnGeneratedElement.generated_block_bid == generated_block_bid,

--- a/src/api/flaskr/service/learn/routes.py
+++ b/src/api/flaskr/service/learn/routes.py
@@ -3,8 +3,10 @@
 import json
 import sys
 import uuid
+from collections.abc import Iterator
 
 from flask import Flask, Response, request, stream_with_context
+from flask.typing import ResponseReturnValue
 from flaskr.common.shifu_context import get_shifu_context_snapshot, with_shifu_context
 from flaskr.dao import (
     db,
@@ -54,7 +56,7 @@ from pydantic import ValidationError
 from sqlalchemy import select
 
 
-def _normalize_user_input(value):
+def _normalize_user_input(value) -> dict[str, list[str]] | None:
     if value is None:
         return None
     if isinstance(value, dict):
@@ -107,7 +109,7 @@ def _stream_sse_response(
     error_event_factory=None,
     terminal_event_factory=None,
 ) -> Response:
-    def event_stream():
+    def event_stream() -> Iterator[str]:
         try:
             for message in message_iter_factory():
                 yield _to_sse_data_line(message)
@@ -152,7 +154,7 @@ def _stream_passthrough_response(
     close_log: str,
     error_log: str,
 ) -> Response:
-    def event_stream():
+    def event_stream() -> Iterator[str]:
         try:
             yield from message_iter_factory()
         except GeneratorExit:
@@ -238,7 +240,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     @app.route(path_prefix + "/shifu/<shifu_bid>", methods=["GET"])
     @bypass_token_validation
     @with_shifu_context()
-    def get_shifu_api(shifu_bid: str):
+    def get_shifu_api(shifu_bid: str) -> ResponseReturnValue:
         """Get shifu.
 
         ---
@@ -281,7 +283,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
 
     @app.route(path_prefix + "/shifu/<shifu_bid>/outline-item-tree", methods=["GET"])
     @with_shifu_context()
-    def get_outline_item_tree_api(shifu_bid: str):
+    def get_outline_item_tree_api(shifu_bid: str) -> ResponseReturnValue:
         """Get outline item tree.
 
         ---
@@ -326,7 +328,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
 
     @app.route(path_prefix + "/shifu/<shifu_bid>/run/<outline_bid>", methods=["PUT"])
     @with_shifu_context()
-    def run_outline_item_api(shifu_bid: str, outline_bid: str):
+    def run_outline_item_api(shifu_bid: str, outline_bid: str) -> ResponseReturnValue:
         """Run the MarkdownFlow of the outline.
 
         ---
@@ -433,7 +435,9 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["POST"],
     )
     @with_shifu_context()
-    def preview_outline_block_api(shifu_bid: str, outline_bid: str):
+    def preview_outline_block_api(
+        shifu_bid: str, outline_bid: str
+    ) -> ResponseReturnValue:
         """Preview a specific outline block.
 
         ---
@@ -589,7 +593,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["GET"],
     )
     @with_shifu_context()
-    def get_run_status_api(shifu_bid: str, outline_bid: str):
+    def get_run_status_api(shifu_bid: str, outline_bid: str) -> ResponseReturnValue:
         """Get run status.
 
         ---
@@ -628,7 +632,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         path_prefix + "/shifu/<shifu_bid>/records/<outline_bid>", methods=["GET"]
     )
     @with_shifu_context()
-    def get_record_api(shifu_bid: str, outline_bid: str):
+    def get_record_api(shifu_bid: str, outline_bid: str) -> ResponseReturnValue:
         """Get learn records of the outline.
 
         ---
@@ -692,7 +696,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         path_prefix + "/shifu/<shifu_bid>/records/<outline_bid>", methods=["DELETE"]
     )
     @with_shifu_context()
-    def delete_record_api(shifu_bid: str, outline_bid: str):
+    def delete_record_api(shifu_bid: str, outline_bid: str) -> ResponseReturnValue:
         """Reset the record of the outline.
 
         ---
@@ -729,7 +733,9 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["POST"],
     )
     @with_shifu_context()
-    def submit_lesson_feedback_api(shifu_bid: str, outline_bid: str):
+    def submit_lesson_feedback_api(
+        shifu_bid: str, outline_bid: str
+    ) -> ResponseReturnValue:
         """Submit lesson feedback.
 
         ---
@@ -791,7 +797,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
 
     @app.route(path_prefix + "/shifu/<shifu_bid>/lesson-feedbacks", methods=["GET"])
     @with_shifu_context()
-    def list_lesson_feedbacks_api(shifu_bid: str):
+    def list_lesson_feedbacks_api(shifu_bid: str) -> ResponseReturnValue:
         """List lesson feedbacks for a course (teacher/authoring side).
 
         ---
@@ -845,7 +851,9 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["POST"],
     )
     @with_shifu_context()
-    def generate_content_api(shifu_bid: str, generated_block_bid: str, action: str):
+    def generate_content_api(
+        shifu_bid: str, generated_block_bid: str, action: str
+    ) -> ResponseReturnValue:
         """Generate the content of the generated block.
 
         ---
@@ -890,7 +898,9 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["GET"],
     )
     @with_shifu_context()
-    def get_generated_content_api(shifu_bid: str, generated_block_bid: str):
+    def get_generated_content_api(
+        shifu_bid: str, generated_block_bid: str
+    ) -> ResponseReturnValue:
         """Get the content of the generated block.
 
         ---
@@ -941,7 +951,9 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["POST"],
     )
     @with_shifu_context()
-    def synthesize_generated_block_audio_api(shifu_bid: str, generated_block_bid: str):
+    def synthesize_generated_block_audio_api(
+        shifu_bid: str, generated_block_bid: str
+    ) -> ResponseReturnValue:
         """Synthesize audio for a generated block (C-end, persisted).
 
         ---
@@ -1009,7 +1021,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
 
     @app.route(path_prefix + "/shifu/<shifu_bid>/tts/preview", methods=["POST"])
     @with_shifu_context()
-    def synthesize_preview_tts_audio_api(shifu_bid: str):
+    def synthesize_preview_tts_audio_api(shifu_bid: str) -> ResponseReturnValue:
         """Synthesize audio for an arbitrary text (editor preview, not persisted).
 
         ---

--- a/src/api/flaskr/service/learn/run/state.py
+++ b/src/api/flaskr/service/learn/run/state.py
@@ -31,6 +31,7 @@ PR3 scope notes (mirroring the emitter's PR1 conventions):
 """
 
 import queue
+from types import ModuleType
 from typing import TYPE_CHECKING
 
 from flaskr.dao import db
@@ -59,7 +60,7 @@ def _find_outline_path_or_raise(
     return path
 
 
-def _runtime():
+def _runtime() -> ModuleType:
     """Resolve the context_v2 module lazily.
 
     Lazy for two reasons: ``context_v2`` imports this module at load time
@@ -99,7 +100,7 @@ class RunStateResolver:
         return self._context._preview_mode
 
     @property
-    def _outline_model(self):
+    def _outline_model(self) -> object:
         return self._context._outline_model
 
     @property
@@ -107,7 +108,7 @@ class RunStateResolver:
         return self._context._user_info.user_id
 
     @property
-    def _current_outline_item(self):
+    def _current_outline_item(self) -> object:
         return self._context._current_outline_item
 
     @property
@@ -216,7 +217,7 @@ class RunStateResolver:
 
         def _mark_sub_node_completed(
             outline_item_info: HistoryItem, res: list[OutlineItemUpdateDTO]
-        ):
+        ) -> None:
             q = queue.Queue()
             q.put(self._struct)
             if ctx._is_leaf_outline_item(outline_item_info):
@@ -283,7 +284,7 @@ class RunStateResolver:
 
         def _mark_sub_node_start(
             outline_item_info: HistoryItem, res: list[OutlineItemUpdateDTO]
-        ):
+        ) -> None:
             path = _find_outline_path_or_raise(self._struct, outline_item_info.bid)
             for item in path:
                 if item.type == "outline":

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -8,7 +8,7 @@ import threading
 import time
 import traceback
 import uuid
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -424,7 +424,7 @@ def run_script_inner(
             def _iter_run_events(
                 events,
                 ready_element_bids_by_block_bid: dict[str, list[str]],
-            ):
+            ) -> Iterator[RunElementSSEMessageDTO]:
                 if element_adapter is None:
                     for event in events:
                         _remember_audio_backfill_ready_element(
@@ -442,7 +442,7 @@ def run_script_inner(
 
             def _iter_audio_backfill_ready_events(
                 ready_element_bids_by_block_bid: dict[str, list[str]],
-            ):
+            ) -> Iterator[RunElementSSEMessageDTO]:
                 if input_type == INPUT_TYPE_ASK:
                     return
                 for (
@@ -764,7 +764,7 @@ def run_script(
         parent_shifu_context = shifu_context_snapshot or get_shifu_context_snapshot()
         producer_thread: threading.Thread | None = None
 
-        def producer():
+        def producer() -> None:
             # Propagate logging thread-local context into this background thread
             if parent_request_id:
                 log_thread_local.request_id = parent_request_id

--- a/src/api/flaskr/service/learn/utils_v2.py
+++ b/src/api/flaskr/service/learn/utils_v2.py
@@ -80,7 +80,7 @@ def safe_format_template(template: str, variables: dict) -> str:
     # Replace {xxx} or {{xxx}} with values from variables dict, keep original if not found
     pattern = re.compile(r"(\{{1,2})([^{}]+)(\}{1,2})")
 
-    def replacer(match):
+    def replacer(match) -> str:
         _, var, _ = match.groups()
         var_name = var.strip()
         # Only process variable names with letters, digits, underscore, hyphen

--- a/src/api/flaskr/service/llm/route.py
+++ b/src/api/flaskr/service/llm/route.py
@@ -1,6 +1,7 @@
 """Expose HTTP routes for LLM routing."""
 
 from flask import Flask
+from flask.typing import ResponseReturnValue
 from flaskr.api.llm import get_current_models
 from flaskr.framework.plugin.inject import inject
 from flaskr.route.common import make_common_response
@@ -12,7 +13,7 @@ def register_llm_routes(app: Flask, path_prefix="/api/llm") -> Flask:
     app.logger.info("register llm routes %s", path_prefix)
 
     @app.route(path_prefix + "/model-list", methods=["GET"])
-    def model_list_api():
+    def model_list_api() -> ResponseReturnValue:
         """Get model list.
 
         ---

--- a/src/api/flaskr/service/metering/routes.py
+++ b/src/api/flaskr/service/metering/routes.py
@@ -3,6 +3,7 @@
 import datetime
 
 from flask import Flask, request
+from flask.typing import ResponseReturnValue
 from flaskr.framework.plugin.inject import inject
 from flaskr.route.common import make_common_response
 from flaskr.service.common.models import raise_param_error
@@ -28,7 +29,7 @@ def register_metering_routes(app: Flask, path_prefix: str = "/api/metering") -> 
     """Register metering routes."""
 
     @app.route(path_prefix + "/usage-summary", methods=["GET"])
-    def get_usage_summary():
+    def get_usage_summary() -> ResponseReturnValue:
         start_date = request.args.get("start_date", "")
         end_date = request.args.get("end_date", "")
         user_bid = request.args.get("user_bid", "")

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -453,7 +453,7 @@ def _load_coupon_code_map(order_bids: list[str]) -> dict[str, list[str]]:
     return dict(coupon_map)
 
 
-def _build_coupon_usage_order_bid_subquery():
+def _build_coupon_usage_order_bid_subquery() -> object:
     return (
         db.session.query(CouponUsage.order_bid.label("order_bid"))
         .filter(
@@ -554,7 +554,7 @@ def _load_matching_shifu_bids_for_course_name(course_name: str) -> list[str]:
     return sorted(matched_shifu_bids)
 
 
-def _build_course_query_shifu_bid_filter(course_query: str):
+def _build_course_query_shifu_bid_filter(course_query: str) -> object:
     normalized_course_query = str(course_query or "").strip()
     like_value = f"%{normalized_course_query}%"
     draft_course_bids = db.session.query(DraftShifu.shifu_bid).filter(
@@ -572,7 +572,7 @@ def _build_course_query_shifu_bid_filter(course_query: str):
     )
 
 
-def _apply_order_source_filter(query, order_source: str):
+def _apply_order_source_filter(query, order_source: str) -> object:
     normalized_order_source = str(order_source or "").strip()
     if not normalized_order_source:
         return query

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -5,7 +5,7 @@ import decimal
 import json
 import re
 from collections.abc import Iterator
-from contextlib import contextmanager, nullcontext, suppress
+from contextlib import AbstractContextManager, contextmanager, nullcontext, suppress
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
@@ -161,7 +161,7 @@ class AICourseBuyRecordDTO:
     def __json__(self) -> dict:
         """Return the AI course buy record as JSON-compatible data."""
 
-        def format_decimal(value):
+        def format_decimal(value) -> str:
             # Convert to a string with two decimal places
             formatted_value = value if isinstance(value, str) else f"{value:.2f}"
             # If the decimal part is .00, remove it
@@ -670,7 +670,9 @@ def generate_charge(
     return None
 
 
-def _order_credential_scope(app: Flask, order: Order, context=None):
+def _order_credential_scope(
+    app: Flask, order: Order, context=None
+) -> AbstractContextManager[object]:
     """Use the immutable credential version snapshotted on the order."""
     integration_bid = str(order.payment_integration_bid or "")
     if not integration_bid:
@@ -1315,7 +1317,7 @@ def _update_stripe_order_snapshot(
     stripe_order: StripeOrder,
     session: dict[str, Any],
     intent: dict[str, Any] | None,
-):
+) -> None:
     if session:
         stripe_order.checkout_session_id = session.get(
             "id", stripe_order.checkout_session_id

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -25,6 +25,8 @@ from .base import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from flask import Flask
 
 _PINGPP_CONFIG_LOCK = threading.RLock()
@@ -40,9 +42,9 @@ class _PingppClientState:
 _pingpp_client_state = _PingppClientState()
 
 
-def _serialized_pingpp_config(func):
+def _serialized_pingpp_config(func) -> Callable[..., object]:
     @wraps(func)
-    def wrapped(*args: object, **kwargs: object):
+    def wrapped(*args: object, **kwargs: object) -> object:
         with _PINGPP_CONFIG_LOCK:
             return func(*args, **kwargs)
 

--- a/src/api/flaskr/service/order/payment_providers/stripe.py
+++ b/src/api/flaskr/service/order/payment_providers/stripe.py
@@ -27,7 +27,7 @@ class StripeProvider(PaymentProvider):
 
     channel = "stripe"
 
-    def _ensure_client(self, app: Flask):
+    def _ensure_client(self, app: Flask) -> object:
         return get_stripe_client_options(app)[0]
 
     def _client_options(self, app: Flask) -> tuple[Any, dict[str, Any]]:

--- a/src/api/flaskr/service/order/payment_providers/wechatpay.py
+++ b/src/api/flaskr/service/order/payment_providers/wechatpay.py
@@ -341,7 +341,7 @@ def _sign_with_merchant_key(message: str) -> str:
     return base64.b64encode(signature).decode("utf-8")
 
 
-def _load_private_key():
+def _load_private_key() -> object:
     inline = str(get_config("WECHATPAY_PRIVATE_KEY", "") or "").strip()
     pem = (
         inline.encode("utf-8")
@@ -351,7 +351,7 @@ def _load_private_key():
     return serialization.load_pem_private_key(pem, password=None)
 
 
-def _load_public_key_from_certificate():
+def _load_public_key_from_certificate() -> object:
     inline = str(get_config("WECHATPAY_PLATFORM_CERT", "") or "").strip()
     pem = (
         inline.encode("utf-8")

--- a/src/api/flaskr/service/profile/funcs.py
+++ b/src/api/flaskr/service/profile/funcs.py
@@ -92,7 +92,7 @@ def _update_aggregate_field(
         aggregate.birthday = value
 
 
-def _normalize_core_value(mapping: str, value):
+def _normalize_core_value(mapping: str, value) -> object:
     if mapping == "user_birth":
         if isinstance(value, datetime.date):
             return value
@@ -105,7 +105,7 @@ def _normalize_core_value(mapping: str, value):
     return value or ""
 
 
-def _apply_core_mapping(user_id: str, mapping: str, value):
+def _apply_core_mapping(user_id: str, mapping: str, value) -> object:
     entity = ensure_user_entity(user_id)
     normalized = _normalize_core_value(mapping, value)
     if mapping == "name":
@@ -119,7 +119,7 @@ def _apply_core_mapping(user_id: str, mapping: str, value):
     return normalized
 
 
-def _current_core_value(aggregate: UserAggregate | None, mapping: str):
+def _current_core_value(aggregate: UserAggregate | None, mapping: str) -> object:
     if not aggregate:
         return None
     if mapping == "name":

--- a/src/api/flaskr/service/profile/learner_profile_optimizer.py
+++ b/src/api/flaskr/service/profile/learner_profile_optimizer.py
@@ -22,6 +22,8 @@ from flaskr.service.profile.learner_profile import (
 from flaskr.util.prompt_loader import load_prompt_template
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from flask import Flask
 
 LEARNER_PROFILE_OPTIMIZATION_TIMEOUT_SECONDS = 15
@@ -39,7 +41,7 @@ def _parse_optimized_profile(raw_response: str) -> str:
     return raw_response
 
 
-def _exception_chain(exc: BaseException):
+def _exception_chain(exc: BaseException) -> Iterator[BaseException | None]:
     seen: set[int] = set()
     current: BaseException | None = exc
     while current is not None and id(current) not in seen:

--- a/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
+++ b/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
@@ -69,7 +69,7 @@ def _admission_key(app: Flask, *, user_id: str) -> str:
     )
 
 
-def _redis_client():
+def _redis_client() -> object:
     from flaskr.dao import get_redis_client
 
     return get_redis_client()

--- a/src/api/flaskr/service/profile/routes.py
+++ b/src/api/flaskr/service/profile/routes.py
@@ -1,6 +1,7 @@
 """Expose HTTP routes for learner profiles."""
 
 from flask import Flask, request
+from flask.typing import ResponseReturnValue
 from flaskr.framework.plugin.inject import inject
 from flaskr.route.common import make_common_response
 from flaskr.service.common import raise_error
@@ -20,7 +21,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
     """Register learner-profile routes on the Flask application."""
 
     @app.route(f"{path_prefix}/get-profile-item-definitions", methods=["GET"])
-    def get_profile_item_defination_api():
+    def get_profile_item_defination_api() -> ResponseReturnValue:
         """Get profile item defination.
 
         ---
@@ -67,7 +68,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/hide-unused-profile-items", methods=["POST"])
-    def hide_unused_profile_items_api():
+    def hide_unused_profile_items_api() -> ResponseReturnValue:
         """Hide all unused custom profile items under a shifu.
 
         ---
@@ -97,7 +98,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/profile-variable-usage", methods=["GET"])
-    def get_profile_variable_usage_api():
+    def get_profile_variable_usage_api() -> ResponseReturnValue:
         """Get variable usage across all outlines for a shifu.
 
         ---
@@ -121,7 +122,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/update-profile-hidden-state", methods=["POST"])
-    def update_profile_hidden_state_api():
+    def update_profile_hidden_state_api() -> ResponseReturnValue:
         """Hide or restore specific custom profile items.
 
         ---
@@ -165,7 +166,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/add-profile-item-quick", methods=["POST"])
-    def add_profile_item_quick_api():
+    def add_profile_item_quick_api() -> ResponseReturnValue:
         """Add profile item.
 
         ---
@@ -209,7 +210,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/save-profile-item", methods=["POST"])
-    def save_profile_item_api():
+    def save_profile_item_api() -> ResponseReturnValue:
         """Save profile item.
 
         ---
@@ -280,7 +281,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/delete-profile-item", methods=["POST"])
-    def delete_profile_item_api():
+    def delete_profile_item_api() -> ResponseReturnValue:
         """Delete profile item.
 
         ---
@@ -323,7 +324,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         return make_common_response(delete_profile_item(app, user_id, profile_id))
 
     @app.route(f"{path_prefix}/get-profile-item", methods=["POST"])
-    def get_profile_item_api():
+    def get_profile_item_api() -> None:
         """Get profile item."""
 
     return app

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -71,6 +71,7 @@ from sqlalchemy import and_, case, func, not_, or_
 
 if TYPE_CHECKING:
     from flask import Flask
+    from sqlalchemy.sql.elements import ColumnElement
 
 PROMOTION_SCOPE_ALL_COURSES = "all_courses"
 PROMOTION_SCOPE_SINGLE_COURSE = "single_course"
@@ -240,7 +241,7 @@ def _build_like_pattern(keyword: str) -> str:
     return f"%{escaped}%"
 
 
-def _build_user_keyword_query(keyword: str):
+def _build_user_keyword_query(keyword: str) -> object:
     like_pattern = _build_like_pattern(keyword)
     return (
         db.session.query(UserEntity.user_bid)
@@ -272,7 +273,9 @@ def _build_user_keyword_query(keyword: str):
     )
 
 
-def _apply_keyword_filter(query, keyword: str, user_bid_field, *text_fields: object):
+def _apply_keyword_filter(
+    query, keyword: str, user_bid_field, *text_fields: object
+) -> object:
     normalized = str(keyword or "").strip().lower()
     if not normalized:
         return query
@@ -285,7 +288,7 @@ def _apply_keyword_filter(query, keyword: str, user_bid_field, *text_fields: obj
     return query.filter(or_(*keyword_filters))
 
 
-def _build_coupon_status_filter(status: str):
+def _build_coupon_status_filter(status: str) -> ColumnElement[bool] | None:
     normalized = str(status or "").strip().lower()
     if not normalized:
         return None
@@ -313,7 +316,7 @@ def _build_coupon_status_filter(status: str):
     return None
 
 
-def _build_campaign_status_filter(status: str):
+def _build_campaign_status_filter(status: str) -> ColumnElement[bool] | None:
     normalized = str(status or "").strip().lower()
     if not normalized:
         return None

--- a/src/api/flaskr/service/promo/funcs.py
+++ b/src/api/flaskr/service/promo/funcs.py
@@ -1,7 +1,7 @@
 """Promo functions."""
 
 import decimal
-from contextlib import nullcontext
+from contextlib import AbstractContextManager, nullcontext
 
 from flask import Flask, has_app_context
 from flaskr.dao import db
@@ -56,7 +56,7 @@ def is_campaign_enabled_for_runtime(campaign) -> bool:
     )
 
 
-def _blank_legacy_bid_expression(column):
+def _blank_legacy_bid_expression(column) -> bool:
     normalized = func.coalesce(column, "")
     normalized = func.replace(normalized, "\t", "")
     normalized = func.replace(normalized, "\n", "")
@@ -88,7 +88,7 @@ def build_campaign_enabled_expression(model_or_columns) -> ColumnElement[bool]:
     )
 
 
-def _app_context_scope(app: Flask):
+def _app_context_scope(app: Flask) -> AbstractContextManager[object]:
     return nullcontext() if has_app_context() else app.app_context()
 
 

--- a/src/api/flaskr/service/referral/campaign_admin.py
+++ b/src/api/flaskr/service/referral/campaign_admin.py
@@ -696,7 +696,7 @@ def _assert_product_code_is_active_plan(product_code: str) -> None:
         raise_param_error("reward_product_code")
 
 
-def _apply_status_filter(query, status: str, *, now: datetime):
+def _apply_status_filter(query, status: str, *, now: datetime) -> object:
     if status == "active":
         return query.filter(
             ReferralCampaign.campaign_status == REFERRAL_CAMPAIGN_STATUS_ACTIVE,

--- a/src/api/flaskr/service/referral/routes.py
+++ b/src/api/flaskr/service/referral/routes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from flask import Flask, request
 from flaskr.route.common import bypass_token_validation, make_common_response
 from flaskr.service.common.models import raise_param_error
@@ -13,12 +15,15 @@ from .service import (
     record_invite_event,
 )
 
+if TYPE_CHECKING:
+    from flask.typing import ResponseReturnValue
+
 
 def register_referral_routes(app: Flask, path_prefix: str = "/api/referral") -> None:
     """Register referral routes."""
 
     @app.route(path_prefix + "/invite-profile", methods=["GET"])
-    def referral_invite_profile_api():
+    def referral_invite_profile_api() -> ResponseReturnValue:
         user = getattr(request, "user", None)
         user_bid = str(getattr(user, "user_id", "") or "").strip()
         if not user_bid:
@@ -28,7 +33,7 @@ def register_referral_routes(app: Flask, path_prefix: str = "/api/referral") -> 
 
     @app.route(path_prefix + "/invite-preview", methods=["GET"])
     @bypass_token_validation
-    def referral_invite_preview_api():
+    def referral_invite_preview_api() -> ResponseReturnValue:
         preview = build_invite_preview(
             app,
             invite_code=str(request.args.get("invite_code") or "").strip(),
@@ -37,7 +42,7 @@ def register_referral_routes(app: Flask, path_prefix: str = "/api/referral") -> 
 
     @app.route(path_prefix + "/invite-event", methods=["POST"])
     @bypass_token_validation
-    def referral_invite_event_api():
+    def referral_invite_event_api() -> ResponseReturnValue:
         payload = request.get_json(silent=True)
         payload = payload if isinstance(payload, dict) else {}
         result = record_invite_event(

--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -53,6 +53,7 @@ from .models import (
 from .reward_queue import build_referral_reward_queue
 
 if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
     from datetime import datetime
 
 _INVITE_CODE_ALPHABET = string.ascii_uppercase + string.digits
@@ -119,7 +120,7 @@ def extract_referral_post_auth_fields(
     }
 
 
-def _with_app_context(app: Flask):
+def _with_app_context(app: Flask) -> AbstractContextManager[object]:
     return app.app_context() if not has_app_context() else _NullContext()
 
 

--- a/src/api/flaskr/service/shifu/admin_course_summaries.py
+++ b/src/api/flaskr/service/shifu/admin_course_summaries.py
@@ -150,7 +150,7 @@ def _build_operator_visible_course_filter(
     shifu_bid_column,
     title_column,
     created_user_bid_column,
-):
+) -> object:
     normalized_shifu_bid = db.func.trim(db.func.coalesce(shifu_bid_column, ""))
     normalized_title = db.func.trim(db.func.coalesce(title_column, ""))
     normalized_created_user_bid = db.func.trim(
@@ -179,7 +179,7 @@ def _build_latest_operator_course_rows_query(
     creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
-):
+) -> object:
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
     )
@@ -221,7 +221,7 @@ def _build_latest_operator_course_rows_subquery(
     start_time: datetime | None,
     end_time: datetime | None,
     alias_name: str,
-):
+) -> object:
     base_query = _build_latest_operator_course_rows_query(
         model,
         shifu_bid=shifu_bid,
@@ -243,7 +243,7 @@ def _build_operator_course_candidate_query(
     start_time: datetime | None,
     end_time: datetime | None,
     include_activity: bool = False,
-):
+) -> object:
     draft_rows_subquery = _build_latest_operator_course_rows_subquery(
         DraftShifu,
         shifu_bid=shifu_bid,
@@ -403,7 +403,7 @@ def _build_latest_outline_activity_subquery(
     candidate_bids_subquery,
     *,
     alias_name: str,
-):
+) -> object:
     latest_outline_rows_subquery = (
         db.session.query(
             model.shifu_bid.label("shifu_bid"),
@@ -462,7 +462,7 @@ def _build_operator_course_latest_activity_subquery(
     candidate_bids_subquery,
     draft_visible_subquery,
     published_visible_subquery,
-):
+) -> object:
     draft_outline_activity_subquery = _build_latest_outline_activity_subquery(
         DraftOutlineItem,
         candidate_bids_subquery,
@@ -543,7 +543,7 @@ def _build_latest_shifus_query(
     updated_start_time: datetime | None,
     updated_end_time: datetime | None,
     lightweight: bool = False,
-):
+) -> object:
     is_mapped_model = hasattr(model, "__mapper__")
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
@@ -585,7 +585,7 @@ def _load_latest_shifus(
     updated_end_time: datetime | None,
     attach_prompt_flags: bool = False,
     lightweight: bool = False,
-):
+) -> list[OperatorCourseListSeed]:
     ordered_query = _build_latest_shifus_query(
         model,
         shifu_bid=shifu_bid,
@@ -746,7 +746,9 @@ def _load_course_activity_map(
     return load_course_activity_map(drafts, published)
 
 
-def _load_latest_course_for_transfer(shifu_bid: str):
+def _load_latest_course_for_transfer(
+    shifu_bid: str,
+) -> DraftShifu | PublishedShifu | None:
     draft = (
         DraftShifu.query.filter(
             DraftShifu.shifu_bid == shifu_bid,
@@ -848,7 +850,7 @@ def _build_outline_history_tree(
 def _merge_courses(
     drafts: Iterable[DraftShifu],
     published: Iterable[PublishedShifu],
-):
+) -> tuple[list[OperatorCourseListSeed], set[str], dict[str, str]]:
     course_map = {}
     published_bids: set[str] = set()
     selected_sources: dict[str, str] = {}
@@ -906,7 +908,7 @@ def _load_latest_courses_by_shifu_bids(
     shifu_bids: Sequence[str],
     *,
     lightweight: bool = False,
-):
+) -> list[OperatorCourseListSeed]:
     normalized_shifu_bids = [
         str(shifu_bid or "").strip() for shifu_bid in shifu_bids if shifu_bid
     ]

--- a/src/api/flaskr/service/shifu/admin_operations/config_rates.py
+++ b/src/api/flaskr/service/shifu/admin_operations/config_rates.py
@@ -37,6 +37,8 @@ from flaskr.util import generate_id
 from flaskr.util.datetime import now_utc, to_utc_iso
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from flask import Flask
 
 _RATE_METRICS = {
@@ -66,7 +68,7 @@ _CREDITS_PER_UNIT_MAX = Decimal("9999999999.9999999999")
 _ActiveRateIndex = dict[tuple[int, int, str, str], CreditUsageRate]
 
 
-def _rate_effective_now():
+def _rate_effective_now() -> datetime:
     # MySQL DATETIME columns in this schema do not keep fractional seconds.
     # Truncate before writing so a just-saved rate is immediately readable and
     # repeated saves in one second hit the same deterministic version.

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
@@ -404,7 +404,9 @@ def _build_course_credit_usage_learn_filter(
     )
 
 
-def _build_operator_course_credit_usage_ledger_totals_subquery(shifu_bid: str):
+def _build_operator_course_credit_usage_ledger_totals_subquery(
+    shifu_bid: str,
+) -> object:
     course_usage_bids = (
         db.session.query(BillUsageRecord.usage_bid.label("usage_bid"))
         .filter(
@@ -446,7 +448,7 @@ def _build_operator_course_credit_usage_base_query(
     shifu_bid: str,
     *,
     outline_item_bids: Sequence[str] | None = None,
-):
+) -> object:
     ledger_totals = _build_operator_course_credit_usage_ledger_totals_subquery(
         shifu_bid
     )
@@ -789,7 +791,7 @@ def _build_course_credit_usage_covered_completed_user_subquery(
     *,
     shifu_bid: str,
     leaf_outline_bids: Sequence[str],
-):
+) -> object:
     normalized_leaf_outline_bids = [
         str(outline_item_bid or "").strip()
         for outline_item_bid in leaf_outline_bids
@@ -1416,7 +1418,7 @@ def _build_latest_bill_usage_record_subquery(
     *,
     user_bid: str = "",
     usage_bids: Sequence[str] | None = None,
-):
+) -> object:
     normalized_user_bid = str(user_bid or "").strip()
     normalized_usage_bids = [
         str(usage_bid or "").strip()

--- a/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     from flask import Flask
 
 
-def _build_course_follow_up_base_subquery(shifu_bid: str):
+def _build_course_follow_up_base_subquery(shifu_bid: str) -> object:
     return (
         db.session.query(
             LearnGeneratedBlock.id.label("id"),

--- a/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
@@ -143,7 +143,7 @@ def _build_operator_visible_course_filter(
     shifu_bid_column,
     title_column,
     created_user_bid_column,
-):
+) -> object:
     normalized_shifu_bid = db.func.trim(db.func.coalesce(shifu_bid_column, ""))
     normalized_title = db.func.trim(db.func.coalesce(title_column, ""))
     normalized_created_user_bid = db.func.trim(
@@ -174,7 +174,7 @@ def _build_latest_operator_course_rows_query(
     creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
-):
+) -> object:
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
     )
@@ -270,7 +270,7 @@ def _build_latest_operator_course_rows_subquery(
     start_time: datetime | None,
     end_time: datetime | None,
     alias_name: str,
-):
+) -> object:
     base_query = _build_latest_operator_course_rows_query(
         model,
         shifu_bid=shifu_bid,
@@ -296,7 +296,7 @@ def _build_operator_course_candidate_query(
     start_time: datetime | None,
     end_time: datetime | None,
     include_activity: bool = False,
-):
+) -> object:
     draft_rows_subquery = _build_latest_operator_course_rows_subquery(
         DraftShifu,
         shifu_bid=shifu_bid,
@@ -478,7 +478,7 @@ def _build_latest_outline_activity_subquery(
     candidate_bids_subquery,
     *,
     alias_name: str,
-):
+) -> object:
     latest_outline_rows_subquery = (
         db.session.query(
             model.shifu_bid.label("shifu_bid"),
@@ -537,7 +537,7 @@ def _build_operator_course_latest_activity_subquery(
     candidate_bids_subquery,
     draft_visible_subquery,
     published_visible_subquery,
-):
+) -> object:
     draft_outline_activity_subquery = _build_latest_outline_activity_subquery(
         DraftOutlineItem,
         candidate_bids_subquery,
@@ -620,7 +620,7 @@ def _build_latest_shifus_query(
     updated_start_time: datetime | None,
     updated_end_time: datetime | None,
     lightweight: bool = False,
-):
+) -> object:
     is_mapped_model = hasattr(model, "__mapper__")
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
@@ -730,7 +730,7 @@ def _load_latest_shifus(
     updated_end_time: datetime | None,
     attach_prompt_flags: bool = False,
     lightweight: bool = False,
-):
+) -> list[OperatorCourseListSeed]:
     ordered_query = _build_latest_shifus_query(
         model,
         shifu_bid=shifu_bid,
@@ -886,7 +886,7 @@ def _apply_operator_course_list_filters(
     updated_start_time: datetime | None,
     updated_end_time: datetime | None,
     apply_updated_filters: bool,
-):
+) -> object:
     if course_status in {COURSE_STATUS_PUBLISHED, COURSE_STATUS_UNPUBLISHED}:
         query = query.filter(candidate_subquery.c.course_status == course_status)
     if quick_filter:
@@ -1008,7 +1008,7 @@ def _load_recent_paid_order_course_bids(
     }
 
 
-def _build_latest_billing_order_subquery(*, creator_bid: str):
+def _build_latest_billing_order_subquery(*, creator_bid: str) -> object:
     normalized_creator_bid = str(creator_bid or "").strip()
     return (
         db.session.query(

--- a/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
@@ -510,7 +510,7 @@ def _resolve_course_user_learning_status(
     return COURSE_USER_LEARNING_STATUS_NOT_STARTED
 
 
-def _build_course_order_amount_expr():
+def _build_course_order_amount_expr() -> object:
     return case(
         (Order.paid_price > 0, Order.paid_price),
         (Order.payable_price > 0, Order.payable_price),
@@ -592,7 +592,7 @@ def _is_operator_visible_course(course) -> bool:
 def _merge_courses(
     drafts: Iterable[DraftShifu],
     published: Iterable[PublishedShifu],
-):
+) -> tuple[list[object], set[str], dict[str, str]]:
     course_map = {}
     published_bids: set[str] = set()
     selected_sources: dict[str, str] = {}
@@ -645,7 +645,7 @@ def _load_latest_course_versions(
     return draft, published
 
 
-def _load_operator_course_detail_source(shifu_bid: str):
+def _load_operator_course_detail_source(shifu_bid: str) -> dict[str, object] | None:
     draft, published = _load_latest_course_versions(shifu_bid)
     visible_draft = draft if draft and _is_operator_visible_course(draft) else None
     visible_published = (
@@ -662,7 +662,9 @@ def _load_operator_course_detail_source(shifu_bid: str):
     }
 
 
-def _load_latest_outline_items(model, shifu_bid: str):
+def _load_latest_outline_items(
+    model, shifu_bid: str
+) -> list[DraftOutlineItem | PublishedOutlineItem]:
     latest_subquery = (
         db.session.query(db.func.max(model.id).label("max_id"))
         .filter(

--- a/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
@@ -69,7 +69,9 @@ if TYPE_CHECKING:
     from datetime import datetime
 
 
-def _load_latest_course_for_transfer(shifu_bid: str):
+def _load_latest_course_for_transfer(
+    shifu_bid: str,
+) -> DraftShifu | PublishedShifu | None:
     draft = (
         DraftShifu.query.filter(
             DraftShifu.shifu_bid == shifu_bid,

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 from flask import Flask, request
 from flaskr.common.config import get_config
@@ -107,6 +108,9 @@ from flaskr.service.shifu.admin_operations.voice_clones import (
 )
 from flaskr.util.datetime import parse_naive_utc
 from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from flask.typing import ResponseReturnValue
 
 MAX_CONTACT_LENGTH = 320
 PHONE_PATTERN = re.compile(r"^\d{11}$")
@@ -311,7 +315,7 @@ def register_admin_operations_routes(
     """Register operator admin operation routes."""
 
     @app.route(path_prefix + "/admin/operations/courses", methods=["GET"])
-    def admin_operations_courses():
+    def admin_operations_courses() -> ResponseReturnValue:
         """Operator course list.
 
         ---
@@ -437,7 +441,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/courses/overview", methods=["GET"])
-    def admin_operations_course_overview():
+    def admin_operations_course_overview() -> ResponseReturnValue:
         """Operator course overview.
 
         ---
@@ -461,7 +465,7 @@ def register_admin_operations_routes(
         return make_common_response(get_operator_course_overview(app))
 
     @app.route(path_prefix + "/admin/operations/users", methods=["GET"])
-    def admin_operations_users():
+    def admin_operations_users() -> ResponseReturnValue:
         """Operator user list.
 
         ---
@@ -576,7 +580,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/users/overview", methods=["GET"])
-    def admin_operations_user_overview():
+    def admin_operations_user_overview() -> ResponseReturnValue:
         """Operator user overview.
 
         ---
@@ -600,7 +604,7 @@ def register_admin_operations_routes(
         return make_common_response(get_operator_user_overview(app))
 
     @app.route(path_prefix + "/admin/operations/voice-clones", methods=["GET"])
-    def admin_operations_voice_clones():
+    def admin_operations_voice_clones() -> ResponseReturnValue:
         """Operator MiniMax cloned voice list.
 
         ---
@@ -721,7 +725,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/voice-clones", methods=["POST"])
-    def admin_operations_register_voice_clone():
+    def admin_operations_register_voice_clone() -> ResponseReturnValue:
         """Register a voice cloned on a provider console and assign it to a teacher.
 
         ---
@@ -763,7 +767,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/orders", methods=["GET"])
-    def admin_operations_orders():
+    def admin_operations_orders() -> ResponseReturnValue:
         """Operator global order list.
 
         ---
@@ -865,7 +869,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/orders/overview", methods=["GET"])
-    def admin_operations_order_overview():
+    def admin_operations_order_overview() -> ResponseReturnValue:
         """Operator learning order overview.
 
         ---
@@ -892,7 +896,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/overview",
         methods=["GET"],
     )
-    def admin_operation_credit_notifications_overview():
+    def admin_operation_credit_notifications_overview() -> ResponseReturnValue:
         """Return global operator credit notification overview."""
         _require_operator()
         return make_common_response(get_operator_credit_notification_overview(app))
@@ -901,7 +905,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications",
         methods=["GET"],
     )
-    def admin_operation_credit_notifications():
+    def admin_operation_credit_notifications() -> ResponseReturnValue:
         """List operator credit notification records."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -973,7 +977,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/<notification_bid>",
         methods=["GET"],
     )
-    def admin_operation_credit_notification_detail(notification_bid: str):
+    def admin_operation_credit_notification_detail(
+        notification_bid: str,
+    ) -> ResponseReturnValue:
         """Return one operator credit notification record detail."""
         _require_operator()
         return make_common_response(
@@ -987,7 +993,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/config",
         methods=["GET"],
     )
-    def admin_operation_credit_notification_config():
+    def admin_operation_credit_notification_config() -> ResponseReturnValue:
         """Get operator credit notification config."""
         _require_operator()
         return make_common_response(get_operator_credit_notification_config(app))
@@ -996,7 +1002,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/config",
         methods=["POST"],
     )
-    def admin_operation_update_credit_notification_config():
+    def admin_operation_update_credit_notification_config() -> ResponseReturnValue:
         """Update operator credit notification config."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1014,7 +1020,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/profile-onboarding",
         methods=["GET"],
     )
-    def admin_operation_profile_onboarding_config():
+    def admin_operation_profile_onboarding_config() -> ResponseReturnValue:
         """Get operator profile onboarding config."""
         _require_operator()
         return make_common_response(get_operator_profile_onboarding_config(app))
@@ -1023,7 +1029,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/profile-onboarding",
         methods=["POST"],
     )
-    def admin_operation_update_profile_onboarding_config():
+    def admin_operation_update_profile_onboarding_config() -> ResponseReturnValue:
         """Update operator profile onboarding config."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1041,7 +1047,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/config/rates",
         methods=["GET"],
     )
-    def admin_operation_rate_config():
+    def admin_operation_rate_config() -> ResponseReturnValue:
         """Get operator-managed model and TTS credit rate config."""
         _require_operator()
         return make_common_response(get_operator_rate_config(app))
@@ -1050,7 +1056,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/config/rates",
         methods=["POST"],
     )
-    def admin_operation_update_rate_config():
+    def admin_operation_update_rate_config() -> ResponseReturnValue:
         """Update one operator-managed model or TTS credit rate config."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1068,7 +1074,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/templates/sync",
         methods=["POST"],
     )
-    def admin_operation_credit_notification_template_sync():
+    def admin_operation_credit_notification_template_sync() -> ResponseReturnValue:
         """Sync one SMS template for operator credit notification config."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1086,7 +1092,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/templates",
         methods=["GET"],
     )
-    def admin_operation_credit_notification_templates():
+    def admin_operation_credit_notification_templates() -> ResponseReturnValue:
         """List SMS templates for operator credit notification config."""
         _require_operator()
         return make_common_response(list_operator_credit_notification_templates(app))
@@ -1095,7 +1101,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/dry-run",
         methods=["POST"],
     )
-    def admin_operation_credit_notification_dry_run():
+    def admin_operation_credit_notification_dry_run() -> ResponseReturnValue:
         """Dry-run operator credit notification scans."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1114,7 +1120,9 @@ def register_admin_operations_routes(
         + "/admin/operations/credit-notifications/<notification_bid>/requeue",
         methods=["POST"],
     )
-    def admin_operation_credit_notification_requeue(notification_bid: str):
+    def admin_operation_credit_notification_requeue(
+        notification_bid: str,
+    ) -> ResponseReturnValue:
         """Requeue one failed provider credit notification."""
         _require_operator()
         return make_common_response(
@@ -1129,7 +1137,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/orders/<order_bid>/detail",
         methods=["GET"],
     )
-    def admin_operation_order_detail(order_bid: str):
+    def admin_operation_order_detail(order_bid: str) -> ResponseReturnValue:
         """Get operator order detail.
 
         ---
@@ -1151,7 +1159,7 @@ def register_admin_operations_routes(
         return make_common_response(get_operator_order_detail(app, order_bid))
 
     @app.route(path_prefix + "/admin/operations/orders/credits", methods=["GET"])
-    def admin_operations_credit_orders():
+    def admin_operations_credit_orders() -> ResponseReturnValue:
         """Operator global credit order list.
 
         ---
@@ -1256,7 +1264,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/orders/credits/overview",
         methods=["GET"],
     )
-    def admin_operations_credit_order_overview():
+    def admin_operations_credit_order_overview() -> ResponseReturnValue:
         """Operator credit order overview.
 
         ---
@@ -1280,7 +1288,7 @@ def register_admin_operations_routes(
         return make_common_response(build_operator_credit_orders_overview(app))
 
     @app.route(path_prefix + "/admin/operations/referrals", methods=["GET"])
-    def admin_operations_referrals():
+    def admin_operations_referrals() -> ResponseReturnValue:
         """List operator-visible referral invite relations."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1336,7 +1344,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/referrals/overview", methods=["GET"])
-    def admin_operations_referrals_overview():
+    def admin_operations_referrals_overview() -> ResponseReturnValue:
         """Return operator referral overview metrics."""
         _require_operator()
         return make_common_response(get_operator_referral_overview(app))
@@ -1345,7 +1353,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/referrals/<relation_bid>",
         methods=["GET"],
     )
-    def admin_operations_referral_detail(relation_bid: str):
+    def admin_operations_referral_detail(relation_bid: str) -> ResponseReturnValue:
         """Return one operator referral relation detail."""
         _require_operator()
         return make_common_response(
@@ -1356,7 +1364,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/referrals/<relation_bid>/status",
         methods=["POST"],
     )
-    def admin_operations_referral_status(relation_bid: str):
+    def admin_operations_referral_status(relation_bid: str) -> ResponseReturnValue:
         """Update one referral relation or reward operator status."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1375,7 +1383,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/referrals/<relation_bid>/adjustment",
         methods=["POST"],
     )
-    def admin_operations_referral_adjustment(relation_bid: str):
+    def admin_operations_referral_adjustment(relation_bid: str) -> ResponseReturnValue:
         """Apply an audited operator adjustment to one referral relation."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1394,7 +1402,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/referral-campaigns",
         methods=["GET"],
     )
-    def admin_operations_promotion_referral_campaigns():
+    def admin_operations_promotion_referral_campaigns() -> ResponseReturnValue:
         """Operator referral campaign configuration list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1443,7 +1451,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/referral-campaigns",
         methods=["POST"],
     )
-    def admin_create_operations_promotion_referral_campaign():
+    def admin_create_operations_promotion_referral_campaign() -> ResponseReturnValue:
         """Create operator referral campaign configuration."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1461,7 +1469,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/referral-campaigns/<campaign_bid>",
         methods=["GET"],
     )
-    def admin_operations_promotion_referral_campaign_detail(campaign_bid: str):
+    def admin_operations_promotion_referral_campaign_detail(
+        campaign_bid: str,
+    ) -> ResponseReturnValue:
         """Get operator referral campaign configuration detail."""
         _require_operator()
         return make_common_response(
@@ -1473,7 +1483,9 @@ def register_admin_operations_routes(
         + "/admin/operations/promotions/referral-campaigns/<campaign_bid>/relations",
         methods=["GET"],
     )
-    def admin_operations_promotion_referral_campaign_relations(campaign_bid: str):
+    def admin_operations_promotion_referral_campaign_relations(
+        campaign_bid: str,
+    ) -> ResponseReturnValue:
         """List invite relations for one referral campaign."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1533,7 +1545,9 @@ def register_admin_operations_routes(
         + "/admin/operations/promotions/referral-campaigns/<campaign_bid>/invitations",
         methods=["GET"],
     )
-    def admin_operations_promotion_referral_campaign_invitations(campaign_bid: str):
+    def admin_operations_promotion_referral_campaign_invitations(
+        campaign_bid: str,
+    ) -> ResponseReturnValue:
         """List invite-code funnel data for one referral campaign."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1585,7 +1599,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/referral-campaigns/<campaign_bid>",
         methods=["POST"],
     )
-    def admin_update_operations_promotion_referral_campaign(campaign_bid: str):
+    def admin_update_operations_promotion_referral_campaign(
+        campaign_bid: str,
+    ) -> ResponseReturnValue:
         """Update operator referral campaign configuration."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1605,7 +1621,9 @@ def register_admin_operations_routes(
         + "/admin/operations/promotions/referral-campaigns/<campaign_bid>/status",
         methods=["POST"],
     )
-    def admin_operations_promotion_referral_campaign_status(campaign_bid: str):
+    def admin_operations_promotion_referral_campaign_status(
+        campaign_bid: str,
+    ) -> ResponseReturnValue:
         """Update operator referral campaign configuration status."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1621,7 +1639,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/promotions/coupons", methods=["GET"])
-    def admin_operations_promotion_coupons():
+    def admin_operations_promotion_coupons() -> ResponseReturnValue:
         """Operator coupon batch list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1670,7 +1688,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/promotions/coupons", methods=["POST"])
-    def admin_create_operations_promotion_coupon():
+    def admin_create_operations_promotion_coupon() -> ResponseReturnValue:
         """Create operator coupon batch."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1682,7 +1700,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>",
         methods=["POST"],
     )
-    def admin_update_operations_promotion_coupon(coupon_bid: str):
+    def admin_update_operations_promotion_coupon(
+        coupon_bid: str,
+    ) -> ResponseReturnValue:
         """Update operator coupon batch."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1696,7 +1716,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/orders/credits/<bill_order_bid>/detail",
         methods=["GET"],
     )
-    def admin_operation_credit_order_detail(bill_order_bid: str):
+    def admin_operation_credit_order_detail(bill_order_bid: str) -> ResponseReturnValue:
         """Get operator credit order detail.
 
         ---
@@ -1726,7 +1746,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>",
         methods=["GET"],
     )
-    def admin_operations_promotion_coupon_detail(coupon_bid: str):
+    def admin_operations_promotion_coupon_detail(
+        coupon_bid: str,
+    ) -> ResponseReturnValue:
         """Get operator coupon batch detail."""
         _require_operator()
         return make_common_response(
@@ -1737,7 +1759,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>/status",
         methods=["POST"],
     )
-    def admin_operations_promotion_coupon_status(coupon_bid: str):
+    def admin_operations_promotion_coupon_status(
+        coupon_bid: str,
+    ) -> ResponseReturnValue:
         """Update operator coupon batch status."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1755,7 +1779,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>/usages",
         methods=["GET"],
     )
-    def admin_operations_promotion_coupon_usages(coupon_bid: str):
+    def admin_operations_promotion_coupon_usages(
+        coupon_bid: str,
+    ) -> ResponseReturnValue:
         """Get operator coupon usage list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1786,7 +1812,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>/codes",
         methods=["GET"],
     )
-    def admin_operations_promotion_coupon_codes(coupon_bid: str):
+    def admin_operations_promotion_coupon_codes(coupon_bid: str) -> ResponseReturnValue:
         """Get operator coupon code pool list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1809,7 +1835,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/promotions/campaigns", methods=["GET"])
-    def admin_operations_promotion_campaigns():
+    def admin_operations_promotion_campaigns() -> ResponseReturnValue:
         """Operator campaign list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1860,7 +1886,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns",
         methods=["POST"],
     )
-    def admin_create_operations_promotion_campaign():
+    def admin_create_operations_promotion_campaign() -> ResponseReturnValue:
         """Create operator campaign."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1872,7 +1898,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns/<promo_bid>",
         methods=["GET"],
     )
-    def admin_operations_promotion_campaign_detail(promo_bid: str):
+    def admin_operations_promotion_campaign_detail(
+        promo_bid: str,
+    ) -> ResponseReturnValue:
         """Get operator campaign detail."""
         _require_operator()
         return make_common_response(
@@ -1883,7 +1911,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns/<promo_bid>",
         methods=["POST"],
     )
-    def admin_update_operations_promotion_campaign(promo_bid: str):
+    def admin_update_operations_promotion_campaign(
+        promo_bid: str,
+    ) -> ResponseReturnValue:
         """Update operator campaign."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1897,7 +1927,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns/<promo_bid>/status",
         methods=["POST"],
     )
-    def admin_operations_promotion_campaign_status(promo_bid: str):
+    def admin_operations_promotion_campaign_status(
+        promo_bid: str,
+    ) -> ResponseReturnValue:
         """Update operator campaign status."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1915,7 +1947,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns/<promo_bid>/redemptions",
         methods=["GET"],
     )
-    def admin_operations_promotion_campaign_redemptions(promo_bid: str):
+    def admin_operations_promotion_campaign_redemptions(
+        promo_bid: str,
+    ) -> ResponseReturnValue:
         """Get operator campaign redemption list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1944,7 +1978,7 @@ def register_admin_operations_routes(
     @app.route(
         path_prefix + "/admin/operations/users/<user_bid>/detail", methods=["GET"]
     )
-    def admin_operation_user_detail(user_bid: str):
+    def admin_operation_user_detail(user_bid: str) -> ResponseReturnValue:
         """Get operator user detail.
 
         ---
@@ -1966,7 +2000,7 @@ def register_admin_operations_routes(
     @app.route(
         path_prefix + "/admin/operations/users/<user_bid>/credits", methods=["GET"]
     )
-    def admin_operation_user_credits(user_bid: str):
+    def admin_operation_user_credits(user_bid: str) -> ResponseReturnValue:
         """Get operator user credits detail.
 
         ---
@@ -2073,7 +2107,9 @@ def register_admin_operations_routes(
         + "/admin/operations/users/<user_bid>/credits/usages/<usage_bid>/detail",
         methods=["GET"],
     )
-    def admin_operation_user_credit_usage_detail(user_bid: str, usage_bid: str):
+    def admin_operation_user_credit_usage_detail(
+        user_bid: str, usage_bid: str
+    ) -> ResponseReturnValue:
         """Get operator user credit usage content detail.
 
         ---
@@ -2107,7 +2143,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/users/<user_bid>/credit-grant/bootstrap",
         methods=["GET"],
     )
-    def admin_operation_user_credit_grant_bootstrap(user_bid: str):
+    def admin_operation_user_credit_grant_bootstrap(
+        user_bid: str,
+    ) -> ResponseReturnValue:
         """Get operator user grant bootstrap.
 
         ---
@@ -2135,7 +2173,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/users/<user_bid>/credits/grant",
         methods=["POST"],
     )
-    def admin_operation_user_credit_grant(user_bid: str):
+    def admin_operation_user_credit_grant(user_bid: str) -> ResponseReturnValue:
         """Grant operator user credits.
 
         ---
@@ -2178,7 +2216,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/users/<user_bid>/packages/grant",
         methods=["POST"],
     )
-    def admin_operation_user_package_grant(user_bid: str):
+    def admin_operation_user_package_grant(user_bid: str) -> ResponseReturnValue:
         """Grant operator user package.
 
         ---
@@ -2221,7 +2259,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/prompt",
         methods=["GET"],
     )
-    def admin_operation_course_prompt(shifu_bid: str):
+    def admin_operation_course_prompt(shifu_bid: str) -> ResponseReturnValue:
         """Get operator course prompt."""
         _require_operator()
         return make_common_response(
@@ -2231,7 +2269,7 @@ def register_admin_operations_routes(
     @app.route(
         path_prefix + "/admin/operations/courses/<shifu_bid>/detail", methods=["GET"]
     )
-    def admin_operation_course_detail(shifu_bid: str):
+    def admin_operation_course_detail(shifu_bid: str) -> ResponseReturnValue:
         """Get operator course detail.
 
         ---
@@ -2270,7 +2308,9 @@ def register_admin_operations_routes(
         + "/admin/operations/courses/<shifu_bid>/chapters/<outline_item_bid>/detail",
         methods=["GET"],
     )
-    def admin_operation_course_chapter_detail(shifu_bid: str, outline_item_bid: str):
+    def admin_operation_course_chapter_detail(
+        shifu_bid: str, outline_item_bid: str
+    ) -> ResponseReturnValue:
         """Get operator course chapter detail.
 
         ---
@@ -2313,7 +2353,7 @@ def register_admin_operations_routes(
     @app.route(
         path_prefix + "/admin/operations/courses/<shifu_bid>/users", methods=["GET"]
     )
-    def admin_operation_course_users(shifu_bid: str):
+    def admin_operation_course_users(shifu_bid: str) -> ResponseReturnValue:
         """Get operator course users.
 
         ---
@@ -2390,7 +2430,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/credit-usages",
         methods=["GET"],
     )
-    def admin_operation_course_credit_usages(shifu_bid: str):
+    def admin_operation_course_credit_usages(shifu_bid: str) -> ResponseReturnValue:
         """Get operator course credit usage list.
 
         ---
@@ -2492,7 +2532,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/credit-usages/details",
         methods=["GET"],
     )
-    def admin_operation_course_credit_usage_details(shifu_bid: str):
+    def admin_operation_course_credit_usage_details(
+        shifu_bid: str,
+    ) -> ResponseReturnValue:
         """Get operator course credit usage detail list.
 
         ---
@@ -2529,7 +2571,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/ratings",
         methods=["GET"],
     )
-    def admin_operation_course_ratings(shifu_bid: str):
+    def admin_operation_course_ratings(shifu_bid: str) -> ResponseReturnValue:
         """Get operator course rating list.
 
         ---
@@ -2654,7 +2696,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/follow-ups",
         methods=["GET"],
     )
-    def admin_operation_course_follow_ups(shifu_bid: str):
+    def admin_operation_course_follow_ups(shifu_bid: str) -> ResponseReturnValue:
         """Get operator course follow-up list.
 
         ---
@@ -2765,7 +2807,7 @@ def register_admin_operations_routes(
     def admin_operation_course_follow_up_detail(
         shifu_bid: str,
         generated_block_bid: str,
-    ):
+    ) -> ResponseReturnValue:
         """Get operator course follow-up detail.
 
         ---
@@ -2799,7 +2841,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/copy",
         methods=["POST"],
     )
-    def admin_copy_course(shifu_bid: str):
+    def admin_copy_course(shifu_bid: str) -> ResponseReturnValue:
         _require_operator()
         payload = request.get_json(silent=True) or {}
         if not isinstance(payload, dict):
@@ -2833,7 +2875,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/transfer-creator",
         methods=["POST"],
     )
-    def admin_transfer_course_creator(shifu_bid: str):
+    def admin_transfer_course_creator(shifu_bid: str) -> ResponseReturnValue:
         _require_operator()
         payload = request.get_json(silent=True) or {}
         if not isinstance(payload, dict):

--- a/src/api/flaskr/service/shifu/admin_operations/users.py
+++ b/src/api/flaskr/service/shifu/admin_operations/users.py
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
     from flask import Flask
 
 
-def _build_user_query_filter(user_query: str):
+def _build_user_query_filter(user_query: str) -> object:
     normalized_query = str(user_query or "").strip()
     like_pattern = f"%{normalized_query}%"
     credential_user_bids = db.session.query(AuthCredential.user_bid).filter(

--- a/src/api/flaskr/service/shifu/admin_user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_user_credits.py
@@ -337,7 +337,9 @@ def _build_course_credit_usage_learn_filter(
     )
 
 
-def _build_operator_course_credit_usage_ledger_totals_subquery(shifu_bid: str):
+def _build_operator_course_credit_usage_ledger_totals_subquery(
+    shifu_bid: str,
+) -> object:
     course_usage_bids = (
         db.session.query(BillUsageRecord.usage_bid.label("usage_bid"))
         .filter(
@@ -379,7 +381,7 @@ def _build_operator_course_credit_usage_base_query(
     shifu_bid: str,
     *,
     outline_item_bids: Sequence[str] | None = None,
-):
+) -> object:
     ledger_totals = _build_operator_course_credit_usage_ledger_totals_subquery(
         shifu_bid
     )
@@ -714,7 +716,7 @@ def _build_course_credit_usage_covered_completed_user_subquery(
     *,
     shifu_bid: str,
     leaf_outline_bids: Sequence[str],
-):
+) -> object:
     normalized_leaf_outline_bids = [
         str(outline_item_bid or "").strip()
         for outline_item_bid in leaf_outline_bids

--- a/src/api/flaskr/service/shifu/admin_user_profiles.py
+++ b/src/api/flaskr/service/shifu/admin_user_profiles.py
@@ -247,7 +247,7 @@ def _resolve_course_user_learning_status(
     return COURSE_USER_LEARNING_STATUS_NOT_STARTED
 
 
-def _build_course_order_amount_expr():
+def _build_course_order_amount_expr() -> object:
     return case(
         (Order.paid_price > 0, Order.paid_price),
         (Order.payable_price > 0, Order.payable_price),
@@ -353,7 +353,7 @@ def _resolve_operator_user_role(
     )[0]
 
 
-def _build_learner_user_bid_subquery():
+def _build_learner_user_bid_subquery() -> object:
     order_query = db.session.query(Order.user_bid.label("user_bid")).filter(
         Order.deleted == 0,
         Order.status == ORDER_STATUS_SUCCESS,
@@ -377,7 +377,7 @@ def _build_recent_learning_active_user_bid_subquery(
     *,
     since: datetime,
     until: datetime,
-):
+) -> object:
     activity_at = db.func.coalesce(
         LearnProgressRecord.updated_at,
         LearnProgressRecord.created_at,
@@ -400,7 +400,7 @@ def _build_recent_paid_user_bid_subquery(
     *,
     since: datetime,
     until: datetime,
-):
+) -> object:
     return (
         db.session.query(Order.user_bid.label("user_bid"))
         .filter(
@@ -415,7 +415,7 @@ def _build_recent_paid_user_bid_subquery(
     )
 
 
-def _build_registered_user_timestamp_subquery():
+def _build_registered_user_timestamp_subquery() -> object:
     registered_states = [USER_STATE_REGISTERED, USER_STATE_TRAIL, USER_STATE_PAID]
     credential_subquery = (
         db.session.query(

--- a/src/api/flaskr/service/shifu/repair.py
+++ b/src/api/flaskr/service/shifu/repair.py
@@ -104,7 +104,7 @@ class OutlineStructureRepairResult:
         }
 
 
-def _apply_shifu_scope(query, shifu_bids: list[str] | str | None):
+def _apply_shifu_scope(query, shifu_bids: list[str] | str | None) -> object:
     if shifu_bids is None:
         return query
     if isinstance(shifu_bids, str):

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -47,6 +47,7 @@ from flask import (
     request,
     send_file,
 )
+from flask.typing import ResponseReturnValue
 from flaskr.api.langfuse import (
     create_trace_with_root_span,
     finalize_langfuse_trace,
@@ -179,7 +180,7 @@ class ShifuTokenValidation:
         """Validate the course token before invoking the route."""
 
         @wraps(f)
-        def decorated_function(*args: object, **kwargs: object):
+        def decorated_function(*args: object, **kwargs: object) -> object:
             token = request.cookies.get("token", None)
             if not token:
                 token = request.args.get("token", None)
@@ -429,7 +430,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/shifus", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def get_shifu_list_api():
+    def get_shifu_list_api() -> ResponseReturnValue:
         """Get shifu list.
 
         ---
@@ -499,21 +500,21 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/shifus/<shifu_id>/archive", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def archive_shifu_api(shifu_id: str):
+    def archive_shifu_api(shifu_id: str) -> ResponseReturnValue:
         user_id = request.user.user_id
         archive_shifu(app, user_id, shifu_id)
         return make_common_response({"archived": True})
 
     @app.route(path_prefix + "/shifus/<shifu_id>/unarchive", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def unarchive_shifu_api(shifu_id: str):
+    def unarchive_shifu_api(shifu_id: str) -> ResponseReturnValue:
         user_id = request.user.user_id
         unarchive_shifu(app, user_id, shifu_id)
         return make_common_response({"archived": False})
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/permissions", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def list_shifu_permissions_api(shifu_bid: str):
+    def list_shifu_permissions_api(shifu_bid: str) -> ResponseReturnValue:
         """List shared permissions for a shifu."""
         owner_id = _require_shifu_owner(shifu_bid)
         contact_type = _normalize_contact_type(request.args.get("contact_type", ""))
@@ -571,7 +572,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
         methods=["POST"],
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def grant_shifu_permissions_api(shifu_bid: str):
+    def grant_shifu_permissions_api(shifu_bid: str) -> ResponseReturnValue:
         """Grant shared permissions for a shifu."""
         owner_id = _require_shifu_owner(shifu_bid)
         payload = request.get_json() or {}
@@ -727,7 +728,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
         methods=["POST"],
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def remove_shifu_permissions_api(shifu_bid: str):
+    def remove_shifu_permissions_api(shifu_bid: str) -> ResponseReturnValue:
         """Remove a shared permission from a shifu."""
         owner_id = _require_shifu_owner(shifu_bid)
         payload = request.get_json() or {}
@@ -749,7 +750,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/shifus", methods=["PUT"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def create_shifu_api():
+    def create_shifu_api() -> ResponseReturnValue:
         """Create shifu.
 
         ---
@@ -803,7 +804,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/detail", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_shifu_detail_api(shifu_bid: str):
+    def get_shifu_detail_api(shifu_bid: str) -> ResponseReturnValue:
         """Get shifu detail.
 
         ---
@@ -842,7 +843,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/detail", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def save_shifu_detail_api(shifu_bid: str):
+    def save_shifu_detail_api(shifu_bid: str) -> ResponseReturnValue:
         """Save shifu detail.
 
         ---
@@ -1033,7 +1034,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/favorite", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
     @with_shifu_context()
-    def mark_favorite_shifu_api():
+    def mark_favorite_shifu_api() -> ResponseReturnValue:
         """Mark favorite shifu.
 
         ---
@@ -1083,7 +1084,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/publish", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.PUBLISH)
     @with_shifu_context()
-    def publish_shifu_api(shifu_bid: str):
+    def publish_shifu_api(shifu_bid: str) -> ResponseReturnValue:
         """Publish shifu.
 
         ---
@@ -1119,7 +1120,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/preview", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def preview_shifu_api(shifu_bid: str):
+    def preview_shifu_api(shifu_bid: str) -> ResponseReturnValue:
         """Preview shifu.
 
         ---
@@ -1166,7 +1167,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/outlines/reorder", methods=["PATCH"])
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def update_chapter_order_api(shifu_bid: str):
+    def update_chapter_order_api(shifu_bid: str) -> ResponseReturnValue:
         """Update chapter order.
 
         Reset the chapter order to the order of the chapter IDs.
@@ -1223,7 +1224,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/outlines", methods=["PUT"])
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def create_outline_api(shifu_bid: str):
+    def create_outline_api(shifu_bid: str) -> ResponseReturnValue:
         """Create unit.
 
         ---
@@ -1306,7 +1307,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/outlines/batch", methods=["PUT"])
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def create_outlines_batch_api(shifu_bid: str):
+    def create_outlines_batch_api(shifu_bid: str) -> ResponseReturnValue:
         """Create multiple outlines atomically.
 
         ---
@@ -1373,7 +1374,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
         path_prefix + "/shifus/<shifu_bid>/outlines/<outline_bid>", methods=["POST"]
     )
     @ShifuTokenValidation(ShifuPermission.EDIT)
-    def modify_outline_api(shifu_bid: str, outline_bid: str):
+    def modify_outline_api(shifu_bid: str, outline_bid: str) -> ResponseReturnValue:
         """Modify outline.
 
         ---
@@ -1450,7 +1451,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_unit_info_api(shifu_bid: str, outline_bid: str):
+    def get_unit_info_api(shifu_bid: str, outline_bid: str) -> ResponseReturnValue:
         """Get unit info.
 
         ---
@@ -1487,7 +1488,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def delete_unit_api(shifu_bid: str, outline_bid: str):
+    def delete_unit_api(shifu_bid: str, outline_bid: str) -> ResponseReturnValue:
         """Delete unit.
 
         ---
@@ -1527,7 +1528,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_mdflow_api(shifu_bid: str, outline_bid: str):
+    def get_mdflow_api(shifu_bid: str, outline_bid: str) -> ResponseReturnValue:
         """Get mdflow.
 
         ---
@@ -1564,7 +1565,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
         methods=["GET"],
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def get_draft_meta_api(shifu_bid: str):
+    def get_draft_meta_api(shifu_bid: str) -> ResponseReturnValue:
         """Get draft meta.
 
         ---
@@ -1619,7 +1620,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def save_mdflow_api(shifu_bid: str, outline_bid: str):
+    def save_mdflow_api(shifu_bid: str, outline_bid: str) -> ResponseReturnValue:
         """Save mdflow.
 
         ---
@@ -1697,7 +1698,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def parse_mdflow_api(shifu_bid: str, outline_bid: str):
+    def parse_mdflow_api(shifu_bid: str, outline_bid: str) -> ResponseReturnValue:
         """Parse mdflow.
 
         ---
@@ -1744,7 +1745,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_mdflow_history_api(shifu_bid: str, outline_bid: str):
+    def get_mdflow_history_api(shifu_bid: str, outline_bid: str) -> ResponseReturnValue:
         """Get mdflow history.
 
         ---
@@ -1821,7 +1822,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     @with_shifu_context()
     def get_mdflow_history_version_detail_api(
         shifu_bid: str, outline_bid: str, version_id: str
-    ):
+    ) -> ResponseReturnValue:
         """Get mdflow history version detail.
 
         ---
@@ -1869,7 +1870,9 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def restore_mdflow_history_api(shifu_bid: str, outline_bid: str):
+    def restore_mdflow_history_api(
+        shifu_bid: str, outline_bid: str
+    ) -> ResponseReturnValue:
         """Restore mdflow history version.
 
         ---
@@ -1956,7 +1959,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
         methods=["POST"],
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def run_mdflow_api(shifu_bid: str, outline_bid: str):
+    def run_mdflow_api(shifu_bid: str, outline_bid: str) -> ResponseReturnValue:
         """Run mdflow.
 
         Raises:
@@ -1969,7 +1972,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/outlines", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_outline_tree_api(shifu_bid: str):
+    def get_outline_tree_api(shifu_bid: str) -> ResponseReturnValue:
         """Get outline tree.
 
         ---
@@ -2001,7 +2004,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
         return make_common_response(get_outline_tree(app, user_id, shifu_bid))
 
     @app.route(path_prefix + "/upfile", methods=["POST"])
-    def upfile_api():
+    def upfile_api() -> ResponseReturnValue:
         """Upfile to oss.
 
         ---
@@ -2040,7 +2043,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
         return make_common_response(upload_file(app, user_id, resource_id, file))
 
     @app.route(path_prefix + "/url-upfile", methods=["POST"])
-    def upload_url_api():
+    def upload_url_api() -> ResponseReturnValue:
         """Upload url to oss.
 
         ---
@@ -2080,7 +2083,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
         return make_common_response(upload_url(app, user_id, url))
 
     @app.route(path_prefix + "/get-video-info", methods=["POST"])
-    def get_video_info_api():
+    def get_video_info_api() -> ResponseReturnValue:
         """Get video info.
 
         ---
@@ -2121,7 +2124,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/export", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def export_shifu_api(shifu_bid: str):
+    def export_shifu_api(shifu_bid: str) -> ResponseReturnValue:
         """Export shifu.
 
         ---
@@ -2145,7 +2148,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
         export_shifu(app, shifu_bid, str(file_path))
 
         @after_this_request
-        def cleanup(response):
+        def cleanup(response) -> Response:
             try:
                 file_path.unlink()
                 Path(temp_dir).rmdir()
@@ -2164,7 +2167,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/ask/config", methods=["GET"])
     @bypass_token_validation
-    def ask_config_api():
+    def ask_config_api() -> ResponseReturnValue:
         """Get ask provider configuration metadata.
 
         ---
@@ -2206,7 +2209,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
             set_language(original_language)
 
     @app.route(path_prefix + "/ask/preview", methods=["POST"])
-    def ask_preview_api():
+    def ask_preview_api() -> ResponseReturnValue:
         """Preview ask provider output with current settings.
 
         ---
@@ -2363,7 +2366,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
                 else 0
             )
 
-            def _chat_llm_stream(stream_messages: list[dict[str, str]]):
+            def _chat_llm_stream(stream_messages: list[dict[str, str]]) -> object:
                 return chat_llm(
                     app,
                     preview_user_id,
@@ -2487,7 +2490,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def list_minimax_tts_voices_api():
+    def list_minimax_tts_voices_api() -> ResponseReturnValue:
         from flaskr.service.tts.api import list_minimax_cloned_voices
 
         user_id = request.user.user_id
@@ -2509,7 +2512,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/clone-cost", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def minimax_tts_clone_cost_api():
+    def minimax_tts_clone_cost_api() -> ResponseReturnValue:
         from flaskr.service.tts.api import build_minimax_clone_cost
 
         user_id = request.user.user_id
@@ -2520,7 +2523,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/validate-id", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def validate_minimax_tts_voice_id_api():
+    def validate_minimax_tts_voice_id_api() -> ResponseReturnValue:
         from flaskr.service.tts.api import (
             is_valid_minimax_custom_voice_id,
         )
@@ -2536,7 +2539,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/clone", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.EDIT, is_creator=True)
-    def clone_minimax_tts_voice_api():
+    def clone_minimax_tts_voice_api() -> ResponseReturnValue:
         from flaskr.service.tts.api import (
             serialize_minimax_cloned_voice,
             submit_minimax_voice_clone,
@@ -2572,7 +2575,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/<voice_bid>", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def get_minimax_tts_voice_api(voice_bid):
+    def get_minimax_tts_voice_api(voice_bid) -> ResponseReturnValue:
         from flaskr.service.tts.api import get_minimax_cloned_voice
 
         return make_common_response(
@@ -2588,7 +2591,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
         methods=["POST"],
     )
     @ShifuTokenValidation(ShifuPermission.EDIT, is_creator=True)
-    def retry_minimax_tts_voice_api(voice_bid):
+    def retry_minimax_tts_voice_api(voice_bid) -> ResponseReturnValue:
         from flaskr.service.tts.api import retry_minimax_voice_clone
 
         return make_common_response(
@@ -2601,7 +2604,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/<voice_bid>", methods=["DELETE"])
     @ShifuTokenValidation(ShifuPermission.EDIT, is_creator=True)
-    def delete_minimax_tts_voice_api(voice_bid):
+    def delete_minimax_tts_voice_api(voice_bid) -> ResponseReturnValue:
         from flaskr.service.tts.api import delete_minimax_cloned_voice
 
         return make_common_response(
@@ -2614,7 +2617,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/config", methods=["GET"])
     @bypass_token_validation
-    def tts_config_api():
+    def tts_config_api() -> ResponseReturnValue:
         """Get TTS provider configuration.
 
         ---
@@ -2638,7 +2641,7 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu") -> Flask:
         return make_common_response(config)
 
     @app.route(path_prefix + "/tts/preview", methods=["POST"])
-    def tts_preview_api():
+    def tts_preview_api() -> ResponseReturnValue:
         """Preview TTS with specified settings.
 
         ---

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -954,7 +954,7 @@ def get_shifu_published_list(
         return PageNationDTO(safe_page_index, page_size, total, shifu_dtos)
 
 
-def _set_shifu_archive_state(app, user_id: str, shifu_id: str, archived: bool):
+def _set_shifu_archive_state(app, user_id: str, shifu_id: str, archived: bool) -> None:
     with app.app_context():
         shifu_draft = get_latest_shifu_draft(shifu_id)
         if not shifu_draft:

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -72,7 +72,9 @@ class HistoryItem(BaseModel, Generic[T]):
         return cls.model_validate_json(json)
 
 
-def _get_latest_draft_log(shifu_bid: str, for_update: bool = False):
+def _get_latest_draft_log(
+    shifu_bid: str, for_update: bool = False
+) -> LogDraftStruct | None:
     query = LogDraftStruct.query.filter_by(
         shifu_bid=shifu_bid,
         deleted=0,
@@ -125,7 +127,9 @@ def iter_outline_item_versions_desc(
         last_id = int(batch[-1].id)
 
 
-def _get_latest_outline_content_log(shifu_bid: str, outline_bid: str):
+def _get_latest_outline_content_log(
+    shifu_bid: str, outline_bid: str
+) -> LogDraftStruct | None:
     latest_version = (
         DraftOutlineItem.query.filter(
             DraftOutlineItem.shifu_bid == shifu_bid,
@@ -277,7 +281,7 @@ def get_shifu_history(app, shifu_bid: str) -> HistoryItem:
 
 def __save_shifu_history(
     app: Flask, user_id: str, shifu_bid: str, history: HistoryItem
-):
+) -> LogDraftStruct:
     """Save shifu history.
 
     Args:
@@ -330,7 +334,7 @@ def __save_new_item_history(
     parent_bid: str,
     item_type: str,
     index: int = 0,
-):
+) -> None:
     """Save new item history internal function.
 
     Args:
@@ -385,7 +389,9 @@ def __save_new_item_history(
     __save_shifu_history(app, user_id, shifu_bid, history)
 
 
-def __delete_item_history(app: Flask, user_id: str, shifu_bid: str, item_bid: str):
+def __delete_item_history(
+    app: Flask, user_id: str, shifu_bid: str, item_bid: str
+) -> None:
     """Delete item history internal function.
 
     Args:

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -688,7 +688,7 @@ def reorder_outline_tree(
             parent_position="",
             parent_bid="",
             history_infos: list[HistoryItem] | None = None,
-        ):
+        ) -> None:
             if history_infos is None:
                 history_infos = []
             for i, outline_dto in enumerate(outline_dtos):

--- a/src/api/flaskr/service/shifu/shifu_publish_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_publish_funcs.py
@@ -155,7 +155,9 @@ def publish_shifu_draft(
         assert_outline_items_publishable(app, shifu_id, outline_items)
         outline_tree = build_outline_tree_from_items(app, outline_items)
 
-        def publish_outline_item(node: ShifuOutlineTreeNode, history_item: HistoryItem):
+        def publish_outline_item(
+            node: ShifuOutlineTreeNode, history_item: HistoryItem
+        ) -> None:
             outline_item = PublishedOutlineItem()
             draft_outline_item: DraftOutlineItem = node.outline
             outline_item.shifu_bid = shifu_id
@@ -226,7 +228,9 @@ def publish_shifu_draft(
         return _build_frontend_url(base_url, f"/c/{shifu_id}")
 
 
-def _run_summary_with_error_handling(app, shifu_id, shifu_context_snapshot=None):
+def _run_summary_with_error_handling(
+    app, shifu_id, shifu_context_snapshot=None
+) -> None:
     """Run shifu summary generation with error handling.
 
     Args:
@@ -310,7 +314,7 @@ def _generate_ask_prompts(
     outline_summary_map: dict[str, dict],
     outline_item_map: dict[str, PublishedOutlineItem],
     ask_prompt_template: str,
-):
+) -> None:
     """Generate ask_prompt for each section.
 
     Args:
@@ -505,7 +509,7 @@ def _make_ask_prompt(
     )
 
 
-def _get_summary(app, prompt, model_name, user_id=None, temperature=0.8):
+def _get_summary(app, prompt, model_name, user_id=None, temperature=0.8) -> str:
     """Call the AI model to generate summary.
 
     Args:

--- a/src/api/flaskr/service/shifu/tts_preview.py
+++ b/src/api/flaskr/service/shifu/tts_preview.py
@@ -6,7 +6,7 @@ import base64
 import json
 import uuid
 from dataclasses import replace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Response, current_app, stream_with_context
 from flaskr.api.tts import (
@@ -28,6 +28,9 @@ from flaskr.service.tts.validation import (
     validate_tts_settings_strict,
 )
 from flaskr.util.uuid import generate_id
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 def _build_tts_preview_usage_metadata(
@@ -121,7 +124,7 @@ def build_tts_preview_response(
         audio_settings=safe_audio_settings,
     )
 
-    def event_stream():
+    def event_stream() -> Iterator[str]:
         total_duration_ms = 0
         total_word_count = 0
         total_output_chars = 0

--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -36,7 +36,9 @@ def _estimated_duration_ms(audio_data: bytes) -> int:
     return int(len(audio_data or b"") / 16000 * 1000)
 
 
-def _load_audio_segment(audio_data: bytes, *, input_format: str = "mp3"):
+def _load_audio_segment(
+    audio_data: bytes, *, input_format: str = "mp3"
+) -> AudioSegment:
     audio_io = io.BytesIO(audio_data)
     if input_format == "mp3" and hasattr(AudioSegment, "from_mp3"):
         return AudioSegment.from_mp3(audio_io)

--- a/src/api/flaskr/service/tts/minimax_voice_clone.py
+++ b/src/api/flaskr/service/tts/minimax_voice_clone.py
@@ -66,6 +66,8 @@ from flaskr.util.datetime import now_utc, to_utc_iso
 from flaskr.util.uuid import generate_id
 
 if TYPE_CHECKING:
+    from decimal import Decimal
+
     from flask import Flask
 
 MINIMAX_FILE_UPLOAD_URL = "https://api.minimaxi.com/v1/files/upload"
@@ -1111,7 +1113,7 @@ def _validate_audio_upload(data: bytes, *, filename: str, max_bytes: int) -> Non
         raise_param_error("unsupported audio file type")
 
 
-def _available_wallet_credits(app: Flask, creator_bid: str):
+def _available_wallet_credits(app: Flask, creator_bid: str) -> Decimal:
     from flaskr.service.billing.models import CreditWallet
 
     with app.app_context():

--- a/src/api/flaskr/service/tts/pipeline.py
+++ b/src/api/flaskr/service/tts/pipeline.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from flask import Flask
+    from flaskr.api.tts import TTSResult
 
 _AV_LATEX_BLOCK = AV_LATEX_BLOCK
 
@@ -286,7 +287,7 @@ def _append_open_close_boundary_candidate(
     close_pattern: re.Pattern[str],
     rewind_start: bool = False,
     extend_end: bool = False,
-):
+) -> None:
     match = _find_first_match_outside_fence(raw, open_pattern, fence_ranges)
     if match is None:
         return
@@ -449,7 +450,7 @@ def build_av_segmentation_contract(raw: str, block_bid: str = "") -> dict:
         start_offset: int,
         end_offset: int,
         after_visual_kind: str,
-    ):
+    ) -> None:
         cleaned = (text or "").strip()
         if not cleaned:
             return
@@ -463,7 +464,7 @@ def build_av_segmentation_contract(raw: str, block_bid: str = "") -> dict:
             }
         )
 
-    def _split(text: str, base_offset: int, after_visual_kind: str):
+    def _split(text: str, base_offset: int, after_visual_kind: str) -> None:
         if not text or not text.strip():
             return
 
@@ -823,7 +824,7 @@ def synthesize_long_text_to_oss(
         audio_parts = [b""] * len(segments)
         segment_map = dict(enumerate(segments))
 
-        def _synthesize_in_app_context(segment_text: str):
+        def _synthesize_in_app_context(segment_text: str) -> TTSResult:
             with app.app_context():
                 return synthesize_text(
                     text=segment_text,

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -16,6 +16,8 @@ from flaskr.util.deprecation import deprecated_alias_getattr
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from redis import Redis
+
 logger = AppLoggerProxy(logging.getLogger(__name__))
 
 _LOCAL_STATE: dict[str, float] = {}
@@ -161,7 +163,7 @@ def _acquire_local_slot(
         )
 
 
-def _get_redis_client():
+def _get_redis_client() -> Redis | None:
     from flaskr.dao import get_redis_client
 
     redis_client = get_redis_client()

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -20,6 +20,7 @@ from typing import Any
 from flask import Flask
 from flaskr.api.tts import (
     AudioSettings,
+    TTSResult,
     VoiceSettings,
     get_default_audio_settings,
     get_default_voice_settings,
@@ -388,7 +389,7 @@ class StreamingTTSProcessor:
         """Yield already-synthesized segments without submitting new text."""
         yield from self._yield_ready_segments()
 
-    def _try_submit_tts_task(self):
+    def _try_submit_tts_task(self) -> None:
         """Submit all complete sentences currently available in the stream buffer."""
         if not self._buffer:
             return
@@ -469,7 +470,7 @@ class StreamingTTSProcessor:
                 lo = mid + 1
         return best
 
-    def _submit_tts_task(self, text: str):
+    def _submit_tts_task(self, text: str) -> None:
         """Submit a TTS synthesis task to the background thread pool."""
         with self._lock:
             segment_index = self._segment_index
@@ -499,7 +500,7 @@ class StreamingTTSProcessor:
         remaining_text: str,
         *,
         include_trailing_fragment: bool = True,
-    ):
+    ) -> None:
         """Submit text sentence-by-sentence.
 
         When ``include_trailing_fragment`` is True, any trailing text without
@@ -548,7 +549,7 @@ class StreamingTTSProcessor:
         tts_provider: str = "",
         tts_model: str = "",
         segment_index: int | None = None,
-    ):
+    ) -> TTSResult:
         result = None
         max_attempts = 2
         attempt = 0
@@ -2146,7 +2147,7 @@ class AVStreamingTTSProcessor:
             # 'fence' | 'svg' | 'iframe' | 'video' | 'html_table' | 'md_table' | 'sandbox' | 'md_img'
         )
 
-    def _update_av_contract(self):
+    def _update_av_contract(self) -> None:
         try:
             self._av_contract = build_av_segmentation_contract(
                 self._raw_full_content, self.generated_block_bid
@@ -2195,7 +2196,7 @@ class AVStreamingTTSProcessor:
         """Return whether an unfinished visual boundary remains."""
         return bool(self._skip_mode)
 
-    def _refresh_next_element_index_from_contract(self):
+    def _refresh_next_element_index_from_contract(self) -> None:
         segments, _ = build_visual_segments_for_block(
             app=self.app,
             raw_content=self._raw_full_content,

--- a/src/api/flaskr/service/tts/tasks.py
+++ b/src/api/flaskr/service/tts/tasks.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from flask import Flask
+
 try:  # pragma: no cover - exercised indirectly when Celery is installed.
     from celery import shared_task
 except ImportError:  # pragma: no cover - local fallback for non-Celery test envs.
@@ -22,7 +24,7 @@ except ImportError:  # pragma: no cover - local fallback for non-Celery test env
         return decorator
 
 
-def _create_task_app():
+def _create_task_app() -> Flask:
     os.environ.setdefault("SKIP_APP_AUTOCREATE", "1")
     from app import create_app
 

--- a/src/api/flaskr/service/user/auth/providers/password.py
+++ b/src/api/flaskr/service/user/auth/providers/password.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from typing import NoReturn
 
     from flask import Flask
+    from flaskr.common.cache_provider import CacheProvider
 
 
 _IDENTIFIER_LIMIT_CONFIG = "PASSWORD_LOGIN_IDENTIFIER_FAILURE_LIMIT"
@@ -65,7 +66,7 @@ def _config_int(app: Flask, name: str, default: int) -> int:
     return max(1, int(app.config.get(name, default)))
 
 
-def _shared_counter_cache(app: Flask):
+def _shared_counter_cache(app: Flask) -> CacheProvider:
     """Return the shared Redis backend required by password throttling."""
     from flaskr.dao import get_redis_client
 

--- a/src/api/migrations/env.py
+++ b/src/api/migrations/env.py
@@ -136,7 +136,7 @@ def run_migrations_online() -> None:
     # this callback is used to prevent an auto-migration from being generated
     # when there are no changes to the schema
     # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
-    def process_revision_directives(context, revision, directives):
+    def process_revision_directives(context, revision, directives) -> None:
         _ = (context, revision)
         if getattr(config.cmd_opts, "autogenerate", False):
             script = directives[0]
@@ -178,7 +178,7 @@ def run_migrations_online() -> None:
                         # merge the related changes into the same migration
                         merge_related_changes(script)
 
-    def is_meaningful_operation(op):
+    def is_meaningful_operation(op) -> bool:
         """Judge if an operation is meaningful (not meaningless type conversion)."""
         op_type = type(op).__name__
 
@@ -230,7 +230,7 @@ def run_migrations_online() -> None:
 
         return True
 
-    def filter_unnecessary_operations(script):
+    def filter_unnecessary_operations(script) -> None:
         """Filter out the unnecessary or duplicate operations."""
         if not hasattr(script, "upgrade_ops") or not script.upgrade_ops:
             return
@@ -268,7 +268,7 @@ def run_migrations_online() -> None:
                 len(filtered_ops),
             )
 
-    def get_operation_signature(op):
+    def get_operation_signature(op) -> str:
         """Generate the unique signature of the operation to detect duplication."""
         op_type = type(op).__name__
 
@@ -296,12 +296,12 @@ def run_migrations_online() -> None:
             return f"{op_type}:{table_name}"
         return f"{op_type}:unknown"
 
-    def should_skip_operation(op):
+    def should_skip_operation(op) -> bool:
         """Judge if it should skip the operation."""
         op_type = type(op).__name__
 
         # dynamically get the application table prefixes, based on the actual defined models
-        def get_app_table_prefixes():
+        def get_app_table_prefixes() -> list[str]:
             """Dynamically get the table prefixes from the actual models."""
             prefixes = set()
 
@@ -332,7 +332,7 @@ def run_migrations_online() -> None:
         app_table_prefixes = get_app_table_prefixes()
 
         # get all registered application table names
-        def get_app_table_names():
+        def get_app_table_names() -> set[str]:
             """Get all registered application table names."""
             table_names = set()
             for mapper in db.Model.registry.mappers:
@@ -486,7 +486,7 @@ def run_migrations_online() -> None:
 
         return False
 
-    def merge_related_changes(script):
+    def merge_related_changes(script) -> None:
         """Merge the related changes into the same migration."""
         if not hasattr(script, "upgrade_ops") or not script.upgrade_ops:
             return
@@ -585,12 +585,12 @@ def run_migrations_online() -> None:
         inspected_default,
         metadata_default,
         rendered_metadata_default,
-    ):
+    ) -> bool:
         """Compare server defaults leniently to reduce false positives."""
         # Normalize how a default value is spelled
         _ = (context, inspected_column, metadata_column, metadata_default)
 
-        def normalize_default(default):
+        def normalize_default(default) -> str | None:
             if default is None:
                 return None
             default_str = str(default).strip()
@@ -614,12 +614,12 @@ def run_migrations_online() -> None:
 
     def compare_comment(
         context, inspected_column, metadata_column, inspected_comment, metadata_comment
-    ):
+    ) -> bool:
         """Compare comments leniently, still reporting real comment changes."""
         # Normalize how a comment is spelled
         _ = inspected_column
 
-        def normalize_comment(comment):
+        def normalize_comment(comment) -> str | None:
             if comment is None:
                 return None
             comment_str = str(comment).strip()
@@ -660,7 +660,7 @@ def run_migrations_online() -> None:
 
     def compare_type(
         context, inspected_column, metadata_column, inspected_type, metadata_type
-    ):
+    ) -> bool | None:
         """Compare column types leniently to reduce false positives."""
         # Treat small type differences as equal
         _ = (context, inspected_column, metadata_column)

--- a/src/api/scripts/check_mdflow_listen_adapter.py
+++ b/src/api/scripts/check_mdflow_listen_adapter.py
@@ -41,15 +41,16 @@ from sqlalchemy.ext.compiler import compiles
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from types import ModuleType
 
 
 @compiles(LONGTEXT, "sqlite")
-def _compile_longtext_sqlite(_type, _compiler, **_kw: object):
+def _compile_longtext_sqlite(_type, _compiler, **_kw: object) -> str:
     return "TEXT"
 
 
 @compiles(BIGINT, "sqlite")
-def _compile_bigint_sqlite(_type, _compiler, **_kw: object):
+def _compile_bigint_sqlite(_type, _compiler, **_kw: object) -> str:
     return "INTEGER"
 
 
@@ -182,7 +183,7 @@ def _load_samples(path: Path, limit: int) -> list[BlockSample]:
     return samples
 
 
-def _bootstrap_mdflow(mdflow_root: str):
+def _bootstrap_mdflow(mdflow_root: str) -> ModuleType:
     root = Path(mdflow_root)
     init_file = root / "markdown_flow" / "__init__.py"
     if not init_file.exists():

--- a/src/api/scripts/check_sse_segmentation.py
+++ b/src/api/scripts/check_sse_segmentation.py
@@ -34,7 +34,7 @@ from flaskr.service.tts import streaming_tts as streaming_tts_module
 from flaskr.service.tts.pipeline import split_av_speakable_segments
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
 DEFAULT_CHUNK_SIZES = (1, 2, 3, 5, 8, 13)
 VISUAL_LEAK_PATTERN = re.compile(
@@ -146,13 +146,13 @@ def _simulate_observed_segments(
             self.position = int(kwargs.get("position", 0) or 0)
             self._parts: list[str] = []
 
-        def process_chunk(self, chunk):
+        def process_chunk(self, chunk) -> Iterator[None]:
             if chunk:
                 self._parts.append(chunk)
             return
             yield
 
-        def finalize(self, commit=True):
+        def finalize(self, commit=True) -> Iterator[None]:
             _ = commit
             text = "".join(self._parts).strip()
             if text:

--- a/src/api/scripts/tts_test_report.py
+++ b/src/api/scripts/tts_test_report.py
@@ -114,7 +114,7 @@ def _build_cases(*, provider_name: str, matrix: str) -> list[dict[str, str]]:
 
     cases: list[dict[str, str]] = []
 
-    def add_case(model_value: str, voice_value: str):
+    def add_case(model_value: str, voice_value: str) -> None:
         cases.append(
             {
                 "provider": provider_name,

--- a/src/api/tests/api/doc/test_feishu_notify.py
+++ b/src/api/tests/api/doc/test_feishu_notify.py
@@ -1,5 +1,7 @@
 """Verify Feishu delivery metadata and failure handling."""
 
+from typing import Never
+
 import requests
 from flaskr.api.doc import feishu
 
@@ -10,15 +12,15 @@ class _Logger:
         self.warnings = []
         self.exceptions = []
 
-    def info(self, *args: object, **kwargs: object):
+    def info(self, *args: object, **kwargs: object) -> None:
         _ = kwargs
         self.infos.append(args)
 
-    def warning(self, *args: object, **kwargs: object):
+    def warning(self, *args: object, **kwargs: object) -> None:
         _ = kwargs
         self.warnings.append(args)
 
-    def exception(self, *args: object, **kwargs: object):
+    def exception(self, *args: object, **kwargs: object) -> None:
         _ = kwargs
         self.exceptions.append(args)
 
@@ -37,7 +39,7 @@ class _Response:
         self._json_value = json_value
         self._json_exc = json_exc
 
-    def json(self):
+    def json(self) -> object:
         if self._json_exc is not None:
             raise self._json_exc
         return self._json_value
@@ -87,7 +89,7 @@ def test_send_notify_returns_none_for_request_error(monkeypatch) -> None:
         feishu, "get_config", lambda _key, _default=None: "https://example.test/webhook"
     )
 
-    def _raise(*args: object, **kwargs: object):
+    def _raise(*args: object, **kwargs: object) -> Never:
         _ = (args, kwargs)
         message = "network down"
         raise requests.RequestException(message)

--- a/src/api/tests/command/test_unified_migration_task.py
+++ b/src/api/tests/command/test_unified_migration_task.py
@@ -15,10 +15,10 @@ class _FakeResult:
     def __init__(self, value) -> None:
         self._value = value
 
-    def scalar(self):
+    def scalar(self) -> object:
         return self._value
 
-    def fetchone(self):
+    def fetchone(self) -> object:
         return self._value
 
 
@@ -29,15 +29,15 @@ class _FakeSession:
         self._value = value
         self.calls = []
 
-    def execute(self, statement, params=None):
+    def execute(self, statement, params=None) -> object:
         self.calls.append((str(statement), params))
         return _FakeResult(self._value)
 
-    def close(self):
+    def close(self) -> None:
         pass
 
 
-def _task_with_session(session):
+def _task_with_session(session) -> object:
     task = UnifiedMigrationTask.__new__(UnifiedMigrationTask)
     task.SessionClass = lambda: session
     return task
@@ -118,13 +118,13 @@ def test_migrate_table_logs_formatted_batch_progress(caplog) -> None:
     task = UnifiedMigrationTask.__new__(UnifiedMigrationTask)
     task.config = MigrationConfig(batch_size=10)
 
-    async def table_exists(_table_name):
+    async def table_exists(_table_name) -> bool:
         return True
 
-    async def table_count(_table_name):
+    async def table_count(_table_name) -> int:
         return 20
 
-    async def process_batch(*_args: object):
+    async def process_batch(*_args: object) -> dict[str, int | list[object]]:
         return {"synced": 5, "errors": 0, "error_messages": []}
 
     task._table_exists_async = table_exists

--- a/src/api/tests/common/fixtures/mock_validators.py
+++ b/src/api/tests/common/fixtures/mock_validators.py
@@ -38,7 +38,7 @@ def always_pass_validator(value) -> bool:
 def range_validator(min_val, max_val) -> Callable[[object], bool]:
     """Create a range validator for numeric values."""
 
-    def validator(value):
+    def validator(value) -> bool:
         try:
             num = float(value)
         except (ValueError, TypeError):
@@ -52,7 +52,7 @@ def range_validator(min_val, max_val) -> Callable[[object], bool]:
 def string_length_validator(min_len=0, max_len=100) -> Callable[[object], bool]:
     """Create a string length validator."""
 
-    def validator(value):
+    def validator(value) -> bool:
         if value is None:
             return False
         s = str(value)
@@ -67,7 +67,7 @@ def regex_validator(pattern) -> Callable[[object], bool]:
 
     compiled = re.compile(pattern)
 
-    def validator(value):
+    def validator(value) -> bool:
         if value is None:
             return False
         return bool(compiled.match(str(value)))
@@ -97,7 +97,7 @@ def dependency_validator(depends_on_key) -> Callable[[object], bool]:
     """Create a validator that checks if another config key is set."""
     _ = depends_on_key
 
-    def validator(value):
+    def validator(value) -> bool:
         # In real usage, this would check if depends_on_key is configured
         # For testing, we just check if value is not empty
         return bool(value)

--- a/src/api/tests/common/test_celery_fork_pool_dispose.py
+++ b/src/api/tests/common/test_celery_fork_pool_dispose.py
@@ -9,7 +9,7 @@ off-by-one protocol desync. The worker_process_init hook must discard the
 inherited pool without touching the parent's file descriptors.
 """
 
-from typing import ClassVar
+from typing import ClassVar, Never
 
 from celery.signals import worker_process_init
 from flaskr.common.celery_app import dispose_inherited_db_pools, get_celery_app
@@ -51,13 +51,13 @@ def test_one_failing_bind_does_not_block_the_rest(app, monkeypatch) -> None:
     disposed = []
 
     class _BrokenEngine:
-        def dispose(self, close):
+        def dispose(self, close) -> Never:
             _ = close
             message = "bind gone"
             raise RuntimeError(message)
 
     class _GoodEngine:
-        def dispose(self, close):
+        def dispose(self, close) -> None:
             disposed.append(close)
 
     class _FakeDB:

--- a/src/api/tests/common/test_common_route.py
+++ b/src/api/tests/common/test_common_route.py
@@ -1,6 +1,7 @@
 """Verify translated error handling on shared HTTP routes."""
 
 from pathlib import Path
+from typing import Never
 
 from flask import Flask
 from flaskr.i18n import _translations, load_translations
@@ -20,7 +21,7 @@ def test_common_handler_returns_translated_unexpected_error_for_unhandled_except
     register_common_handler(app)
 
     @app.route("/boom")
-    def _boom():
+    def _boom() -> Never:
         message = "unexpected failure"
         raise RuntimeError(message)
 
@@ -43,7 +44,7 @@ def test_common_handler_uses_request_language_for_unhandled_exceptions(
     register_common_handler(app)
 
     @app.route("/boom-zh")
-    def _boom_zh():
+    def _boom_zh() -> Never:
         message = "unexpected failure"
         raise RuntimeError(message)
 
@@ -91,7 +92,7 @@ def test_common_handler_uses_json_language_for_patch_requests(monkeypatch) -> No
     register_common_handler(app)
 
     @app.route("/boom-patch", methods=["PATCH"])
-    def _boom_patch():
+    def _boom_patch() -> Never:
         message = "unexpected failure"
         raise RuntimeError(message)
 

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -90,7 +90,7 @@ def test_invalidate_session_uses_fake_sessions_directly() -> None:
     calls = []
 
     class _Fake:
-        def invalidate(self):
+        def invalidate(self) -> None:
             calls.append(1)
 
     assert invalidate_session(source="test fake", session=_Fake()) is True
@@ -101,10 +101,10 @@ def test_cleanup_rolls_back_on_server_delivered_errors() -> None:
     events = []
 
     class _Fake:
-        def invalidate(self):
+        def invalidate(self) -> None:
             events.append("invalidate")
 
-        def rollback(self):
+        def rollback(self) -> None:
             events.append("rollback")
 
     outcome = cleanup_session_after(ValueError("business"), source="t", session=_Fake())
@@ -116,10 +116,10 @@ def test_cleanup_invalidates_on_interrupting_terminations() -> None:
     events = []
 
     class _Fake:
-        def invalidate(self):
+        def invalidate(self) -> None:
             events.append("invalidate")
 
-        def rollback(self):
+        def rollback(self) -> None:
             events.append("rollback")
 
     outcome = cleanup_session_after(GeneratorExit(), source="t", session=_Fake())
@@ -131,10 +131,10 @@ def test_cleanup_escalates_to_invalidate_when_rollback_fails() -> None:
     events = []
 
     class _Fake:
-        def invalidate(self):
+        def invalidate(self) -> None:
             events.append("invalidate")
 
-        def rollback(self):
+        def rollback(self) -> Never:
             events.append("rollback")
             message = "rollback broke"
             raise RuntimeError(message)
@@ -156,7 +156,7 @@ def test_teardown_hook_invalidates_before_session_removal(app, monkeypatch) -> N
     )
     original_remove = db.session.remove
 
-    def _tracking_remove():
+    def _tracking_remove() -> object:
         order.append("remove")
         return original_remove()
 

--- a/src/api/tests/common/test_gevent_hub_observer.py
+++ b/src/api/tests/common/test_gevent_hub_observer.py
@@ -7,6 +7,7 @@ the application log while the hub's original behavior is preserved.
 """
 
 import logging
+from typing import Never
 
 from flaskr.common.gevent_hub_observer import install_hub_error_observer
 
@@ -15,14 +16,14 @@ class _StubHub:
     def __init__(self) -> None:
         self.calls = []
 
-        def _original(context, exc_type, value, tb):
+        def _original(context, exc_type, value, tb) -> str:
             self.calls.append((context, exc_type, value, tb))
             return "original-result"
 
         self.handle_error = _original
 
 
-def _fire(hub, context=None, exc=None):
+def _fire(hub, context=None, exc=None) -> object:
     exc = exc if exc is not None else AssertionError("(None, <callback>)")
     return hub.handle_error(context, type(exc), exc, None)
 
@@ -67,7 +68,7 @@ def test_logger_failure_never_blocks_the_original_handler() -> None:
     hub = _StubHub()
 
     class _BrokenLogger:
-        def error(self, *args: object, **kwargs: object):
+        def error(self, *args: object, **kwargs: object) -> Never:
             _ = (args, kwargs)
             message = "logging backend down"
             raise RuntimeError(message)

--- a/src/api/tests/common/test_gunicorn_post_fork_langfuse.py
+++ b/src/api/tests/common/test_gunicorn_post_fork_langfuse.py
@@ -8,6 +8,8 @@ after the reset, constructing a client again must produce a NEW resource
 manager (not the cached one) and a NEW tracer provider.
 """
 
+from collections.abc import Iterator
+
 import pytest
 
 pytest.importorskip("langfuse")
@@ -19,7 +21,7 @@ from opentelemetry import trace as otel_trace_api
 from opentelemetry.util._once import Once
 
 
-def _reset_langfuse_after_fork():
+def _reset_langfuse_after_fork() -> None:
     # Mirrors the sequence in src/api/gunicorn.conf.py post_fork. Kept in
     # sync manually; the assertions below are what the hook relies on.
     LangfuseResourceManager._instances.clear()
@@ -28,7 +30,7 @@ def _reset_langfuse_after_fork():
 
 
 @pytest.fixture(autouse=True)
-def _clean_singletons():
+def _clean_singletons() -> Iterator[None]:
     _reset_langfuse_after_fork()
     yield
     _reset_langfuse_after_fork()

--- a/src/api/tests/common/test_i18n_loader.py
+++ b/src/api/tests/common/test_i18n_loader.py
@@ -1,5 +1,6 @@
 """Verify translation loading, fallback, and locale selection."""
 
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -21,7 +22,7 @@ def _shared_i18n_root() -> Path:
 
 
 @pytest.fixture(autouse=True)
-def _isolate_i18n_state(monkeypatch):
+def _isolate_i18n_state(monkeypatch) -> Iterator[None]:
     # SHARED_I18N_ROOT is restored by monkeypatch; the thread-local language
     # set via set_language() must be cleared so later tests (e.g. ask provider
     # adapters asserting en-US messages) are not affected by test order.

--- a/src/api/tests/common/test_i18n_utils.py
+++ b/src/api/tests/common/test_i18n_utils.py
@@ -1,5 +1,7 @@
 """Verify native language labels reach generated prompts."""
 
+from collections.abc import Iterator
+
 from flaskr.common.i18n_utils import resolve_markdownflow_output_language
 from markdown_flow import MarkdownFlow, ProcessMode
 
@@ -19,13 +21,13 @@ def test_french_native_name_reaches_content_and_interaction_prompts() -> None:
         def __init__(self) -> None:
             self.calls = []
 
-        def complete(self, messages, **_kwargs: object):
+        def complete(self, messages, **_kwargs: object) -> str:
             self.calls.append(messages)
             if "JSON Interaction Translation Task" in messages[0]["content"]:
                 return '{"buttons":["Continuer"]}'
             return "Réponse"
 
-        def stream(self, _messages, **_kwargs: object):
+        def stream(self, _messages, **_kwargs: object) -> Iterator[object]:
             return iter(())
 
     provider = CapturingProvider()

--- a/src/api/tests/common/test_log.py
+++ b/src/api/tests/common/test_log.py
@@ -1,13 +1,14 @@
 """Verify Feishu logging failure isolation and payload limits."""
 
 import logging
+from typing import Never
 
 import requests
 from flaskr.common.log import FeishuLogHandler
 
 
 class _FailingResponse:
-    def raise_for_status(self):
+    def raise_for_status(self) -> Never:
         message = "400 Client Error"
         raise requests.exceptions.HTTPError(message)
 
@@ -15,7 +16,7 @@ class _FailingResponse:
 def test_feishu_log_handler_does_not_reemit_webhook_failures(monkeypatch) -> None:
     calls = []
 
-    def fake_post(*args: object, **kwargs: object):
+    def fake_post(*args: object, **kwargs: object) -> object:
         calls.append((args, kwargs))
         return _FailingResponse()
 
@@ -43,7 +44,7 @@ def test_feishu_log_handler_surfaces_delivery_failure_without_recursion(
 ) -> None:
     calls = []
 
-    def fake_post(*args: object, **kwargs: object):
+    def fake_post(*args: object, **kwargs: object) -> object:
         calls.append((args, kwargs))
         return _FailingResponse()
 
@@ -71,7 +72,7 @@ def test_feishu_log_handler_surfaces_delivery_failure_without_recursion(
 def test_feishu_log_handler_reentrancy_guard_blocks_nested_emit(monkeypatch) -> None:
     calls = []
 
-    def fake_post(*args: object, **kwargs: object):
+    def fake_post(*args: object, **kwargs: object) -> object:
         calls.append((args, kwargs))
         return type("Response", (), {"raise_for_status": lambda _self: None})()
 
@@ -99,7 +100,7 @@ def test_feishu_log_handler_reentrancy_guard_blocks_nested_emit(monkeypatch) -> 
 def test_feishu_log_handler_truncates_oversized_payload(monkeypatch) -> None:
     captured = {}
 
-    def fake_post(_url, *, json, timeout):
+    def fake_post(_url, *, json, timeout) -> object:
         captured["payload"] = json
         captured["timeout"] = timeout
         return type("Response", (), {"raise_for_status": lambda _self: None})()

--- a/src/api/tests/common/test_module_state_owners.py
+++ b/src/api/tests/common/test_module_state_owners.py
@@ -31,7 +31,7 @@ def test_redis_initialization_updates_the_owned_client(monkeypatch) -> None:
     sentinel = object()
     captured: dict[str, object] = {}
 
-    def fake_redis(**kwargs: object):
+    def fake_redis(**kwargs: object) -> object:
         captured.update(kwargs)
         return sentinel
 

--- a/src/api/tests/common/test_pool_desync_detection.py
+++ b/src/api/tests/common/test_pool_desync_detection.py
@@ -22,10 +22,10 @@ class _FakePyMySQLConnection:
         self.closed = False
 
     # QueuePool reset/close hooks
-    def rollback(self):
+    def rollback(self) -> None:
         pass
 
-    def close(self):
+    def close(self) -> None:
         self.closed = True
         self._sock.close()
 
@@ -73,7 +73,7 @@ def test_pool_discards_connection_desynced_during_use(sock_pair) -> None:
     ]
     made = []
 
-    def _creator():
+    def _creator() -> object:
         conn = connections[len(made) % len(connections)]
         made.append(conn)
         return conn
@@ -106,7 +106,7 @@ def test_checkout_rejects_connection_that_became_dirty_in_pool(sock_pair) -> Non
     connections = [dirty_conn, _FakePyMySQLConnection(clean_sock_a)]
     made = []
 
-    def _creator():
+    def _creator() -> object:
         conn = connections[len(made) % len(connections)]
         made.append(conn)
         return conn
@@ -145,7 +145,7 @@ def test_probe_timeout_waits_for_in_flight_data(sock_pair) -> None:
     # Zero-timeout probe sees nothing yet.
     assert dao._socket_has_unread_data(conn) is False
 
-    def _late_send():
+    def _late_send() -> None:
         time_module.sleep(0.001)
         right.sendall(b"\x05late-owed-response")
 
@@ -176,7 +176,7 @@ class _FakePingablePyMySQLConnection(_FakePyMySQLConnection):
         super().__init__(sock)
         self.pings = 0
 
-    def ping(self, reconnect):
+    def ping(self, reconnect) -> None:
         _ = reconnect
         self.pings += 1
 

--- a/src/api/tests/common/test_pre_execute_desync_interception.py
+++ b/src/api/tests/common/test_pre_execute_desync_interception.py
@@ -45,7 +45,7 @@ def test_pre_execute_probe_blocks_desynced_connection() -> None:
             info: ClassVar[dict[str, object]] = {}
             invalidated_count = 0
 
-            def invalidate(self):
+            def invalidate(self) -> None:
                 type(self).invalidated_count += 1
 
         conn = _FakeConn()

--- a/src/api/tests/common/test_protected_checkout_ping.py
+++ b/src/api/tests/common/test_protected_checkout_ping.py
@@ -19,7 +19,7 @@ class _FakeRecord:
     def __init__(self) -> None:
         self.invalidated_with = []
 
-    def invalidate(self, e=None):
+    def invalidate(self, e=None) -> None:
         self.invalidated_with.append(e)
 
 
@@ -27,11 +27,11 @@ class _FakeGreenletExit(BaseException):
     pass
 
 
-def _make_conn(sock, ping_exc=None):
+def _make_conn(sock, ping_exc=None) -> object:
     class _Conn:
         _sock = sock
 
-        def ping(self, reconnect):
+        def ping(self, reconnect) -> None:
             assert reconnect is False
             if ping_exc is not None:
                 raise ping_exc

--- a/src/api/tests/common/test_swagger_docstrings.py
+++ b/src/api/tests/common/test_swagger_docstrings.py
@@ -1,6 +1,7 @@
 """Validate every source-defined Flasgger docstring as a runtime contract."""
 
 import ast
+from collections.abc import Iterator
 from pathlib import Path
 
 from flasgger.utils import parse_docstring
@@ -16,7 +17,7 @@ KNOWN_UNPARSEABLE_SWAGGER_DOCSTRINGS = {
 }
 
 
-def _swagger_docstrings():
+def _swagger_docstrings() -> Iterator[tuple[object, object, object]]:
     for path in (API_ROOT / "flaskr").rglob("*.py"):
         source = path.read_text()
         tree = ast.parse(source)
@@ -48,7 +49,7 @@ def test_all_swagger_docstrings_keep_valid_yaml_after_summary() -> None:
         assert separator_index > 1, (path, function_name)
         assert lines[1].strip() == "", (path, function_name)
 
-        def view():
+        def view() -> None:
             pass
 
         view.__doc__ = docstring

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -55,17 +55,21 @@ class _TestPluginManager:
         self.extensible_generic_functions = {}
         self.is_enabled = False
 
-    def register_extension(self, target_func_name, func):
+    def register_extension(self, target_func_name, func) -> None:
         self.extension_functions.setdefault(target_func_name, []).append(func)
 
-    def execute_extensions(self, _func_name, result, *args: object, **kwargs: object):
+    def execute_extensions(
+        self, _func_name, result, *args: object, **kwargs: object
+    ) -> object:
         _ = (args, kwargs)
         return result
 
-    def register_extensible_generic(self, func_name, func):
+    def register_extensible_generic(self, func_name, func) -> None:
         self.extensible_generic_functions.setdefault(func_name, []).append(func)
 
-    def execute_extensible_generic(self, _func_name, *args: object, **kwargs: object):
+    def execute_extensible_generic(
+        self, _func_name, *args: object, **kwargs: object
+    ) -> None:
         _ = (args, kwargs)
 
 
@@ -73,12 +77,12 @@ set_plugin_manager(_TestPluginManager())
 
 
 @compiles(LONGTEXT, "sqlite")
-def _compile_longtext_sqlite(_type, _compiler, **_kw: object):
+def _compile_longtext_sqlite(_type, _compiler, **_kw: object) -> str:
     return "TEXT"
 
 
 @compiles(BIGINT, "sqlite")
-def _compile_bigint_sqlite(_type, _compiler, **_kw: object):
+def _compile_bigint_sqlite(_type, _compiler, **_kw: object) -> str:
     return "INTEGER"
 
 

--- a/src/api/tests/contract/test_sms_contract.py
+++ b/src/api/tests/contract/test_sms_contract.py
@@ -2,6 +2,7 @@
 
 import logging
 from types import SimpleNamespace
+from typing import Never
 
 import pytest
 from flask import Flask
@@ -16,7 +17,7 @@ def test_send_sms_ali_builds_request_for_generic_template(monkeypatch) -> None:
         def __init__(self, config) -> None:
             captured["config"] = config
 
-        def send_sms_with_options(self, request, runtime):
+        def send_sms_with_options(self, request, runtime) -> SimpleNamespace:
             captured["request"] = request
             captured["runtime"] = runtime
             return SimpleNamespace(body=SimpleNamespace(code="OK"))
@@ -59,7 +60,7 @@ def test_send_sms_code_ali_builds_request(monkeypatch) -> None:
         def __init__(self, config) -> None:
             captured["config"] = config
 
-        def send_sms_with_options(self, request, runtime):
+        def send_sms_with_options(self, request, runtime) -> SimpleNamespace:
             captured["request"] = request
             captured["runtime"] = runtime
             return SimpleNamespace(body=SimpleNamespace(code="OK"))
@@ -90,7 +91,7 @@ def test_send_sms_code_ali_builds_request(monkeypatch) -> None:
 def test_send_sms_code_ali_returns_none_without_keys(monkeypatch) -> None:
     from flaskr.api.sms import aliyun as sms_aliyun
 
-    def fake_client(_config):
+    def fake_client(_config) -> Never:
         message = "client should not be created"
         raise AssertionError(message)
 
@@ -124,11 +125,11 @@ def test_send_sms_code_ali_handles_client_error(monkeypatch) -> None:
         def __init__(self, config) -> None:
             captured["config"] = config
 
-        def send_sms_with_options(self, request, runtime):
+        def send_sms_with_options(self, request, runtime) -> Never:
             _ = (request, runtime)
             raise DummyError
 
-    def fake_assert(message):
+    def fake_assert(message) -> None:
         captured["assert_message"] = message
 
     monkeypatch.setattr(sms_aliyun, "Dysmsapi20170525Client", FakeClient)
@@ -157,7 +158,7 @@ def test_send_sms_ali_returns_none_when_provider_response_is_not_ok(
         def __init__(self, _config) -> None:
             pass
 
-        def send_sms_with_options(self, request, runtime):
+        def send_sms_with_options(self, request, runtime) -> SimpleNamespace:
             del request, runtime
             return SimpleNamespace(
                 body=SimpleNamespace(
@@ -203,7 +204,7 @@ def test_send_sms_ali_logs_recipient_throttle_as_warning(
         def __init__(self, _config) -> None:
             pass
 
-        def send_sms_with_options(self, request, runtime):
+        def send_sms_with_options(self, request, runtime) -> SimpleNamespace:
             del request, runtime
             return SimpleNamespace(
                 body=SimpleNamespace(
@@ -250,7 +251,7 @@ def test_send_sms_ali_logs_illegal_recipient_number_as_warning(
         def __init__(self, _config) -> None:
             pass
 
-        def send_sms_with_options(self, request, runtime):
+        def send_sms_with_options(self, request, runtime) -> SimpleNamespace:
             del request, runtime
             return SimpleNamespace(
                 body=SimpleNamespace(

--- a/src/api/tests/migrations/test_learner_profile_migration.py
+++ b/src/api/tests/migrations/test_learner_profile_migration.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import importlib.util
 from contextlib import contextmanager
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from sqlalchemy.dialects import mysql
 from sqlalchemy.schema import CreateColumn
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 API_ROOT = Path(__file__).resolve().parents[2]
 MIGRATION_PATH = (
@@ -24,7 +28,7 @@ MERGE_MIGRATION_PATH = (
 )
 
 
-def _load_migration_module(path=MIGRATION_PATH):
+def _load_migration_module(path=MIGRATION_PATH) -> object:
     spec = importlib.util.spec_from_file_location(
         "test_learner_profile_migration_module",
         path,
@@ -45,18 +49,20 @@ def test_learner_profile_column_remains_nullable_for_rolling_writers() -> None:
     executed_statements = []
 
     class _BatchOperations:
-        def add_column(self, column):
+        def add_column(self, column) -> None:
             added_columns.append(column)
 
-        def alter_column(self, column_name, **kwargs: object):
+        def alter_column(self, column_name, **kwargs: object) -> None:
             altered_columns.append((column_name, kwargs))
 
     class _Operations:
         @contextmanager
-        def batch_alter_table(self, *_args: object, **_kwargs: object):
+        def batch_alter_table(
+            self, *_args: object, **_kwargs: object
+        ) -> Iterator[object]:
             yield _BatchOperations()
 
-        def execute(self, statement):
+        def execute(self, statement) -> None:
             executed_statements.append(str(statement))
 
     migration.op = _Operations()

--- a/src/api/tests/route/test_user_language_context.py
+++ b/src/api/tests/route/test_user_language_context.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import flaskr.route.user as user_route
 from flask import Flask, jsonify
+from flask.typing import ResponseReturnValue
 from flaskr.i18n import clear_language, get_current_language
 from flaskr.route.user import register_user_handler
 
@@ -21,7 +22,7 @@ def test_authenticated_request_prefers_accept_language_for_runtime_context(
     register_user_handler(app, "/api/user")
 
     @app.route("/runtime-language")
-    def runtime_language():
+    def runtime_language() -> ResponseReturnValue:
         return jsonify({"language": get_current_language()})
 
     try:
@@ -48,7 +49,7 @@ def test_authenticated_request_normalizes_accept_language_for_runtime_context(
     register_user_handler(app, "/api/user")
 
     @app.route("/runtime-language")
-    def runtime_language():
+    def runtime_language() -> ResponseReturnValue:
         return jsonify({"language": get_current_language()})
 
     try:
@@ -75,7 +76,7 @@ def test_authenticated_request_reads_json_payload_language_for_runtime_context(
     register_user_handler(app, "/api/user")
 
     @app.route("/runtime-language", methods=["POST"])
-    def runtime_language():
+    def runtime_language() -> ResponseReturnValue:
         return jsonify({"language": get_current_language()})
 
     try:

--- a/src/api/tests/scripts/test_observability_consistency_probes.py
+++ b/src/api/tests/scripts/test_observability_consistency_probes.py
@@ -16,7 +16,7 @@ class _Db:
         self.session = session
 
 
-def _build_db():
+def _build_db() -> SimpleNamespace:
     engine = create_engine("sqlite:///:memory:")
     session = sessionmaker(bind=engine)()
     session.execute(
@@ -70,13 +70,13 @@ def _build_db():
     return SimpleNamespace(engine=engine, session=session, db=_Db(session))
 
 
-def _args():
+def _args() -> argparse.Namespace:
     return argparse.Namespace(limit=20)
 
 
 def _insert_wallet(
     session, *, wallet_bid: str, creator_bid: str, available: str, reserved: str = "0"
-):
+) -> None:
     session.execute(
         text(
             """
@@ -105,7 +105,7 @@ def _insert_bucket(
     source_type: int = 7411,
     effective_from: datetime,
     effective_to: datetime | None = None,
-):
+) -> None:
     session.execute(
         text(
             """
@@ -147,7 +147,7 @@ def _insert_bucket(
     )
 
 
-def _insert_active_subscription(session, *, creator_bid: str, now: datetime):
+def _insert_active_subscription(session, *, creator_bid: str, now: datetime) -> None:
     session.execute(
         text(
             """
@@ -168,7 +168,7 @@ def _insert_active_subscription(session, *, creator_bid: str, now: datetime):
     )
 
 
-def _probe(env, *, now: datetime):
+def _probe(env, *, now: datetime) -> object:
     return probe_wallet_snapshot(
         env.db,
         inspect(env.engine),

--- a/src/api/tests/service/billing/billing_write_routes_test_helpers.py
+++ b/src/api/tests/service/billing/billing_write_routes_test_helpers.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import flaskr.common.config as common_config
 import flaskr.service.billing.checkout as billing_checkout_module
 import flaskr.service.billing.subscriptions as billing_subscriptions_module
-from flask import Flask, jsonify, request
+from flask import Flask, Response, jsonify, request
 from flaskr import dao
 from flaskr.i18n import load_translations, set_language
 from flaskr.service.billing.consts import (
@@ -392,7 +392,7 @@ def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
     refund_requests: list[dict] = []
 
     class FakeStripeProvider:
-        def create_payment(self, *, request, app):
+        def create_payment(self, *, request, app) -> PaymentCreationResult:
             _ = app
             stripe_requests.append(
                 {
@@ -413,10 +413,12 @@ def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
                 extra={"url": "https://stripe.test/checkout"},
             )
 
-        def create_subscription(self, *, request, app):
+        def create_subscription(self, *, request, app) -> object:
             return self.create_payment(request=request, app=app)
 
-        def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+        def sync_reference(
+            self, *, provider_reference: str, reference_type: str, app
+        ) -> PaymentNotificationResult:
             _ = app
             assert reference_type == "checkout_session"
             return PaymentNotificationResult(
@@ -441,7 +443,7 @@ def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
 
         def cancel_subscription(
             self, *, subscription_bid: str, provider_subscription_id: str, app
-        ):
+        ) -> SubscriptionUpdateResult:
             _ = app
             return SubscriptionUpdateResult(
                 provider_reference=provider_subscription_id,
@@ -457,7 +459,7 @@ def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
 
         def resume_subscription(
             self, *, subscription_bid: str, provider_subscription_id: str, app
-        ):
+        ) -> SubscriptionUpdateResult:
             _ = app
             return SubscriptionUpdateResult(
                 provider_reference=provider_subscription_id,
@@ -471,7 +473,7 @@ def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
                 extra={"cancel_at_period_end": False},
             )
 
-        def refund_payment(self, *, request, app):
+        def refund_payment(self, *, request, app) -> PaymentRefundResult:
             _ = app
             refund_requests.append(
                 {
@@ -488,7 +490,7 @@ def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
             )
 
     class FakePingxxProvider:
-        def create_payment(self, *, request, app):
+        def create_payment(self, *, request, app) -> PaymentCreationResult:
             _ = app
             pingxx_requests.append(
                 {
@@ -505,7 +507,9 @@ def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
                 extra={"credential": {"alipay_qr": "https://pingxx.test/qr"}},
             )
 
-        def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+        def sync_reference(
+            self, *, provider_reference: str, reference_type: str, app
+        ) -> PaymentNotificationResult:
             _ = app
             assert reference_type == "charge"
             return PaymentNotificationResult(
@@ -515,7 +519,9 @@ def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
                 charge_id=provider_reference,
             )
 
-    def _fake_get_payment_provider(channel: str):
+    def _fake_get_payment_provider(
+        channel: str,
+    ) -> FakeStripeProvider | FakePingxxProvider:
         if channel == "stripe":
             return FakeStripeProvider()
         if channel == "pingxx":
@@ -540,7 +546,7 @@ def billing_write_client(monkeypatch) -> Iterator[dict[str, object]]:
     )
 
     @app.errorhandler(AppError)
-    def _handle_app_exception(error: AppError):
+    def _handle_app_exception(error: AppError) -> Response:
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response

--- a/src/api/tests/service/billing/test_admin_billing_routes.py
+++ b/src/api/tests/service/billing/test_admin_billing_routes.py
@@ -15,7 +15,7 @@ import flaskr.service.billing.serializers as billing_serializers_module
 import flaskr.service.billing.wallets as billing_wallets_module
 import flaskr.service.common.contact_identifiers as contact_identifiers_module
 import pytest
-from flask import Flask, jsonify, request
+from flask import Flask, Response, jsonify, request
 from flaskr import dao
 from flaskr.i18n import _translations, load_translations, set_language
 from flaskr.service.billing.campaigns import (
@@ -154,7 +154,7 @@ def admin_billing_client(monkeypatch) -> Iterator[dict[str, object]]:
     load_translations(app)
 
     @app.errorhandler(AppError)
-    def _handle_app_exception(error: AppError):
+    def _handle_app_exception(error: AppError) -> Response:
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response
@@ -1289,7 +1289,9 @@ class TestAdminBillingRoutes:
             _resolve_existing_target,
         )
 
-        def _save_branding(_app, creator_bid, payload, **kwargs: object):
+        def _save_branding(
+            _app, creator_bid, payload, **kwargs: object
+        ) -> dict[str, object | None]:
             captured["creator_bid"] = creator_bid
             captured["payload"] = payload
             captured["kwargs"] = kwargs

--- a/src/api/tests/service/billing/test_admin_ops_state.py
+++ b/src/api/tests/service/billing/test_admin_ops_state.py
@@ -9,11 +9,11 @@ class _TrackingLock:
         self._events = events
         self._key = key
 
-    def acquire(self, **_kwargs: object):
+    def acquire(self, **_kwargs: object) -> bool:
         self._events.append(("acquire", self._key))
         return True
 
-    def release(self):
+    def release(self) -> None:
         self._events.append(("release", self._key))
 
 
@@ -21,18 +21,18 @@ class _TrackingRedis:
     def __init__(self) -> None:
         self.events = []
 
-    def lock(self, key, **_kwargs: object):
+    def lock(self, key, **_kwargs: object) -> object:
         self.events.append(("lock", key))
         return _TrackingLock(self.events, key)
 
 
-def _patch_config_store(monkeypatch):
+def _patch_config_store(monkeypatch) -> dict[object, object]:
     store = {}
 
-    def fake_get_config(key, default=None):
+    def fake_get_config(key, default=None) -> object:
         return store.get(key, default)
 
-    def fake_update_config(_app, key, value, **kwargs: object):
+    def fake_update_config(_app, key, value, **kwargs: object) -> bool:
         store[key] = value
         store[(key, "meta")] = kwargs
         return True

--- a/src/api/tests/service/billing/test_billing_callbacks.py
+++ b/src/api/tests/service/billing/test_billing_callbacks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Never
 
 import pytest
 from flask import Flask
@@ -606,7 +606,7 @@ class TestBillingNativeCallbacks:
         self, billing_callback_app, monkeypatch
     ) -> None:
         class FakeAlipayProvider:
-            def handle_notification(self, *, payload, app):
+            def handle_notification(self, *, payload, app) -> PaymentNotificationResult:
                 _ = (payload, app)
                 return _alipay_notification("bill-native-alipay-1", "TRADE_SUCCESS")
 
@@ -796,7 +796,7 @@ class TestBillingNativeCallbacks:
         self, billing_callback_app, monkeypatch
     ) -> None:
         class FakeAlipayProvider:
-            def handle_notification(self, *, payload, app):
+            def handle_notification(self, *, payload, app) -> PaymentNotificationResult:
                 _ = (payload, app)
                 return _alipay_notification("missing-native-order", "TRADE_SUCCESS")
 
@@ -822,7 +822,9 @@ class TestBillingNativeCallbacks:
         self, billing_callback_app, monkeypatch
     ) -> None:
         class FakeWechatPayProvider:
-            def verify_webhook(self, *, headers, raw_body, app):
+            def verify_webhook(
+                self, *, headers, raw_body, app
+            ) -> PaymentNotificationResult:
                 _ = (headers, raw_body, app)
                 return _wechatpay_notification("legacy-wechatpay-attempt-1", "SUCCESS")
 
@@ -888,7 +890,7 @@ class TestBillingNativeCallbacks:
         self, billing_callback_app, monkeypatch
     ) -> None:
         class FakeWechatPayProvider:
-            def verify_webhook(self, *, headers, raw_body, app):
+            def verify_webhook(self, *, headers, raw_body, app) -> Never:
                 _ = (headers, raw_body, app)
                 message = "secret verification detail"
                 raise RuntimeError(message)

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -66,7 +66,7 @@ def billing_cli_runner() -> FlaskCliRunner:
     app.testing = True
 
     @app.cli.group()
-    def console():
+    def console() -> None:
         """Test console root."""
 
     register_billing_commands(console)
@@ -91,7 +91,7 @@ def billing_cli_db_app() -> Iterator[Flask]:
     dao.db.init_app(app)
 
     @app.cli.group()
-    def console():
+    def console() -> None:
         """Test console root."""
 
     register_billing_commands(console)

--- a/src/api/tests/service/billing/test_billing_credit_audit.py
+++ b/src/api/tests/service/billing/test_billing_credit_audit.py
@@ -49,7 +49,7 @@ def billing_credit_audit_app() -> Iterator[Flask]:
     dao.db.init_app(app)
 
     @app.cli.group()
-    def console():
+    def console() -> None:
         """Test console root."""
 
     register_billing_commands(console)

--- a/src/api/tests/service/billing/test_billing_cycle_transitions.py
+++ b/src/api/tests/service/billing/test_billing_cycle_transitions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from types import SimpleNamespace
+from typing import Never
 
 import pytest
 from flaskr.service.billing.consts import (
@@ -20,7 +21,7 @@ from flaskr.service.billing.cycle_transitions import (
 )
 
 
-def _raise_unexpected_call(*_args: object, **_kwargs: object):
+def _raise_unexpected_call(*_args: object, **_kwargs: object) -> Never:
     message = "unexpected callback call"
     raise AssertionError(message)
 

--- a/src/api/tests/service/billing/test_billing_domains.py
+++ b/src/api/tests/service/billing/test_billing_domains.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 import flaskr.service.billing.domains as billing_domains
 import pytest
-from flask import Flask, jsonify, request
+from flask import Flask, Response, jsonify, request
 from flaskr import dao
 from flaskr.common.shifu_context import get_shifu_creator_bid, with_shifu_context
 from flaskr.service.billing.consts import (
@@ -35,6 +35,8 @@ from tests.service.billing.route_loader import (
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from flask.typing import ResponseReturnValue
+
 billing_routes_module = load_billing_routes_module()
 register_billing_routes = load_register_billing_routes()
 
@@ -56,7 +58,7 @@ def billing_domain_client(monkeypatch) -> Iterator[dict[str, object]]:
     dao.db.init_app(app)
 
     @app.errorhandler(AppError)
-    def _handle_app_exception(error: AppError):
+    def _handle_app_exception(error: AppError) -> Response:
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response
@@ -72,7 +74,7 @@ def billing_domain_client(monkeypatch) -> Iterator[dict[str, object]]:
 
     @app.route("/_domain-context", methods=["GET"])
     @with_shifu_context()
-    def _domain_context():
+    def _domain_context() -> ResponseReturnValue:
         return jsonify({"creator_bid": get_shifu_creator_bid()})
 
     monkeypatch.setattr(
@@ -184,7 +186,7 @@ class TestBillingDomains:
             verification_token="verify-token",
         )
 
-        def fake_resolve(name, record_type, lifetime):
+        def fake_resolve(name, record_type, lifetime) -> list[SimpleNamespace]:
             assert lifetime == 5
             if record_type == "TXT":
                 assert name == "_ai-shifu-verification.learn.example.com"

--- a/src/api/tests/service/billing/test_billing_entitlements.py
+++ b/src/api/tests/service/billing/test_billing_entitlements.py
@@ -55,7 +55,7 @@ def billing_entitlement_app() -> Flask:
         dao.db.drop_all()
 
 
-def _seed_products_with_yearly_entitlements():
+def _seed_products_with_yearly_entitlements() -> object:
     return build_bill_products(
         overrides_by_bid={
             "bill-product-plan-yearly": {

--- a/src/api/tests/service/billing/test_billing_error_specificity.py
+++ b/src/api/tests/service/billing/test_billing_error_specificity.py
@@ -32,7 +32,7 @@ class _UnavailableLock:
 
 
 class _LockFactory:
-    def lock(self, *_args: object, **_kwargs: object):
+    def lock(self, *_args: object, **_kwargs: object) -> object:
         return _UnavailableLock()
 
 

--- a/src/api/tests/service/billing/test_billing_renewal_compensation.py
+++ b/src/api/tests/service/billing/test_billing_renewal_compensation.py
@@ -58,7 +58,9 @@ def billing_renewal_compensation_env(
     sync_state: dict[str, dict] = {"subscription": {}}
 
     class FakeStripeProvider:
-        def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+        def sync_reference(
+            self, *, provider_reference: str, reference_type: str, app
+        ) -> PaymentNotificationResult:
             _ = app
             assert reference_type == "subscription"
             assert provider_reference == sync_state["subscription"]["id"]

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -14,7 +14,7 @@ import flaskr.service.billing.queries as billing_queries_module
 import flaskr.service.billing.read_models as billing_read_models_module
 import flaskr.service.billing.serializers as billing_serializers_module
 import pytest
-from flask import Flask, jsonify, request
+from flask import Flask, Response, jsonify, request
 from flaskr import dao
 from flaskr.service.billing.capabilities import build_billing_route_bootstrap
 from flaskr.service.billing.consts import (
@@ -119,7 +119,7 @@ def _freeze_billing_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(billing_serializers_module, "now_utc", lambda: _frozen_now)
 
 
-def _seed_products_with_yearly_entitlements():
+def _seed_products_with_yearly_entitlements() -> object:
     return build_bill_products(
         overrides_by_bid={
             "bill-product-plan-yearly": {
@@ -156,7 +156,7 @@ def billing_test_client(monkeypatch) -> Iterator[FlaskClient]:
     dao.db.init_app(app)
 
     @app.errorhandler(AppError)
-    def _handle_app_exception(error: AppError):
+    def _handle_app_exception(error: AppError) -> Response:
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response
@@ -1226,7 +1226,7 @@ class TestBillingRoutes:
         with app.app_context():
             order_select_count = 0
 
-            def _count_order_selects(_conn, _cursor, statement, *_args: object):
+            def _count_order_selects(_conn, _cursor, statement, *_args: object) -> None:
                 nonlocal order_select_count
                 if "bill_orders" in statement.lower():
                     order_select_count += 1
@@ -1695,7 +1695,7 @@ class TestBillingRoutes:
 
         order_select_count = 0
 
-        def _count_order_selects(_conn, _cursor, statement, *_args: object):
+        def _count_order_selects(_conn, _cursor, statement, *_args: object) -> None:
             nonlocal order_select_count
             if "bill_orders" in statement.lower():
                 order_select_count += 1

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -6,7 +6,7 @@ import sys
 import types
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Never
 
 import pytest
 from flask import Flask
@@ -145,7 +145,7 @@ def _billing_paid_feishu_payload(
     }
 
 
-def _raise_if_send_notify_called(*args: object, **kwargs: object):
+def _raise_if_send_notify_called(*args: object, **kwargs: object) -> Never:
     _ = (args, kwargs)
     message = "billing paid Feishu delivery should run in a Celery task"
     raise AssertionError(message)
@@ -265,7 +265,9 @@ def test_sync_billing_order_enqueues_subscription_purchase_sms_once(
     enqueued: list[str] = []
 
     class FakeStripeProvider:
-        def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+        def sync_reference(
+            self, *, provider_reference: str, reference_type: str, app
+        ) -> PaymentNotificationResult:
             _ = app
             assert reference_type == "subscription"
             return PaymentNotificationResult(
@@ -418,7 +420,9 @@ def test_sync_billing_order_enqueues_subscription_paid_feishu_once(
     enqueued: list[str] = []
 
     class FakeStripeProvider:
-        def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+        def sync_reference(
+            self, *, provider_reference: str, reference_type: str, app
+        ) -> PaymentNotificationResult:
             _ = app
             assert reference_type == "subscription"
             return PaymentNotificationResult(
@@ -588,7 +592,9 @@ def test_sync_billing_topup_enqueues_billing_paid_feishu_once(
     enqueued: list[str] = []
 
     class FakePingxxProvider:
-        def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+        def sync_reference(
+            self, *, provider_reference: str, reference_type: str, app
+        ) -> PaymentNotificationResult:
             _ = app
             assert provider_reference == "ch_billing_feishu_topup_sync_1"
             assert reference_type == "charge"
@@ -673,7 +679,9 @@ def test_sync_pingxx_order_syncs_manual_trial_subscription_provider(
     paid_at = datetime(2026, 7, 31, 4, 0, 53)
 
     class FakePingxxProvider:
-        def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+        def sync_reference(
+            self, *, provider_reference: str, reference_type: str, app
+        ) -> PaymentNotificationResult:
             _ = app
             assert provider_reference == "ch_trial_upgrade_sync_pingxx_1"
             assert reference_type == "charge"
@@ -1146,7 +1154,7 @@ def test_requeue_subscription_purchase_sms_enqueues_failed_provider_order(
     captured_kwargs: list[dict[str, str]] = []
 
     class FakeTask:
-        def apply_async(self, kwargs):
+        def apply_async(self, kwargs) -> None:
             captured_kwargs.append(dict(kwargs))
 
     fake_celery = SimpleNamespace(tasks={SUBSCRIPTION_SMS_TASK_NAME: FakeTask()})

--- a/src/api/tests/service/billing/test_billing_tasks.py
+++ b/src/api/tests/service/billing/test_billing_tasks.py
@@ -111,7 +111,7 @@ def test_settle_usage_task_calls_settlement_engine(
 
     captured: dict[str, object] = {}
 
-    def _fake_settle_bill_usage(app, *, usage_bid: str = ""):
+    def _fake_settle_bill_usage(app, *, usage_bid: str = "") -> dict[str, str]:
         captured["app"] = app
         captured["usage_bid"] = usage_bid
         return {
@@ -170,7 +170,7 @@ def test_aggregate_daily_usage_metrics_task_calls_helper(
         stat_date: str = "",
         creator_bid: str = "",
         finalize: bool = False,
-    ):
+    ) -> dict[str, str | bool | None]:
         captured["app"] = app
         captured["stat_date"] = stat_date
         captured["creator_bid"] = creator_bid
@@ -217,7 +217,7 @@ def test_aggregate_daily_ledger_summary_task_calls_helper(
         stat_date: str = "",
         creator_bid: str = "",
         finalize: bool = False,
-    ):
+    ) -> dict[str, str | bool | None]:
         captured["app"] = app
         captured["stat_date"] = stat_date
         captured["creator_bid"] = creator_bid
@@ -266,7 +266,7 @@ def test_finalize_daily_ledger_summary_task_defaults_to_previous_day(
         *,
         stat_date: str = "",
         creator_bid: str = "",
-    ):
+    ) -> dict[str, str | bool | None]:
         captured["app"] = app
         captured["stat_date"] = stat_date
         captured["creator_bid"] = creator_bid
@@ -307,7 +307,7 @@ def test_finalize_daily_ledger_summary_task_accepts_explicit_stat_date(
         *,
         stat_date: str = "",
         creator_bid: str = "",
-    ):
+    ) -> dict[str, str | bool | None]:
         captured["app"] = app
         captured["stat_date"] = stat_date
         captured["creator_bid"] = creator_bid
@@ -352,7 +352,7 @@ def test_rebuild_daily_aggregates_task_calls_helper(
         shifu_bid: str = "",
         date_from: str = "",
         date_to: str = "",
-    ):
+    ) -> dict[str, str | None]:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["shifu_bid"] = shifu_bid
@@ -404,7 +404,7 @@ def test_verify_domain_binding_task_calls_helper(
         domain_binding_bid: str = "",
         host: str = "",
         verification_token: str = "",
-    ):
+    ) -> dict[str, str | dict[str, str | None] | None]:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["domain_binding_bid"] = domain_binding_bid
@@ -460,7 +460,7 @@ def test_settle_usage_task_serializes_same_creator_concurrent_usage(
             self._events = events
             self._second_attempted = second_attempted
 
-        def acquire(self, blocking: bool = True, blocking_timeout=None):
+        def acquire(self, blocking: bool = True, blocking_timeout=None) -> object:
             self._events.append(
                 {
                     "type": "attempt",
@@ -510,7 +510,7 @@ def test_settle_usage_task_serializes_same_creator_concurrent_usage(
             self.events: list[dict[str, object]] = []
             self.second_attempted = threading.Event()
 
-        def lock(self, key: str, timeout=None, blocking_timeout=None):
+        def lock(self, key: str, timeout=None, blocking_timeout=None) -> object:
             del timeout, blocking_timeout
             with self._guard:
                 raw_lock = self._locks.setdefault(key, threading.Lock())
@@ -536,7 +536,7 @@ def test_settle_usage_task_serializes_same_creator_concurrent_usage(
 
     original_build_usage_metric_charges = settlement_module.build_usage_metric_charges
 
-    def _blocking_build_usage_metric_charges(*args: object, **kwargs: object):
+    def _blocking_build_usage_metric_charges(*args: object, **kwargs: object) -> object:
         usage = args[0]
         if usage.usage_bid == "usage-concurrent-1":
             entered_first_charge.set()
@@ -760,7 +760,7 @@ def test_replay_usage_settlement_task_calls_replay_helper(
         creator_bid: str = "",
         usage_bid: str = "",
         usage_id=None,
-    ):
+    ) -> dict[str, str | bool]:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["usage_bid"] = usage_bid
@@ -801,7 +801,9 @@ def test_expire_wallet_buckets_task_calls_wallet_helper(
 
     captured: dict[str, object] = {}
 
-    def _fake_expire_credit_wallet_buckets(app, *, creator_bid="", expire_before=None):
+    def _fake_expire_credit_wallet_buckets(
+        app, *, creator_bid="", expire_before=None
+    ) -> dict[str, str | int]:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["expire_before"] = expire_before
@@ -856,7 +858,9 @@ def test_expire_pending_orders_task_delegates_to_sync_flow(
 
     captured: dict[str, object] = {}
 
-    def _fake_sync_billing_order(app, creator_bid: str, bill_order_bid: str, payload):
+    def _fake_sync_billing_order(
+        app, creator_bid: str, bill_order_bid: str, payload
+    ) -> SimpleNamespace:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["bill_order_bid"] = bill_order_bid
@@ -925,7 +929,9 @@ def test_expire_pending_orders_task_includes_legacy_orders_without_expires_at(
 
     captured: dict[str, object] = {}
 
-    def _fake_sync_billing_order(app, creator_bid: str, bill_order_bid: str, payload):
+    def _fake_sync_billing_order(
+        app, creator_bid: str, bill_order_bid: str, payload
+    ) -> SimpleNamespace:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["bill_order_bid"] = bill_order_bid
@@ -1051,7 +1057,7 @@ def test_sync_billing_order_runs_under_per_creator_credit_ledger_lock(
             events.append(("release", self._key))
 
     class _RecordingCache:
-        def lock(self, key, timeout=None, blocking_timeout=None):
+        def lock(self, key, timeout=None, blocking_timeout=None) -> object:
             _ = (timeout, blocking_timeout)
             return _RecordingLock(key)
 
@@ -1111,7 +1117,7 @@ def test_reconcile_provider_reference_task_delegates_to_reconcile_helper(
         provider_reference_id="",
         bill_order_bid="",
         session_id="",
-    ):
+    ) -> dict[str, object]:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["payment_provider"] = payment_provider
@@ -1194,7 +1200,7 @@ def test_dispatch_due_renewal_events_task_noops_when_disabled(
 
     called = {"apply_async": 0}
 
-    def _fake_apply_async(*, kwargs=None, **options: object):
+    def _fake_apply_async(*, kwargs=None, **options: object) -> None:
         del kwargs, options
         called["apply_async"] += 1
 
@@ -1336,7 +1342,7 @@ def test_dispatch_due_renewal_events_task_enqueues_due_pending_events_only(
 
     captured_calls: list[dict[str, object]] = []
 
-    def _fake_apply_async(*, kwargs=None, **options: object):
+    def _fake_apply_async(*, kwargs=None, **options: object) -> None:
         captured_calls.append(
             {
                 "kwargs": dict(kwargs or {}),
@@ -1427,7 +1433,7 @@ def test_dispatch_due_renewal_events_recovers_stale_processing_events(
 
     captured_calls: list[dict[str, object]] = []
 
-    def _fake_apply_async(*, kwargs=None, **options: object):
+    def _fake_apply_async(*, kwargs=None, **options: object) -> None:
         captured_calls.append(
             {
                 "kwargs": dict(kwargs or {}),
@@ -1505,7 +1511,7 @@ def test_dispatch_due_renewal_events_uses_dedicated_queue_when_enabled(
 
     captured_calls: list[dict[str, object]] = []
 
-    def _fake_apply_async(*, kwargs=None, **options: object):
+    def _fake_apply_async(*, kwargs=None, **options: object) -> None:
         captured_calls.append(
             {
                 "kwargs": dict(kwargs or {}),
@@ -1621,7 +1627,7 @@ def test_retry_failed_renewal_task_reuses_reconcile_helper_when_reference_exists
         provider_reference_id="",
         bill_order_bid="",
         session_id="",
-    ):
+    ) -> dict[str, object]:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["payment_provider"] = payment_provider

--- a/src/api/tests/service/billing/test_billing_trial_credits.py
+++ b/src/api/tests/service/billing/test_billing_trial_credits.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
-from flask import Flask, jsonify, request
+from flask import Flask, Response, jsonify, request
 from flaskr import dao
 from flaskr.service.billing.consts import (
     BILLING_LEGACY_NEW_CREATOR_TRIAL_PROGRAM_CODE,
@@ -80,7 +80,7 @@ def trial_billing_client(monkeypatch) -> FlaskClient:
     dao.db.init_app(app)
 
     @app.errorhandler(AppError)
-    def _handle_app_exception(error: AppError):
+    def _handle_app_exception(error: AppError) -> Response:
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
@@ -464,7 +464,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_realigned_during_refresh(
 
         real_refresh = wallets_mod.db.session.refresh
 
-        def _refresh_with_realign(target_bucket):
+        def _refresh_with_realign(target_bucket) -> object:
             if (
                 isinstance(target_bucket, CreditWalletBucket)
                 and target_bucket.wallet_bucket_bid == "bucket-expire-realigned"
@@ -565,7 +565,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_consumed_before_write(
         real_expire = wallets_mod._expire_bucket_available_credits_if_unchanged
         changed = {"done": False}
 
-        def _consume_before_expire(target_bucket, **kwargs: object):
+        def _consume_before_expire(target_bucket, **kwargs: object) -> object:
             if (
                 not changed["done"]
                 and target_bucket.wallet_bucket_bid
@@ -687,7 +687,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_extended_before_write(
         real_expire = wallets_mod._expire_bucket_available_credits_if_unchanged
         changed = {"done": False}
 
-        def _extend_before_expire(target_bucket, **kwargs: object):
+        def _extend_before_expire(target_bucket, **kwargs: object) -> object:
             if (
                 not changed["done"]
                 and target_bucket.wallet_bucket_bid
@@ -777,7 +777,7 @@ def test_expire_credit_wallet_buckets_skips_empty_bucket_released_before_status_
         real_sync = wallets_mod._sync_empty_available_bucket_status_if_unchanged
         changed = {"done": False}
 
-        def _release_before_status_sync(target_bucket, **kwargs: object):
+        def _release_before_status_sync(target_bucket, **kwargs: object) -> object:
             if not changed["done"]:
                 changed["done"] = True
                 CreditWalletBucket.query.filter(
@@ -885,7 +885,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_deleted_during_refresh(
 
         real_refresh = wallets_mod.db.session.refresh
 
-        def _refresh_with_deleted_bucket(target_bucket):
+        def _refresh_with_deleted_bucket(target_bucket) -> object:
             if (
                 isinstance(target_bucket, CreditWalletBucket)
                 and target_bucket.wallet_bucket_bid == "bucket-expire-refresh-skip"
@@ -977,7 +977,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_when_refresh_raises_deleted(
 
         real_refresh = wallets_mod.db.session.refresh
 
-        def _refresh_with_deleted_error(target_bucket):
+        def _refresh_with_deleted_error(target_bucket) -> object:
             if (
                 isinstance(target_bucket, CreditWalletBucket)
                 and target_bucket.wallet_bucket_bid == "bucket-expire-refresh-error"
@@ -1063,7 +1063,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_on_wallet_version_conflict(
         real_persist = wallets_mod.persist_credit_wallet_snapshot
         state = {"calls": 0}
 
-        def _persist_conflict_once(target_wallet, **kwargs: object):
+        def _persist_conflict_once(target_wallet, **kwargs: object) -> object:
             state["calls"] += 1
             if state["calls"] == 1:
                 message = "credit_wallet_version_conflict"

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_grants.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_grants.py
@@ -165,7 +165,7 @@ def test_grant_manual_credit_wallet_balance_returns_noop_existing_after_integrit
     original_commit = dao.db.session.commit
     state = {"raised": False}
 
-    def _commit_once_with_duplicate():
+    def _commit_once_with_duplicate() -> object:
         if not state["raised"]:
             state["raised"] = True
             dao.db.session.rollback()

--- a/src/api/tests/service/billing/test_billing_write_routes_checkout.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_checkout.py
@@ -76,7 +76,7 @@ class TestBillingWriteRoutesCheckout:
     ) -> None:
         client = billing_write_client["client"]
 
-        def fake_get_config(key, default=None):
+        def fake_get_config(key, default=None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "stripe"
             return default

--- a/src/api/tests/service/billing/test_billing_write_routes_subscription_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_subscription_lifecycle.py
@@ -457,7 +457,7 @@ class TestBillingWriteRoutesSubscriptionLifecycle:
     ) -> None:
         client = billing_write_client["client"]
 
-        def fake_get_config(key, default=None):
+        def fake_get_config(key, default=None) -> object:
             if key == "PINGXX_APP_ID":
                 return "app_billing_test"
             return default

--- a/src/api/tests/service/billing/test_billing_write_routes_topup.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_topup.py
@@ -600,7 +600,7 @@ class TestBillingWriteRoutesTopup:
         app = billing_write_client["app"]
         add_active_subscription(app, subscription_bid="sub-topup-default-provider-1")
 
-        def fake_get_config(key, default=None):
+        def fake_get_config(key, default=None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "pingxx"
             return default

--- a/src/api/tests/service/billing/test_creator_customization.py
+++ b/src/api/tests/service/billing/test_creator_customization.py
@@ -615,7 +615,7 @@ def test_creator_brand_logo_upload_uses_courses_oss_and_can_be_saved(
     _require_saas_config_plugin()
     monkeypatch.setattr(customization, "is_creator_customization_enabled", lambda: True)
 
-    def fake_get_config(key, default=None):
+    def fake_get_config(key, default=None) -> object:
         if key == "ALIBABA_CLOUD_OSS_COURSES_URL":
             return "https://courses-oss.example.com"
         if key == "ALIBABA_CLOUD_OSS_BASE_URL":
@@ -624,7 +624,7 @@ def test_creator_brand_logo_upload_uses_courses_oss_and_can_be_saved(
 
     uploaded = {}
 
-    def fake_upload_to_storage(_app, **kwargs: object):
+    def fake_upload_to_storage(_app, **kwargs: object) -> SimpleNamespace:
         uploaded.update(kwargs)
         return SimpleNamespace(
             url=f"https://courses-oss.example.com/{kwargs['object_key']}",
@@ -669,7 +669,7 @@ def test_creator_brand_logo_upload_uses_courses_oss_and_can_be_saved(
 def test_unavailable_saas_plugin_keeps_optional_customization_reads_empty(
     app, monkeypatch
 ) -> None:
-    def missing_plugin(name):
+    def missing_plugin(name) -> object:
         if name.startswith("flaskr.plugins.ai_shifu_saas_plugin"):
             raise ModuleNotFoundError(name=name)
         return import_module(name)
@@ -700,7 +700,7 @@ def test_installed_but_disabled_saas_plugin_falls_back(app, monkeypatch) -> None
             message = "SaaS plugin must not be used while SAAS_PLUGIN_ENABLED is false"
             raise AssertionError(message)
 
-    def fake_import(name):
+    def fake_import(name) -> object:
         if name.startswith("flaskr.plugins.ai_shifu_saas_plugin"):
             return _ExplodingModule()
         return import_module(name)
@@ -732,7 +732,7 @@ def test_creator_brand_favicon_upload_converts_png_to_ico(app, monkeypatch) -> N
 
     uploaded = {}
 
-    def fake_upload_to_storage(_app, **kwargs: object):
+    def fake_upload_to_storage(_app, **kwargs: object) -> SimpleNamespace:
         uploaded.update(kwargs)
         return SimpleNamespace(
             url=f"https://courses-oss.example.com/{kwargs['object_key']}",
@@ -828,7 +828,7 @@ def test_runtime_branding_falls_back_to_square_logo_for_favicon(app) -> None:
 def test_creator_branding_home_url_roundtrip(app, monkeypatch) -> None:
     monkeypatch.setattr(customization, "is_creator_customization_enabled", lambda: True)
 
-    def missing_plugin(name):
+    def missing_plugin(name) -> object:
         if name.startswith("flaskr.plugins.ai_shifu_saas_plugin"):
             raise ModuleNotFoundError(name=name)
         return import_module(name)
@@ -927,7 +927,7 @@ def test_creator_brand_logo_upload_rejects_invalid_or_oversized_image(
 def test_creator_brand_logo_upload_normalizes_square_variant(app, monkeypatch) -> None:
     uploaded = {}
 
-    def fake_upload_to_storage(_app, **kwargs: object):
+    def fake_upload_to_storage(_app, **kwargs: object) -> object:
         content = kwargs["file_content"].read()
         uploaded["content"] = content
         return type("UploadResult", (), {"url": "https://cdn.example.com/logo.png"})()
@@ -966,7 +966,7 @@ def test_creator_brand_logo_upload_preserves_wide_retina_variant(
 ) -> None:
     uploaded = {}
 
-    def fake_upload_to_storage(_app, **kwargs: object):
+    def fake_upload_to_storage(_app, **kwargs: object) -> object:
         content = kwargs["file_content"].read()
         uploaded["content"] = content
         return type("UploadResult", (), {"url": "https://cdn.example.com/logo.png"})()

--- a/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
@@ -23,6 +23,7 @@ import secrets
 from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import Never
 
 import pytest
 from flask import Flask
@@ -91,7 +92,7 @@ def credit_notification_uow_app(tmp_path) -> Flask:
 
 
 @pytest.fixture(autouse=True)
-def _neutralize_savepoints_on_sqlite(monkeypatch):
+def _neutralize_savepoints_on_sqlite(monkeypatch) -> None:
     """Make begin_nested a no-op under the SQLite test engine.
 
     ``_stage_notification_record`` wraps its INSERT in
@@ -249,8 +250,10 @@ def _seed_credit_ledger(*, ledger_bid: str, creator_bid: str) -> None:
     dao.db.session.commit()
 
 
-def _stub_send_sms(monkeypatch: pytest.MonkeyPatch, sends: list[dict]):
-    def fake_send(app, mobile, *, template_code, template_params, sign_name=None):
+def _stub_send_sms(monkeypatch: pytest.MonkeyPatch, sends: list[dict]) -> None:
+    def fake_send(
+        app, mobile, *, template_code, template_params, sign_name=None
+    ) -> SimpleNamespace:
         _ = (app, sign_name)
         sends.append(
             {
@@ -293,7 +296,7 @@ def test_scan_item_failure_is_isolated_from_neighbor_items(
 
     original_stage = credit_notifications._stage_notification_record
 
-    def staging_then_boom(app_arg, **kwargs: object):
+    def staging_then_boom(app_arg, **kwargs: object) -> object:
         result = original_stage(app_arg, **kwargs)
         if kwargs.get("creator_bid") == "creator-uow-2":
             message = "boom in creator-uow-2"
@@ -401,7 +404,7 @@ def test_failed_provider_marker_persists_and_stays_retryable(
     )
     notification_bid = str(staged["notification_bid"])
 
-    def crashing_send(*_args: object, **_kwargs: object):
+    def crashing_send(*_args: object, **_kwargs: object) -> Never:
         message = "provider connection dropped"
         raise RuntimeError(message)
 

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -2226,7 +2226,7 @@ def test_failed_provider_notification_can_be_requeued(
     captured_kwargs: list[dict[str, str]] = []
 
     class FakeTask:
-        def apply_async(self, kwargs):
+        def apply_async(self, kwargs) -> None:
             captured_kwargs.append(dict(kwargs))
 
     def get_celery_app(flask_app: object | None = None) -> object:

--- a/src/api/tests/service/billing/test_operation_credit_reservations.py
+++ b/src/api/tests/service/billing/test_operation_credit_reservations.py
@@ -508,15 +508,15 @@ def test_operation_credit_mutations_request_wallet_and_bucket_locks(
     real_load_active_buckets = operation_credits._load_active_buckets
     real_iter_hold_buckets = operation_credits._iter_hold_buckets
 
-    def spy_load_wallet(creator_bid: str, *, lock: bool = False):
+    def spy_load_wallet(creator_bid: str, *, lock: bool = False) -> object:
         wallet_lock_calls.append(lock)
         return real_load_wallet(creator_bid, lock=lock)
 
-    def spy_load_active_buckets(wallet, operation_at, *, lock: bool = False):
+    def spy_load_active_buckets(wallet, operation_at, *, lock: bool = False) -> object:
         active_bucket_lock_calls.append(lock)
         return real_load_active_buckets(wallet, operation_at, lock=lock)
 
-    def spy_iter_hold_buckets(hold, *, lock: bool = False):
+    def spy_iter_hold_buckets(hold, *, lock: bool = False) -> object:
         hold_bucket_lock_calls.append(lock)
         return real_iter_hold_buckets(hold, lock=lock)
 

--- a/src/api/tests/service/billing/test_provider_catalog.py
+++ b/src/api/tests/service/billing/test_provider_catalog.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Never
+
 import pytest
 from flaskr.service.billing.consts import (
     BILLING_INTERVAL_MONTH,
@@ -29,7 +31,7 @@ class _StripeObject:
     def __init__(self, payload) -> None:
         self._payload = payload
 
-    def to_dict(self):
+    def to_dict(self) -> dict[object, object]:
         return dict(self._payload)
 
 
@@ -38,7 +40,7 @@ class _FakeStripeResource:
         self.payload = payload
         self.calls = []
 
-    def retrieve(self, *args: object, **kwargs: object):
+    def retrieve(self, *args: object, **kwargs: object) -> object:
         self.calls.append({"args": args, "kwargs": kwargs})
         return _StripeObject(self.payload)
 
@@ -86,7 +88,7 @@ class _FakeStripe:
 
 
 class _FailingStripeResource:
-    def retrieve(self, *args: object, **kwargs: object):
+    def retrieve(self, *args: object, **kwargs: object) -> Never:
         _ = (args, kwargs)
         message = "secret sk_test_should_not_leak"
         raise RuntimeError(message)
@@ -102,7 +104,7 @@ class _FakeStripeAdapter(StripeCatalogReadAdapter):
     def __init__(self, stripe) -> None:
         self.stripe = stripe
 
-    def _client_options(self, app):
+    def _client_options(self, app) -> tuple[object, object]:
         _ = app
         return self.stripe, build_stripe_request_options()
 
@@ -205,7 +207,7 @@ def _snapshot(
         )
 
 
-def _validate(product: BillingProduct, snapshot: ProviderCatalogSnapshot):
+def _validate(product: BillingProduct, snapshot: ProviderCatalogSnapshot) -> object:
     return validate_provider_price_mapping(
         product,
         snapshot,

--- a/src/api/tests/service/billing/test_referral_plan_rewards.py
+++ b/src/api/tests/service/billing/test_referral_plan_rewards.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from decimal import Decimal
+from typing import Never
 
 import pytest
 from flask import Flask
@@ -964,7 +965,7 @@ def test_pingxx_renewal_event_preserves_paid_referral_reward_order(
     boundary_at = normalize_mysql_datetime(now_utc() - timedelta(minutes=1))
     current_cycle_start = boundary_at - timedelta(days=30)
 
-    def _fail_provider_sync(*_args: object, **_kwargs: object):
+    def _fail_provider_sync(*_args: object, **_kwargs: object) -> Never:
         message = "paid referral reward orders must not sync providers"
         raise AssertionError(message)
 

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Never
 
 import pytest
 from flask import Flask
@@ -159,14 +159,16 @@ def _seed_event(
     return event
 
 
-def _failing_lifecycle_sync(monkeypatch: pytest.MonkeyPatch, *, failing_bids: set):
+def _failing_lifecycle_sync(
+    monkeypatch: pytest.MonkeyPatch, *, failing_bids: set
+) -> None:
     """Fail the cancel-effective handler mid-flow for selected subscriptions.
 
     The failure point sits after the subscription mutation and before the
     event completion, simulating any late in-transaction error.
     """
 
-    def fake_sync(_app, subscription):
+    def fake_sync(_app, subscription) -> None:
         if subscription.subscription_bid in failing_bids:
             message = f"boom in {subscription.subscription_bid}"
             raise RuntimeError(message)
@@ -316,7 +318,7 @@ def test_renewal_order_persists_before_provider_sync_crash(
     )
     dao.db.session.commit()
 
-    def crashing_sync(*_args: object, **_kwargs: object):
+    def crashing_sync(*_args: object, **_kwargs: object) -> Never:
         message = "provider sync crash"
         raise RuntimeError(message)
 
@@ -952,7 +954,7 @@ def test_provider_guard_renews_lease_before_cross_transaction_sync(
 
     recovery_counts: list[int] = []
 
-    def fake_sync(*_args: object, **_kwargs: object):
+    def fake_sync(*_args: object, **_kwargs: object) -> SimpleNamespace:
         recovery_counts.append(
             billing_tasks._recover_stale_processing_renewal_events(
                 stale_before=now_utc() - timedelta(minutes=30),
@@ -1067,7 +1069,7 @@ def test_upsert_recovers_when_concurrent_insert_wins(
         event_type: int,
         scheduled_at,
         for_update: bool = False,
-    ):
+    ) -> object:
         nonlocal calls
         calls += 1
         if calls == 1:
@@ -1140,7 +1142,7 @@ def test_upsert_recovers_when_cross_session_insert_wins(
         event_type: int,
         scheduled_at,
         for_update: bool = False,
-    ):
+    ) -> object:
         calls.append(for_update)
         if len(calls) == 1:
             session_factory = sessionmaker(bind=dao.db.engine)

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -263,7 +263,7 @@ def test_runtime_config_uses_origin_header_for_google_redirect_when_host_url_mis
 ) -> None:
     original_route_get_config = config_route.get_config
 
-    def get_config_override(key, default=""):
+    def get_config_override(key, default="") -> object:
         if key == "HOST_URL":
             return ""
         return original_route_get_config(key, default)
@@ -293,7 +293,7 @@ def test_runtime_config_returns_empty_official_site_url_when_unconfigured(
 ) -> None:
     original_route_get_config = config_route.get_config
 
-    def get_config_override(key, default=""):
+    def get_config_override(key, default="") -> object:
         if key == "OFFICIAL_SITE_URL":
             return ""
         return original_route_get_config(key, default)
@@ -313,7 +313,7 @@ def test_runtime_config_uses_registered_home_url_default_on_config_lock_miss(
 ) -> None:
     original_route_get_config = config_route.get_config
 
-    def get_config_override(key, default=None):
+    def get_config_override(key, default=None) -> object:
         if key == "HOME_URL":
             return default
         return original_route_get_config(key, default)

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -1120,7 +1120,7 @@ def test_settle_usage_acquires_creator_scoped_lock(
             self.acquire_calls: list[bool] = []
             self.release_calls = 0
 
-        def acquire(self, blocking: bool = True, blocking_timeout=None):
+        def acquire(self, blocking: bool = True, blocking_timeout=None) -> bool:
             _ = blocking_timeout
             self.acquire_calls.append(bool(blocking))
             return True
@@ -1133,7 +1133,7 @@ def test_settle_usage_acquires_creator_scoped_lock(
             self.calls: list[dict[str, object]] = []
             self.lock_instance = _DummyLock()
 
-        def lock(self, key: str, timeout=None, blocking_timeout=None):
+        def lock(self, key: str, timeout=None, blocking_timeout=None) -> object:
             self.calls.append(
                 {
                     "key": key,
@@ -1207,7 +1207,7 @@ def test_settle_usage_releases_creator_lock_on_error(
         def __init__(self) -> None:
             self.release_calls = 0
 
-        def acquire(self, blocking: bool = True, blocking_timeout=None):
+        def acquire(self, blocking: bool = True, blocking_timeout=None) -> bool:
             _ = (blocking, blocking_timeout)
             return True
 
@@ -1631,7 +1631,7 @@ def test_resolve_credit_multiplier_label_uses_utc_default_settlement(
 
     monkeypatch.setattr(charges, "now_utc", lambda: utc_sentinel)
 
-    def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
+    def fake_load_usage_rate(*, usage, billing_metric, settlement_at) -> None:
         _ = (usage, billing_metric)
         captured.append(settlement_at)
 

--- a/src/api/tests/service/common/test_storage.py
+++ b/src/api/tests/service/common/test_storage.py
@@ -117,15 +117,15 @@ def test_read_storage_bytes_fetches_from_oss_when_local_file_is_missing(
     )
 
     class FakeObject:
-        def read(self):
+        def read(self) -> bytes:
             return b"remote-audio"
 
     class FakeBucket:
-        def get_object(self, object_key: str):
+        def get_object(self, object_key: str) -> FakeObject:
             assert object_key == "tts/minimax/source.webm"
             return FakeObject()
 
-    def fake_create_oss_bucket(config):
+    def fake_create_oss_bucket(config) -> FakeBucket:
         assert config.bucket == "resource-bucket"
         return FakeBucket()
 

--- a/src/api/tests/service/common/test_umami_client.py
+++ b/src/api/tests/service/common/test_umami_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Never
 
 import requests
 from flaskr.common import umami_client
@@ -33,7 +34,7 @@ def test_get_course_visit_count_30d_counts_all_metric_pages(app, monkeypatch) ->
 
     calls: list[dict[str, object]] = []
 
-    def _fake_get(url, params=None, headers=None, timeout=None):
+    def _fake_get(url, params=None, headers=None, timeout=None) -> SimpleNamespace:
         calls.append(
             {
                 "url": url,
@@ -79,7 +80,7 @@ def test_get_course_visit_count_30d_uses_cached_value(app, monkeypatch) -> None:
 
     request_count = {"value": 0}
 
-    def _fake_get(url, params=None, headers=None, timeout=None):
+    def _fake_get(url, params=None, headers=None, timeout=None) -> SimpleNamespace:
         _ = (url, params, headers, timeout)
         request_count["value"] += 1
         return SimpleNamespace(
@@ -136,7 +137,7 @@ def test_get_course_visit_count_30d_caches_failures_briefly(app, monkeypatch) ->
 
     request_count = {"value": 0}
 
-    def _fake_get(url, params=None, headers=None, timeout=None):
+    def _fake_get(url, params=None, headers=None, timeout=None) -> Never:
         _ = (url, params, headers, timeout)
         request_count["value"] += 1
         message = "umami unavailable"
@@ -192,18 +193,18 @@ def test_get_course_visit_count_30d_returns_fetched_value_when_cache_write_fails
         def __init__(self) -> None:
             self._cache = InMemoryCacheProvider()
 
-        def get(self, key):
+        def get(self, key) -> object:
             return self._cache.get(key)
 
-        def delete(self, *keys: str):
+        def delete(self, *keys: str) -> int:
             return self._cache.delete(*keys)
 
-        def setex(self, key, ttl, value):
+        def setex(self, key, ttl, value) -> Never:
             _ = (key, ttl, value)
             message = "cache unavailable"
             raise RuntimeError(message)
 
-        def lock(self, key, timeout=None, blocking_timeout=None):
+        def lock(self, key, timeout=None, blocking_timeout=None) -> object:
             return self._cache.lock(
                 key, timeout=timeout, blocking_timeout=blocking_timeout
             )
@@ -238,18 +239,18 @@ def test_get_course_visit_count_30d_returns_zero_when_failure_cache_write_fails(
         def __init__(self) -> None:
             self._cache = InMemoryCacheProvider()
 
-        def get(self, key):
+        def get(self, key) -> object:
             return self._cache.get(key)
 
-        def delete(self, *keys: str):
+        def delete(self, *keys: str) -> int:
             return self._cache.delete(*keys)
 
-        def setex(self, key, ttl, value):
+        def setex(self, key, ttl, value) -> Never:
             _ = (key, ttl, value)
             message = "cache unavailable"
             raise RuntimeError(message)
 
-        def lock(self, key, timeout=None, blocking_timeout=None):
+        def lock(self, key, timeout=None, blocking_timeout=None) -> object:
             return self._cache.lock(
                 key, timeout=timeout, blocking_timeout=blocking_timeout
             )
@@ -283,25 +284,25 @@ def test_get_course_visit_count_30d_waits_for_cache_on_lock_contention(
     )
 
     class BusyLock:
-        def acquire(self, blocking=True, blocking_timeout=None):
+        def acquire(self, blocking=True, blocking_timeout=None) -> bool:
             _ = (blocking, blocking_timeout)
             return False
 
-        def release(self):
+        def release(self) -> None:
             return None
 
     class CacheWrapper:
-        def get(self, key):
+        def get(self, key) -> None:
             _ = key
 
-        def delete(self, *keys: str):
+        def delete(self, *keys: str) -> int:
             _ = keys
             return 0
 
-        def setex(self, key, ttl, value):
+        def setex(self, key, ttl, value) -> None:
             _ = (key, ttl, value)
 
-        def lock(self, key, timeout=None, blocking_timeout=None):
+        def lock(self, key, timeout=None, blocking_timeout=None) -> BusyLock:
             _ = (key, timeout, blocking_timeout)
             return BusyLock()
 
@@ -332,24 +333,24 @@ def test_login_for_access_token_rechecks_cache_when_lock_is_busy(monkeypatch) ->
     )
 
     class BusyLock:
-        def acquire(self, blocking=True, blocking_timeout=None):
+        def acquire(self, blocking=True, blocking_timeout=None) -> bool:
             _ = (blocking, blocking_timeout)
             return False
 
-        def release(self):
+        def release(self) -> None:
             return None
 
     cache_provider = InMemoryCacheProvider()
     cache_provider.setex("test:analytics:umami:access-token", 60, "fresh-token")
 
     class CacheWrapper:
-        def get(self, key):
+        def get(self, key) -> object:
             return cache_provider.get(key)
 
-        def setex(self, key, ttl, value):
+        def setex(self, key, ttl, value) -> object:
             return cache_provider.setex(key, ttl, value)
 
-        def lock(self, key, timeout=None, blocking_timeout=None):
+        def lock(self, key, timeout=None, blocking_timeout=None) -> BusyLock:
             _ = (key, timeout, blocking_timeout)
             return BusyLock()
 
@@ -377,15 +378,15 @@ def test_login_for_access_token_returns_token_when_cache_write_fails(
         def __init__(self) -> None:
             self._cache = InMemoryCacheProvider()
 
-        def get(self, key):
+        def get(self, key) -> object:
             return self._cache.get(key)
 
-        def setex(self, key, ttl, value):
+        def setex(self, key, ttl, value) -> Never:
             _ = (key, ttl, value)
             message = "cache unavailable"
             raise RuntimeError(message)
 
-        def lock(self, key, timeout=None, blocking_timeout=None):
+        def lock(self, key, timeout=None, blocking_timeout=None) -> object:
             return self._cache.lock(
                 key, timeout=timeout, blocking_timeout=blocking_timeout
             )

--- a/src/api/tests/service/common/test_uow.py
+++ b/src/api/tests/service/common/test_uow.py
@@ -33,7 +33,7 @@ def test_outermost_commits_on_clean_exit(app) -> None:
 def test_outermost_rolls_back_on_exception(app) -> None:
     with app.app_context():
 
-        def write_then_fail():
+        def write_then_fail() -> Never:
             with uow.unit_of_work():
                 dao.db.session.add(_make_shifu("uow-rollback-1"))
                 dao.db.session.flush()
@@ -48,11 +48,11 @@ def test_outermost_rolls_back_on_exception(app) -> None:
 def test_nested_block_joins_outer_transaction(app) -> None:
     with app.app_context():
 
-        def helper():
+        def helper() -> None:
             with uow.unit_of_work():
                 dao.db.session.add(_make_shifu("uow-nested-inner-1"))
 
-        def outer_fails_after_helper():
+        def outer_fails_after_helper() -> Never:
             with uow.unit_of_work():
                 helper()
                 dao.db.session.add(_make_shifu("uow-nested-outer-1"))
@@ -90,7 +90,7 @@ def test_depth_is_isolated_per_thread(app) -> None:
     """The /run producer runs in its own thread; depth must not leak across."""
     seen = {}
 
-    def worker():
+    def worker() -> None:
         seen["inside_thread"] = uow.in_unit_of_work()
 
     with app.app_context(), uow.unit_of_work():
@@ -130,7 +130,7 @@ def test_on_commit_dropped_on_rollback(app) -> None:
     calls = []
     with app.app_context():
 
-        def schedule_then_fail():
+        def schedule_then_fail() -> Never:
             with uow.unit_of_work():
                 uow.on_commit(lambda: calls.append("never"))
                 message = "boom"
@@ -144,7 +144,7 @@ def test_on_commit_dropped_on_rollback(app) -> None:
 def test_on_commit_callback_exception_does_not_propagate(app) -> None:
     calls = []
 
-    def boom():
+    def boom() -> Never:
         message = "callback boom"
         raise RuntimeError(message)
 

--- a/src/api/tests/service/creator_analytics/conftest.py
+++ b/src/api/tests/service/creator_analytics/conftest.py
@@ -30,7 +30,7 @@ from flaskr.service.user.models import UserInfo
 from flaskr.util.datetime import now_utc
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
     from datetime import datetime
 
 
@@ -56,7 +56,7 @@ def _clear_tables() -> None:
 
 
 @pytest.fixture(autouse=True)
-def _isolate_creator_analytics_tables(app):
+def _isolate_creator_analytics_tables(app) -> Iterator[None]:
     if app is None:
         yield
         return

--- a/src/api/tests/service/creator_analytics/test_credit_detail.py
+++ b/src/api/tests/service/creator_analytics/test_credit_detail.py
@@ -12,6 +12,7 @@ matches a usage record.
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
 import pytest
 from flaskr.service.billing.consts import (
@@ -26,17 +27,22 @@ from .conftest import (
     seed_owned_course,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from werkzeug.test import TestResponse
+
 ENDPOINT = "/api/creator-analytics/credit-detail"
 
 
 @pytest.fixture(autouse=True)
-def _reset_analytics_engine_singleton():
+def _reset_analytics_engine_singleton() -> Iterator[None]:
     analytics_engine.reset_for_tests()
     yield
     analytics_engine.reset_for_tests()
 
 
-def _post(test_client, body):
+def _post(test_client, body) -> TestResponse:
     return test_client.post(ENDPOINT, json=body)
 
 

--- a/src/api/tests/service/creator_analytics/test_dsl.py
+++ b/src/api/tests/service/creator_analytics/test_dsl.py
@@ -20,7 +20,7 @@ from flaskr.service.creator_analytics.dsl import (
 DEFAULT_LIMIT_MAX = 1000
 
 
-def _payload(**overrides: object):
+def _payload(**overrides: object) -> dict[str, str | list[str] | int]:
     base = {
         "shifu_bid": "shifu-abc",
         "table": "learn_progress_records",
@@ -31,7 +31,7 @@ def _payload(**overrides: object):
     return base
 
 
-def _parse(payload):
+def _parse(payload) -> object:
     return parse_dsl(payload, limit_max=DEFAULT_LIMIT_MAX)
 
 
@@ -372,7 +372,7 @@ def test_select_user_bid_with_group_by_other_dimension_is_rejected() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _content_payload(**overrides: object):
+def _content_payload(**overrides: object) -> dict[str, object]:
     base = {
         "shifu_bid": "shifu-abc",
         "table": "learn_generated_blocks",
@@ -436,7 +436,9 @@ def test_generated_content_limit_at_100_is_allowed() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _user_users_payload(**overrides: object):
+def _user_users_payload(
+    **overrides: object,
+) -> dict[str, str | list[str] | list[dict[str, str | list[str]]] | int]:
     base = {
         "shifu_bid": "shifu-abc",
         "table": "user_users",
@@ -504,7 +506,9 @@ def test_user_users_select_disallowed_column_rejected() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _user_users_identify_payload(**overrides: object):
+def _user_users_identify_payload(
+    **overrides: object,
+) -> dict[str, str | list[str] | list[dict[str, str]] | int]:
     base = {
         "shifu_bid": "shifu-abc",
         "table": "user_users",
@@ -579,7 +583,9 @@ def test_user_users_user_identify_not_groupable() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _daily_metric_payload(**overrides: object):
+def _daily_metric_payload(
+    **overrides: object,
+) -> dict[str, str | list[dict[str, str]] | list[dict[str, str | int]] | int]:
     base = {
         "shifu_bid": "shifu-abc",
         "table": "bill_daily_usage_metrics",
@@ -651,7 +657,9 @@ def test_bill_usage_table_rejected() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _generated_blocks_payload(**overrides: object):
+def _generated_blocks_payload(
+    **overrides: object,
+) -> dict[str, str | list[dict[str, str | int]] | list[dict[str, str]] | int]:
     """Build a baseline DSL payload for learn_generated_blocks tests."""
     base = {
         "shifu_bid": "shifu-abc",
@@ -763,7 +771,9 @@ def test_bill_daily_creator_bid_filter_rejected() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _shifu_meta_payload(table_key="shifu_published_shifus", **overrides: object):
+def _shifu_meta_payload(
+    table_key="shifu_published_shifus", **overrides: object
+) -> dict[str, object]:
     """Build a baseline DSL payload for shifu metadata-table tests."""
     base = {
         "shifu_bid": "shifu-abc",

--- a/src/api/tests/service/creator_analytics/test_query.py
+++ b/src/api/tests/service/creator_analytics/test_query.py
@@ -7,6 +7,8 @@ SQL build → SQLite engine. The token middleware is bypassed by mocking
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from flaskr.service.creator_analytics import engine as analytics_engine
 
@@ -20,18 +22,23 @@ from .conftest import (
     seed_user_info,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from werkzeug.test import TestResponse
+
 ENDPOINT = "/api/creator-analytics/query"
 
 
 @pytest.fixture(autouse=True)
-def _reset_analytics_engine_singleton():
+def _reset_analytics_engine_singleton() -> Iterator[None]:
     """Ensure each test starts with the cached fallback engine cleared."""
     analytics_engine.reset_for_tests()
     yield
     analytics_engine.reset_for_tests()
 
 
-def _post(test_client, body):
+def _post(test_client, body) -> TestResponse:
     return test_client.post(ENDPOINT, json=body)
 
 
@@ -701,7 +708,7 @@ def test_dedicated_engine_replacement_disposes_previous_owner(app, monkeypatch) 
 
     created: list[_FakeEngine] = []
 
-    def fake_create_engine(uri, **_kwargs: object):
+    def fake_create_engine(uri, **_kwargs: object) -> object:
         engine = _FakeEngine(uri)
         created.append(engine)
         return engine

--- a/src/api/tests/service/creator_analytics/test_sql_builder.py
+++ b/src/api/tests/service/creator_analytics/test_sql_builder.py
@@ -14,7 +14,7 @@ from sqlalchemy.dialects import mysql, sqlite
 LIMIT_MAX = 1000
 
 
-def _compile_for(dialect, payload, dialect_name, user_id=""):
+def _compile_for(dialect, payload, dialect_name, user_id="") -> str:
     dsl = parse_dsl(payload, limit_max=LIMIT_MAX, user_id=user_id)
     stmt = build_statement(dsl, dialect_name=dialect_name)
     return str(
@@ -25,11 +25,11 @@ def _compile_for(dialect, payload, dialect_name, user_id=""):
     )
 
 
-def _compile_mysql(payload, user_id=""):
+def _compile_mysql(payload, user_id="") -> object:
     return _compile_for(mysql.dialect(), payload, "mysql", user_id=user_id)
 
 
-def _compile_sqlite(payload, user_id=""):
+def _compile_sqlite(payload, user_id="") -> object:
     return _compile_for(sqlite.dialect(), payload, "sqlite", user_id=user_id)
 
 
@@ -290,7 +290,9 @@ def test_generated_blocks_status_explicit_filter_does_not_override_auto() -> Non
 # ---------------------------------------------------------------------------
 
 
-def _meta_payload(table_key="shifu_published_shifus", **overrides: object):
+def _meta_payload(
+    table_key="shifu_published_shifus", **overrides: object
+) -> dict[str, object]:
     """Build a baseline DSL payload for shifu metadata-table compile tests."""
     base = {
         "shifu_bid": "shifu-abc",

--- a/src/api/tests/service/dashboard/test_dashboard_routes.py
+++ b/src/api/tests/service/dashboard/test_dashboard_routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 from flaskr.dao import db
@@ -37,6 +38,9 @@ from flaskr.service.shifu.models import (
 from flaskr.service.user.models import AuthCredential, UserInfo, UserToken
 from flaskr.util.datetime import now_utc
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 def _clear_dashboard_tables() -> None:
     db.session.query(UserToken).delete()
@@ -56,7 +60,7 @@ def _clear_dashboard_tables() -> None:
 
 
 @pytest.fixture(autouse=True)
-def _isolate_dashboard_tables(app):
+def _isolate_dashboard_tables(app) -> Iterator[None]:
     if app is None:
         yield
         return
@@ -74,7 +78,7 @@ def _isolate_dashboard_tables(app):
 class TestDashboardRoutes:
     """Verify dashboard routes behavior."""
 
-    def _mock_request_user(self, monkeypatch, *, user_id: str = "teacher-1"):
+    def _mock_request_user(self, monkeypatch, *, user_id: str = "teacher-1") -> None:
         dummy_user = SimpleNamespace(
             user_id=user_id,
             language="en-US",

--- a/src/api/tests/service/learn/run/test_run_disconnect_e2e.py
+++ b/src/api/tests/service/learn/run/test_run_disconnect_e2e.py
@@ -44,7 +44,7 @@ STREAMED_MARKER = "Hello "
 STREAMED_FULL_TEXT = "Hello golden learner."
 
 
-def _open_run_generator(app, user_bid: str, shifu, *, input_type: str):
+def _open_run_generator(app, user_bid: str, shifu, *, input_type: str) -> object:
     from flaskr.service.learn.runscript_v2 import run_script_inner
 
     return run_script_inner(
@@ -73,7 +73,9 @@ def _consume_until_streaming(generator) -> list:
     raise AssertionError(message)
 
 
-def _load_rows(app, user_bid: str):
+def _load_rows(
+    app, user_bid: str
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
     from flaskr.service.learn.models import LearnGeneratedBlock, LearnProgressRecord
 
     with app.app_context():

--- a/src/api/tests/service/learn/run/test_run_emitter.py
+++ b/src/api/tests/service/learn/run/test_run_emitter.py
@@ -7,6 +7,7 @@ a payload smoke for emitter-side event construction.
 
 import types
 import unittest
+from collections.abc import Iterator
 
 from flask import Flask
 from flaskr import dao
@@ -30,25 +31,27 @@ class _RecordingEmitter:
     def __init__(self) -> None:
         self.calls = []
 
-    def render_outline_updates(self, outline_updates, new_chapter=False):
+    def render_outline_updates(
+        self, outline_updates, new_chapter=False
+    ) -> Iterator[str]:
         self.calls.append(("render_outline_updates", outline_updates, new_chapter))
         yield "outline-event"
 
-    def emit_next_chapter_interaction(self, progress_record):
+    def emit_next_chapter_interaction(self, progress_record) -> Iterator[str]:
         self.calls.append(("emit_next_chapter_interaction", progress_record))
         yield "next-event"
 
-    def emit_lesson_feedback_interaction(self, progress_record):
+    def emit_lesson_feedback_interaction(self, progress_record) -> Iterator[str]:
         self.calls.append(("emit_lesson_feedback_interaction", progress_record))
         yield "feedback-event"
 
-    def is_access_gate_blocking_interaction(self, parsed_interaction):
+    def is_access_gate_blocking_interaction(self, parsed_interaction) -> bool:
         self.calls.append(("is_access_gate_blocking_interaction", parsed_interaction))
         return True
 
     def maybe_emit_feedback_after_access_gate(
         self, *, parsed_interaction, progress_record, is_tail_gate
-    ):
+    ) -> Iterator[str]:
         self.calls.append(
             (
                 "maybe_emit_feedback_after_access_gate",
@@ -59,21 +62,21 @@ class _RecordingEmitter:
         )
         yield "gate-feedback-event"
 
-    def emit_feedback_after_exception_gate(self):
+    def emit_feedback_after_exception_gate(self) -> Iterator[str]:
         self.calls.append(("emit_feedback_after_exception_gate",))
         yield "exception-feedback-event"
 
-    def ensure_current_attend_for_gate_interaction(self):
+    def ensure_current_attend_for_gate_interaction(self) -> str:
         self.calls.append(("ensure_current_attend_for_gate_interaction",))
         return "attend"
 
-    def emit_current_progress_gate_interaction(self, content):
+    def emit_current_progress_gate_interaction(self, content) -> Iterator[str]:
         self.calls.append(("emit_current_progress_gate_interaction", content))
         yield "gate-interaction-event"
 
     def emit_completion_tail_interactions(
         self, *, progress_record, current_outline_completed, has_next_outline_item
-    ):
+    ) -> Iterator[str]:
         self.calls.append(
             (
                 "emit_completion_tail_interactions",
@@ -182,11 +185,11 @@ class EmitterContextSeamTests(unittest.TestCase):
         ctx = _make_context()
         calls: list[str] = []
 
-        def _emit_feedback(_progress):
+        def _emit_feedback(_progress) -> Iterator[str]:
             calls.append("feedback")
             yield "feedback-event"
 
-        def _emit_next(_progress):
+        def _emit_next(_progress) -> Iterator[str]:
             calls.append("next")
             yield "next-event"
 
@@ -208,7 +211,7 @@ class EmitterContextSeamTests(unittest.TestCase):
         ctx = _make_context()
         calls: list[str] = []
 
-        def _emit_feedback(_progress):
+        def _emit_feedback(_progress) -> Iterator[str]:
             calls.append("feedback")
             yield "feedback-event"
 

--- a/src/api/tests/service/learn/run/test_run_recorder.py
+++ b/src/api/tests/service/learn/run/test_run_recorder.py
@@ -49,7 +49,9 @@ def recorder_app() -> Flask:
         dao.db.drop_all()
 
 
-def _seed_attend(progress_record_bid: str = "progress-recorder-0001"):
+def _seed_attend(
+    progress_record_bid: str = "progress-recorder-0001",
+) -> LearnProgressRecord:
     attend = LearnProgressRecord(
         progress_record_bid=progress_record_bid,
         shifu_bid=SHIFU_BID,
@@ -82,7 +84,7 @@ def _fail_next_flush(monkeypatch, exc: Exception) -> None:
     real_flush = dao.db.session.flush
     state = {"fired": False}
 
-    def _boom(*args: object, **kwargs: object):
+    def _boom(*args: object, **kwargs: object) -> object:
         if not state["fired"]:
             state["fired"] = True
             raise exc

--- a/src/api/tests/service/learn/test_ask_provider_adapters.py
+++ b/src/api/tests/service/learn/test_ask_provider_adapters.py
@@ -1,6 +1,8 @@
 """Verify ask provider adapter behavior."""
 
 import types
+from collections.abc import Iterator
+from typing import Never
 
 import pytest
 import requests
@@ -32,15 +34,15 @@ class _FakeResponse:
         self._json_data = json_data
         self._json_error = json_error
 
-    def iter_lines(self, decode_unicode=True):
+    def iter_lines(self, decode_unicode=True) -> Iterator[object]:
         _ = decode_unicode
         yield from self._lines
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         if self._http_error is not None:
             raise self._http_error
 
-    def json(self):
+    def json(self) -> object:
         if self._json_error is not None:
             raise self._json_error
         return self._json_data
@@ -58,7 +60,7 @@ def test_dify_adapter_streams_success_content(app, monkeypatch) -> None:
         }.get,
     )
 
-    def _fake_post(*_args: object, **kwargs: object):
+    def _fake_post(*_args: object, **kwargs: object) -> object:
         request_state["json"] = kwargs.get("json")
         return _FakeResponse(
             lines=[
@@ -114,7 +116,7 @@ def test_coze_adapter_timeout_raises_timeout_error(app, monkeypatch) -> None:
         }.get,
     )
 
-    def _raise_timeout(*_args: object, **_kwargs: object):
+    def _raise_timeout(*_args: object, **_kwargs: object) -> Never:
         message = "timeout"
         raise requests.Timeout(message)
 
@@ -206,7 +208,7 @@ def test_coze_workflow_adapter_streams_success_content(app, monkeypatch) -> None
         }.get,
     )
 
-    def _fake_post(url, **kwargs: object):
+    def _fake_post(url, **kwargs: object) -> object:
         request_state["url"] = url
         request_state["json"] = kwargs.get("json")
         request_state["headers"] = kwargs.get("headers") or {}
@@ -362,7 +364,7 @@ def test_coze_adapter_uses_default_base_url_when_missing(app, monkeypatch) -> No
         }.get,
     )
 
-    def _fake_post(url, **kwargs: object):
+    def _fake_post(url, **kwargs: object) -> object:
         request_state["url"] = url
         request_state["json"] = kwargs["json"]
         return _FakeResponse(
@@ -407,7 +409,7 @@ def test_volc_knowledge_adapter_streams_success_content(app, monkeypatch) -> Non
 
     request_state = {}
 
-    def _fake_request(*_args: object, **kwargs: object):
+    def _fake_request(*_args: object, **kwargs: object) -> object:
         request_state["method"] = kwargs.get("method")
         request_state["headers"] = kwargs.get("headers") or {}
         request_state["url"] = kwargs.get("url")
@@ -491,7 +493,7 @@ def test_get_biji_knowledge_adapter_synthesizes_with_llm_context(
 
     request_state = {}
 
-    def _fake_post(url, **kwargs: object):
+    def _fake_post(url, **kwargs: object) -> object:
         request_state["url"] = url
         request_state["headers"] = kwargs.get("headers") or {}
         request_state["json"] = kwargs.get("json")
@@ -527,7 +529,7 @@ def test_get_biji_knowledge_adapter_synthesizes_with_llm_context(
 
     captured_context = {}
 
-    def _context_stream_factory(knowledge_context):
+    def _context_stream_factory(knowledge_context) -> Iterator[types.SimpleNamespace]:
         captured_context["value"] = knowledge_context
         return iter(
             [
@@ -608,7 +610,7 @@ def test_get_biji_knowledge_adapter_skips_results_without_title_or_content(
 
     captured_context = {}
 
-    def _context_stream_factory(knowledge_context):
+    def _context_stream_factory(knowledge_context) -> Iterator[types.SimpleNamespace]:
         captured_context["value"] = knowledge_context
         return iter([types.SimpleNamespace(result="answer")])
 
@@ -652,7 +654,7 @@ def test_get_biji_knowledge_adapter_empty_results_synthesizes_with_empty_context
 
     captured_context = {}
 
-    def _context_stream_factory(knowledge_context):
+    def _context_stream_factory(knowledge_context) -> Iterator[types.SimpleNamespace]:
         captured_context["value"] = knowledge_context
         return iter([types.SimpleNamespace(result="fallback answer")])
 
@@ -760,7 +762,7 @@ def test_get_biji_knowledge_adapter_timeout_raises_timeout_error(
 ) -> None:
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
 
-    def _raise_timeout(*_args: object, **_kwargs: object):
+    def _raise_timeout(*_args: object, **_kwargs: object) -> Never:
         message = "timeout"
         raise requests.Timeout(message)
 

--- a/src/api/tests/service/learn/test_ask_provider_langfuse.py
+++ b/src/api/tests/service/learn/test_ask_provider_langfuse.py
@@ -12,7 +12,7 @@ class _DummyGeneration:
         self.kwargs = kwargs
         self.end_kwargs = {}
 
-    def end(self, **kwargs: object):
+    def end(self, **kwargs: object) -> None:
         self.end_kwargs = kwargs
 
 
@@ -22,7 +22,7 @@ class _DummySpan:
         self.id = span_id
         self.generations = []
 
-    def generation(self, **kwargs: object):
+    def generation(self, **kwargs: object) -> object:
         generation = _DummyGeneration(**kwargs)
         self.generations.append(generation)
         return generation

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -8,6 +8,8 @@ import threading
 import time
 import types
 import unittest
+from collections.abc import AsyncIterator, Iterator
+from typing import Never
 from unittest.mock import MagicMock, call, patch
 
 from flask import Flask
@@ -19,7 +21,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> Never:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -149,10 +151,10 @@ class _FakeLangfuseSpan:
         self.updated = {}
         self.end_kwargs = {}
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updated = kwargs
 
-    def end(self, **kwargs: object):
+    def end(self, **kwargs: object) -> None:
         self.end_kwargs = kwargs
 
 
@@ -160,7 +162,7 @@ class _FakeLangfuseTrace:
     def __init__(self) -> None:
         self.updated = {}
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updated = kwargs
 
 
@@ -232,7 +234,7 @@ class CollectAsyncGeneratorTests(unittest.TestCase):
     def test_without_running_loop(self) -> None:
         ctx = _make_context()
 
-        async def sample():
+        async def sample() -> AsyncIterator[str]:
             yield "one"
             yield "two"
 
@@ -243,10 +245,10 @@ class CollectAsyncGeneratorTests(unittest.TestCase):
     def test_inside_running_loop(self) -> None:
         ctx = _make_context()
 
-        async def sample():
+        async def sample() -> AsyncIterator[str]:
             yield "alpha"
 
-        async def runner():
+        async def runner() -> None:
             result = ctx._collect_async_generator(sample)
             assert result == ["alpha"]
 
@@ -263,7 +265,7 @@ class RunAsyncInSafeContextTests(unittest.TestCase):
     def test_without_running_loop(self) -> None:
         ctx = _make_context()
 
-        async def sample():
+        async def sample() -> str:
             return "result"
 
         assert ctx._run_async_in_safe_context(sample) == "result"
@@ -271,10 +273,10 @@ class RunAsyncInSafeContextTests(unittest.TestCase):
     def test_inside_running_loop(self) -> None:
         ctx = _make_context()
 
-        async def sample():
+        async def sample() -> str:
             return "loop"
 
-        async def runner():
+        async def runner() -> None:
             assert ctx._run_async_in_safe_context(sample) == "loop"
 
         asyncio.run(runner())
@@ -372,11 +374,11 @@ class CompletionTailInteractionTests(unittest.TestCase):
         ctx = _make_context()
         calls: list[str] = []
 
-        def _emit_feedback(_progress):
+        def _emit_feedback(_progress) -> Iterator[str]:
             calls.append("feedback")
             yield "feedback-event"
 
-        def _emit_next(_progress):
+        def _emit_next(_progress) -> Iterator[str]:
             calls.append("next")
             yield "next-event"
 
@@ -398,11 +400,11 @@ class CompletionTailInteractionTests(unittest.TestCase):
         ctx = _make_context()
         calls: list[str] = []
 
-        def _emit_feedback(_progress):
+        def _emit_feedback(_progress) -> Iterator[str]:
             calls.append("feedback")
             yield "feedback-event"
 
-        def _emit_next(_progress):
+        def _emit_next(_progress) -> Iterator[str]:
             calls.append("next")
             yield "next-event"
 
@@ -424,11 +426,11 @@ class CompletionTailInteractionTests(unittest.TestCase):
         ctx = _make_context()
         calls: list[str] = []
 
-        def _emit_feedback(_progress):
+        def _emit_feedback(_progress) -> Iterator[str]:
             calls.append("feedback")
             yield "feedback-event"
 
-        def _emit_next(_progress):
+        def _emit_next(_progress) -> Iterator[str]:
             calls.append("next")
             yield "next-event"
 
@@ -460,7 +462,7 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
         class _Column:
             __hash__ = None
 
-            def in_(self, _values):
+            def in_(self, _values) -> "_Column":
                 return self
 
             def __eq__(self, _other) -> "_Column":
@@ -473,17 +475,17 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
             deleted = _Column()
 
         class _FakeQuery:
-            def filter(self, *_args: object, **_kwargs: object):
+            def filter(self, *_args: object, **_kwargs: object) -> "_FakeQuery":
                 return self
 
-            def all(self):
+            def all(self) -> list[tuple[str, bool, str]]:
                 return [("outline-1", False, "Outline 1")]
 
         class _FakeMarkdownFlow:
             def __init__(self, *args: object, **kwargs: object) -> None:
                 pass
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> list[object]:
                 return [object(), object()]
 
         outline_item = HistoryItem(
@@ -545,7 +547,7 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
             def __init__(self, *args: object, **kwargs: object) -> None:
                 pass
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> list[object]:
                 return [object(), object()]
 
         with (
@@ -732,11 +734,11 @@ class StreamTtsGateTests(unittest.TestCase):
 
         idle_ticks: list[int] = []
 
-        def delayed_stream():
+        def delayed_stream() -> Iterator[str]:
             time.sleep(0.05)
             yield "chunk-1"
 
-        def on_idle():
+        def on_idle() -> Iterator[str]:
             idle_ticks.append(len(idle_ticks))
             yield f"idle-{len(idle_ticks)}"
 
@@ -780,7 +782,7 @@ class StreamTtsGateTests(unittest.TestCase):
                     raise StopIteration
                 return "chunk-2"
 
-            def close(self):
+            def close(self) -> None:
                 self.close_calls += 1
 
         stream = ClosableStream()
@@ -1072,14 +1074,14 @@ class StreamTtsTeardownTests(unittest.TestCase):
             def __init__(self) -> None:
                 self.finalize_calls = []
 
-            def finalize(self, *, commit=True):
+            def finalize(self, *, commit=True) -> Iterator[str]:
                 self.finalize_calls.append(commit)
                 yield "audio-complete"
 
         flush_calls: list[str] = []
         processor = _FakeProcessor()
 
-        def _flush_content_cache():
+        def _flush_content_cache() -> Iterator[str]:
             flush_calls.append("flush")
             yield "content-flush"
 
@@ -1109,7 +1111,7 @@ class StreamTtsTeardownTests(unittest.TestCase):
             def __init__(self) -> None:
                 self.finalize_calls = 0
 
-            def finalize(self, *, commit=True):
+            def finalize(self, *, commit=True) -> Iterator[str]:
                 _ = commit
                 self.finalize_calls += 1
                 yield "audio-complete"
@@ -1117,7 +1119,7 @@ class StreamTtsTeardownTests(unittest.TestCase):
         flush_calls: list[str] = []
         processor = _FakeProcessor()
 
-        def _flush_content_cache():
+        def _flush_content_cache() -> Iterator[str]:
             flush_calls.append("flush")
             yield "content-flush"
 
@@ -1146,7 +1148,9 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
                 self.args = args
                 self.kwargs = kwargs
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(
+                self, *_args: object, **_kwargs: object
+            ) -> "FakeMarkdownFlow":
                 return self
 
         with patch("flaskr.service.learn.context_v2.MarkdownFlow", FakeMarkdownFlow):
@@ -1160,10 +1164,12 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
                 _ = (args, kwargs)
                 self.visual_mode = None
 
-            def set_visual_mode(self, visual_mode):
+            def set_visual_mode(self, visual_mode) -> None:
                 self.visual_mode = visual_mode
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(
+                self, *_args: object, **_kwargs: object
+            ) -> "FakeMarkdownFlow":
                 return self
 
         with patch("flaskr.service.learn.context_v2.MarkdownFlow", FakeMarkdownFlow):
@@ -1177,7 +1183,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
                 _ = (args, kwargs)
                 self.output_language = None
 
-            def set_output_language(self, language):
+            def set_output_language(self, language) -> "FakeMarkdownFlow":
                 self.output_language = language
                 return self
 
@@ -1732,7 +1738,7 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
 
         def _fake_create_trace_with_root_span(
             *, client, trace_payload, root_span_payload
-        ):
+        ) -> tuple[object, object]:
             captured["client"] = client
             captured["trace_payload"] = trace_payload
             captured["root_span_payload"] = root_span_payload
@@ -1848,10 +1854,10 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
             def __init__(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def get_context(self, *_args: object, **_kwargs: object):
+            def get_context(self, *_args: object, **_kwargs: object) -> list[object]:
                 return []
 
-            def replace_context(self, *_args: object, **_kwargs: object):
+            def replace_context(self, *_args: object, **_kwargs: object) -> None:
                 return None
 
         class _FakePreviewMdflowContext:
@@ -1866,12 +1872,12 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
             def filter_context_by_output_language(context, _output_language) -> object:
                 return context
 
-            def get_block(self, _block_index):
+            def get_block(self, _block_index) -> types.SimpleNamespace:
                 return types.SimpleNamespace(
                     block_type=PreviewBlockType.CONTENT, content="Prompt block"
                 )
 
-            def process(self, **_kwargs: object):
+            def process(self, **_kwargs: object) -> Iterator[object]:
                 return (
                     item
                     for item in [
@@ -1887,12 +1893,12 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
             def __init__(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def process(self, events):
+            def process(self, events) -> object:
                 return events
 
         def _fake_create_trace_with_root_span(
             *, client, trace_payload, root_span_payload
-        ):
+        ) -> tuple[object, object]:
             _ = client, root_span_payload
             captured["trace_payload"] = trace_payload
             trace = _FakeLangfuseTrace()
@@ -2193,10 +2199,10 @@ class _InMemoryCache:
     def __init__(self) -> None:
         self.store: dict[str, str] = {}
 
-    def get(self, key: str):
+    def get(self, key: str) -> object:
         return self.store.get(key)
 
-    def setex(self, key: str, _ttl: int, value):
+    def setex(self, key: str, _ttl: int, value) -> None:
         self.store[key] = value
 
     def delete(self, *keys: str) -> int:
@@ -2284,7 +2290,7 @@ class PreviewSentPromptCaptureTests(unittest.TestCase):
 class PreviewContextStoreTruncationTests(unittest.TestCase):
     """Verify preview context store truncation behavior."""
 
-    def _populate(self, store, doc, indices):
+    def _populate(self, store, doc, indices) -> None:
         for idx in indices:
             store.append_context(doc, idx, f"u{idx}", f"a{idx}")
 
@@ -2431,7 +2437,7 @@ class RuntimeExceptionLangfuseTests(unittest.TestCase):
         app = Flask("runtime-langfuse-paid")
         ctx = _make_context()
 
-        def _raise_paid(_app):
+        def _raise_paid(_app) -> Never:
             raise PaidError
 
         ctx.run_inner = _raise_paid
@@ -2455,7 +2461,7 @@ class BuildContextFromBlocksTests(unittest.TestCase):
         "Second content {{nickname}}."
     )
 
-    def _blocks(self):
+    def _blocks(self) -> list[types.SimpleNamespace]:
         return [
             types.SimpleNamespace(
                 type=BLOCK_TYPE_MDCONTENT_VALUE,
@@ -2595,7 +2601,9 @@ class StreamContentBlockPromptCaptureTests(unittest.TestCase):
         with cls.app.app_context():
             dao.db.create_all()
 
-    def _run_stream_phase(self, stream_items):
+    def _run_stream_phase(
+        self, stream_items
+    ) -> tuple[RunScriptContextV2, list[object]]:
         ctx = _make_context()
         ctx.app = self.app
         ctx._input_type = "normal"
@@ -2608,7 +2616,7 @@ class StreamContentBlockPromptCaptureTests(unittest.TestCase):
         # _recorder is a lazy read-only property backed by __dict__.
         ctx.__dict__["_run_recorder"] = MagicMock()
 
-        def fake_stream():
+        def fake_stream() -> Iterator[object]:
             yield from stream_items
 
         mdflow_context = types.SimpleNamespace(process=lambda **_kwargs: fake_stream())
@@ -2691,7 +2699,7 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
             default_key="profile_name",
         ) == {"legacy_key": ["Alice"]}
 
-    def _blocks(self, selection):
+    def _blocks(self, selection) -> list[types.SimpleNamespace]:
         return [
             types.SimpleNamespace(
                 type=BLOCK_TYPE_MDCONTENT_VALUE,

--- a/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
+++ b/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
@@ -3,13 +3,14 @@
 import threading
 import time
 import types
+from collections.abc import Iterator
 
 from flaskr.service.learn.context_v2 import RunScriptContextV2
 
 _PRODUCER_THREAD_NAME = "mdflow_stream_result_producer"
 
 
-def _make_context_stub(app):
+def _make_context_stub(app) -> types.SimpleNamespace:
     stub = types.SimpleNamespace(app=app)
     stub._stop_requested = lambda: False
     stub._stop_if_requested = lambda: None
@@ -19,7 +20,7 @@ def _make_context_stub(app):
 def test_stream_producer_stops_when_consumer_exits_early(app) -> None:
     stop_streaming = threading.Event()
 
-    def endless_stream():
+    def endless_stream() -> Iterator[int]:
         index = 0
         while not stop_streaming.is_set():
             yield index
@@ -59,7 +60,7 @@ def test_early_consumer_exit_invalidates_producer_session(app, monkeypatch) -> N
 
     stop_streaming = threading.Event()
 
-    def endless_stream():
+    def endless_stream() -> Iterator[int]:
         index = 0
         while not stop_streaming.is_set():
             yield index
@@ -93,7 +94,7 @@ def test_natural_exhaustion_does_not_invalidate_producer_session(
         lambda *, source, _session=None: invalidations.append(source) or True,
     )
 
-    def short_stream():
+    def short_stream() -> Iterator[str]:
         yield "a"
         yield "b"
 
@@ -131,7 +132,7 @@ def test_tts_finalize_failure_runs_classified_cleanup(app, monkeypatch) -> None:
     class _FailingProcessor:
         next_element_index = 0
 
-        def finalize(self, *, commit):
+        def finalize(self, *, commit) -> Iterator[None]:
             _ = commit
             message = "desynced during finalize"
             raise ResourceClosedError(message)

--- a/src/api/tests/service/learn/test_element_protocol.py
+++ b/src/api/tests/service/learn/test_element_protocol.py
@@ -9,14 +9,14 @@ Covers:
 """
 
 import types
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from flask import Flask
+    from flaskr.service.learn.learn_dtos import ElementDTO
 
 
 @pytest.fixture
@@ -48,7 +48,7 @@ class _FollowUpDummyGeneration:
         self.kwargs = kwargs
         self.end_kwargs = {}
 
-    def end(self, **kwargs: object):
+    def end(self, **kwargs: object) -> None:
         self.end_kwargs = kwargs
 
 
@@ -58,21 +58,21 @@ class _FollowUpDummySpan:
         self.updated = {}
         self.output = ""
 
-    def generation(self, **kwargs: object):
+    def generation(self, **kwargs: object) -> object:
         generation = _FollowUpDummyGeneration(**kwargs)
         self.generations.append(generation)
         return generation
 
-    def span(self, **_kwargs: object):
+    def span(self, **_kwargs: object) -> object:
         return _FollowUpDummySpan()
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updated = kwargs
 
-    def event(self, **_kwargs: object):
+    def event(self, **_kwargs: object) -> None:
         return None
 
-    def end(self, output=None, **kwargs: object):
+    def end(self, output=None, **kwargs: object) -> None:
         self.output = output or ""
         self.end_kwargs = {"output": output, **kwargs}
 
@@ -81,10 +81,10 @@ class _FollowUpDummyTrace:
     def __init__(self) -> None:
         self.updated = {}
 
-    def span(self, **_kwargs: object):
+    def span(self, **_kwargs: object) -> object:
         return _FollowUpDummySpan()
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updated = kwargs
 
 
@@ -93,10 +93,10 @@ class _FollowUpContext:
         self._shifu_info = types.SimpleNamespace(use_learner_language=0)
         self.langfuse_outputs = []
 
-    def get_system_prompt(self, _outline_bid: str):
+    def get_system_prompt(self, _outline_bid: str) -> str:
         return "COURSE_PROMPT"
 
-    def append_langfuse_output(self, value: str):
+    def append_langfuse_output(self, value: str) -> None:
         self.langfuse_outputs.append(value)
 
 
@@ -120,7 +120,7 @@ def _setup_handle_input_ask_test_doubles(
     ask_provider_config,
     *,
     patch_generated_blocks: bool = True,
-):
+) -> None:
     from flaskr.service.learn.ask_provider_adapters import AskProviderError
 
     class _DummyLLMSettings:
@@ -182,7 +182,9 @@ def _setup_handle_input_ask_test_doubles(
 
         call_counter = {"index": 0}
 
-        def _fake_init_generated_block(*_args: object, **_kwargs: object):
+        def _fake_init_generated_block(
+            *_args: object, **_kwargs: object
+        ) -> types.SimpleNamespace:
             call_counter["index"] += 1
             return types.SimpleNamespace(
                 generated_block_bid=f"gb-{call_counter['index']}",
@@ -265,7 +267,7 @@ class TestElementType:
 class TestElementDTONewFields:
     """Verify element DTO new fields behavior."""
 
-    def _make_dto(self, **overrides: object):
+    def _make_dto(self, **overrides: object) -> "ElementDTO":
         from flaskr.service.learn.learn_dtos import ElementDTO, ElementType
 
         defaults = {
@@ -586,7 +588,7 @@ class TestVisualKindMapping:
 # ---------------------------------------------------------------------------
 
 
-def _require_app(app):
+def _require_app(app) -> None:
     if app is None:
         pytest.skip("App fixture disabled")
 
@@ -2487,7 +2489,7 @@ class TestHandleAskAdapter:
                 patch_generated_blocks=False,
             )
 
-            def _raise_provider_error(**_kwargs: object):
+            def _raise_provider_error(**_kwargs: object) -> Iterator[None]:
                 if False:
                     yield None
                 message = "provider failed"

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from types import SimpleNamespace
+from typing import Never
 
 import pytest
 from flask import Flask
@@ -28,7 +29,7 @@ def _patch_run_tts_processor(
     *,
     voice_settings: _FakeVoiceSettings | None = None,
     tts_model: str = "test-model",
-):
+) -> list[object]:
     synthesized_texts = []
     resolved_voice_settings = voice_settings or _FakeVoiceSettings()
 
@@ -54,7 +55,7 @@ def _patch_run_tts_processor(
         lambda _provider: False,
     )
 
-    def _fake_synthesize_text(**kwargs: object):
+    def _fake_synthesize_text(**kwargs: object) -> SimpleNamespace:
         synthesized_texts.append(kwargs["text"])
         return SimpleNamespace(
             audio_data=f"fake-audio:{kwargs['text']}".encode(),
@@ -935,7 +936,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
         synthesized_texts = _patch_run_tts_processor(monkeypatch)
 
-        def _fail_sem_acquire(*_args: object, **_kwargs: object):
+        def _fail_sem_acquire(*_args: object, **_kwargs: object) -> Never:
             message = "cache fast-path should not acquire the synthesis semaphore"
             raise AssertionError(message)
 
@@ -1159,7 +1160,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
         synthesized_texts = _patch_run_tts_processor(monkeypatch)
 
-        def _fail_sem_acquire(*_args: object, **_kwargs: object):
+        def _fail_sem_acquire(*_args: object, **_kwargs: object) -> Never:
             message = "markup-only blocks should not acquire the synthesis semaphore"
             raise AssertionError(message)
 

--- a/src/api/tests/service/learn/test_handle_input_ask_provider.py
+++ b/src/api/tests/service/learn/test_handle_input_ask_provider.py
@@ -3,6 +3,8 @@
 import importlib
 import sys
 import types
+from collections.abc import Iterator
+from typing import Never
 
 
 def _install_litellm_stub() -> None:
@@ -11,7 +13,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> Never:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -90,21 +92,21 @@ class _DummyColumn:
 
 
 class _DummyOrderColumn(_DummyColumn):
-    def desc(self):
+    def desc(self) -> "_DummyOrderColumn":
         return self
 
 
 class _DummyQuery:
-    def filter(self, *_args: object, **_kwargs: object):
+    def filter(self, *_args: object, **_kwargs: object) -> "_DummyQuery":
         return self
 
-    def order_by(self, *_args: object, **_kwargs: object):
+    def order_by(self, *_args: object, **_kwargs: object) -> "_DummyQuery":
         return self
 
-    def limit(self, *_args: object, **_kwargs: object):
+    def limit(self, *_args: object, **_kwargs: object) -> "_DummyQuery":
         return self
 
-    def all(self):
+    def all(self) -> list[object]:
         return []
 
 
@@ -118,10 +120,10 @@ class _DummyLearnGeneratedBlockModel:
 class _DummyNoneQuery:
     """Query that always returns None for .first()."""
 
-    def filter(self, *_args: object, **_kwargs: object):
+    def filter(self, *_args: object, **_kwargs: object) -> "_DummyNoneQuery":
         return self
 
-    def first(self):
+    def first(self) -> None:
         return None
 
 
@@ -150,7 +152,7 @@ class _DummyGeneration:
         self.kwargs = kwargs
         self.end_kwargs = {}
 
-    def end(self, **kwargs: object):
+    def end(self, **kwargs: object) -> None:
         self.end_kwargs = kwargs
 
 
@@ -164,23 +166,23 @@ class _DummySpan:
         self.end_kwargs = {}
         self.events = []
 
-    def generation(self, **kwargs: object):
+    def generation(self, **kwargs: object) -> object:
         generation = _DummyGeneration(**kwargs)
         self.generations.append(generation)
         return generation
 
-    def span(self, **kwargs: object):
+    def span(self, **kwargs: object) -> object:
         self.span_calls.append(kwargs)
         self.last_span = _DummySpan()
         return self.last_span
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updated = kwargs
 
-    def event(self, **kwargs: object):
+    def event(self, **kwargs: object) -> None:
         self.events.append(kwargs)
 
-    def end(self, output=None, **kwargs: object):
+    def end(self, output=None, **kwargs: object) -> None:
         self.output = output or ""
         self.end_kwargs = {"output": output, **kwargs}
 
@@ -191,11 +193,11 @@ class _DummyTrace:
         self.updated = {}
         self.last_span = None
 
-    def span(self, **_kwargs: object):
+    def span(self, **_kwargs: object) -> object:
         self.last_span = _DummySpan()
         return self.last_span
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updated = kwargs
 
 
@@ -209,14 +211,14 @@ class _Context:
         self._shifu_info = types.SimpleNamespace(use_learner_language=0)
         self.langfuse_outputs = []
 
-    def get_system_prompt(self, _outline_bid: str):
+    def get_system_prompt(self, _outline_bid: str) -> str:
         return "COURSE_PROMPT"
 
-    def append_langfuse_output(self, value: str):
+    def append_langfuse_output(self, value: str) -> None:
         self.langfuse_outputs.append(value)
 
 
-def _setup_handle_input_ask_patches(monkeypatch, module, ask_provider_config):
+def _setup_handle_input_ask_patches(monkeypatch, module, ask_provider_config) -> None:
     class _DummyLLMSettings:
         def __init__(self, model, temperature) -> None:
             self.model = model
@@ -277,7 +279,9 @@ def _setup_handle_input_ask_patches(monkeypatch, module, ask_provider_config):
 
     call_counter = {"index": 0}
 
-    def _fake_init_generated_block(*_args: object, **_kwargs: object):
+    def _fake_init_generated_block(
+        *_args: object, **_kwargs: object
+    ) -> types.SimpleNamespace:
         call_counter["index"] += 1
         return types.SimpleNamespace(
             generated_block_bid=f"gb-{call_counter['index']}",
@@ -290,7 +294,7 @@ def _setup_handle_input_ask_patches(monkeypatch, module, ask_provider_config):
     monkeypatch.setattr(module, "init_generated_block", _fake_init_generated_block)
 
 
-def _collect_content_chunks(events):
+def _collect_content_chunks(events) -> list[object]:
     return [event.content for event in events if event.type == GeneratedType.CONTENT]
 
 
@@ -311,13 +315,13 @@ def test_handle_input_ask_provider_only_returns_provider_error_without_llm(
 
     llm_call_counter = {"count": 0}
 
-    def _fake_chat_llm(*_args: object, **_kwargs: object):
+    def _fake_chat_llm(*_args: object, **_kwargs: object) -> Iterator[object]:
         llm_call_counter["count"] += 1
         yield _LLMChunk("should-not-run")
 
     monkeypatch.setattr(module, "chat_llm", _fake_chat_llm)
 
-    def _raise_provider_error(**_kwargs: object):
+    def _raise_provider_error(**_kwargs: object) -> Iterator[None]:
         if False:
             yield None
         message = "provider failed"
@@ -377,13 +381,15 @@ def test_handle_input_ask_provider_then_llm_falls_back_to_llm(app, monkeypatch) 
 
     llm_call_counter = {"count": 0}
 
-    def _fake_chat_llm(*_args: object, **_kwargs: object):
+    def _fake_chat_llm(*_args: object, **_kwargs: object) -> Iterator[object]:
         llm_call_counter["count"] += 1
         yield _LLMChunk("llm-fallback-answer")
 
     monkeypatch.setattr(module, "chat_llm", _fake_chat_llm)
 
-    def _provider_then_llm_stream(**kwargs: object):
+    def _provider_then_llm_stream(
+        **kwargs: object,
+    ) -> Iterator[object] | Iterator[types.SimpleNamespace]:
         if kwargs.get("provider") == "llm":
             runtime = kwargs.get("runtime")
             if runtime is None or runtime.llm_stream_factory is None:
@@ -451,13 +457,13 @@ def test_handle_input_ask_get_biji_synthesizes_via_context_factory(
 
     llm_calls = []
 
-    def _fake_chat_llm(*_args: object, **kwargs: object):
+    def _fake_chat_llm(*_args: object, **kwargs: object) -> Iterator[object]:
         llm_calls.append(kwargs)
         yield _LLMChunk("synthesized-answer")
 
     monkeypatch.setattr(module, "chat_llm", _fake_chat_llm)
 
-    def _retrieval_provider_stream(**kwargs: object):
+    def _retrieval_provider_stream(**kwargs: object) -> Iterator[types.SimpleNamespace]:
         # Mimic a retrieval adapter: synthesize through the runtime factory.
         runtime = kwargs.get("runtime")
         assert runtime is not None
@@ -522,7 +528,7 @@ def test_handle_input_ask_provider_response_skips_llm(app, monkeypatch) -> None:
 
     llm_call_counter = {"count": 0}
 
-    def _fake_chat_llm(*_args: object, **_kwargs: object):
+    def _fake_chat_llm(*_args: object, **_kwargs: object) -> Iterator[object]:
         llm_call_counter["count"] += 1
         yield _LLMChunk("should-not-run")
 
@@ -592,7 +598,9 @@ def test_handle_input_ask_dify_uses_context_without_follow_up_prompt(
 
     captured = {"messages": None}
 
-    def _fake_stream_ask_provider_response(**kwargs: object):
+    def _fake_stream_ask_provider_response(
+        **kwargs: object,
+    ) -> Iterator[types.SimpleNamespace] | Iterator[object]:
         if kwargs.get("provider") == "dify":
             captured["messages"] = kwargs.get("messages")
             return iter([types.SimpleNamespace(content="provider-answer")])
@@ -694,7 +702,7 @@ def test_handle_input_ask_formats_provider_prompt_with_request_language(
         template,
         *,
         profile_overrides=None,
-    ):
+    ) -> object:
         captured["profile_overrides"] = profile_overrides
         profiles = {
             "language": "zh-CN",
@@ -703,7 +711,9 @@ def test_handle_input_ask_formats_provider_prompt_with_request_language(
         }
         return template.format(**profiles)
 
-    def _fake_stream_ask_provider_response(**kwargs: object):
+    def _fake_stream_ask_provider_response(
+        **kwargs: object,
+    ) -> Iterator[types.SimpleNamespace]:
         captured["messages"] = kwargs.get("messages")
         return iter([types.SimpleNamespace(content="provider-answer")])
 
@@ -753,11 +763,11 @@ def test_handle_input_ask_formats_provider_prompt_with_request_language(
 # ---------------------------------------------------------------------------
 
 
-def _setup_llm_only_patches(monkeypatch, module, llm_chunks):
+def _setup_llm_only_patches(monkeypatch, module, llm_chunks) -> None:
     ask_provider_config = {"provider": "llm", "mode": "provider_then_llm", "config": {}}
     _setup_handle_input_ask_patches(monkeypatch, module, ask_provider_config)
 
-    def _fake_stream(**_kwargs: object):
+    def _fake_stream(**_kwargs: object) -> Iterator[types.SimpleNamespace]:
         for chunk in llm_chunks:
             yield types.SimpleNamespace(content=chunk)
 

--- a/src/api/tests/service/learn/test_learn_funcs.py
+++ b/src/api/tests/service/learn/test_learn_funcs.py
@@ -4,6 +4,7 @@ import sys
 import types
 import unittest
 import unittest.mock
+from collections.abc import Iterator
 
 from flask import Flask
 
@@ -253,25 +254,27 @@ class LearnRecordLoadTests(unittest.TestCase):
                 _ = (args, kwargs)
                 self.blocks = [DummyBlock(BlockType.CONTENT, "md content", 0)]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(
+                self, *_args: object, **_kwargs: object
+            ) -> "FakeMarkdownFlow":
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> list[DummyBlock]:
                 return self.blocks
 
-            def get_block(self, block_index):
+            def get_block(self, block_index) -> DummyBlock:
                 return self.blocks[block_index]
 
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
-            ):
+            ) -> object:
                 _ = (block_index, mode, variables, user_input)
                 FakeMarkdownFlow.last_context = context
 
-                def _gen():
+                def _gen() -> Iterator[DummyLLMResult]:
                     yield DummyLLMResult("chunk")
 
                 return _gen()
@@ -381,27 +384,29 @@ class LearnRecordLoadTests(unittest.TestCase):
                     ),
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(
+                self, *_args: object, **_kwargs: object
+            ) -> "FakeMarkdownFlow":
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> list[DummyBlock]:
                 return self.blocks
 
-            def get_block(self, block_index):
+            def get_block(self, block_index) -> DummyBlock:
                 return self.blocks[block_index]
 
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
-            ):
+            ) -> object:
                 _ = (mode, variables, context, user_input)
                 block = self.blocks[block_index]
                 if block.block_type == MarkdownFlowBlockType.INTERACTION:
                     return types.SimpleNamespace(content=block.content)
 
-                def _gen():
+                def _gen() -> Iterator[DummyLLMResult]:
                     yield DummyLLMResult(block.content)
 
                 return _gen()
@@ -523,21 +528,23 @@ class LearnRecordLoadTests(unittest.TestCase):
                 _ = (args, kwargs)
                 self.blocks = [DummyBlock(BlockType.CONTENT, "===fixed output===", 0)]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(
+                self, *_args: object, **_kwargs: object
+            ) -> "FakeMarkdownFlow":
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> list[DummyBlock]:
                 return self.blocks
 
-            def get_block(self, block_index):
+            def get_block(self, block_index) -> DummyBlock:
                 return self.blocks[block_index]
 
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
-            ):
+            ) -> types.SimpleNamespace:
                 _ = (block_index, mode, variables, context, user_input)
                 FakeMarkdownFlow.process_called = True
                 return types.SimpleNamespace(content="should-not-be-emitted")
@@ -653,21 +660,23 @@ class LearnRecordLoadTests(unittest.TestCase):
                     DummyBlock(BlockType.INTERACTION, "?[%{{v}} A|B]", 1),
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(
+                self, *_args: object, **_kwargs: object
+            ) -> "FakeMarkdownFlow":
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> list[DummyBlock]:
                 return self.blocks
 
-            def get_block(self, block_index):
+            def get_block(self, block_index) -> DummyBlock:
                 return self.blocks[block_index]
 
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
-            ):
+            ) -> types.SimpleNamespace:
                 _ = (block_index, mode, variables, context, user_input)
                 FakeMarkdownFlow.process_called = True
                 return types.SimpleNamespace(content="should-not-be-called")
@@ -776,21 +785,23 @@ class LearnRecordLoadTests(unittest.TestCase):
                     DummyBlock(BlockType.INTERACTION, "?[%{{v}} A|B]", 1),
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(
+                self, *_args: object, **_kwargs: object
+            ) -> "FakeMarkdownFlow":
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> list[DummyBlock]:
                 return self.blocks
 
-            def get_block(self, block_index):
+            def get_block(self, block_index) -> DummyBlock:
                 return self.blocks[block_index]
 
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
-            ):
+            ) -> types.SimpleNamespace:
                 _ = (block_index, mode, variables, context, user_input)
                 FakeMarkdownFlow.process_called = True
                 return types.SimpleNamespace(content="should-not-be-called")

--- a/src/api/tests/service/learn/test_learn_record.py
+++ b/src/api/tests/service/learn/test_learn_record.py
@@ -70,10 +70,10 @@ class LearnRecordFallbackTests(unittest.TestCase):
         dao.db.session.commit()
         return progress
 
-    def _set_request_user(self, mobile: str = ""):
+    def _set_request_user(self, mobile: str = "") -> None:
         request.user = types.SimpleNamespace(mobile=mobile, user_id="user-1")
 
-    def _seed_struct(self, outline_bids: list[str]):
+    def _seed_struct(self, outline_bids: list[str]) -> None:
         struct = HistoryItem(
             bid="shifu-1",
             id=1,

--- a/src/api/tests/service/learn/test_learn_record_slides.py
+++ b/src/api/tests/service/learn/test_learn_record_slides.py
@@ -6,7 +6,7 @@ import pytest
 from flask import request
 
 
-def _require_app(app):
+def _require_app(app) -> None:
     if app is None:
         pytest.skip("App fixture disabled")
 

--- a/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
+++ b/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
@@ -7,6 +7,8 @@ The helpers must invalidate the session BEFORE the finally-remove would
 otherwise roll back on a possibly desynced connection.
 """
 
+from collections.abc import Iterator
+
 import pytest
 from flaskr.service.learn import routes as learn_routes
 from sqlalchemy.exc import ResourceClosedError
@@ -28,7 +30,7 @@ def invalidations(monkeypatch) -> list[str]:
     return calls
 
 
-def _iter_stream(app, helper, iter_factory):
+def _iter_stream(app, helper, iter_factory) -> object:
     with app.test_request_context("/"):
         response = helper(
             app,
@@ -40,7 +42,7 @@ def _iter_stream(app, helper, iter_factory):
 
 
 def test_sse_close_invalidates_session(app, invalidations) -> None:
-    def factory():
+    def factory() -> Iterator[dict[str, str]]:
         yield {"type": "chunk"}
         yield {"type": "chunk2"}
 
@@ -59,7 +61,7 @@ def test_sse_close_invalidates_session(app, invalidations) -> None:
 
 
 def test_sse_protocol_error_invalidates_session(app, invalidations) -> None:
-    def factory():
+    def factory() -> Iterator[dict[str, str]]:
         yield {"type": "chunk"}
         message = "desynced"
         raise ResourceClosedError(message)
@@ -80,7 +82,7 @@ def test_sse_protocol_error_invalidates_session(app, invalidations) -> None:
 
 
 def test_sse_business_error_does_not_invalidate(app, invalidations) -> None:
-    def factory():
+    def factory() -> Iterator[dict[str, str]]:
         yield {"type": "chunk"}
         message = "business"
         raise ValueError(message)
@@ -101,7 +103,7 @@ def test_sse_business_error_does_not_invalidate(app, invalidations) -> None:
 
 
 def test_passthrough_close_invalidates_session(app, invalidations) -> None:
-    def factory():
+    def factory() -> Iterator[str]:
         yield "data: 1\n\n"
         yield "data: 2\n\n"
 
@@ -120,7 +122,7 @@ def test_passthrough_close_invalidates_session(app, invalidations) -> None:
 
 
 def test_passthrough_close_disguised_as_runtime_error(app, invalidations) -> None:
-    def factory():
+    def factory() -> Iterator[str]:
         yield "data: 1\n\n"
         message = "generator ignored GeneratorExit"
         raise RuntimeError(message)
@@ -141,7 +143,7 @@ def test_passthrough_close_disguised_as_runtime_error(app, invalidations) -> Non
 
 
 def test_passthrough_normal_exhaustion_does_not_invalidate(app, invalidations) -> None:
-    def factory():
+    def factory() -> Iterator[str]:
         yield "data: 1\n\n"
 
     with app.test_request_context("/"):

--- a/src/api/tests/service/learn/test_listen_element_history_subtitles.py
+++ b/src/api/tests/service/learn/test_listen_element_history_subtitles.py
@@ -129,7 +129,7 @@ class TestListenElementHistorySubtitles:
             element_type: str,
             content_text: str,
             is_speakable: int,
-        ):
+        ) -> None:
             db.session.add(
                 self.LearnGeneratedElement(
                     element_bid=element_bid,
@@ -163,7 +163,7 @@ class TestListenElementHistorySubtitles:
                 )
             )
 
-        def add_audio(*, position: int):
+        def add_audio(*, position: int) -> None:
             db.session.add(
                 self.LearnGeneratedAudio(
                     audio_bid=f"audio-history-multi-{position}",
@@ -259,7 +259,7 @@ class TestListenElementHistorySubtitles:
             element_bid: str,
             element_index: int,
             content_text: str,
-        ):
+        ) -> None:
             db.session.add(
                 self.LearnGeneratedElement(
                     element_bid=element_bid,

--- a/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
+++ b/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
@@ -5,6 +5,7 @@
 import json
 import sys
 import types
+from typing import Never
 
 
 def _install_litellm_stub() -> None:
@@ -13,7 +14,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> Never:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -1,5 +1,7 @@
 """Verify listen element run persistence behavior."""
 
+from typing import Never
+
 import pytest
 from flaskr.dao import db
 from flaskr.service.learn import listen_element_run_persistence
@@ -14,7 +16,7 @@ def _make_row(
     target_element_bid: str = "",
     run_event_seq: int,
     status: int = 1,
-):
+) -> LearnGeneratedElement:
     return LearnGeneratedElement(
         element_bid=element_bid,
         target_element_bid=target_element_bid,
@@ -109,31 +111,31 @@ def test_find_active_element_row_ids_invalidates_desynced_connection(
     app, monkeypatch
 ) -> None:
     class _DesyncedResult:
-        def fetchall(self):
+        def fetchall(self) -> Never:
             message = (
                 "This result object does not return rows. "
                 "It has been closed automatically."
             )
             raise ResourceClosedError(message)
 
-        def close(self):
+        def close(self) -> None:
             pass
 
     class _FakeConnection:
         def __init__(self) -> None:
             self.invalidated = 0
 
-        def execute(self, *_args: object, **_kwargs: object):
+        def execute(self, *_args: object, **_kwargs: object) -> object:
             return _DesyncedResult()
 
-        def invalidate(self):
+        def invalidate(self) -> None:
             self.invalidated += 1
 
     class _FakeSession:
         def __init__(self, connection) -> None:
             self._connection = connection
 
-        def connection(self):
+        def connection(self) -> object:
             return self._connection
 
     fake_connection = _FakeConnection()
@@ -238,7 +240,7 @@ def test_desync_forensics_capture_fingerprints_the_stale_response() -> None:
         _result = _FakePrevResult()
         _sock = None
 
-        def thread_id(self):
+        def thread_id(self) -> int:
             return 555001
 
     class _FakeConnection:
@@ -287,7 +289,7 @@ def test_desync_forensics_logs_only_packet_header_not_payload() -> None:
             _result = None
             _sock = left
 
-            def thread_id(self):
+            def thread_id(self) -> int:
                 return 1
 
         class _FakeConnection:

--- a/src/api/tests/service/learn/test_listen_elements.py
+++ b/src/api/tests/service/learn/test_listen_elements.py
@@ -3,11 +3,12 @@
 import json
 import time
 import types
+from collections.abc import Iterator
 
 import pytest
 
 
-def _require_app(app):
+def _require_app(app) -> None:
     if app is None:
         pytest.skip("App fixture disabled")
 
@@ -1424,25 +1425,27 @@ def test_listen_run_persists_content_block_before_element_rows(app) -> None:
                     )
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(
+                self, *_args: object, **_kwargs: object
+            ) -> "FakeMarkdownFlow":
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> list[DummyBlock]:
                 return self.blocks
 
-            def get_block(self, block_index):
+            def get_block(self, block_index) -> DummyBlock:
                 return self.blocks[block_index]
 
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
-            ):
+            ) -> object:
                 _ = (mode, variables, context, user_input)
                 block = self.blocks[block_index]
 
-                def _gen():
+                def _gen() -> Iterator[DummyLLMResult]:
                     yield DummyLLMResult(block.content)
 
                 return _gen()
@@ -1617,24 +1620,26 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app) -> None:
                     )
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(
+                self, *_args: object, **_kwargs: object
+            ) -> "FakeMarkdownFlow":
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> list[DummyBlock]:
                 return self.blocks
 
-            def get_block(self, block_index):
+            def get_block(self, block_index) -> DummyBlock:
                 return self.blocks[block_index]
 
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
-            ):
+            ) -> object:
                 _ = (block_index, mode, variables, context, user_input)
 
-                def _gen():
+                def _gen() -> Iterator[DummyLLMResult]:
                     yield DummyLLMResult(
                         [DummyFormattedElement("Intro narration.\n", "text", 0)]
                     )
@@ -1666,15 +1671,15 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app) -> None:
                 self.stream_element_number = stream_element_number
                 self.stream_element_type = stream_element_type
 
-            def process_chunk(self, chunk_content):
+            def process_chunk(self, chunk_content) -> Iterator[object]:
                 if False:
                     yield chunk_content
 
-            def drain_ready_segments(self):
+            def drain_ready_segments(self) -> Iterator[None]:
                 if False:
                     yield None
 
-            def finalize(self, *, commit=True):
+            def finalize(self, *, commit=True) -> Iterator[RunMarkdownFlowDTO]:
                 _ = commit
                 if self.stream_element_number == 0:
                     time.sleep(0.02)
@@ -1703,7 +1708,7 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app) -> None:
             stream_element_number,
             stream_element_type,
             **_kwargs: object,
-        ):
+        ) -> FakeTTSProcessor:
             _ = self
             return FakeTTSProcessor(
                 generated_block_bid,
@@ -1859,7 +1864,7 @@ def test_listen_run_persists_exception_gate_block_before_element_rows(app) -> No
             ctx,
         )
 
-        def _raise_paid(self, current_app):
+        def _raise_paid(self, current_app) -> Iterator[None]:
             _ = (self, current_app)
             raise PaidError
             yield  # pragma: no cover

--- a/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
+++ b/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
@@ -10,7 +10,7 @@ class _EchoResult:
     def __init__(self, value) -> None:
         self._value = value
 
-    def scalar(self):
+    def scalar(self) -> object:
         return self._value
 
 
@@ -18,7 +18,7 @@ class _FakeConnection:
     def __init__(self) -> None:
         self.invalidated = 0
 
-    def invalidate(self):
+    def invalidate(self) -> None:
         self.invalidated += 1
 
 
@@ -33,10 +33,10 @@ class _FakeSession:
         self.invalidations = 0
         self._connection = _FakeConnection()
 
-    def invalidate(self):
+    def invalidate(self) -> None:
         self.invalidations += 1
 
-    def execute(self, _statement, params):
+    def execute(self, _statement, params) -> object:
         self.executed += 1
         behaviour = self._behaviours.pop(0)
         if behaviour == "ok":
@@ -50,14 +50,14 @@ class _FakeSession:
             )
         return _EchoResult(behaviour)
 
-    def connection(self):
+    def connection(self) -> object:
         return self._connection
 
-    def rollback(self):
+    def rollback(self) -> None:
         self.rollbacks += 1
 
 
-def _patch_session(monkeypatch, behaviours):
+def _patch_session(monkeypatch, behaviours) -> object:
     session = _FakeSession(behaviours)
 
     class _FakeDb:

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from typing import Never
 
 import pytest
 from flask import Flask, has_app_context
@@ -19,7 +20,7 @@ from flaskr.service.learn.learn_dtos import (
 
 
 @pytest.fixture(autouse=True)
-def _skip_connection_probe(monkeypatch):
+def _skip_connection_probe(monkeypatch) -> None:
     # These tests exercise run-script locking and orchestration with minimal
     # fake sessions; the connection health probe has its own dedicated tests
     # in test_runscript_v2_connection_probe.py.
@@ -153,7 +154,7 @@ def test_sse_chunk_serializes_datetime_as_utc_iso_z() -> None:
     assert events == [{"created_at": "2026-06-30T11:57:03Z"}]
 
 
-def _patch_fake_element_adapter(monkeypatch):
+def _patch_fake_element_adapter(monkeypatch) -> None:
     monkeypatch.setattr(
         runscript_v2, "ListenElementRunAdapter", FakeListenElementAdapter
     )
@@ -168,7 +169,7 @@ def test_run_script_retries_lock_then_streams(monkeypatch) -> None:
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         monkeypatch.setattr(runscript_v2.time, "sleep", lambda *_args, **_kwargs: None)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[RunMarkdownFlowDTO]:
             with app.app_context():
                 yield from [
                     RunMarkdownFlowDTO(
@@ -216,7 +217,7 @@ def test_run_script_producer_owns_app_context(monkeypatch) -> None:
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         observed = {"has_app_context": None, "manage_app_context": None}
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[RunMarkdownFlowDTO]:
             observed["has_app_context"] = has_app_context()
             observed["manage_app_context"] = _kwargs.get("manage_app_context")
             yield RunMarkdownFlowDTO(
@@ -263,7 +264,7 @@ def test_run_script_removes_producer_db_session(monkeypatch) -> None:
             ),
         )
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[RunMarkdownFlowDTO]:
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
                 generated_block_bid="generated-1",
@@ -299,7 +300,7 @@ def test_run_script_producer_done_survives_db_session_remove_failure(
         remove_calls = []
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def _remove():
+        def _remove() -> Never:
             remove_calls.append("remove")
             message = "remove failed"
             raise RuntimeError(message)
@@ -310,7 +311,7 @@ def test_run_script_producer_done_survives_db_session_remove_failure(
             SimpleNamespace(session=SimpleNamespace(remove=_remove)),
         )
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[RunMarkdownFlowDTO]:
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
                 generated_block_bid="generated-1",
@@ -344,7 +345,7 @@ def test_run_script_read_mode_keeps_interaction_after_block_break(monkeypatch) -
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[RunMarkdownFlowDTO]:
             with app.app_context():
                 yield from [
                     RunMarkdownFlowDTO(
@@ -398,7 +399,7 @@ def test_run_script_ask_mode_uses_element_protocol(monkeypatch) -> None:
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[object]:
             with app.app_context():
                 element_adapter = _kwargs["element_adapter"]
                 yield from element_adapter.process(
@@ -453,7 +454,7 @@ def test_run_script_ask_mode_ignores_listen_flag(monkeypatch) -> None:
         observed: dict[str, object] = {}
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[RunMarkdownFlowDTO]:
             observed["listen"] = _kwargs["listen"]
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
@@ -536,19 +537,19 @@ def test_run_script_inner_ask_mode_routes_events_through_element_adapter(
         def __init__(self, **_kwargs: object) -> None:
             self._has_next = True
 
-        def set_input(self, *_args: object, **_kwargs: object):
+        def set_input(self, *_args: object, **_kwargs: object) -> None:
             return None
 
-        def reload(self, *_args: object, **_kwargs: object):
+        def reload(self, *_args: object, **_kwargs: object) -> list[object]:
             return []
 
-        def has_next(self):
+        def has_next(self) -> bool:
             if self._has_next:
                 self._has_next = False
                 return True
             return False
 
-        def run(self, _app):
+        def run(self, _app) -> list[RunMarkdownFlowDTO]:
             return [
                 RunMarkdownFlowDTO(
                     outline_bid="outline-1",
@@ -577,7 +578,7 @@ def test_run_script_inner_ask_mode_routes_events_through_element_adapter(
         def __init__(self) -> None:
             self.calls = []
 
-        def process(self, events):
+        def process(self, events) -> Iterator[str]:
             captured = list(events)
             self.calls.append(captured)
             return iter([f"converted:{event.type.value}" for event in captured])
@@ -690,13 +691,13 @@ def test_run_script_inner_rolls_back_on_unexpected_exception(monkeypatch) -> Non
     commit_calls = []
     remove_calls = []
 
-    def _commit():
+    def _commit() -> None:
         commit_calls.append("commit")
 
-    def _rollback():
+    def _rollback() -> None:
         rollback_calls.append("rollback")
 
-    def _remove():
+    def _remove() -> Never:
         remove_calls.append("remove")
         message = "remove failed"
         raise RuntimeError(message)
@@ -738,19 +739,19 @@ def test_run_script_inner_rolls_back_on_unexpected_exception(monkeypatch) -> Non
         def __init__(self, **_kwargs: object) -> None:
             self._has_next = True
 
-        def set_input(self, *_args: object, **_kwargs: object):
+        def set_input(self, *_args: object, **_kwargs: object) -> None:
             return None
 
-        def reload(self, *_args: object, **_kwargs: object):
+        def reload(self, *_args: object, **_kwargs: object) -> list[object]:
             return []
 
-        def has_next(self):
+        def has_next(self) -> bool:
             if self._has_next:
                 self._has_next = False
                 return True
             return False
 
-        def run(self, _app):
+        def run(self, _app) -> Never:
             message = "boom"
             raise RuntimeError(message)
 
@@ -826,19 +827,19 @@ def test_run_script_inner_finalizes_langfuse_after_loop(monkeypatch) -> None:
             self.finalize_calls = 0
             FakeRunScriptContext.last_instance = self
 
-        def set_input(self, *_args: object, **_kwargs: object):
+        def set_input(self, *_args: object, **_kwargs: object) -> None:
             return None
 
-        def reload(self, *_args: object, **_kwargs: object):
+        def reload(self, *_args: object, **_kwargs: object) -> list[object]:
             return []
 
-        def has_next(self):
+        def has_next(self) -> bool:
             if self._has_next:
                 self._has_next = False
                 return True
             return False
 
-        def run(self, _app):
+        def run(self, _app) -> list[RunMarkdownFlowDTO]:
             return [
                 RunMarkdownFlowDTO(
                     outline_bid="outline-1",
@@ -854,7 +855,7 @@ def test_run_script_inner_finalizes_langfuse_after_loop(monkeypatch) -> None:
                 ),
             ]
 
-        def _finalize_langfuse_trace(self):
+        def _finalize_langfuse_trace(self) -> None:
             self.finalize_calls += 1
 
     monkeypatch.setattr(runscript_v2, "RunScriptContextV2", FakeRunScriptContext)
@@ -928,19 +929,19 @@ def test_run_script_inner_emits_audio_backfill_ready_after_final_commit(
         def __init__(self, **_kwargs: object) -> None:
             self._has_next = True
 
-        def set_input(self, *_args: object, **_kwargs: object):
+        def set_input(self, *_args: object, **_kwargs: object) -> None:
             return None
 
-        def reload(self, *_args: object, **_kwargs: object):
+        def reload(self, *_args: object, **_kwargs: object) -> list[object]:
             return []
 
-        def has_next(self):
+        def has_next(self) -> bool:
             if self._has_next:
                 self._has_next = False
                 return True
             return False
 
-        def run(self, _app):
+        def run(self, _app) -> list[RunMarkdownFlowDTO]:
             return [
                 RunMarkdownFlowDTO(
                     outline_bid="outline-1",
@@ -959,7 +960,7 @@ def test_run_script_inner_emits_audio_backfill_ready_after_final_commit(
     monkeypatch.setattr(runscript_v2, "RunScriptContextV2", FakeRunScriptContext)
 
     class ElementAdapter:
-        def process(self, events):
+        def process(self, events) -> Iterator[RunElementSSEMessageDTO]:
             for event in events:
                 if event.type == GeneratedType.CONTENT:
                     yield RunElementSSEMessageDTO(
@@ -1059,19 +1060,19 @@ def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(
         def __init__(self, **_kwargs: object) -> None:
             self._has_next = True
 
-        def set_input(self, *_args: object, **_kwargs: object):
+        def set_input(self, *_args: object, **_kwargs: object) -> None:
             return None
 
-        def reload(self, *_args: object, **_kwargs: object):
+        def reload(self, *_args: object, **_kwargs: object) -> list[object]:
             return []
 
-        def has_next(self):
+        def has_next(self) -> bool:
             if self._has_next:
                 self._has_next = False
                 return True
             return False
 
-        def run(self, _app):
+        def run(self, _app) -> Iterator[RunMarkdownFlowDTO]:
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
                 generated_block_bid="generated-1",
@@ -1083,7 +1084,7 @@ def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(
     monkeypatch.setattr(runscript_v2, "RunScriptContextV2", FakeRunScriptContext)
 
     class ElementAdapter:
-        def process(self, events):
+        def process(self, events) -> Iterator[RunElementSSEMessageDTO]:
             for event in events:
                 if event.type == GeneratedType.CONTENT:
                     yield RunElementSSEMessageDTO(
@@ -1135,7 +1136,7 @@ def test_run_script_listen_keeps_interaction_after_block_done(monkeypatch) -> No
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[object]:
             with app.app_context():
                 element_adapter = _kwargs["element_adapter"]
                 yield from element_adapter.process(
@@ -1255,7 +1256,7 @@ def test_run_script_maps_llm_stream_connection_error_to_retryable_message(
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         monkeypatch.setattr(runscript_v2, "_", lambda key: f"translated:{key}")
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[None]:
             message = "litellm.APIConnectionError: APIConnectionError: OpenAIException - [SSL] record layer failure (_ssl.c:2590)"
             raise RuntimeError(message)
             yield  # pragma: no cover
@@ -1291,7 +1292,7 @@ def test_run_script_maps_standard_timeout_error_to_retryable_message(
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         monkeypatch.setattr(runscript_v2, "_", lambda key: f"translated:{key}")
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[None]:
             message = "stream failed"
             raise RuntimeError(message) from TimeoutError(
                 "The read operation timed out"
@@ -1326,7 +1327,7 @@ def test_run_script_listen_done_uses_element_protocol(monkeypatch) -> None:
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[None]:
             if False:
                 yield None
 
@@ -1384,7 +1385,7 @@ def test_get_run_status_reports_true_while_stream_is_open(monkeypatch) -> None:
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         monkeypatch.setattr(runscript_v2.time, "time", lambda: 120.0)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[RunMarkdownFlowDTO]:
             with app.app_context():
                 yield RunMarkdownFlowDTO(
                     outline_bid="outline-1",
@@ -1437,7 +1438,7 @@ def test_run_script_close_during_data_yield_does_not_raise_runtime_error(
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[RunMarkdownFlowDTO]:
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
                 generated_block_bid="generated-1",
@@ -1483,7 +1484,7 @@ def test_run_script_propagates_explicit_language_to_producer(monkeypatch) -> Non
 
         seen_languages: list[str] = []
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> Iterator[RunMarkdownFlowDTO]:
             with app.app_context():
                 seen_languages.append(get_current_language())
                 yield RunMarkdownFlowDTO(

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -12,6 +12,7 @@ rolling back on it.
 """
 
 import types
+from collections.abc import Iterator
 from typing import ClassVar
 
 import pytest
@@ -30,16 +31,16 @@ class _FakeSession:
         self.invalidations = 0
         self.removed = 0
 
-    def rollback(self):
+    def rollback(self) -> None:
         self.rollbacks += 1
 
-    def commit(self):
+    def commit(self) -> None:
         self.commits += 1
 
-    def invalidate(self):
+    def invalidate(self) -> None:
         self.invalidations += 1
 
-    def remove(self):
+    def remove(self) -> None:
         self.removed += 1
 
 
@@ -51,20 +52,20 @@ class _StubRunContext:
     def __init__(self, **_kwargs: object) -> None:
         self._steps = iter([True, False])
 
-    def set_input(self, *_args: object, **_kwargs: object):
+    def set_input(self, *_args: object, **_kwargs: object) -> None:
         pass
 
-    def has_next(self):
+    def has_next(self) -> bool:
         return next(self._steps, False)
 
-    def run(self, _app):
+    def run(self, _app) -> Iterator[object]:
         for item in type(self).script:
             if isinstance(item, BaseException):
                 raise item
             yield item
 
 
-def _patch_run_dependencies(monkeypatch, script):
+def _patch_run_dependencies(monkeypatch, script) -> object:
     session = _FakeSession()
 
     class _FakeDb:
@@ -102,7 +103,7 @@ def _patch_run_dependencies(monkeypatch, script):
     return session
 
 
-def _start_stream(app):
+def _start_stream(app) -> object:
     generator = run_script_inner(
         app=app,
         user_bid="user-1",

--- a/src/api/tests/service/learn/test_runtime_tts_admission.py
+++ b/src/api/tests/service/learn/test_runtime_tts_admission.py
@@ -9,8 +9,12 @@ import logging
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from typing import TYPE_CHECKING, Never
 
 from flask import Flask
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 def _install_litellm_stub() -> None:
@@ -19,7 +23,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> Never:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -128,7 +132,9 @@ def _find_call_by_name(node: ast.AST, name: str) -> ast.Call:
     raise AssertionError(message)
 
 
-def _mock_user(monkeypatch, user_id: str, *, is_creator: bool = False):
+def _mock_user(
+    monkeypatch, user_id: str, *, is_creator: bool = False
+) -> SimpleNamespace:
     dummy_user = SimpleNamespace(
         user_id=user_id,
         is_creator=is_creator,
@@ -153,7 +159,7 @@ def test_stream_passthrough_releases_request_db_session(monkeypatch) -> None:
         SimpleNamespace(session=SimpleNamespace(remove=lambda: calls.append("remove"))),
     )
 
-    def _messages():
+    def _messages() -> Iterator[str]:
         calls.append("iterate")
         yield 'data: {"type":"done"}\n\n'
 
@@ -179,7 +185,7 @@ def test_stream_passthrough_ignores_request_db_session_remove_failure(
     app = Flask(__name__)
     calls = []
 
-    def _remove():
+    def _remove() -> Never:
         calls.append("remove")
         message = "remove failed"
         raise RuntimeError(message)
@@ -190,7 +196,7 @@ def test_stream_passthrough_ignores_request_db_session_remove_failure(
         SimpleNamespace(session=SimpleNamespace(remove=_remove)),
     )
 
-    def _messages():
+    def _messages() -> Iterator[str]:
         calls.append("iterate")
         yield 'data: {"type":"done"}\n\n'
 
@@ -219,7 +225,7 @@ def test_stream_sse_logs_business_errors_as_warning(monkeypatch, caplog) -> None
         SimpleNamespace(session=SimpleNamespace(remove=lambda: None)),
     )
 
-    def _messages():
+    def _messages() -> Iterator[None]:
         message = "TTS provider quota exceeded"
         raise AppError(message, 45000292)
         yield  # pragma: no cover
@@ -251,7 +257,7 @@ def test_stream_sse_keeps_unexpected_errors_at_error_level(monkeypatch, caplog) 
         SimpleNamespace(session=SimpleNamespace(remove=lambda: None)),
     )
 
-    def _messages():
+    def _messages() -> Iterator[None]:
         message = "tts worker crashed"
         raise RuntimeError(message)
         yield  # pragma: no cover
@@ -283,7 +289,7 @@ def test_stream_sse_emits_error_event_for_business_error_with_factory(
         SimpleNamespace(session=SimpleNamespace(remove=lambda: None)),
     )
 
-    def _messages():
+    def _messages() -> Iterator[None]:
         message = "TTS provider quota exceeded"
         raise AppError(message, 45000292)
         yield  # pragma: no cover
@@ -414,7 +420,7 @@ def test_run_route_skips_runtime_admission_payload_for_builtin_demo(
         ),
     )
 
-    def _fake_run_script(*_args: object, **kwargs: object):
+    def _fake_run_script(*_args: object, **kwargs: object) -> Iterator[str]:
         assert "runtime_admission_payload" not in kwargs
         yield 'data: {"type":"done","event_type":"done","content":""}\n\n'
 
@@ -446,7 +452,7 @@ def test_run_route_uses_payload_language_as_generation_snapshot(
         lambda _app, shifu_bid: shifu_bid == "builtin-demo-1",
     )
 
-    def _fake_run_script(*_args: object, **kwargs: object):
+    def _fake_run_script(*_args: object, **kwargs: object) -> Iterator[str]:
         captured.update(kwargs)
         yield 'data: {"type":"done","event_type":"done","content":""}\n\n'
 

--- a/src/api/tests/service/learn/test_runtime_tts_voice_id.py
+++ b/src/api/tests/service/learn/test_runtime_tts_voice_id.py
@@ -35,7 +35,7 @@ def voice_app() -> Iterator[Flask]:
 
 def _patch_provider(
     monkeypatch, built_in=("builtin-1",), default_voice_id="default-voice"
-):
+) -> None:
     provider_config = SimpleNamespace(voices=[{"value": value} for value in built_in])
     monkeypatch.setattr(
         "flaskr.service.learn.learn_funcs.get_tts_provider",
@@ -47,7 +47,7 @@ def _patch_provider(
     )
 
 
-def _add_clone(shifu_bid, voice_id, status, voice_bid, provider="minimax"):
+def _add_clone(shifu_bid, voice_id, status, voice_bid, provider="minimax") -> None:
     dao.db.session.add(
         TTSMiniMaxClonedVoice(
             voice_bid=voice_bid,

--- a/src/api/tests/service/learn/test_sse_element_split_from_db.py
+++ b/src/api/tests/service/learn/test_sse_element_split_from_db.py
@@ -60,7 +60,7 @@ def _record_diagnostics(request: pytest.FixtureRequest, lines: list[str]) -> Non
     request.node.add_report_section("call", "SSE diagnostics", "\n".join(lines))
 
 
-def _fetch_blocks_raw(app, limit=100):
+def _fetch_blocks_raw(app, limit=100) -> list[dict[str, object]]:
     """Fetch latest generated blocks with content directly via SQLAlchemy."""
     from flaskr.service.learn.models import LearnGeneratedBlock
 
@@ -93,13 +93,13 @@ def _fetch_blocks_raw(app, limit=100):
         ]
 
 
-def _role_str(role_int):
+def _role_str(role_int) -> str:
     if role_int == ROLE_STUDENT:
         return "student"
     return "teacher"
 
 
-def _try_simulate_sse_for_block(app, block, *, with_av_contract=True):
+def _try_simulate_sse_for_block(app, block, *, with_av_contract=True) -> object:
     """Simulate SSE for a block, returning None when the simulation fails.
 
     Callers scan a sample of production-shaped rows and skip the ones the
@@ -111,7 +111,7 @@ def _try_simulate_sse_for_block(app, block, *, with_av_contract=True):
         return None
 
 
-def _simulate_sse_for_block(app, block, *, with_av_contract=True):
+def _simulate_sse_for_block(app, block, *, with_av_contract=True) -> list[object]:
     """Simulate SSE stream for a single block via ListenElementRunAdapter.
 
     When with_av_contract=True (default), builds an AV segmentation contract

--- a/src/api/tests/service/learn/test_tts_error_mapping.py
+++ b/src/api/tests/service/learn/test_tts_error_mapping.py
@@ -1,6 +1,7 @@
 """Verify TTS error mapping behavior."""
 
 import logging
+from collections.abc import Iterator
 
 import pytest
 from flaskr.service.common.models import ERROR_CODE, AppError
@@ -9,7 +10,7 @@ from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeoutError
 
 
 def test_rpm_queue_timeout_maps_to_rate_limited_not_unknown(app, caplog) -> None:
-    def _body():
+    def _body() -> Iterator[None]:
         message = "TTS RPM queue wait exceeded 10.00s"
         raise TTSRpmQueueTimeoutError(message)
         yield  # pragma: no cover
@@ -35,7 +36,7 @@ def test_rpm_queue_timeout_maps_to_rate_limited_not_unknown(app, caplog) -> None
 
 
 def test_unexpected_error_still_maps_to_unknown_error(app, caplog) -> None:
-    def _body():
+    def _body() -> Iterator[None]:
         message = "tts worker crashed"
         raise RuntimeError(message)
         yield  # pragma: no cover

--- a/src/api/tests/service/learn/test_tts_synth_concurrency.py
+++ b/src/api/tests/service/learn/test_tts_synth_concurrency.py
@@ -1,5 +1,6 @@
 """Verify TTS synth concurrency behavior."""
 
+from collections.abc import Iterator
 from typing import Never
 
 from flaskr import dao
@@ -114,7 +115,7 @@ def test_yield_tts_synthesis_sheds_request_when_full(app, monkeypatch) -> None:
 
     body_calls = {"n": 0}
 
-    def _body():
+    def _body() -> Iterator[str]:
         body_calls["n"] += 1
         yield "chunk"
 
@@ -143,7 +144,7 @@ def test_yield_tts_synthesis_runs_and_releases_slot(app, monkeypatch) -> None:
     monkeypatch.setattr(dao._redis_state, "client", fake)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
 
-    def _body():
+    def _body() -> Iterator[str]:
         yield "a"
         yield "b"
 
@@ -172,7 +173,7 @@ def test_yield_tts_synthesis_bypass_does_not_release(app, monkeypatch) -> None:
     monkeypatch.setattr(dao._redis_state, "client", boom)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
 
-    def _body():
+    def _body() -> Iterator[str]:
         yield "a"
 
     with app.app_context():

--- a/src/api/tests/service/metering/test_recording.py
+++ b/src/api/tests/service/metering/test_recording.py
@@ -1,6 +1,7 @@
 """Verify billable usage is persisted and queued for settlement."""
 
 from collections.abc import Iterator
+from typing import Never
 
 import pytest
 from flask import Flask
@@ -351,7 +352,7 @@ def test_persist_cleanup_targets_failed_session_inside_context(
 
     events = []
 
-    def _fake_cleanup(exc, *, source, session=None):
+    def _fake_cleanup(exc, *, source, session=None) -> str:
         # Must be called while the pushed app context is active.
         _ = (source, session)
         events.append((type(exc).__name__, current_app._get_current_object() is app))
@@ -360,10 +361,10 @@ def test_persist_cleanup_targets_failed_session_inside_context(
     monkeypatch.setattr(recorder_module, "cleanup_session_after", _fake_cleanup)
 
     class _FailingSession:
-        def add(self, _record):
+        def add(self, _record) -> None:
             pass
 
-        def commit(self):
+        def commit(self) -> Never:
             message = "desynced"
             raise ResourceClosedError(message)
 
@@ -391,10 +392,10 @@ def test_persist_invalidates_on_base_exception_interrupt(app, monkeypatch) -> No
         pass
 
     class _InterruptedSession:
-        def add(self, _record):
+        def add(self, _record) -> None:
             pass
 
-        def commit(self):
+        def commit(self) -> Never:
             raise _Interrupt
 
     monkeypatch.setattr(

--- a/src/api/tests/service/metering/test_tts_usage_recorder.py
+++ b/src/api/tests/service/metering/test_tts_usage_recorder.py
@@ -12,7 +12,7 @@ from flaskr.service.tts.tts_usage_recorder import (
 )
 
 
-def _voice_settings():
+def _voice_settings() -> SimpleNamespace:
     return SimpleNamespace(
         voice_id="voice-1",
         speed=1.0,
@@ -22,7 +22,7 @@ def _voice_settings():
     )
 
 
-def _audio_settings():
+def _audio_settings() -> SimpleNamespace:
     return SimpleNamespace(format="mp3", sample_rate=32000)
 
 

--- a/src/api/tests/service/order/test_import_activation_parse.py
+++ b/src/api/tests/service/order/test_import_activation_parse.py
@@ -233,7 +233,7 @@ def test_import_activation_does_not_consult_profile_state_for_nickname_defaults(
         read_order: list[tuple[str, str, bool, bool]] = []
         reads_before_ensure: list[tuple[str, str, bool, bool]] = []
 
-        def track_first(query):
+        def track_first(query) -> object:
             statement = str(query.statement)
             parameters = query.statement.compile().params
             lookup_value = str(
@@ -258,7 +258,7 @@ def test_import_activation_does_not_consult_profile_state_for_nickname_defaults(
 
         original_ensure_user = order_admin.ensure_user_for_identifier
 
-        def track_ensure_user(*args: object, **kwargs: object):
+        def track_ensure_user(*args: object, **kwargs: object) -> object:
             reads_before_ensure.extend(read_order)
             return original_ensure_user(*args, **kwargs)
 

--- a/src/api/tests/service/order/test_import_activation_permissions.py
+++ b/src/api/tests/service/order/test_import_activation_permissions.py
@@ -48,7 +48,9 @@ def _add_shared_permission(app, shifu_bid: str, user_id: str) -> None:
         dao.db.session.commit()
 
 
-def _mock_user(monkeypatch, user_id: str, *, is_creator: bool = True):
+def _mock_user(
+    monkeypatch, user_id: str, *, is_creator: bool = True
+) -> SimpleNamespace:
     dummy_user = SimpleNamespace(
         user_id=user_id,
         is_creator=is_creator,

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -95,7 +95,7 @@ def test_legacy_order_purchase_flow_stays_on_order_tables(
         lambda *_args, **_kwargs: None,
     )
 
-    def _fake_pingxx_charge(**kwargs: object):
+    def _fake_pingxx_charge(**kwargs: object) -> BuyRecordDTO:
         buy_record = kwargs["buy_record"]
         buy_record.status = ORDER_STATUS_TO_BE_PAID
         dao.db.session.add(buy_record)
@@ -200,7 +200,7 @@ class _FakeSaasConfigFuncs:
     def get_sass_config(self, user_bid: str, key: str, default: str = "") -> str:
         return self._by_user_key.get((user_bid, key), default)
 
-    def get_saas_user_config_value_by_bid(self, app, config_bid: str):
+    def get_saas_user_config_value_by_bid(self, app, config_bid: str) -> object:
         del app
         record = self._by_bid.get(config_bid)
         return None if record is None else record["value"]
@@ -249,7 +249,7 @@ class _FakeSaasQuery:
     def order_by(self, *_args: object) -> _FakeSaasQuery:
         return self
 
-    def first(self):
+    def first(self) -> SimpleNamespace | None:
         rows = sorted(
             self._fake_saas._by_bid.values(),
             key=lambda row: int(row["id"]),
@@ -261,7 +261,7 @@ class _FakeSaasQuery:
         return None
 
 
-def _make_fake_saas_model(fake_saas: _FakeSaasConfigFuncs):
+def _make_fake_saas_model(fake_saas: _FakeSaasConfigFuncs) -> type[object]:
     class FakeSaasUserConfig:
         id = _FakeSaasColumn("id")
         user_bid = _FakeSaasColumn("user_bid")
@@ -288,7 +288,7 @@ def test_creator_payment_config_smoke_supports_alipay_and_wechatpay_checkout(
         def __init__(self, provider_name: str) -> None:
             self.provider_name = provider_name
 
-        def create_payment(self, *, request, app):
+        def create_payment(self, *, request, app) -> PaymentCreationResult:
             del app
             if self.provider_name == "alipay":
                 assert request.channel == "alipay_qr"
@@ -499,7 +499,7 @@ def test_legacy_stripe_checkout_urls_are_derived_from_host_url(
     stripe_requests: list[dict] = []
 
     class FakeStripeProvider:
-        def create_payment(self, *, request, app):
+        def create_payment(self, *, request, app) -> PaymentCreationResult:
             _ = app
             stripe_requests.append(
                 {

--- a/src/api/tests/service/order/test_native_payment_split_tables.py
+++ b/src/api/tests/service/order/test_native_payment_split_tables.py
@@ -231,7 +231,9 @@ def test_learner_sync_and_admin_payment_detail_read_alipay_table(
     monkeypatch,
 ) -> None:
     class FakeAlipayProvider:
-        def sync_reference(self, *, provider_reference, reference_type, app):
+        def sync_reference(
+            self, *, provider_reference, reference_type, app
+        ) -> PaymentNotificationResult:
             _ = app
             assert reference_type == "payment"
             return PaymentNotificationResult(
@@ -312,7 +314,9 @@ def test_learner_sync_does_not_mark_paid_when_native_amount_mismatches(
     monkeypatch,
 ) -> None:
     class FakeAlipayProvider:
-        def sync_reference(self, *, provider_reference, reference_type, app):
+        def sync_reference(
+            self, *, provider_reference, reference_type, app
+        ) -> PaymentNotificationResult:
             _ = app
             assert reference_type == "payment"
             return PaymentNotificationResult(

--- a/src/api/tests/service/order/test_order_import_error_specificity.py
+++ b/src/api/tests/service/order/test_order_import_error_specificity.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Never
+
 import flaskr.service.order.admin as order_admin
 from flaskr.i18n import _
 
@@ -9,7 +11,7 @@ from flaskr.i18n import _
 def test_import_activation_orders_unexpected_failure_returns_specific_message(
     app, monkeypatch
 ) -> None:
-    def raise_unexpected(*_args: object, **_kwargs: object):
+    def raise_unexpected(*_args: object, **_kwargs: object) -> Never:
         message = "boom"
         raise RuntimeError(message)
 
@@ -35,7 +37,7 @@ def test_import_activation_orders_unexpected_failure_returns_specific_message(
 def test_import_activation_orders_from_entries_unexpected_failure_returns_specific_message(
     app, monkeypatch
 ) -> None:
-    def raise_unexpected(*_args: object, **_kwargs: object):
+    def raise_unexpected(*_args: object, **_kwargs: object) -> Never:
         message = "boom"
         raise RuntimeError(message)
 

--- a/src/api/tests/service/order/test_order_init_lock.py
+++ b/src/api/tests/service/order/test_order_init_lock.py
@@ -1,5 +1,7 @@
 """Verify order init lock behavior."""
 
+from typing import Never
+
 import flaskr.service.order.funs as order_funs
 
 
@@ -62,7 +64,7 @@ def test_order_init_lock_uses_prefixed_key(monkeypatch) -> None:
 
 def test_order_init_lock_skips_when_cache_provider_errors(monkeypatch) -> None:
     class _BrokenCacheProvider:
-        def lock(self, *args: object, **kwargs: object):
+        def lock(self, *args: object, **kwargs: object) -> Never:
             _ = (args, kwargs)
             message = "lock unavailable"
             raise RuntimeError(message)

--- a/src/api/tests/service/order/test_payment_channel_resolution.py
+++ b/src/api/tests/service/order/test_payment_channel_resolution.py
@@ -55,7 +55,7 @@ class TestResolvePaymentChannel:
     def test_stripe_only_configuration_overrides_pingxx_default(
         self, monkeypatch
     ) -> None:
-        def fake_get_config(key, default=None):
+        def fake_get_config(key, default=None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "stripe"
             return default
@@ -77,7 +77,7 @@ class TestResolvePaymentChannel:
     def test_disabled_payment_channel_raises_for_explicit_request(
         self, monkeypatch
     ) -> None:
-        def fake_get_config(key, default=None):
+        def fake_get_config(key, default=None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "stripe"
             return default
@@ -95,7 +95,7 @@ class TestResolvePaymentChannel:
             )
 
     def test_alipay_qr_prefers_native_when_enabled(self, monkeypatch) -> None:
-        def fake_get_config(key, default=None):
+        def fake_get_config(key, default=None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "alipay,pingxx"
             return default
@@ -116,7 +116,7 @@ class TestResolvePaymentChannel:
     def test_alipay_qr_falls_back_to_pingxx_when_native_disabled(
         self, monkeypatch
     ) -> None:
-        def fake_get_config(key, default=None):
+        def fake_get_config(key, default=None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "pingxx"
             return default
@@ -135,7 +135,7 @@ class TestResolvePaymentChannel:
         assert sub_channel == "alipay_qr"
 
     def test_wechat_jsapi_prefers_native_when_enabled(self, monkeypatch) -> None:
-        def fake_get_config(key, default=None):
+        def fake_get_config(key, default=None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "wechatpay,pingxx"
             return default
@@ -154,7 +154,7 @@ class TestResolvePaymentChannel:
         assert sub_channel == "wx_pub"
 
     def test_explicit_wechatpay_defaults_to_qr_channel(self, monkeypatch) -> None:
-        def fake_get_config(key, default=None):
+        def fake_get_config(key, default=None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "wechatpay"
             return default
@@ -187,7 +187,7 @@ class TestResolvePaymentChannel:
     def test_explicit_native_provider_rejects_unsupported_channel(
         self, monkeypatch
     ) -> None:
-        def fake_get_config(key, default=None):
+        def fake_get_config(key, default=None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "alipay"
             return default

--- a/src/api/tests/service/order/test_provider_public_urls.py
+++ b/src/api/tests/service/order/test_provider_public_urls.py
@@ -50,7 +50,7 @@ def test_alipay_precreate_uses_host_url_notify_url(monkeypatch) -> None:
             self.biz_model = biz_model
 
     class FakeClient:
-        def execute(self, precreate_request):
+        def execute(self, precreate_request) -> dict[str, dict[str, str]]:
             captured["notify_url"] = precreate_request.notify_url
             return {
                 "alipay_trade_precreate_response": {
@@ -108,7 +108,7 @@ def test_wechatpay_native_uses_host_url_notify_url(monkeypatch) -> None:
 
     provider = WechatPayProvider()
 
-    def fake_request(*, method, path, body, app):
+    def fake_request(*, method, path, body, app) -> dict[str, str]:
         del method, path, app
         captured.update(json.loads(body))
         return {"code_url": "https://wechatpay.test/qr"}

--- a/src/api/tests/service/order/test_stripe_refund.py
+++ b/src/api/tests/service/order/test_stripe_refund.py
@@ -44,7 +44,7 @@ def app() -> Iterator[Flask]:
         dao.db.drop_all()
 
 
-def _ensure_order(status, order_bid):
+def _ensure_order(status, order_bid) -> Order:
     order = Order.query.filter(Order.order_bid == order_bid).first()
     if not order:
         order = Order(order_bid=order_bid, shifu_bid="shifu-1", user_bid="user-1")

--- a/src/api/tests/service/order/test_stripe_webhook.py
+++ b/src/api/tests/service/order/test_stripe_webhook.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
-def _load_route_module(module_name: str):
+def _load_route_module(module_name: str) -> object:
     return importlib.import_module(f"flaskr.route.{module_name}")
 
 
@@ -74,7 +74,7 @@ def stripe_webhook_app() -> Iterator[Flask]:
         dao.db.drop_all()
 
 
-def _ensure_order(status, order_bid):
+def _ensure_order(status, order_bid) -> Order:
     order = Order.query.filter(Order.order_bid == order_bid).first()
     if not order:
         order = Order(order_bid=order_bid, shifu_bid="shifu-1", user_bid="user-1")
@@ -86,7 +86,7 @@ def _ensure_order(status, order_bid):
     return order
 
 
-def _ensure_billing_subscription(status, subscription_bid):
+def _ensure_billing_subscription(status, subscription_bid) -> BillingSubscription:
     subscription = BillingSubscription.query.filter(
         BillingSubscription.subscription_bid == subscription_bid
     ).first()
@@ -110,7 +110,7 @@ def _ensure_billing_subscription(status, subscription_bid):
     return subscription
 
 
-def _ensure_billing_order(status, bill_order_bid, subscription_bid):
+def _ensure_billing_order(status, bill_order_bid, subscription_bid) -> BillingOrder:
     order = BillingOrder.query.filter(
         BillingOrder.bill_order_bid == bill_order_bid
     ).first()
@@ -141,7 +141,7 @@ def _ensure_billing_order(status, bill_order_bid, subscription_bid):
     return order
 
 
-def _ensure_billing_stripe_raw_snapshot(bill_order_bid):
+def _ensure_billing_stripe_raw_snapshot(bill_order_bid) -> StripeOrder:
     raw_order = StripeOrder.query.filter(
         StripeOrder.bill_order_bid == bill_order_bid,
         StripeOrder.biz_domain == "billing",

--- a/src/api/tests/service/order/test_uow_failure_paths.py
+++ b/src/api/tests/service/order/test_uow_failure_paths.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import datetime
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Never
 
 import pytest
 from flask import Flask
@@ -108,7 +108,7 @@ def _fail_after_pricing_sync(monkeypatch: pytest.MonkeyPatch) -> None:
     """Run the real pricing sync, then fail — simulating any late step error."""
     real_sync = order_funs._sync_order_campaign_pricing
 
-    def failing_sync(*args: object, **kwargs: object):
+    def failing_sync(*args: object, **kwargs: object) -> Never:
         real_sync(*args, **kwargs)
         message = "boom after pricing sync"
         raise RuntimeError(message)
@@ -143,7 +143,7 @@ def test_init_buy_record_late_failure_persists_nothing(
     """
     _ = stub_shifu
 
-    def fake_apply_promo(_app, **kwargs: object):
+    def fake_apply_promo(_app, **kwargs: object) -> list[PromoRedemption]:
         application = PromoRedemption(
             redemption_bid="uow-redemption-1",
             promo_bid="uow-promo-1",

--- a/src/api/tests/service/profile/test_profile.py
+++ b/src/api/tests/service/profile/test_profile.py
@@ -26,11 +26,11 @@ def test_add_profile_item_quick_creates_definition(app) -> None:
 def test_hide_unused_profile_items_no_unused(monkeypatch) -> None:
     calls = []
 
-    def fake_get_unused(_app, parent_id):
+    def fake_get_unused(_app, parent_id) -> list[object]:
         calls.append(("unused", parent_id))
         return []
 
-    def fake_get_defs(_app, parent_id=None):
+    def fake_get_defs(_app, parent_id=None) -> list[str]:
         calls.append(("defs", parent_id))
         return ["defs"]
 
@@ -51,11 +51,11 @@ def test_hide_unused_profile_items_no_unused(monkeypatch) -> None:
 def test_hide_unused_profile_items_updates_hidden(monkeypatch) -> None:
     calls = []
 
-    def fake_get_unused(_app, parent_id):
+    def fake_get_unused(_app, parent_id) -> list[str]:
         calls.append(("unused", parent_id))
         return ["v1", "v2"]
 
-    def fake_update(_app, parent_id, profile_keys, hidden, user_id):
+    def fake_update(_app, parent_id, profile_keys, hidden, user_id) -> list[str]:
         calls.append(("update", parent_id, tuple(profile_keys), hidden, user_id))
         return ["updated"]
 
@@ -74,7 +74,7 @@ def test_hide_unused_profile_items_updates_hidden(monkeypatch) -> None:
 def test_get_profile_variable_usage_groups_keys(monkeypatch) -> None:
     calls = []
 
-    def fake_get_defs(_app, parent_id=None, _type="all"):
+    def fake_get_defs(_app, parent_id=None, _type="all") -> list[object]:
         calls.append(("defs", parent_id))
         return [
             # system key should be ignored
@@ -85,7 +85,7 @@ def test_get_profile_variable_usage_groups_keys(monkeypatch) -> None:
             object.__class__("obj", (), {"profile_scope": "user", "profile_key": "k2"}),
         ]
 
-    def fake_collect(_app, parent_id):
+    def fake_collect(_app, parent_id) -> set[str]:
         calls.append(("collect", parent_id))
         return {"k2"}
 

--- a/src/api/tests/service/profile/test_profile_routes.py
+++ b/src/api/tests/service/profile/test_profile_routes.py
@@ -12,7 +12,7 @@ _dummy_lock = SimpleNamespace(
 
 
 @pytest.fixture(autouse=True)
-def _stub_profile_config_cache(monkeypatch):
+def _stub_profile_config_cache(monkeypatch) -> None:
     monkeypatch.setattr(
         config_funcs,
         "redis",
@@ -28,7 +28,7 @@ def _stub_profile_config_cache(monkeypatch):
 class TestProfileRoutes:
     """Verify profile routes behavior."""
 
-    def _mock_request_user(self, monkeypatch):
+    def _mock_request_user(self, monkeypatch) -> None:
         dummy_user = SimpleNamespace(user_id="test-user", language="en-US")
         monkeypatch.setattr(
             "flaskr.route.user.validate_user",
@@ -41,7 +41,7 @@ class TestProfileRoutes:
     ) -> None:
         called = {}
 
-        def fake_get_definitions(_app_ctx, parent_id, definition_type):
+        def fake_get_definitions(_app_ctx, parent_id, definition_type) -> list[object]:
             called["parent_id"] = parent_id
             called["definition_type"] = definition_type
             return []
@@ -73,7 +73,7 @@ class TestProfileRoutes:
     def test_hide_unused_profile_items_ok(self, monkeypatch, test_client) -> None:
         called = {}
 
-        def fake_hide(_app_ctx, parent_id, user_id):
+        def fake_hide(_app_ctx, parent_id, user_id) -> list[dict[str, str]]:
             called["parent_id"] = parent_id
             called["user_id"] = user_id
             return [
@@ -115,7 +115,9 @@ class TestProfileRoutes:
     def test_update_profile_hidden_state_ok(self, monkeypatch, test_client) -> None:
         called = {}
 
-        def fake_update(_app_ctx, parent_id, profile_keys, hidden, user_id):
+        def fake_update(
+            _app_ctx, parent_id, profile_keys, hidden, user_id
+        ) -> list[dict[str, str | int]]:
             called["parent_id"] = parent_id
             called["profile_keys"] = profile_keys
             called["hidden"] = hidden
@@ -171,7 +173,9 @@ class TestProfileRoutes:
     ) -> None:
         called = {}
 
-        def fake_save(_app_ctx, profile_id, parent_id, user_id, key):
+        def fake_save(
+            _app_ctx, profile_id, parent_id, user_id, key
+        ) -> dict[str, object]:
             called["profile_id"] = profile_id
             called["parent_id"] = parent_id
             called["user_id"] = user_id

--- a/src/api/tests/service/promo/test_admin_promotions.py
+++ b/src/api/tests/service/promo/test_admin_promotions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 from flaskr.dao import db
@@ -41,9 +42,12 @@ from flaskr.service.user.models import AuthCredential
 from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.util.datetime import now_utc, parse_naive_utc
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture(autouse=True)
-def _isolate_tables(app):
+def _isolate_tables(app) -> Iterator[None]:
     with app.app_context():
         db.session.query(PromoRedemption).delete()
         db.session.query(PromoCampaign).delete()
@@ -159,7 +163,7 @@ def _mock_creator(monkeypatch, user_id: str = "creator-1") -> None:
 
 def _seed_user(
     user_bid: str, identifier: str, nickname: str, *, is_operator: bool = False
-):
+) -> UserEntity:
     user = UserEntity()
     user.user_bid = user_bid
     user.user_identify = identifier
@@ -178,7 +182,9 @@ def _seed_user(
     return user
 
 
-def _seed_course(shifu_bid: str, title: str, *, creator_user_bid: str = "operator-1"):
+def _seed_course(
+    shifu_bid: str, title: str, *, creator_user_bid: str = "operator-1"
+) -> PublishedShifu:
     course = PublishedShifu()
     course.shifu_bid = shifu_bid
     course.title = title
@@ -196,7 +202,7 @@ def _seed_order(
     *,
     payable: str = "99.00",
     paid: str = "79.00",
-):
+) -> Order:
     order = Order()
     order.order_bid = order_bid
     order.shifu_bid = shifu_bid
@@ -710,7 +716,9 @@ def test_creator_redemption_code_list_accepts_utc_date_filter_bounds(
     _mock_creator(monkeypatch, user_id="creator-1")
     captured_filters = {}
 
-    def fake_list(_app, creator_user_bid, page_index, page_size, filters):
+    def fake_list(
+        _app, creator_user_bid, page_index, page_size, filters
+    ) -> dict[str, object]:
         captured_filters.update(filters)
         assert creator_user_bid == "creator-1"
         assert page_index == 1

--- a/src/api/tests/service/promo/test_promo_error_specificity.py
+++ b/src/api/tests/service/promo/test_promo_error_specificity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import flaskr.service.promo.admin as promo_admin
 import pytest
@@ -11,9 +12,12 @@ from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.promo.consts import COUPON_STATUS_ACTIVE, COUPON_TYPE_FIXED
 from flaskr.service.promo.models import Coupon, CouponUsage
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture(autouse=True)
-def _isolate_coupon_tables(app):
+def _isolate_coupon_tables(app) -> Iterator[None]:
     with app.app_context():
         CouponUsage.query.delete()
         Coupon.query.delete()

--- a/src/api/tests/service/referral/test_referral_campaign_admin.py
+++ b/src/api/tests/service/referral/test_referral_campaign_admin.py
@@ -61,7 +61,7 @@ def _seed_plan_product(product_code: str = "creator-plan-monthly-pro") -> None:
     db.session.commit()
 
 
-def _payload(**overrides: object):
+def _payload(**overrides: object) -> dict[str, str | bool | int | dict[str, bool]]:
     payload = {
         "campaign_code": "domestic_creator_invite_202606",
         "campaign_name": "Domestic creator invite",

--- a/src/api/tests/service/referral/test_referral_campaign_admin_routes.py
+++ b/src/api/tests/service/referral/test_referral_campaign_admin_routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 from flaskr.dao import db
@@ -26,9 +27,12 @@ from flaskr.service.referral.models import (
     ReferralInviteReward,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture(autouse=True)
-def _isolate_referral_campaign_tables(app):
+def _isolate_referral_campaign_tables(app) -> Iterator[None]:
     with app.app_context():
         db.session.query(ReferralInviteEvent).delete()
         db.session.query(ReferralInviteReward).delete()
@@ -83,7 +87,7 @@ def _seed_plan_product() -> None:
     db.session.commit()
 
 
-def _payload():
+def _payload() -> dict[str, str | bool | int | dict[str, bool]]:
     return {
         "campaign_code": "domestic_creator_invite_202606",
         "campaign_name": "Domestic creator invite",

--- a/src/api/tests/service/referral/test_referral_service.py
+++ b/src/api/tests/service/referral/test_referral_service.py
@@ -450,7 +450,7 @@ def test_post_auth_binding_is_idempotent_and_creates_reward(
         )
         db.session.commit()
 
-        def fake_grant(_app: Flask, *, reward: ReferralInviteReward):
+        def fake_grant(_app: Flask, *, reward: ReferralInviteReward) -> object:
             grant_calls.append(reward.reward_bid)
             reward.reward_status = REFERRAL_REWARD_STATUS_GENERATED
             reward.billing_artifacts = {

--- a/src/api/tests/service/shifu/test_admin_config_rates.py
+++ b/src/api/tests/service/shifu/test_admin_config_rates.py
@@ -89,7 +89,7 @@ def _seed_default_llm_rates() -> None:
 def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(
     monkeypatch, app
 ) -> None:
-    def config_getter(key, default=None):
+    def config_getter(key, default=None) -> object:
         return {
             "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
             "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS": "3000",
@@ -320,14 +320,14 @@ def test_update_db_only_llm_alias_only_supersedes_explicit_alias(
 
 
 def test_update_new_llm_rate_uses_default_metric_ratios(monkeypatch, app) -> None:
-    def config_getter(key, default=None):
+    def config_getter(key, default=None) -> object:
         return {
             "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
             "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS": "3000",
             "TTS_CHARS_PER_LLM_TOKEN": "1",
         }.get(key, default)
 
-    def resolve_identity(model: str):
+    def resolve_identity(model: str) -> tuple[object, list[object]]:
         provider, actual_model = model.split("/", 1)
         return provider, [actual_model, model]
 
@@ -393,7 +393,7 @@ def test_update_new_llm_rate_uses_default_metric_ratios(monkeypatch, app) -> Non
 def test_operator_rate_config_exposes_fixed_credit_1x_baseline(
     monkeypatch, app
 ) -> None:
-    def config_getter(key, default=None):
+    def config_getter(key, default=None) -> object:
         return {
             "DEFAULT_LLM_MODEL": "ark/doubao-seed-2-0-lite-260428",
             "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS": "0.066667",
@@ -438,7 +438,7 @@ def test_operator_rate_config_exposes_fixed_credit_1x_baseline(
 
 
 def test_update_rate_rejects_missing_credit_1x_anchor(monkeypatch, app) -> None:
-    def config_getter(key, default=None):
+    def config_getter(key, default=None) -> object:
         return {
             "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
             "TTS_CHARS_PER_LLM_TOKEN": "1",
@@ -628,7 +628,7 @@ def test_operator_rate_config_appends_only_current_exact_db_identities(
             _parameters,
             _context,
             _executemany,
-        ):
+        ) -> None:
             nonlocal active_rate_selects
             if "credit_usage_rates" in statement.lower():
                 active_rate_selects += 1

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -7,6 +7,7 @@ import sys
 from datetime import UTC, datetime
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 from flaskr.dao import db
@@ -80,6 +81,9 @@ from flaskr.service.user.models import (
 )
 from flaskr.service.user.repository import create_user_entity, upsert_credential
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 def _clear_tables() -> None:
     db.session.query(CreditLedgerEntry).delete()
@@ -105,7 +109,7 @@ def _clear_tables() -> None:
 
 
 @pytest.fixture(autouse=True)
-def _pin_app_timezone_to_utc(app):
+def _pin_app_timezone_to_utc(app) -> Iterator[None]:
     original_tz = app.config.get("TZ")
     app.config["TZ"] = "UTC"
     try:
@@ -118,7 +122,7 @@ def _pin_app_timezone_to_utc(app):
 
 
 @pytest.fixture(autouse=True)
-def _mock_bcrypt_module(monkeypatch):
+def _mock_bcrypt_module(monkeypatch) -> None:
     monkeypatch.setitem(
         sys.modules,
         "bcrypt",
@@ -131,7 +135,7 @@ def _mock_bcrypt_module(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _isolate_tables(app):
+def _isolate_tables(app) -> Iterator[None]:
     with app.app_context():
         _clear_tables()
     yield
@@ -2479,14 +2483,16 @@ def test_admin_operation_course_credit_usage_model_labels_are_cached_per_request
     created_at = datetime(2026, 4, 1, 9, 0, 0)
     load_counts = {"llm": 0, "tts": 0}
 
-    def fake_get_current_models(_app):
+    def fake_get_current_models(_app) -> list[dict[str, str]]:
         load_counts["llm"] += 1
         return [
             {"model": "gpt-known", "display_name": "GPT Known"},
             {"model": "shared-model", "display_name": "Shared Model"},
         ]
 
-    def fake_get_all_provider_configs():
+    def fake_get_all_provider_configs() -> dict[
+        str, list[object] | list[dict[str, str]]
+    ]:
         load_counts["tts"] += 1
         return {
             "providers": [],

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -243,7 +243,7 @@ def test_list_operator_courses_attaches_prompt_flags_for_lightweight_page_items(
         updated_at=datetime(2025, 4, 3, 10, 0, 0),
     )
 
-    def attach_prompt_flags(model, rows):
+    def attach_prompt_flags(model, rows) -> None:
         for row in rows:
             row.has_course_prompt = model is PublishedShifu
 

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -6,6 +6,7 @@ import sys
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, Never
 
 import pytest
 from flaskr.dao import db
@@ -105,9 +106,12 @@ from flaskr.util.datetime import now_utc
 
 from tests.common.fixtures.billing_products import build_bill_products
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture(autouse=True)
-def _mock_bcrypt_module(monkeypatch):
+def _mock_bcrypt_module(monkeypatch) -> None:
     monkeypatch.setitem(
         sys.modules,
         "bcrypt",
@@ -120,7 +124,7 @@ def _mock_bcrypt_module(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _isolate_tables(app):
+def _isolate_tables(app) -> Iterator[None]:
     with app.app_context():
         db.session.query(CreditLedgerEntry).delete()
         db.session.query(BillUsageRecord).delete()
@@ -185,7 +189,7 @@ def _mock_operator(
     )
 
 
-def _z(value):
+def _z(value) -> object:
     """Serialize a datetime the way flaskr.route.common.fmt does (UTC ISO 'Z')."""
     if value.tzinfo is None:
         value = value.replace(tzinfo=UTC)
@@ -215,7 +219,7 @@ def _seed_user(
     updated_at: datetime,
     providers: list[tuple[str, str]] | None = None,
     credential_created_at: datetime | None = None,
-):
+) -> None:
     entity = create_user_entity(
         user_bid=user_bid,
         identify=identify,
@@ -255,7 +259,7 @@ def _seed_course(
     creator_user_bid: str,
     created_at: datetime,
     updated_at: datetime,
-):
+) -> object:
     course = model(
         shifu_bid=shifu_bid,
         title=title,
@@ -278,7 +282,7 @@ def _seed_success_order(
     created_at: datetime,
     paid_price: str = "0.00",
     payable_price: str = "0.00",
-):
+) -> Order:
     order = Order(
         order_bid=order_bid,
         shifu_bid=shifu_bid,
@@ -303,7 +307,7 @@ def _seed_published_outline_item(
     parent_bid: str,
     position: str,
     hidden: int = 0,
-):
+) -> PublishedOutlineItem:
     outline_item = PublishedOutlineItem(
         shifu_bid=shifu_bid,
         outline_item_bid=outline_item_bid,
@@ -323,7 +327,7 @@ def _seed_credit_wallet(
     creator_bid: str,
     wallet_bid: str,
     available_credits: str,
-):
+) -> CreditWallet:
     wallet = CreditWallet(
         wallet_bid=wallet_bid,
         creator_bid=creator_bid,
@@ -340,7 +344,7 @@ def _seed_billing_order(
     creator_bid: str,
     bill_order_bid: str,
     metadata_json: dict | None = None,
-):
+) -> BillingOrder:
     order = BillingOrder(
         bill_order_bid=bill_order_bid,
         creator_bid=creator_bid,
@@ -373,7 +377,7 @@ def _seed_billing_subscription(
     billing_provider: str = "manual",
     provider_subscription_id: str = "",
     provider_customer_id: str = "",
-):
+) -> BillingSubscription:
     subscription = BillingSubscription(
         subscription_bid=subscription_bid,
         creator_bid=creator_bid,
@@ -404,7 +408,7 @@ def _seed_credit_wallet_bucket(
     source_type: int,
     effective_from: datetime,
     effective_to: datetime | None = None,
-):
+) -> CreditWalletBucket:
     bucket = CreditWalletBucket(
         wallet_bucket_bid=bucket_bid,
         wallet_bid=wallet_bid,
@@ -443,7 +447,7 @@ def _seed_credit_ledger_entry(
     expires_at: datetime | None = None,
     consumable_from: datetime | None = None,
     metadata_json: dict | None = None,
-):
+) -> CreditLedgerEntry:
     entry = CreditLedgerEntry(
         ledger_bid=ledger_bid,
         creator_bid=creator_bid,
@@ -488,7 +492,7 @@ def _seed_bill_usage_record(
     duration_ms: int = 0,
     segment_index: int = 0,
     segment_count: int = 0,
-):
+) -> BillUsageRecord:
     usage = BillUsageRecord(
         usage_bid=usage_bid,
         parent_usage_bid=parent_usage_bid,
@@ -533,7 +537,7 @@ def _seed_generated_block(
     outline_item_bid: str,
     generated_content: str,
     created_at: datetime,
-):
+) -> LearnGeneratedBlock:
     block = LearnGeneratedBlock(
         generated_block_bid=generated_block_bid,
         progress_record_bid=progress_record_bid,
@@ -563,7 +567,7 @@ def _seed_generated_element(
     audio_segments: str,
     sequence_number: int,
     created_at: datetime,
-):
+) -> LearnGeneratedElement:
     element = LearnGeneratedElement(
         element_bid=element_bid,
         generated_block_bid=generated_block_bid,
@@ -594,7 +598,7 @@ def _seed_learn_progress(
     user_bid: str,
     status: int,
     created_at: datetime,
-):
+) -> LearnProgressRecord:
     progress_record = LearnProgressRecord(
         progress_record_bid=f"progress-{user_bid}-{outline_item_bid}-{status}",
         shifu_bid=shifu_bid,
@@ -616,7 +620,7 @@ def _seed_course_auth(
     user_id: str,
     created_at: datetime,
     status: int = 1,
-):
+) -> AiCourseAuth:
     course_auth = AiCourseAuth(
         course_auth_id=f"course-auth-{user_id}-{course_id}",
         course_id=course_id,
@@ -632,7 +636,7 @@ def _seed_course_auth(
     return course_auth
 
 
-def _seed_user_token(*, user_bid: str, token: str, created_at: datetime):
+def _seed_user_token(*, user_bid: str, token: str, created_at: datetime) -> UserToken:
     user_token = UserToken(
         user_id=user_bid,
         token=token,
@@ -1251,7 +1255,7 @@ def test_list_operator_users_returns_learning_and_created_courses(app) -> None:
 def test_user_course_count_maps_use_lightweight_course_rows(app, monkeypatch) -> None:
     load_calls = []
 
-    def fake_load_latest_shifus(model, **kwargs: object):
+    def fake_load_latest_shifus(model, **kwargs: object) -> list[object]:
         load_calls.append(("latest", model.__name__, kwargs.get("lightweight")))
         return []
 
@@ -1260,7 +1264,7 @@ def test_user_course_count_maps_use_lightweight_course_rows(app, monkeypatch) ->
         shifu_bids,
         *,
         lightweight=False,
-    ):
+    ) -> list[object]:
         load_calls.append(("by_bids", model.__name__, tuple(shifu_bids), lightweight))
         return []
 
@@ -1953,7 +1957,7 @@ def test_get_operator_user_credits_loads_order_metadata_only_for_order_sources(
     captured_source_bids: list[str] = []
     original_load_billing_order_map = user_credits_module._load_billing_order_map
 
-    def capture_order_source_bids(source_bids):
+    def capture_order_source_bids(source_bids) -> object:
         captured_source_bids.extend(list(source_bids))
         return original_load_billing_order_map(source_bids)
 
@@ -4848,7 +4852,7 @@ def test_registration_source_map_skips_user_query_when_users_argument_is_empty(
     app, monkeypatch
 ) -> None:
     class ForbiddenUserQuery:
-        def filter(self, *_args: object, **_kwargs: object):
+        def filter(self, *_args: object, **_kwargs: object) -> Never:
             message = "expected no user query when users=[] is provided"
             raise AssertionError(message)
 
@@ -4906,7 +4910,7 @@ def test_contact_map_skips_user_query_when_users_argument_is_empty(
     app, monkeypatch
 ) -> None:
     class ForbiddenUserQuery:
-        def filter(self, *_args: object, **_kwargs: object):
+        def filter(self, *_args: object, **_kwargs: object) -> Never:
             message = "expected no user query when users=[] is provided"
             raise AssertionError(message)
 

--- a/src/api/tests/service/shifu/test_archive.py
+++ b/src/api/tests/service/shifu/test_archive.py
@@ -2,13 +2,24 @@
 
 from datetime import datetime
 from decimal import Decimal
+from typing import TYPE_CHECKING, Never
 
 import pytest
 from flaskr import dao
 from flaskr.service.common.models import AppError
 
+if TYPE_CHECKING:
+    from flaskr.service.shifu.models import (
+        DraftOutlineItem,
+        DraftShifu,
+        LogDraftStruct,
+        ShifuUserArchive,
+    )
 
-def _get_models():
+
+def _get_models() -> (
+    "tuple[type[DraftOutlineItem], type[DraftShifu], type[LogDraftStruct], type[ShifuUserArchive]]"
+):
     from flaskr.service.shifu.models import (
         DraftOutlineItem,
         DraftShifu,
@@ -19,19 +30,19 @@ def _get_models():
     return DraftOutlineItem, DraftShifu, LogDraftStruct, ShifuUserArchive
 
 
-def _get_archive_funcs():
+def _get_archive_funcs() -> tuple[object, object]:
     from flaskr.service.shifu import shifu_draft_funcs
 
     return shifu_draft_funcs.archive_shifu, shifu_draft_funcs.unarchive_shifu
 
 
-def _get_draft_module():
+def _get_draft_module() -> object:
     from flaskr.service.shifu import shifu_draft_funcs
 
     return shifu_draft_funcs
 
 
-def _seed_shifu(app, shifu_bid: str, owner_bid: str):
+def _seed_shifu(app, shifu_bid: str, owner_bid: str) -> None:
     """Create draft shifu row and clear archive state for testing."""
     with app.app_context():
         _, draft_shifu_model, _, shifu_user_archive_model = _get_models()
@@ -321,7 +332,7 @@ def test_create_shifu_draft_skips_risk_check_for_default_outline_content(
 
     monkeypatch.setattr(draft_module, "generate_id", lambda _app: "shifu-risk-skip")
 
-    def fake_draft_risk(*args: object, **kwargs: object):
+    def fake_draft_risk(*args: object, **kwargs: object) -> None:
         draft_risk_calls.append((args, kwargs))
 
     monkeypatch.setattr(
@@ -332,7 +343,7 @@ def test_create_shifu_draft_skips_risk_check_for_default_outline_content(
 
     from flaskr.service.shifu import shifu_outline_funcs
 
-    def fail_outline_risk(*_args: object, **_kwargs: object):
+    def fail_outline_risk(*_args: object, **_kwargs: object) -> Never:
         message = "default outline content should not trigger risk check"
         raise AssertionError(message)
 
@@ -371,7 +382,7 @@ def test_create_shifu_draft_raises_when_default_outline_init_fails(
         lambda *_args, **_kwargs: None,
     )
 
-    def fail_default_outlines(*_args: object, **_kwargs: object):
+    def fail_default_outlines(*_args: object, **_kwargs: object) -> Never:
         message = "outline init failed"
         raise AppError(message)
 

--- a/src/api/tests/service/shifu/test_ask_preview_route.py
+++ b/src/api/tests/service/shifu/test_ask_preview_route.py
@@ -1,5 +1,6 @@
 """Verify ask preview HTTP route behavior."""
 
+from collections.abc import Iterator
 from types import SimpleNamespace
 
 from flaskr.service.common.models import ERROR_CODE
@@ -24,36 +25,36 @@ class _FakeObservation:
         self.span_calls = []
         self.last_span = None
 
-    def start_span(self, **kwargs: object):
+    def start_span(self, **kwargs: object) -> object:
         self.span_calls.append(kwargs)
         child = _FakeObservation("span", **kwargs)
         self.last_span = child
         return child
 
-    def start_observation(self, as_type="span", **kwargs: object):
+    def start_observation(self, as_type="span", **kwargs: object) -> object:
         child = _FakeObservation(as_type, **kwargs)
         if as_type == "generation":
             self.generations.append(child)
         return child
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updates.append(kwargs)
 
-    def update_trace(self, **kwargs: object):
+    def update_trace(self, **kwargs: object) -> None:
         self.trace_updates.append(kwargs)
 
-    def end(self):
+    def end(self) -> None:
         self.ended = True
 
     @property
-    def end_kwargs(self):
+    def end_kwargs(self) -> dict[object, object]:
         merged = {}
         for item in self.updates:
             merged.update(item)
         return merged
 
     @property
-    def updated(self):
+    def updated(self) -> dict[object, object]:
         merged = {}
         for item in self.trace_updates:
             merged.update(item)
@@ -64,7 +65,7 @@ class _FakeLangfuseClient:
     def __init__(self) -> None:
         self.traces = []
 
-    def start_span(self, trace_context=None, **kwargs: object):
+    def start_span(self, trace_context=None, **kwargs: object) -> object:
         root = _FakeObservation("span", **kwargs)
         root.trace_context = trace_context or {}
         self.traces.append(root)
@@ -99,7 +100,9 @@ def test_ask_preview_route_success_with_provider(monkeypatch, test_client) -> No
     _mock_authenticated_user(monkeypatch)
     fake_langfuse = _FakeLangfuseClient()
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(
+        *args: object, **kwargs: object
+    ) -> Iterator[SimpleNamespace]:
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "dify"
@@ -159,7 +162,9 @@ def test_ask_preview_route_success_with_provider(monkeypatch, test_client) -> No
 def test_ask_preview_route_fallbacks_to_llm(monkeypatch, test_client) -> None:
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(
+        *args: object, **kwargs: object
+    ) -> Iterator[SimpleNamespace]:
         _ = args
         provider = kwargs.get("provider", "")
         if provider == "dify":
@@ -232,7 +237,9 @@ def test_ask_preview_route_provider_only_does_not_require_ask_model(
 ) -> None:
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(
+        *args: object, **kwargs: object
+    ) -> Iterator[SimpleNamespace]:
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "coze"
@@ -275,7 +282,9 @@ def test_ask_preview_route_provider_only_accepts_coze_workflow(
 ) -> None:
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(
+        *args: object, **kwargs: object
+    ) -> Iterator[SimpleNamespace]:
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "coze_workflow"
@@ -319,7 +328,9 @@ def test_ask_preview_route_provider_only_accepts_get_biji_knowledge(
     _mock_authenticated_user(monkeypatch)
     captured: dict[str, object] = {}
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(
+        *args: object, **kwargs: object
+    ) -> Iterator[SimpleNamespace]:
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "get_biji_knowledge"
@@ -369,7 +380,9 @@ def test_ask_preview_route_surfaces_friendly_provider_error(
 ) -> None:
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(
+        *args: object, **kwargs: object
+    ) -> Iterator[None]:
         _ = (args, kwargs)
         message = (
             "get_biji_knowledge request failed: 401 Client Error for url: "
@@ -417,7 +430,9 @@ def test_ask_preview_route_falls_back_to_generic_provider_error(
 ) -> None:
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(
+        *args: object, **kwargs: object
+    ) -> Iterator[None]:
         _ = (args, kwargs)
         message = "dify request failed: 500 | {raw body}"
         raise AskProviderError(message)
@@ -477,12 +492,14 @@ def test_ask_preview_route_uses_authenticated_creator_for_debug_billing(
         raising=False,
     )
 
-    def fake_chat_llm(*args: object, **kwargs: object):
+    def fake_chat_llm(*args: object, **kwargs: object) -> Iterator[SimpleNamespace]:
         _ = args
         captured["chat_llm"] = kwargs
         yield SimpleNamespace(content="debug answer")
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(
+        *args: object, **kwargs: object
+    ) -> Iterator[object]:
         _ = args
         runtime = kwargs.get("runtime")
         assert runtime is not None
@@ -534,12 +551,14 @@ def test_ask_preview_route_passes_debug_usage_context_for_creator(
     fake_langfuse = _FakeLangfuseClient()
     captured: dict[str, object] = {}
 
-    def fake_chat_llm(*args: object, **kwargs: object):
+    def fake_chat_llm(*args: object, **kwargs: object) -> Iterator[SimpleNamespace]:
         _ = args
         captured.update(kwargs)
         yield SimpleNamespace(content="debug answer")
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(
+        *args: object, **kwargs: object
+    ) -> Iterator[object]:
         _ = args
         runtime = kwargs.get("runtime")
         assert runtime is not None

--- a/src/api/tests/service/shifu/test_billing_debug_admission_contracts.py
+++ b/src/api/tests/service/shifu/test_billing_debug_admission_contracts.py
@@ -20,10 +20,14 @@ def test_shifu_preview_routes_gate_creator_debug_usage_with_billing_admission() 
     )
     assert source.count("_admit_creator_debug_usage()") >= 3
     assert "_admit_creator_preview_usage_for_shifu(shifu_bid)" in source
-    assert "def ask_preview_api():" in source
-    assert "def tts_preview_api():" in source
-    assert "@bypass_token_validation\n    def ask_preview_api():" not in source
-    assert "@bypass_token_validation\n    def tts_preview_api():" not in source
+    assert "def ask_preview_api() -> ResponseReturnValue:" in source
+    assert "def tts_preview_api() -> ResponseReturnValue:" in source
+    assert (
+        "@bypass_token_validation\n    def ask_preview_api() -> ResponseReturnValue:"
+    ) not in source
+    assert (
+        "@bypass_token_validation\n    def tts_preview_api() -> ResponseReturnValue:"
+    ) not in source
 
 
 def test_shifu_ask_preview_routes_pass_debug_usage_context_into_chat_llm() -> None:

--- a/src/api/tests/service/shifu/test_course_copy.py
+++ b/src/api/tests/service/shifu/test_course_copy.py
@@ -33,7 +33,7 @@ def _unique_email(label: str) -> str:
 
 
 @pytest.fixture(autouse=True)
-def _stub_copy_course_risk_control(monkeypatch):
+def _stub_copy_course_risk_control(monkeypatch) -> None:
     monkeypatch.setattr(
         "flaskr.service.shifu.admin.check_text_with_risk_control",
         lambda *_args, **_kwargs: None,
@@ -202,7 +202,7 @@ def _seed_course_with_outlines(
     }
 
 
-def _mock_operator(monkeypatch, user_id: str = SOURCE_OPERATOR_BID):
+def _mock_operator(monkeypatch, user_id: str = SOURCE_OPERATOR_BID) -> SimpleNamespace:
     dummy_user = SimpleNamespace(
         user_id=user_id,
         is_operator=True,
@@ -743,7 +743,7 @@ def test_copy_course_risk_rejection_does_not_create_target_user(
         )
         db.session.commit()
 
-    def _reject_risk(*args: object, **kwargs: object):
+    def _reject_risk(*args: object, **kwargs: object) -> None:
         _ = (args, kwargs)
         raise_error("server.check.checkRiskControlReject")
 

--- a/src/api/tests/service/shifu/test_create_outlines_batch.py
+++ b/src/api/tests/service/shifu/test_create_outlines_batch.py
@@ -26,7 +26,7 @@ from flaskr.service.shifu.shifu_outline_funcs import (
 
 
 @pytest.fixture(autouse=True)
-def _isolate_side_effects(monkeypatch):
+def _isolate_side_effects(monkeypatch) -> None:
     """Drop the external risk check and history machinery: these tests only exercise position allocation and publishability."""
     monkeypatch.setattr(
         shifu_outline_funcs,

--- a/src/api/tests/service/shifu/test_mdflow_history_routes.py
+++ b/src/api/tests/service/shifu/test_mdflow_history_routes.py
@@ -2,18 +2,22 @@
 
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 from flaskr import dao
 from flaskr.service.common.models import ERROR_CODE
 
+if TYPE_CHECKING:
+    from flaskr.service.shifu.models import DraftOutlineItem, DraftShifu
 
-def _get_models():
+
+def _get_models() -> "tuple[type[DraftShifu], type[DraftOutlineItem]]":
     from flaskr.service.shifu.models import DraftOutlineItem, DraftShifu
 
     return DraftShifu, DraftOutlineItem
 
 
-def _mock_user(monkeypatch, user_id: str, is_creator: bool = True):
+def _mock_user(monkeypatch, user_id: str, is_creator: bool = True) -> SimpleNamespace:
     dummy_user = SimpleNamespace(
         user_id=user_id,
         is_creator=is_creator,

--- a/src/api/tests/service/shifu/test_operator_voice_clone_register.py
+++ b/src/api/tests/service/shifu/test_operator_voice_clone_register.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Never
 
 from flaskr.dao import db
 from flaskr.service.common.models import ERROR_CODE
@@ -185,7 +186,7 @@ def _mock_volcengine_status(monkeypatch, status: int) -> None:
 
 
 def _forbid_minimax_synthesis(monkeypatch) -> None:
-    def _fail(*_args: object, **_kwargs: object):
+    def _fail(*_args: object, **_kwargs: object) -> Never:
         message = "synthesize_text must not be called for volcengine"
         raise AssertionError(message)
 

--- a/src/api/tests/service/shifu/test_outline_history_buffered_pagination.py
+++ b/src/api/tests/service/shifu/test_outline_history_buffered_pagination.py
@@ -33,7 +33,7 @@ def _seed_versions(count: int) -> list[int]:
     return sorted((int(row.id) for row in rows), reverse=True)
 
 
-def _cleanup():
+def _cleanup() -> None:
     DraftOutlineItem.query.filter(DraftOutlineItem.shifu_bid == SHIFU).delete()
     db.session.commit()
 

--- a/src/api/tests/service/shifu/test_permissions.py
+++ b/src/api/tests/service/shifu/test_permissions.py
@@ -4,6 +4,7 @@ import contextlib
 import json
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
 import pytest
 from flaskr import dao
@@ -16,14 +17,17 @@ from flaskr.service.user.repository import create_user_entity, upsert_credential
 
 from tests.common.fixtures.bill_products import build_bill_products
 
+if TYPE_CHECKING:
+    from flaskr.service.shifu.models import AiCourseAuth, DraftShifu
 
-def _get_models():
+
+def _get_models() -> "tuple[type[DraftShifu], type[AiCourseAuth]]":
     from flaskr.service.shifu.models import AiCourseAuth, DraftShifu
 
     return DraftShifu, AiCourseAuth
 
 
-def _seed_shifu(app, shifu_bid: str, owner_bid: str):
+def _seed_shifu(app, shifu_bid: str, owner_bid: str) -> None:
     with app.app_context():
         draft_shifu_model, course_auth_model = _get_models()
         draft_shifu_model.query.filter_by(shifu_bid=shifu_bid).delete()
@@ -46,7 +50,7 @@ def _seed_shifu(app, shifu_bid: str, owner_bid: str):
         dao.db.session.commit()
 
 
-def _mock_user(monkeypatch, user_id: str, is_creator: bool = True):
+def _mock_user(monkeypatch, user_id: str, is_creator: bool = True) -> SimpleNamespace:
     dummy_user = SimpleNamespace(
         user_id=user_id,
         is_creator=is_creator,
@@ -73,7 +77,7 @@ def _allow_email_login(monkeypatch) -> None:
     _clear_config_caches()
 
 
-def _add_auth(app, shifu_bid: str, user_id: str, status: int):
+def _add_auth(app, shifu_bid: str, user_id: str, status: int) -> None:
     with app.app_context():
         _, course_auth_model = _get_models()
         dao.db.session.add(
@@ -88,7 +92,7 @@ def _add_auth(app, shifu_bid: str, user_id: str, status: int):
         dao.db.session.commit()
 
 
-def _seed_user(app, *, user_bid: str, email: str):
+def _seed_user(app, *, user_bid: str, email: str) -> None:
     with app.app_context():
         entity = create_user_entity(
             user_bid=user_bid,
@@ -111,7 +115,7 @@ def _seed_user(app, *, user_bid: str, email: str):
         dao.db.session.commit()
 
 
-def _ensure_trial_billing_enabled(monkeypatch):
+def _ensure_trial_billing_enabled(monkeypatch) -> None:
     import flaskr.service.billing.auth_hooks  # noqa: F401
 
     monkeypatch.setattr(
@@ -142,7 +146,7 @@ class TestShifuPermissions:
         _add_auth(app, shifu_bid, active_user, status=1)
         _add_auth(app, shifu_bid, inactive_user, status=0)
 
-        def fake_load_user_aggregate(user_id: str):
+        def fake_load_user_aggregate(user_id: str) -> SimpleNamespace:
             return SimpleNamespace(
                 user_bid=user_id,
                 mobile="13800000000",

--- a/src/api/tests/service/shifu/test_reorder_outline_tree.py
+++ b/src/api/tests/service/shifu/test_reorder_outline_tree.py
@@ -15,7 +15,7 @@ from flaskr.service.shifu.shifu_outline_funcs import (
 
 
 @pytest.fixture(autouse=True)
-def _stub_reorder_side_effects(monkeypatch):
+def _stub_reorder_side_effects(monkeypatch) -> None:
     monkeypatch.setattr(
         shifu_outline_funcs,
         "cleanup_outline_history_versions",

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -15,7 +15,7 @@ def _seed_shifu(
     owner_bid: str,
     price: Decimal,
     ask_provider_config: str = "{}",
-):
+) -> None:
     from flaskr.service.shifu.models import DraftShifu
 
     with app.app_context():
@@ -43,7 +43,7 @@ def _seed_shifu(
         dao.db.session.commit()
 
 
-def _mock_shifu_permissions(monkeypatch):
+def _mock_shifu_permissions(monkeypatch) -> None:
     from flaskr.service.shifu import shifu_draft_funcs
 
     monkeypatch.setattr(
@@ -60,7 +60,7 @@ def _mock_shifu_permissions(monkeypatch):
     )
 
 
-def _mock_route_user(monkeypatch, user_id: str):
+def _mock_route_user(monkeypatch, user_id: str) -> SimpleNamespace:
     from types import SimpleNamespace
 
     dummy_user = SimpleNamespace(
@@ -76,10 +76,10 @@ def _mock_route_user(monkeypatch, user_id: str):
     return dummy_user
 
 
-def _mock_route_permission(monkeypatch, permission_map: dict[str, bool]):
+def _mock_route_permission(monkeypatch, permission_map: dict[str, bool]) -> None:
     from flaskr.service.shifu import route
 
-    def _has_permission(_app, _user_id, _shifu_bid, permission: str):
+    def _has_permission(_app, _user_id, _shifu_bid, permission: str) -> object:
         return permission_map.get(permission, False)
 
     monkeypatch.setattr(
@@ -214,7 +214,7 @@ def test_save_shifu_draft_info_normalizes_removed_tts_fields(app, monkeypatch) -
 
     captured: dict[str, object] = {}
 
-    def _fake_validate_tts_settings_strict(**kwargs: object):
+    def _fake_validate_tts_settings_strict(**kwargs: object) -> SimpleNamespace:
         captured.update(kwargs)
         return SimpleNamespace(
             provider="minimax",
@@ -295,7 +295,7 @@ def test_save_shifu_draft_info_normalizes_legacy_tts_fields_when_omitted(
         legacy.tts_emotion = "happy"
         dao.db.session.commit()
 
-    def _fake_validate_tts_settings_strict(**kwargs: object):
+    def _fake_validate_tts_settings_strict(**kwargs: object) -> SimpleNamespace:
         return SimpleNamespace(
             provider=kwargs["provider"],
             model=kwargs["model"],

--- a/src/api/tests/service/shifu/test_shifu_outline_tree.py
+++ b/src/api/tests/service/shifu/test_shifu_outline_tree.py
@@ -18,7 +18,7 @@ from flaskr.service.shifu.shifu_outline_funcs import (
 from sqlalchemy import inspect as sa_inspect
 
 
-def _mk_item(shifu_bid, bid, position, parent_bid=""):
+def _mk_item(shifu_bid, bid, position, parent_bid="") -> DraftOutlineItem:
     item = DraftOutlineItem()
     item.outline_item_bid = bid
     item.shifu_bid = shifu_bid

--- a/src/api/tests/service/shifu/test_shifu_public_urls.py
+++ b/src/api/tests/service/shifu/test_shifu_public_urls.py
@@ -97,7 +97,7 @@ def _seed_preview_route_course(
         dao.db.session.commit()
 
 
-def _build_detail_for_base_url(monkeypatch, base_url: str):
+def _build_detail_for_base_url(monkeypatch, base_url: str) -> object:
     from flaskr.service.shifu import shifu_draft_funcs
 
     monkeypatch.setattr(

--- a/src/api/tests/service/shifu/test_shifu_publish_funcs.py
+++ b/src/api/tests/service/shifu/test_shifu_publish_funcs.py
@@ -3,6 +3,7 @@
 import sys
 import types
 from datetime import datetime
+from typing import Never
 
 from flask import Flask
 from flaskr.dao import db
@@ -20,7 +21,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> Never:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -99,33 +100,33 @@ class _FakeObservation:
         self.id = f"fake-{kind}-id"
         self.generations = []
 
-    def start_span(self, **kwargs: object):
+    def start_span(self, **kwargs: object) -> object:
         return _FakeObservation("span", **kwargs)
 
-    def start_observation(self, as_type="span", **kwargs: object):
+    def start_observation(self, as_type="span", **kwargs: object) -> object:
         child = _FakeObservation(as_type, **kwargs)
         if as_type == "generation":
             self.generations.append(child)
         return child
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updates.append(kwargs)
 
-    def update_trace(self, **kwargs: object):
+    def update_trace(self, **kwargs: object) -> None:
         self.trace_updates.append(kwargs)
 
-    def end(self):
+    def end(self) -> None:
         self.ended = True
 
     @property
-    def end_kwargs(self):
+    def end_kwargs(self) -> dict[object, object]:
         merged = {}
         for item in self.updates:
             merged.update(item)
         return merged
 
     @property
-    def updated(self):
+    def updated(self) -> dict[object, object]:
         merged = {}
         for item in self.trace_updates:
             merged.update(item)
@@ -136,7 +137,7 @@ class _FakeLangfuseClient:
     def __init__(self) -> None:
         self.traces = []
 
-    def start_span(self, trace_context=None, **kwargs: object):
+    def start_span(self, trace_context=None, **kwargs: object) -> object:
         root = _FakeObservation("span", **kwargs)
         root.trace_context = trace_context or {}
         self.traces.append(root)
@@ -222,7 +223,7 @@ def test_run_summary_downgrades_shutdown_race_to_warning(monkeypatch) -> None:
 
     monkeypatch.setattr(module, "apply_shifu_context_snapshot", lambda *_a, **_k: None)
 
-    def _raise_shutdown(*_a: object, **_k: object):
+    def _raise_shutdown(*_a: object, **_k: object) -> Never:
         message = (
             "litellm.MidStreamFallbackError: APIConnectionError: OpenAIException - "
             "cannot schedule new futures after shutdown"
@@ -250,7 +251,7 @@ def test_run_summary_logs_error_for_other_failures(monkeypatch) -> None:
 
     monkeypatch.setattr(module, "apply_shifu_context_snapshot", lambda *_a, **_k: None)
 
-    def _raise_other(*_a: object, **_k: object):
+    def _raise_other(*_a: object, **_k: object) -> Never:
         message = "boom"
         raise ValueError(message)
 
@@ -275,7 +276,7 @@ def test_publish_shifu_draft_preserves_outline_updated_at(app, monkeypatch) -> N
     original_load_existing_outline_items = module.load_existing_outline_items
     outline_load_calls = []
 
-    def _record_outline_load(*args: object, **kwargs: object):
+    def _record_outline_load(*args: object, **kwargs: object) -> object:
         outline_load_calls.append((args, kwargs))
         return original_load_existing_outline_items(*args, **kwargs)
 

--- a/src/api/tests/service/shifu/test_transfer_creator.py
+++ b/src/api/tests/service/shifu/test_transfer_creator.py
@@ -113,7 +113,7 @@ def _seed_published_course(shifu_bid: str, creator_user_bid: str) -> None:
     db.session.flush()
 
 
-def _mock_operator(monkeypatch, user_id: str = "operator-1"):
+def _mock_operator(monkeypatch, user_id: str = "operator-1") -> SimpleNamespace:
     dummy_user = SimpleNamespace(
         user_id=user_id,
         is_operator=True,

--- a/src/api/tests/service/shifu/test_tts_preview_helper.py
+++ b/src/api/tests/service/shifu/test_tts_preview_helper.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from types import SimpleNamespace
+from typing import Never
 
 import pytest
 from flask import Flask
@@ -93,7 +94,7 @@ def test_build_tts_preview_response_records_debug_usage_and_summary(
         raising=False,
     )
 
-    def _fake_record_tts_usage(app, context, **kwargs: object):
+    def _fake_record_tts_usage(app, context, **kwargs: object) -> object | str | None:
         captured.append(
             {
                 "app": app,
@@ -153,7 +154,7 @@ def test_build_tts_preview_response_normalizes_removed_fields(monkeypatch) -> No
     app = Flask(__name__)
     captured: dict[str, object] = {}
 
-    def _fake_validate_tts_settings_strict(**kwargs: object):
+    def _fake_validate_tts_settings_strict(**kwargs: object) -> SimpleNamespace:
         captured.update(kwargs)
         return SimpleNamespace(
             provider="fake",
@@ -247,7 +248,7 @@ def test_build_tts_preview_response_guards_minimax_custom_voice(monkeypatch) -> 
         raising=False,
     )
 
-    def _fake_guard(_app, *, provider, voice_id, owner_user_bid):
+    def _fake_guard(_app, *, provider, voice_id, owner_user_bid) -> Never:
         guard_calls.append(
             {
                 "provider": provider,
@@ -291,7 +292,7 @@ def test_build_tts_preview_response_guards_minimax_custom_voice(monkeypatch) -> 
     ]
 
 
-def _stub_preview_pipeline(monkeypatch):
+def _stub_preview_pipeline(monkeypatch) -> None:
     monkeypatch.setattr(
         "flaskr.service.shifu.tts_preview.validate_tts_settings_strict",
         lambda **_kwargs: SimpleNamespace(

--- a/src/api/tests/service/tts/test_aliyun_nls_token.py
+++ b/src/api/tests/service/tts/test_aliyun_nls_token.py
@@ -2,7 +2,7 @@
 
 import json
 import time
-from typing import ClassVar
+from typing import ClassVar, Never
 from urllib.parse import parse_qs, unquote, urlparse
 
 import requests
@@ -13,7 +13,7 @@ from flaskr.api.tts.aliyun_provider import AliyunTTSProvider
 def test_get_aliyun_nls_token_uses_override_when_configured(monkeypatch) -> None:
     monkeypatch.setenv("ALIYUN_TTS_TOKEN", "override-token")
 
-    def fake_get(*args: object, **kwargs: object):
+    def fake_get(*args: object, **kwargs: object) -> Never:
         _ = (args, kwargs)
         message = "requests.get should not be called when override token exists"
         raise AssertionError(message)
@@ -44,10 +44,10 @@ def test_get_aliyun_nls_token_fetches_and_caches(monkeypatch) -> None:
         status_code = 200
         text = ""
 
-        def json(self):
+        def json(self) -> dict[str, dict[str, str | int]]:
             return {"Token": {"Id": "tok-1", "ExpireTime": int(time.time()) + 3600}}
 
-    def fake_get(url, headers=None, timeout=None):
+    def fake_get(url, headers=None, timeout=None) -> DummyResponse:
         captured["calls"] += 1
         captured["url"] = url
         captured["headers"] = headers
@@ -96,7 +96,7 @@ def test_get_aliyun_nls_token_refresh_falls_back_to_cached_token(monkeypatch) ->
 
     captured = {"calls": 0}
 
-    def fake_get(*args: object, **kwargs: object):
+    def fake_get(*args: object, **kwargs: object) -> Never:
         _ = (args, kwargs)
         captured["calls"] += 1
         message = "network down"
@@ -134,7 +134,7 @@ def test_aliyun_provider_synthesize_uses_dynamic_token(monkeypatch) -> None:
         headers: ClassVar[dict[str, str]] = {"Content-Type": "audio/mpeg"}
         content = b"audio-bytes"
 
-    def fake_post(url, json=None, headers=None, timeout=None):
+    def fake_post(url, json=None, headers=None, timeout=None) -> DummyResponse:
         captured["url"] = url
         captured["json"] = json
         captured["headers"] = headers

--- a/src/api/tests/service/tts/test_audio_utils.py
+++ b/src/api/tests/service/tts/test_audio_utils.py
@@ -16,7 +16,7 @@ class _FakeSegment:
     def __len__(self) -> int:
         return self.duration_ms
 
-    def append(self, other, crossfade=100):
+    def append(self, other, crossfade=100) -> object:
         _FakeSegment.append_crossfades.append(crossfade)
         if crossfade > len(self):
             message = (
@@ -39,7 +39,7 @@ class _FakeSegment:
             return _FakeSegment(max(stop - start, 0))
         return self
 
-    def export(self, output_io, format="mp3", bitrate="128k"):  # noqa: A002 - mirrors the pydub API
+    def export(self, output_io, format="mp3", bitrate="128k") -> None:  # noqa: A002 - mirrors the pydub API
         _ = (format, bitrate)
         output_io.write(f"duration={self.duration_ms}".encode())
 

--- a/src/api/tests/service/tts/test_av_speakable_segmentation.py
+++ b/src/api/tests/service/tts/test_av_speakable_segmentation.py
@@ -3,7 +3,7 @@
 import pytest
 
 
-def _require_app(app):
+def _require_app(app) -> None:
     if app is None:
         pytest.skip("App fixture disabled")
 

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -1,6 +1,7 @@
 """Verify MiniMax HTTP streaming behavior."""
 
 import json
+from collections.abc import Iterator
 from types import SimpleNamespace
 
 import pytest
@@ -13,19 +14,19 @@ class _FakeResponse:
         self._json_payload = json_payload or {}
         self.headers = {"content-type": "text/event-stream"}
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         if self._status_error:
             raise self._status_error
 
-    def iter_lines(self, decode_unicode=True):
+    def iter_lines(self, decode_unicode=True) -> Iterator[object]:
         _ = decode_unicode
         yield from self._lines
 
-    def json(self):
+    def json(self) -> object:
         return self._json_payload
 
 
-def _sse_line(payload):
+def _sse_line(payload) -> str:
     return f"data: {json.dumps(payload)}"
 
 
@@ -55,7 +56,7 @@ def test_minimax_http_streaming_parses_audio_and_final_subtitles(monkeypatch) ->
         lambda **kwargs: gate_calls.append(kwargs),
     )
 
-    def _fake_post(url, **kwargs: object):
+    def _fake_post(url, **kwargs: object) -> object:
         post_calls.append((url, kwargs))
         return _FakeResponse(
             [
@@ -149,7 +150,7 @@ def test_minimax_synthesize_splits_word_count_and_usage_characters(monkeypatch) 
         lambda key: config.get(key, ""),
     )
 
-    def _fake_post(url, **kwargs: object):
+    def _fake_post(url, **kwargs: object) -> object:
         post_calls.append((url, kwargs))
         return _FakeResponse(
             json_payload={
@@ -226,7 +227,7 @@ def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
     aggregate_usage_calls = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **kwargs: object):
+        def stream_synthesize(self, **kwargs: object) -> Iterator[SimpleNamespace]:
             calls.append(kwargs["text"])
             yield SimpleNamespace(
                 audio_data=b"fake-mp3",
@@ -361,7 +362,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_for_partial_subtitles(
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs: object):
+        def stream_synthesize(self, **_kwargs: object) -> Iterator[SimpleNamespace]:
             yield SimpleNamespace(
                 audio_data=b"fake-mp3",
                 is_final=False,
@@ -482,7 +483,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
     synthesize_calls = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **kwargs: object):
+        def stream_synthesize(self, **kwargs: object) -> Iterator[SimpleNamespace]:
             stream_calls.append(kwargs["text"])
             yield SimpleNamespace(
                 audio_data=b"broken-stream-mp3",
@@ -494,7 +495,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
                 trace_id="trace-invalid-audio",
             )
 
-        def synthesize(self, **kwargs: object):
+        def synthesize(self, **kwargs: object) -> SimpleNamespace:
             synthesize_calls.append(kwargs["text"])
             return SimpleNamespace(
                 audio_data=b"complete-mp3",
@@ -503,7 +504,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
                 word_count=12,
             )
 
-    def _fake_try_get_duration(audio_data, audio_format="mp3"):
+    def _fake_try_get_duration(audio_data, audio_format="mp3") -> int | None:
         _ = audio_format
         if audio_data == b"broken-stream-mp3":
             return None
@@ -603,7 +604,7 @@ def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitle
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs: object):
+        def stream_synthesize(self, **_kwargs: object) -> Iterator[SimpleNamespace]:
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -630,7 +631,7 @@ def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitle
 
     export_calls = []
 
-    def _fake_export(_audio_data, **kwargs: object):
+    def _fake_export(_audio_data, **kwargs: object) -> tuple[bytes, int]:
         export_calls.append(kwargs)
         end_ms = kwargs.get("end_ms")
         start_ms = int(kwargs.get("start_ms") or 0)
@@ -729,7 +730,7 @@ def test_streaming_tts_minimax_http_stream_does_not_emit_audio_past_subtitles(
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs: object):
+        def stream_synthesize(self, **_kwargs: object) -> Iterator[SimpleNamespace]:
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -778,7 +779,7 @@ def test_streaming_tts_minimax_http_stream_does_not_emit_audio_past_subtitles(
 
     export_calls = []
 
-    def _fake_export(_audio_data, **kwargs: object):
+    def _fake_export(_audio_data, **kwargs: object) -> tuple[bytes, int]:
         export_calls.append(kwargs)
         end_ms = int(kwargs.get("end_ms") or 0)
         start_ms = int(kwargs.get("start_ms") or 0)
@@ -870,7 +871,7 @@ def test_streaming_tts_minimax_http_stream_offsets_live_cues_by_emitted_audio(
     saved_records = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **kwargs: object):
+        def stream_synthesize(self, **kwargs: object) -> Iterator[SimpleNamespace]:
             calls.append(kwargs["text"])
             if kwargs["text"] == "First sentence.":
                 yield SimpleNamespace(
@@ -903,12 +904,12 @@ def test_streaming_tts_minimax_http_stream_offsets_live_cues_by_emitted_audio(
                 ],
             )
 
-    def _fake_export(audio_data, **_kwargs: object):
+    def _fake_export(audio_data, **_kwargs: object) -> tuple[object, int]:
         if audio_data == b"first-mp3":
             return audio_data, 1000
         return audio_data, 1200
 
-    def _fake_build_completed_audio_record(**kwargs: object):
+    def _fake_build_completed_audio_record(**kwargs: object) -> SimpleNamespace:
         saved_records.append(kwargs)
         return SimpleNamespace(**kwargs)
 
@@ -1025,7 +1026,7 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs: object):
+        def stream_synthesize(self, **_kwargs: object) -> Iterator[SimpleNamespace]:
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -1052,7 +1053,7 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
                 ],
             )
 
-    def _fake_export(_audio_data, **kwargs: object):
+    def _fake_export(_audio_data, **kwargs: object) -> tuple[bytes, int]:
         end_ms = kwargs.get("end_ms")
         start_ms = int(kwargs.get("start_ms") or 0)
         if end_ms is None:
@@ -1083,7 +1084,7 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
     )
     saved_records = []
 
-    def _fake_build_completed_audio_record(**kwargs: object):
+    def _fake_build_completed_audio_record(**kwargs: object) -> SimpleNamespace:
         saved_records.append(kwargs)
         return SimpleNamespace(**kwargs)
 
@@ -1164,7 +1165,7 @@ def test_streaming_tts_minimax_http_stream_keeps_provider_middle_cue_timing(
     saved_records = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs: object):
+        def stream_synthesize(self, **_kwargs: object) -> Iterator[SimpleNamespace]:
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -1201,14 +1202,14 @@ def test_streaming_tts_minimax_http_stream_keeps_provider_middle_cue_timing(
                 ],
             )
 
-    def _fake_export(_audio_data, **kwargs: object):
+    def _fake_export(_audio_data, **kwargs: object) -> tuple[bytes, int]:
         end_ms = kwargs.get("end_ms")
         start_ms = int(kwargs.get("start_ms") or 0)
         if end_ms is None:
             return b"early-piece", 1900
         return b"final-piece", int(end_ms or 0) - start_ms
 
-    def _fake_build_completed_audio_record(**kwargs: object):
+    def _fake_build_completed_audio_record(**kwargs: object) -> SimpleNamespace:
         saved_records.append(kwargs)
         return SimpleNamespace(**kwargs)
 
@@ -1325,7 +1326,7 @@ def test_streaming_tts_minimax_http_stream_freezes_emitted_prefix_for_same_count
     saved_records = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs: object):
+        def stream_synthesize(self, **_kwargs: object) -> Iterator[SimpleNamespace]:
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -1355,14 +1356,14 @@ def test_streaming_tts_minimax_http_stream_freezes_emitted_prefix_for_same_count
                 ],
             )
 
-    def _fake_export(_audio_data, **kwargs: object):
+    def _fake_export(_audio_data, **kwargs: object) -> tuple[bytes, int]:
         end_ms = kwargs.get("end_ms")
         start_ms = int(kwargs.get("start_ms") or 0)
         if end_ms is None:
             return b"early-piece", 1946
         return b"final-piece", int(end_ms or 0) - start_ms
 
-    def _fake_build_completed_audio_record(**kwargs: object):
+    def _fake_build_completed_audio_record(**kwargs: object) -> SimpleNamespace:
         saved_records.append(kwargs)
         return SimpleNamespace(**kwargs)
 

--- a/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
+++ b/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
@@ -20,7 +20,7 @@ _BUILT_IN_VOICE_ID = "female-shaonv"
 
 
 @pytest.fixture(autouse=True)
-def _fake_minimax_provider(monkeypatch):
+def _fake_minimax_provider(monkeypatch) -> None:
     """Isolate the guard from real provider config/credentials."""
     provider = SimpleNamespace(
         get_provider_config=lambda: SimpleNamespace(
@@ -47,7 +47,7 @@ def _seed_clone(
     status: str,
     deleted: int = 0,
     provider: str = "minimax",
-):
+) -> None:
     with app.app_context():
         db.session.add(
             TTSMiniMaxClonedVoice(

--- a/src/api/tests/service/tts/test_minimax_rpm_limit.py
+++ b/src/api/tests/service/tts/test_minimax_rpm_limit.py
@@ -3,7 +3,7 @@
 from flaskr.api.tts import minimax_provider
 
 
-def _set_config(monkeypatch, mapping):
+def _set_config(monkeypatch, mapping) -> None:
     monkeypatch.setattr(
         minimax_provider,
         "get_config",

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Never, Self
 
 import pytest
 from flask import Flask
@@ -169,7 +169,7 @@ def test_normalize_audio_blob_validates_duration_and_exports_wav(monkeypatch) ->
         def __len__(self) -> int:
             return 12_000
 
-        def export(self, out, format="wav"):  # noqa: A002 - mirrors the pydub API
+        def export(self, out, format="wav") -> None:  # noqa: A002 - mirrors the pydub API
             assert format == "wav"
             out.write(b"WAV-BYTES")
 
@@ -206,10 +206,10 @@ def test_minimax_upload_file_accepts_official_file_response(monkeypatch) -> None
     )
 
     class FakeResponse:
-        def raise_for_status(self):
+        def raise_for_status(self) -> None:
             return None
 
-        def json(self):
+        def json(self) -> dict[str, dict[str, int | str]]:
             return {
                 "file": {
                     "file_id": 123456789012345680,
@@ -220,7 +220,7 @@ def test_minimax_upload_file_accepts_official_file_response(monkeypatch) -> None
                 "base_resp": {"status_code": 0, "status_msg": "success"},
             }
 
-    def fake_post(url, headers, data, files, timeout):
+    def fake_post(url, headers, data, files, timeout) -> FakeResponse:
         assert url.endswith("/v1/files/upload?GroupId=test-group")
         assert headers["Authorization"] == "Bearer test-api-key"
         assert data == {"purpose": "voice_clone"}
@@ -254,10 +254,10 @@ def test_minimax_clone_voice_sends_numeric_file_id(monkeypatch) -> None:
     )
 
     class FakeResponse:
-        def raise_for_status(self):
+        def raise_for_status(self) -> None:
             return None
 
-        def json(self):
+        def json(self) -> dict[str, bool | str | dict[str, int] | dict[str, int | str]]:
             return {
                 "input_sensitive": False,
                 "demo_audio": "https://example.test/demo.mp3",
@@ -265,7 +265,7 @@ def test_minimax_clone_voice_sends_numeric_file_id(monkeypatch) -> None:
                 "base_resp": {"status_code": 0, "status_msg": "success"},
             }
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout) -> FakeResponse:
         assert url.endswith("/v1/voice_clone?GroupId=test-group")
         assert headers["Authorization"] == "Bearer test-api-key"
         assert headers["Content-Type"] == "application/json"
@@ -321,18 +321,20 @@ def test_run_minimax_voice_clone_success_captures_credit_once(
     )
 
     class FakeClient:
-        def upload_clone_audio(self, audio_bytes, filename, content_type):
+        def upload_clone_audio(
+            self, audio_bytes, filename, content_type
+        ) -> SimpleNamespace:
             assert audio_bytes == b"WAV"
             assert filename.endswith(".wav")
             assert content_type == "audio/wav"
             return SimpleNamespace(file_id="file-source")
 
-        def upload_prompt_audio(self, audio_bytes, filename, content_type):
+        def upload_prompt_audio(self, audio_bytes, filename, content_type) -> Never:
             _ = (audio_bytes, filename, content_type)
             message = "prompt upload should not be called"
             raise AssertionError(message)
 
-        def clone_voice(self, **kwargs: object):
+        def clone_voice(self, **kwargs: object) -> SimpleNamespace:
             assert kwargs["file_id"] == "file-source"
             return SimpleNamespace(
                 voice_id=kwargs["voice_id"],
@@ -403,7 +405,9 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
     stored_objects: dict[str, bytes] = {}
     read_calls: list[tuple[str, str]] = []
 
-    def fake_upload_to_storage(_app, *, file_content, object_key, **_kwargs: object):
+    def fake_upload_to_storage(
+        _app, *, file_content, object_key, **_kwargs: object
+    ) -> SimpleNamespace:
         if hasattr(file_content, "seek"):
             file_content.seek(0)
         stored_objects[object_key] = file_content.read()
@@ -413,7 +417,7 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
             url=f"https://cdn.example/{object_key}",
         )
 
-    def fake_read_storage_bytes(*, object_key, profile, bucket_name):
+    def fake_read_storage_bytes(*, object_key, profile, bucket_name) -> object:
         _ = profile
         read_calls.append((object_key, bucket_name))
         return stored_objects[object_key]
@@ -439,17 +443,19 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
     )
 
     class FakeClient:
-        def upload_clone_audio(self, audio_bytes, filename, content_type):
+        def upload_clone_audio(
+            self, audio_bytes, filename, content_type
+        ) -> SimpleNamespace:
             _ = (filename, content_type)
             assert audio_bytes == b"WAV"
             return SimpleNamespace(file_id="file-source")
 
-        def upload_prompt_audio(self, audio_bytes, filename, content_type):
+        def upload_prompt_audio(self, audio_bytes, filename, content_type) -> Never:
             _ = (audio_bytes, filename, content_type)
             message = "prompt upload should not be called"
             raise AssertionError(message)
 
-        def clone_voice(self, **kwargs: object):
+        def clone_voice(self, **kwargs: object) -> SimpleNamespace:
             return SimpleNamespace(
                 voice_id=kwargs["voice_id"],
                 demo_audio="https://example.test/demo.mp3",
@@ -511,7 +517,7 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(
     stored_calls: list[dict[str, str]] = []
 
     class FakeApp:
-        def app_context(self):
+        def app_context(self) -> object:
             class Context:
                 def __enter__(self) -> Self:
                     nonlocal in_context
@@ -571,7 +577,7 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(
         _normalize_audio,
     )
 
-    def fake_store_resource_bytes(_app, **kwargs: object):
+    def fake_store_resource_bytes(_app, **kwargs: object) -> SimpleNamespace:
         stored_calls.append(
             {
                 "owner_user_bid": kwargs["owner_user_bid"],
@@ -607,16 +613,18 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(
     )
 
     class FakeClient:
-        def upload_clone_audio(self, audio_bytes, filename, content_type):
+        def upload_clone_audio(
+            self, audio_bytes, filename, content_type
+        ) -> SimpleNamespace:
             _ = (audio_bytes, filename, content_type)
             return SimpleNamespace(file_id="file-source")
 
-        def upload_prompt_audio(self, audio_bytes, filename, content_type):
+        def upload_prompt_audio(self, audio_bytes, filename, content_type) -> Never:
             _ = (audio_bytes, filename, content_type)
             message = "prompt upload should not be called"
             raise AssertionError(message)
 
-        def clone_voice(self, **kwargs: object):
+        def clone_voice(self, **kwargs: object) -> SimpleNamespace:
             return SimpleNamespace(
                 voice_id=kwargs["voice_id"],
                 demo_audio="https://example.test/demo.mp3",

--- a/src/api/tests/service/tts/test_provider_error_responses.py
+++ b/src/api/tests/service/tts/test_provider_error_responses.py
@@ -15,7 +15,7 @@ class _Response:
         self._payload = payload
         self.text = text
 
-    def json(self):
+    def json(self) -> dict[str, object]:
         if self._payload is None:
             message = "no json"
             raise ValueError(message)

--- a/src/api/tests/service/tts/test_streaming_tts_av_contract.py
+++ b/src/api/tests/service/tts/test_streaming_tts_av_contract.py
@@ -1,9 +1,11 @@
 """Verify streaming TTS AV contract behavior."""
 
+from collections.abc import Iterator
+
 import pytest
 
 
-def _require_app(app):
+def _require_app(app) -> None:
     if app is None:
         pytest.skip("App fixture disabled")
 
@@ -28,7 +30,7 @@ def test_av_streaming_tts_processor_emits_av_contract_in_events(
             self.position = int(kwargs.get("position", 0) or 0)
             self.av_contract = kwargs.get("av_contract")
 
-        def process_chunk(self, chunk):
+        def process_chunk(self, chunk) -> Iterator[RunMarkdownFlowDTO]:
             if not (chunk or "").strip():
                 return
             yield RunMarkdownFlowDTO(
@@ -45,7 +47,7 @@ def test_av_streaming_tts_processor_emits_av_contract_in_events(
                 ),
             )
 
-        def finalize(self, commit=True):
+        def finalize(self, commit=True) -> Iterator[RunMarkdownFlowDTO]:
             _ = commit
             yield RunMarkdownFlowDTO(
                 outline_bid=self.outline_bid,
@@ -105,13 +107,13 @@ def test_av_streaming_tts_processor_skips_chunked_markdown_image(
         def __init__(self, **kwargs: object) -> None:
             _ = kwargs
 
-        def process_chunk(self, chunk):
+        def process_chunk(self, chunk) -> Iterator[None]:
             if (chunk or "").strip():
                 captured_chunks.append(chunk)
             return
             yield
 
-        def finalize(self, commit=True):
+        def finalize(self, commit=True) -> Iterator[None]:
             _ = commit
             return
             yield
@@ -163,13 +165,13 @@ def test_av_streaming_tts_processor_skips_chunked_html_img_tag(
         def __init__(self, **kwargs: object) -> None:
             _ = kwargs
 
-        def process_chunk(self, chunk):
+        def process_chunk(self, chunk) -> Iterator[None]:
             if (chunk or "").strip():
                 captured_chunks.append(chunk)
             return
             yield
 
-        def finalize(self, commit=True):
+        def finalize(self, commit=True) -> Iterator[None]:
             _ = commit
             return
             yield
@@ -221,13 +223,13 @@ def test_av_streaming_tts_processor_does_not_split_markdown_h2_after_svg(
             self.position = int(kwargs.get("position", 0) or 0)
             self._parts: list[str] = []
 
-        def process_chunk(self, chunk):
+        def process_chunk(self, chunk) -> Iterator[None]:
             if chunk:
                 self._parts.append(chunk)
             return
             yield
 
-        def finalize(self, commit=True):
+        def finalize(self, commit=True) -> Iterator[None]:
             _ = commit
             text = "".join(self._parts).strip()
             if text:
@@ -292,12 +294,12 @@ def test_av_streaming_tts_processor_advances_position_when_segment_has_no_audio(
             self.position = int(kwargs.get("position", 0) or 0)
             self._buffer = ""
 
-        def process_chunk(self, chunk):
+        def process_chunk(self, chunk) -> Iterator[None]:
             self._buffer += chunk or ""
             return
             yield
 
-        def finalize(self, commit=True):
+        def finalize(self, commit=True) -> Iterator[RunMarkdownFlowDTO | None]:
             _ = commit
             # Simulate provider behavior: very short text produces no audio completion.
             if len((self._buffer or "").strip()) < 2:
@@ -360,7 +362,7 @@ def test_av_streaming_tts_processor_never_emits_new_slide_event(
             self.outline_bid = kwargs.get("outline_bid", "")
             self.position = int(kwargs.get("position", 0) or 0)
 
-        def process_chunk(self, chunk):
+        def process_chunk(self, chunk) -> Iterator[RunMarkdownFlowDTO]:
             if not (chunk or "").strip():
                 return
             yield RunMarkdownFlowDTO(
@@ -376,7 +378,7 @@ def test_av_streaming_tts_processor_never_emits_new_slide_event(
                 ),
             )
 
-        def finalize(self, commit=True):
+        def finalize(self, commit=True) -> Iterator[None]:
             _ = commit
             return
             yield
@@ -419,17 +421,19 @@ def test_av_streaming_tts_processor_updates_next_element_index_from_contract(
         def __init__(self, **kwargs: object) -> None:
             _ = kwargs
 
-        def process_chunk(self, chunk):
+        def process_chunk(self, chunk) -> Iterator[None]:
             _ = chunk
             return
             yield
 
-        def finalize(self, commit=True):
+        def finalize(self, commit=True) -> Iterator[None]:
             _ = commit
             return
             yield
 
-    def _fake_build_visual_segments(**kwargs: object):
+    def _fake_build_visual_segments(
+        **kwargs: object,
+    ) -> tuple[list[VisualSegment], dict[int, str]]:
         _ = kwargs
         seg = VisualSegment(
             segment_id="seg-1",
@@ -477,13 +481,13 @@ def test_av_streaming_tts_processor_releases_sentence_before_long_list_tail(
         def __init__(self, **kwargs: object) -> None:
             _ = kwargs
 
-        def process_chunk(self, chunk):
+        def process_chunk(self, chunk) -> Iterator[None]:
             if chunk:
                 captured_chunks.append(chunk)
             return
             yield
 
-        def finalize(self, commit=True):
+        def finalize(self, commit=True) -> Iterator[None]:
             _ = commit
             return
             yield

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -50,7 +50,7 @@ class TestFinalizeSegmentation:
         processor = create_test_processor(mock_app)
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> MagicMock:
             _ = kwargs
             if len(args) > 1:
                 segment = args[1]
@@ -91,7 +91,7 @@ class TestFinalizeSegmentation:
         # Track submitted tasks
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> MagicMock:
             # Positional args are the thread target followed by segment,
             # voice settings, audio settings, provider and model.
             # Capture the segment text from args[1]
@@ -133,7 +133,7 @@ class TestFinalizeSegmentation:
 
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> MagicMock:
             # Positional args are the thread target followed by segment,
             # voice settings, audio settings, provider and model.
             _ = kwargs
@@ -166,7 +166,7 @@ class TestFinalizeSegmentation:
 
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> MagicMock:
             # Positional args are the thread target followed by segment,
             # voice settings, audio settings, provider and model.
             _ = kwargs
@@ -230,7 +230,7 @@ class TestFinalizeSegmentation:
 
         remaining_text = "First sentence. Second sentence."
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> MagicMock:
             _ = (args, kwargs)
             future = MagicMock()
             future.result.return_value = None
@@ -653,7 +653,7 @@ class TestOffsetDriftRegression:
         processor = create_test_processor(mock_app)
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> MagicMock:
             _ = kwargs
             if len(args) > 1:
                 segment = args[1]
@@ -695,7 +695,7 @@ class TestOffsetDriftRegression:
         processor = create_test_processor(mock_app)
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> MagicMock:
             _ = kwargs
             if len(args) > 1:
                 segment = args[1]

--- a/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
+++ b/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
@@ -34,11 +34,13 @@ def test_rate_limit_detector(message, expected) -> None:
     assert _is_retryable_rate_limit_error(ValueError(message)) is expected
 
 
-def _run_retry(monkeypatch, outcomes, segment_index=0):
+def _run_retry(
+    monkeypatch, outcomes, segment_index=0
+) -> tuple[object, list[object], list[object]]:
     calls = []
     sleeps = []
 
-    def _fake_synthesize_text(**kwargs: object):
+    def _fake_synthesize_text(**kwargs: object) -> object:
         calls.append(kwargs)
         outcome = outcomes[min(len(calls) - 1, len(outcomes) - 1)]
         if isinstance(outcome, Exception):

--- a/src/api/tests/service/tts/test_tencent_provider.py
+++ b/src/api/tests/service/tts/test_tencent_provider.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import json
 import re
+from collections.abc import Iterator
 
 import pytest
 from flaskr.service.common.models import AppError
@@ -16,14 +17,14 @@ class _FakeSSEStreamingResponse:
         self.headers = headers or {"content-type": "text/event-stream"}
         self.closed = False
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         return None
 
-    def iter_lines(self, decode_unicode=True):
+    def iter_lines(self, decode_unicode=True) -> Iterator[object]:
         _ = decode_unicode
         yield from self._lines
 
-    def close(self):
+    def close(self) -> None:
         self.closed = True
 
 
@@ -52,7 +53,7 @@ def _expected_tc3_authorization(*, payload_json: str, timestamp: int) -> str:
         ]
     )
 
-    def sign(key, msg):
+    def sign(key, msg) -> object:
         return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
 
     secret_date = sign(("TC3" + secret_key).encode("utf-8"), date)
@@ -69,7 +70,7 @@ def _expected_tc3_authorization(*, payload_json: str, timestamp: int) -> str:
     )
 
 
-def _patch_tencent_config(monkeypatch, tencent_provider):
+def _patch_tencent_config(monkeypatch, tencent_provider) -> None:
     config = {
         "TENCENT_TTS_APP_ID": "1400000000",
         "TENCENT_TTS_SECRET_ID": "secret-id",
@@ -193,7 +194,7 @@ def test_tencent_provider_stream_synthesize_parses_sse_audio_and_alignments(
     _patch_tencent_config(monkeypatch, tencent_provider)
     post_calls = []
 
-    def fake_post(url, data, headers, stream, timeout):
+    def fake_post(url, data, headers, stream, timeout) -> object:
         post_calls.append(
             {
                 "url": url,
@@ -276,7 +277,7 @@ def test_tencent_provider_synthesize_collects_audio_and_sentence_subtitles(
 
     _patch_tencent_config(monkeypatch, tencent_provider)
 
-    def fake_post(url, data, headers, stream, timeout):
+    def fake_post(url, data, headers, stream, timeout) -> object:
         _ = url, data, headers, stream, timeout
         return _FakeSSEStreamingResponse(
             [
@@ -370,7 +371,7 @@ def test_tencent_provider_raises_sanitized_error_on_sse_error(monkeypatch) -> No
 
     _patch_tencent_config(monkeypatch, tencent_provider)
 
-    def fake_post(url, data, headers, stream, timeout):
+    def fake_post(url, data, headers, stream, timeout) -> object:
         _ = url, data, headers, stream, timeout
         return _FakeSSEStreamingResponse(
             [

--- a/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
+++ b/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
@@ -33,7 +33,7 @@ def _expected_tc3_authorization(*, payload_json: str, timestamp: int) -> str:
         ]
     )
 
-    def sign(key, msg):
+    def sign(key, msg) -> object:
         return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
 
     secret_date = sign(("TC3" + secret_key).encode("utf-8"), date)
@@ -50,7 +50,7 @@ def _expected_tc3_authorization(*, payload_json: str, timestamp: int) -> str:
     )
 
 
-def _patch_credentials(monkeypatch):
+def _patch_credentials(monkeypatch) -> None:
     from flaskr.api.tts import tencent_texttovoice_provider as module
 
     config = {
@@ -68,7 +68,7 @@ class _FakeResponse:
     def __init__(self, body) -> None:
         self._body = body
 
-    def json(self):
+    def json(self) -> object:
         return self._body
 
 
@@ -175,7 +175,7 @@ def test_synthesize_builds_payload_and_concatenates_segments(monkeypatch) -> Non
     _patch_credentials(monkeypatch)
     captured_payloads = []
 
-    def _fake_post(url, data=None, headers=None, timeout=None):
+    def _fake_post(url, data=None, headers=None, timeout=None) -> object:
         _ = (url, headers, timeout)
         captured_payloads.append(json.loads(data.decode("utf-8")))
         return _FakeResponse(

--- a/src/api/tests/service/tts/test_tts_config_options.py
+++ b/src/api/tests/service/tts/test_tts_config_options.py
@@ -1,6 +1,7 @@
 """Verify TTS config options behavior."""
 
 import json
+from collections.abc import Callable
 from decimal import Decimal
 
 from flask import Flask
@@ -8,7 +9,7 @@ from flaskr.api.tts import base
 
 
 class _FakeMinimaxProvider:
-    def get_provider_config(self):
+    def get_provider_config(self) -> base.ProviderConfig:
         return base.ProviderConfig(
             name="MiniMax",
             label="MiniMax",
@@ -25,7 +26,7 @@ class _FakeMinimaxProvider:
 
 
 class _FakeBaiduProvider:
-    def get_provider_config(self):
+    def get_provider_config(self) -> base.ProviderConfig:
         return base.ProviderConfig(
             name="baidu",
             label="Baidu",
@@ -110,8 +111,8 @@ class _FakeRate:
         self.model = model
 
 
-def _chars_per_token_config(value: str):
-    def _get_config(key, default=None):
+def _chars_per_token_config(value: str) -> Callable[..., object]:
+    def _get_config(key, default=None) -> object:
         if key == "TTS_CHARS_PER_LLM_TOKEN":
             return value
         return default
@@ -126,7 +127,7 @@ def test_tts_credit_multiplier_uses_shared_llm_anchor(monkeypatch) -> None:
 
     captured = []
 
-    def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
+    def fake_load_usage_rate(*, usage, billing_metric, settlement_at) -> object:
         _ = settlement_at
         captured.append((usage.usage_type, usage.provider, usage.model, billing_metric))
         if (
@@ -163,7 +164,7 @@ def test_tts_credit_multiplier_scales_with_chars_per_token(monkeypatch) -> None:
     from flaskr.service.billing.consts import BILLING_METRIC_TTS_OUTPUT_CHARS
     from flaskr.service.metering.consts import BILL_USAGE_TYPE_TTS
 
-    def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
+    def fake_load_usage_rate(*, usage, billing_metric, settlement_at) -> object:
         _ = settlement_at
         if (
             usage.usage_type == BILL_USAGE_TYPE_TTS
@@ -195,7 +196,7 @@ def test_tts_credit_multiplier_scales_with_chars_per_token(monkeypatch) -> None:
 def test_tts_credit_multiplier_none_when_tts_rate_missing(monkeypatch) -> None:
     import flaskr.api.tts as tts_api
 
-    def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
+    def fake_load_usage_rate(*, usage, billing_metric, settlement_at) -> None:
         _ = (usage, billing_metric, settlement_at)  # no curated TTS rate
 
     monkeypatch.setattr(tts_api, "get_config", _chars_per_token_config("0.216"))
@@ -214,7 +215,7 @@ def test_tts_credit_multiplier_none_when_tts_rate_missing(monkeypatch) -> None:
 def test_tts_credit_multiplier_none_when_conversion_unset(monkeypatch) -> None:
     import flaskr.api.tts as tts_api
 
-    def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
+    def fake_load_usage_rate(*, usage, billing_metric, settlement_at) -> object:
         _ = (usage, billing_metric, settlement_at)
         return _FakeRate("8", 10000, "tencent", "")
 
@@ -330,7 +331,7 @@ def test_usage_rate_unit_cost_uses_utc_settlement(monkeypatch) -> None:
 
     captured = {}
 
-    def fake_load_usage_rate(*, usage, billing_metric, settlement_at):
+    def fake_load_usage_rate(*, usage, billing_metric, settlement_at) -> None:
         _ = (usage, billing_metric)
         captured["settlement_at"] = settlement_at
 
@@ -363,7 +364,7 @@ def test_tts_config_three_tier_allowlist_orders_and_localizes(monkeypatch) -> No
     from flaskr.i18n import clear_language, set_language
 
     class _FakeVolcengineProvider:
-        def get_provider_config(self):
+        def get_provider_config(self) -> base.ProviderConfig:
             return base.ProviderConfig(
                 name="volcengine",
                 label="火山引擎",
@@ -427,7 +428,7 @@ def test_tts_config_three_tier_allowlist_orders_and_localizes(monkeypatch) -> No
     ]
 
 
-def _patch_two_provider_registry(monkeypatch, tts_api):
+def _patch_two_provider_registry(monkeypatch, tts_api) -> None:
     monkeypatch.setattr(
         tts_api,
         "_PROVIDER_REGISTRY",

--- a/src/api/tests/service/tts/test_tts_rpm_gate.py
+++ b/src/api/tests/service/tts/test_tts_rpm_gate.py
@@ -1,5 +1,7 @@
 """Verify TTS rate-limit queues isolate credentials and models."""
 
+from collections.abc import Callable, Iterator
+
 import pytest
 from flaskr.service.tts import rpm_gate
 
@@ -8,11 +10,11 @@ class _FakeRedisLock:
     def __init__(self) -> None:
         self.released = False
 
-    def acquire(self, blocking=True, blocking_timeout=None):
+    def acquire(self, blocking=True, blocking_timeout=None) -> bool:
         _ = blocking, blocking_timeout
         return True
 
-    def release(self):
+    def release(self) -> None:
         self.released = True
 
 
@@ -21,35 +23,35 @@ class _FakeRedis:
         self.values = {}
         self.locks = []
 
-    def get(self, key):
+    def get(self, key) -> object:
         return self.values.get(key)
 
-    def set(self, key, value, ex=None):
+    def set(self, key, value, ex=None) -> bool:
         _ = ex
         self.values[key] = str(value).encode("utf-8")
         return True
 
-    def lock(self, key, timeout=None, blocking_timeout=None):
+    def lock(self, key, timeout=None, blocking_timeout=None) -> object:
         _ = key, timeout, blocking_timeout
         lock = _FakeRedisLock()
         self.locks.append(lock)
         return lock
 
 
-def _clock(start=1000.0):
+def _clock(start=1000.0) -> tuple[Callable[..., object], Callable[..., object]]:
     now = {"value": float(start)}
 
-    def now_fn():
+    def now_fn() -> object:
         return now["value"]
 
-    def sleep_fn(seconds):
+    def sleep_fn(seconds) -> None:
         now["value"] += seconds
 
     return now_fn, sleep_fn
 
 
 @pytest.fixture(autouse=True)
-def _reset_gate_state():
+def _reset_gate_state() -> Iterator[None]:
     rpm_gate._LOCAL_STATE.clear()
     rpm_gate._FALLBACK_WARNING_KEYS.clear()
     yield

--- a/src/api/tests/service/tts/test_tts_text_preprocess.py
+++ b/src/api/tests/service/tts/test_tts_text_preprocess.py
@@ -3,7 +3,7 @@
 import pytest
 
 
-def _require_app(app):
+def _require_app(app) -> None:
     if app is None:
         pytest.skip("App fixture disabled")
 
@@ -138,7 +138,7 @@ def test_streaming_tts_processor_skips_svg_and_keeps_following_text(
 
     captured: list[str] = []
 
-    def _capture_submit(self, text: str):
+    def _capture_submit(self, text: str) -> None:
         _ = self
         captured.append(text)
 
@@ -185,7 +185,7 @@ def test_streaming_tts_processor_skips_chunked_markdown_image(app, monkeypatch) 
 
     captured: list[str] = []
 
-    def _capture_submit(self, text: str):
+    def _capture_submit(self, text: str) -> None:
         _ = self
         captured.append(text)
 

--- a/src/api/tests/service/tts/test_tts_validation_cloned_voice.py
+++ b/src/api/tests/service/tts/test_tts_validation_cloned_voice.py
@@ -16,10 +16,10 @@ from flaskr.service.tts.validation import validate_tts_settings_strict
 
 
 @pytest.fixture(autouse=True)
-def _fake_providers(monkeypatch):
+def _fake_providers(monkeypatch) -> None:
     """Serve static voice/model lists without real provider credentials."""
 
-    def _fake_get_tts_provider(name):
+    def _fake_get_tts_provider(name) -> SimpleNamespace:
         if name == "volcengine":
             cfg = SimpleNamespace(
                 voices=[{"value": "zh_female_vv_uranus_bigtts"}],
@@ -67,7 +67,7 @@ def _seed_ready_clone(app, *, provider: str, voice_id: str) -> None:
         db.session.commit()
 
 
-def _validate(provider: str, model: str, voice_id: str):
+def _validate(provider: str, model: str, voice_id: str) -> object:
     return validate_tts_settings_strict(
         provider=provider,
         model=model,

--- a/src/api/tests/service/tts/test_volcengine_http_provider.py
+++ b/src/api/tests/service/tts/test_volcengine_http_provider.py
@@ -28,10 +28,10 @@ def test_volcengine_http_synthesize_success(monkeypatch) -> None:
         headers: ClassVar[dict[str, str]] = {"Content-Type": "application/json"}
         text = ""
 
-        def raise_for_status(self):
+        def raise_for_status(self) -> None:
             return None
 
-        def json(self):
+        def json(self) -> dict[str, object]:
             return {
                 "reqid": "reqid",
                 "code": 3000,
@@ -41,7 +41,7 @@ def test_volcengine_http_synthesize_success(monkeypatch) -> None:
                 "addition": {"duration": "1234"},
             }
 
-    def fake_post(url, json=None, headers=None, timeout=None):
+    def fake_post(url, json=None, headers=None, timeout=None) -> DummyResponse:
         captured["url"] = url
         captured["json"] = json
         captured["headers"] = headers
@@ -95,10 +95,10 @@ def test_volcengine_http_legacy_resource_id_overrides_default_cluster(
         headers: ClassVar[dict[str, str]] = {"Content-Type": "application/json"}
         text = ""
 
-        def raise_for_status(self):
+        def raise_for_status(self) -> None:
             return None
 
-        def json(self):
+        def json(self) -> dict[str, object]:
             return {
                 "reqid": "reqid",
                 "code": 3000,
@@ -108,7 +108,7 @@ def test_volcengine_http_legacy_resource_id_overrides_default_cluster(
                 "addition": {"duration": "0"},
             }
 
-    def fake_post(url, json=None, headers=None, timeout=None):
+    def fake_post(url, json=None, headers=None, timeout=None) -> DummyResponse:
         captured["url"] = url
         captured["json"] = json
         captured["headers"] = headers

--- a/src/api/tests/service/tts/test_volcengine_voice_clone.py
+++ b/src/api/tests/service/tts/test_volcengine_voice_clone.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Never
+
 import pytest
 from flaskr.service.common.models import AppError
 from flaskr.service.tts import volcengine_voice_clone
@@ -19,7 +21,7 @@ _TEST_CONFIG = {
 }
 
 
-def _patch_config(monkeypatch, config=None):
+def _patch_config(monkeypatch, config=None) -> None:
     values = _TEST_CONFIG if config is None else config
     monkeypatch.setattr(
         volcengine_voice_clone,
@@ -34,7 +36,7 @@ class _FakeResponse:
         self.status_code = status_code
         self.text = ""
 
-    def json(self):
+    def json(self) -> dict[str, object]:
         return self._payload
 
 
@@ -61,7 +63,7 @@ def test_is_valid_volcengine_custom_voice_id(value, expected) -> None:
 def test_query_status_sends_expected_request(monkeypatch) -> None:
     _patch_config(monkeypatch)
 
-    def fake_post(url, headers, json, timeout):
+    def fake_post(url, headers, json, timeout) -> object:
         assert url == VOLCENGINE_MEGA_TTS_STATUS_URL
         assert headers["Authorization"] == "Bearer;test-token"
         assert headers["Resource-Id"] == VOLCENGINE_ICL_RESOURCE_ID
@@ -100,7 +102,7 @@ def test_query_status_converts_transport_error_to_param_error(monkeypatch) -> No
 
     _patch_config(monkeypatch)
 
-    def _raise_transport_error(*args: object, **kwargs: object):
+    def _raise_transport_error(*args: object, **kwargs: object) -> Never:
         _ = (args, kwargs)
         message = "connect timeout"
         raise requests_lib.exceptions.ConnectTimeout(message)
@@ -117,7 +119,7 @@ def test_query_status_converts_invalid_json_to_param_error(monkeypatch) -> None:
         status_code = 200
         text = "<html>gateway error</html>"
 
-        def json(self):
+        def json(self) -> Never:
             message = "no json"
             raise ValueError(message)
 

--- a/src/api/tests/service/tts/test_volcengine_ws_provider.py
+++ b/src/api/tests/service/tts/test_volcengine_ws_provider.py
@@ -55,25 +55,25 @@ def test_volcengine_ws_waits_for_session_started_before_task_request(
     captured = {}
 
     class FakeProtocol:
-        def encode_start_connection(self):
+        def encode_start_connection(self) -> bytes:
             return b"start_connection"
 
-        def encode_start_session(self, **kwargs: object):
+        def encode_start_session(self, **kwargs: object) -> bytes:
             captured["start_session_kwargs"] = kwargs
             return b"start_session"
 
-        def encode_task_request(self, session_id, text):
+        def encode_task_request(self, session_id, text) -> bytes:
             _ = (session_id, text)
             return b"task_request"
 
-        def encode_finish_session(self, session_id):
+        def encode_finish_session(self, session_id) -> bytes:
             _ = session_id
             return b"finish_session"
 
-        def encode_finish_connection(self):
+        def encode_finish_connection(self) -> bytes:
             return b"finish_connection"
 
-        def decode_frame(self, message):
+        def decode_frame(self, message) -> SimpleNamespace:
             if message == b"connection_started":
                 return SimpleNamespace(
                     event=volcengine_provider.Event.CONNECTION_STARTED,
@@ -149,11 +149,11 @@ def test_volcengine_ws_waits_for_session_started_before_task_request(
             self.session_started_sent = False
             captured["ws"] = self
 
-        def run_forever(self, **kwargs: object):
+        def run_forever(self, **kwargs: object) -> None:
             _ = kwargs
             self.on_open(self)
 
-        def send(self, frame, opcode=None):
+        def send(self, frame, opcode=None) -> None:
             _ = opcode
             self.sent.append(frame)
             if frame == b"start_connection":
@@ -173,11 +173,11 @@ def test_volcengine_ws_waits_for_session_started_before_task_request(
                 self.on_message(self, b"subtitle")
                 self.on_message(self, b"session_finished")
 
-        def _emit_session_started(self):
+        def _emit_session_started(self) -> None:
             self.session_started_sent = True
             self.on_message(self, b"session_started")
 
-        def close(self):
+        def close(self) -> None:
             self.on_close(self, None, None)
 
     fake_websocket = SimpleNamespace(

--- a/src/api/tests/service/user/test_captcha_routes.py
+++ b/src/api/tests/service/user/test_captcha_routes.py
@@ -6,9 +6,10 @@ from io import BytesIO
 
 from flasgger.utils import parse_docstring
 from PIL import Image
+from werkzeug.test import TestResponse
 
 
-def _post_json(client, path: str, payload: dict):
+def _post_json(client, path: str, payload: dict) -> tuple[TestResponse, object]:
     resp = client.post(
         path,
         data=json.dumps(payload),
@@ -17,7 +18,7 @@ def _post_json(client, path: str, payload: dict):
     return resp, resp.get_json(force=True)
 
 
-def _get_captcha(client, app):
+def _get_captcha(client, app) -> object:
     app.config["ENV"] = "development"
     app.config["CAPTCHA_CODE_OVERRIDE"] = "0000"
     response = client.get("/api/user/captcha")
@@ -27,7 +28,7 @@ def _get_captcha(client, app):
     return body["data"]
 
 
-def _get_ticket(client, app):
+def _get_ticket(client, app) -> object:
     captcha = _get_captcha(client, app)
     response, body = _post_json(
         client,

--- a/src/api/tests/service/user/test_google_auth.py
+++ b/src/api/tests/service/user/test_google_auth.py
@@ -40,10 +40,10 @@ class _FakeGoogleResponse:
     def __init__(self, payload) -> None:
         self._payload = payload
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         return None
 
-    def json(self):
+    def json(self) -> dict[str, object]:
         return self._payload
 
 
@@ -52,23 +52,25 @@ class _FakeGoogleSession:
         self._profile = profile
         self._fetch_token_error = fetch_token_error
 
-    def fetch_token(self, *_args: object, **_kwargs: object):
+    def fetch_token(self, *_args: object, **_kwargs: object) -> dict[str, str]:
         if self._fetch_token_error is not None:
             raise self._fetch_token_error
         return {"access_token": "fake-access-token"}
 
-    def get(self, *_args: object, **_kwargs: object):
+    def get(self, *_args: object, **_kwargs: object) -> object:
         return _FakeGoogleResponse(self._profile)
 
 
-def _reset_user_auth_tables():
+def _reset_user_auth_tables() -> None:
     UserTokenModel.query.delete()
     AuthCredential.query.delete()
     UserEntity.query.delete()
     db.session.commit()
 
 
-def _run_google_callback(app, monkeypatch, profile, *, fetch_token_error=None):
+def _run_google_callback(
+    app, monkeypatch, profile, *, fetch_token_error=None
+) -> object:
     monkeypatch.setenv("HOST_URL", "http://localhost")
     _reset_config_cache("HOST_URL")
     provider = GoogleAuthProvider()
@@ -208,7 +210,7 @@ def test_google_existing_account_keeps_pre_profile_display_name_behavior(
             original_first = query_type.first
             reads: list[tuple[str, str, bool, bool]] = []
 
-            def track_first(query):
+            def track_first(query) -> object:
                 statement = str(query.statement)
                 parameters = query.statement.compile().params
                 table = (

--- a/src/api/tests/service/user/test_import_user_command.py
+++ b/src/api/tests/service/user/test_import_user_command.py
@@ -141,7 +141,7 @@ def test_import_user_does_not_consult_profile_state_before_nickname_defaults(
         read_order: list[tuple[str, str, bool, bool]] = []
         reads_before_ensure: list[tuple[str, str, bool, bool]] = []
 
-        def track_first(query):
+        def track_first(query) -> object:
             statement = str(query.statement)
             parameters = query.statement.compile().params
             lookup_value = str(
@@ -166,7 +166,7 @@ def test_import_user_does_not_consult_profile_state_before_nickname_defaults(
 
         original_ensure_user = import_user_module.ensure_user_for_identifier
 
-        def track_ensure_user(*args: object, **kwargs: object):
+        def track_ensure_user(*args: object, **kwargs: object) -> object:
             reads_before_ensure.extend(read_order)
             return original_ensure_user(*args, **kwargs)
 

--- a/src/api/tests/service/user/test_learner_profile_optimizer.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, Never
 
 import pytest
 from flaskr.api.check import CHECK_RESULT_UNKNOWN
@@ -15,6 +16,9 @@ from flaskr.service.metering.consts import BILL_USAGE_SCENE_PROD
 from flaskr.service.profile import learner_profile_optimizer as optimizer
 from flaskr.service.user.models import UserInfo, UserOnboardingState
 from flaskr.service.user.repository import create_user_entity
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
 
 PROFILE_UPDATED_AT = datetime(2026, 8, 14, 8, 30, tzinfo=UTC)
 STATE_COMPLETED_AT = datetime(2026, 8, 14, 8, 45, tzinfo=UTC)
@@ -59,8 +63,8 @@ def _snapshot_profile_state(user_bid: str) -> tuple:
     )
 
 
-def _successful_llm(raw_output: str, captured: dict):
-    def invoke(*args: object, **kwargs: object):
+def _successful_llm(raw_output: str, captured: dict) -> Callable[..., object]:
+    def invoke(*args: object, **kwargs: object) -> Iterator[SimpleNamespace]:
         captured["call_count"] = captured.get("call_count", 0) + 1
         captured["args"] = args
         captured["kwargs"] = kwargs
@@ -73,11 +77,11 @@ def _install_trace_spies(monkeypatch, captured: dict) -> None:
     trace = object()
     root_span = object()
 
-    def create_trace(**kwargs: object):
+    def create_trace(**kwargs: object) -> tuple[object, object]:
         captured["trace_create"] = kwargs
         return trace, root_span
 
-    def finalize_trace(**kwargs: object):
+    def finalize_trace(**kwargs: object) -> None:
         captured["trace_finalize"] = kwargs
 
     monkeypatch.setattr(optimizer, "create_trace_with_root_span", create_trace)
@@ -311,7 +315,9 @@ def test_optimize_rejects_moderation_without_calling_llm_or_changing_state(
     invoked = False
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: False)
 
-    def unexpected_invoke(*_args: object, **_kwargs: object):
+    def unexpected_invoke(
+        *_args: object, **_kwargs: object
+    ) -> Iterator[SimpleNamespace]:
         nonlocal invoked
         invoked = True
         yield SimpleNamespace(result="unexpected")
@@ -387,7 +393,9 @@ def test_optimize_missing_default_model_does_not_call_llm_or_change_state(
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
     monkeypatch.setitem(app.config, "DEFAULT_LLM_MODEL", "")
 
-    def unexpected_invoke(*_args: object, **_kwargs: object):
+    def unexpected_invoke(
+        *_args: object, **_kwargs: object
+    ) -> Iterator[SimpleNamespace]:
         nonlocal invoked
         invoked = True
         yield SimpleNamespace(result="unexpected")
@@ -454,7 +462,7 @@ def test_optimize_timeout_finalizes_trace_without_changing_state(
     captured: dict = {}
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
-    def timeout_invoke(*_args: object, **_kwargs: object):
+    def timeout_invoke(*_args: object, **_kwargs: object) -> Iterator[None]:
         message = "provider timeout"
         raise TimeoutError(message)
         yield  # pragma: no cover
@@ -484,7 +492,7 @@ def test_optimize_reports_a_wrapped_timeout_as_timeout(app, monkeypatch) -> None
     user_bid = "profile-optimize-wrapped-timeout"
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
-    def timeout_invoke(*_args: object, **_kwargs: object):
+    def timeout_invoke(*_args: object, **_kwargs: object) -> Iterator[None]:
         try:
             # The wrapped-timeout shape is exactly what this test asserts.
             message = "provider timeout"
@@ -525,7 +533,7 @@ def test_optimize_reports_runtime_failure_reason_without_changing_state(
     captured: dict = {}
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
-    def failed_invoke(*_args: object, **_kwargs: object):
+    def failed_invoke(*_args: object, **_kwargs: object) -> Iterator[None]:
         raise provider_error
         yield  # pragma: no cover
 
@@ -554,11 +562,13 @@ def test_optimize_reports_moderation_failure_reason_without_calling_llm(
 ) -> None:
     invoked = False
 
-    def failed_moderation(*_args: object):
+    def failed_moderation(*_args: object) -> Never:
         message = "moderation unavailable"
         raise RuntimeError(message)
 
-    def unexpected_invoke(*_args: object, **_kwargs: object):
+    def unexpected_invoke(
+        *_args: object, **_kwargs: object
+    ) -> Iterator[SimpleNamespace]:
         nonlocal invoked
         invoked = True
         yield SimpleNamespace(result="unexpected")
@@ -584,7 +594,7 @@ def test_optimize_rejects_invalid_input_before_moderation(
 ) -> None:
     moderated = False
 
-    def unexpected_moderation(*_args: object):
+    def unexpected_moderation(*_args: object) -> bool:
         nonlocal moderated
         moderated = True
         return True

--- a/src/api/tests/service/user/test_learner_profile_service.py
+++ b/src/api/tests/service/user/test_learner_profile_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Never
 
 import pytest
 from flaskr.api.check.dto import (
@@ -83,7 +84,7 @@ def _track_profile_lock_reads(monkeypatch) -> list[tuple[str, str, bool, bool]]:
     original_first = query_type.first
     read_order: list[tuple[str, str, bool, bool]] = []
 
-    def track_first(query):
+    def track_first(query) -> object:
         statement = str(query.statement)
         parameters = query.statement.compile().params
         table = (
@@ -702,7 +703,7 @@ def test_nickname_rejection_rolls_back_profile_nickname_and_state(
 
     checked: list[str] = []
 
-    def reject_nickname(_app, _user_id, text):
+    def reject_nickname(_app, _user_id, text) -> bool:
         checked.append(text)
         return text != "Rejected nickname"
 
@@ -768,7 +769,7 @@ def test_profile_safety_audit_records_text_and_provider_response(
     profile = "称呼：小明\n职业背景：医疗产品经理"
     checked: dict[str, str] = {}
 
-    def fake_check_text(_app, check_id, text, user_id):
+    def fake_check_text(_app, check_id, text, user_id) -> CheckResultDTO:
         checked.update(check_id=check_id, text=text, user_id=user_id)
         return CheckResultDTO(
             check_result=CHECK_RESULT_PASS,
@@ -947,7 +948,7 @@ def test_save_locks_user_then_state_before_writing_profile(app, monkeypatch) -> 
         read_order = _track_profile_lock_reads(monkeypatch)
         reads_when_moderated: list[tuple[str, str, bool, bool]] = []
 
-        def allow_after_user_lock(_app, _user_id, _text):
+        def allow_after_user_lock(_app, _user_id, _text) -> bool:
             reads_when_moderated.extend(read_order)
             return True
 
@@ -986,11 +987,11 @@ def test_save_moderates_once_when_state_creation_retries(app, monkeypatch) -> No
     moderation_calls: list[str] = []
     operation_calls = 0
 
-    def allow_once(_app, _user_id, text):
+    def allow_once(_app, _user_id, text) -> bool:
         moderation_calls.append(text)
         return True
 
-    def run_twice(operation, *, user_id):
+    def run_twice(operation, *, user_id) -> object:
         nonlocal operation_calls
         assert user_id == "profile-save-moderation-retry"
         operation()
@@ -1271,7 +1272,7 @@ def test_complete_rolls_back_profile_and_state_together(app, monkeypatch) -> Non
         db.session.commit()
         original_commit = db.session.commit
 
-        def fail_commit():
+        def fail_commit() -> Never:
             message = "database unavailable"
             raise RuntimeError(message)
 
@@ -1316,7 +1317,7 @@ def test_clear_rolls_back_profile_and_state_together(app, monkeypatch) -> None:
         db.session.commit()
         original_commit = db.session.commit
 
-        def fail_commit():
+        def fail_commit() -> Never:
             message = "database unavailable"
             raise RuntimeError(message)
 

--- a/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
+++ b/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import UTC, datetime
+from typing import Never
 
 import pytest
 from flaskr.dao import db
@@ -44,10 +45,10 @@ def _assert_orm_utc(value: datetime | None, expected: datetime) -> None:
 
 
 class _FakeRedis:
-    def get(self, _key):
+    def get(self, _key) -> None:
         return None
 
-    def delete(self, *_keys: str):
+    def delete(self, *_keys: str) -> None:
         return None
 
 
@@ -55,10 +56,10 @@ class _FakeGoogleResponse:
     def __init__(self, payload) -> None:
         self._payload = payload
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         return None
 
-    def json(self):
+    def json(self) -> dict[str, object]:
         return self._payload
 
 
@@ -66,10 +67,10 @@ class _FakeGoogleSession:
     def __init__(self, profile) -> None:
         self._profile = profile
 
-    def fetch_token(self, *_args: object, **_kwargs: object):
+    def fetch_token(self, *_args: object, **_kwargs: object) -> dict[str, str]:
         return {"access_token": "fake-access-token"}
 
-    def get(self, *_args: object, **_kwargs: object):
+    def get(self, *_args: object, **_kwargs: object) -> object:
         return _FakeGoogleResponse(self._profile)
 
 
@@ -580,7 +581,7 @@ def test_merge_helper_rolls_back_with_sign_in_transaction(app) -> None:
         _add_state(source.user_bid, status="completed")
         db.session.commit()
 
-        def merge_then_fail():
+        def merge_then_fail() -> Never:
             with transactional_session():
                 merge_learner_profile_for_sign_in(
                     source_user_id=source.user_bid,
@@ -618,7 +619,7 @@ def test_merge_helper_locks_target_then_source_profile_snapshots(
         original_first = query_type.first
         read_order: list[tuple[str, str, bool, bool]] = []
 
-        def track_first(query):
+        def track_first(query) -> object:
             statement = str(query.statement)
             parameters = query.statement.compile().params
             user_bid = str(parameters.get("user_bid_1", ""))

--- a/src/api/tests/service/user/test_legacy_learner_profile_compatibility.py
+++ b/src/api/tests/service/user/test_legacy_learner_profile_compatibility.py
@@ -96,7 +96,7 @@ def test_legacy_nickname_writers_keep_pre_profile_mapping_behavior(
         original_first = query_type.first
         reads: list[tuple[str, str, bool, bool]] = []
 
-        def track_first(query):
+        def track_first(query) -> object:
             statement = str(query.statement)
             parameters = query.statement.compile().params
             table = (

--- a/src/api/tests/service/user/test_oauth_origins.py
+++ b/src/api/tests/service/user/test_oauth_origins.py
@@ -8,6 +8,8 @@ pin that check down.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Never
+
 import flaskr.common.config as common_config
 import pytest
 from flaskr.service.common.models import AppError
@@ -17,6 +19,9 @@ from flaskr.service.user.auth.providers.google import (
     _require_matching_initiator,
     resolve_state_return_origin,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 PLATFORM_CALLBACK = "https://app.example.com/login/google-callback"
 PLATFORM_ORIGIN = "https://app.example.com"
@@ -30,7 +35,7 @@ def _reset_config_cache(*keys: str) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _shared_callback(monkeypatch):
+def _shared_callback(monkeypatch) -> Iterator[None]:
     """Pin the deployment to one shared callback URL."""
     _reset_config_cache("HOST_URL", "GOOGLE_OAUTH_REDIRECT_URI")
     monkeypatch.setattr(
@@ -44,7 +49,7 @@ def _shared_callback(monkeypatch):
 
 
 @pytest.fixture
-def _verified_custom_domain(monkeypatch):
+def _verified_custom_domain(monkeypatch) -> None:
     """Treat exactly one host as a verified, TLS-active custom domain."""
     monkeypatch.setattr(
         oauth_origins,
@@ -86,7 +91,7 @@ class TestIsAllowedOAuthOrigin:
         )
 
     def test_lookup_failure_refuses_rather_than_allows(self, app, monkeypatch) -> None:
-        def _boom(app, host):
+        def _boom(app, host) -> Never:
             _ = (app, host)
             message = "database is down"
             raise RuntimeError(message)

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -613,7 +613,7 @@ def test_complete_onboarding_scene_handles_integrity_error(
     original_commit = db.session.commit
     state = {"raised": False}
 
-    def flaky_commit():
+    def flaky_commit() -> object:
         if not state["raised"]:
             state["raised"] = True
             message = "duplicate"

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     import pytest
     from flask import Flask
     from flask.testing import FlaskClient
+    from werkzeug.test import TestResponse
 
     from tests.common.fixtures.fake_redis import FakeRedis
 
@@ -35,7 +36,7 @@ def _post_json(
     payload: dict,
     headers: dict | None = None,
     environ_overrides: dict | None = None,
-):
+) -> tuple[TestResponse, object]:
     resp = client.post(
         path,
         data=json.dumps(payload),

--- a/src/api/tests/service/user/test_profile_onboarding.py
+++ b/src/api/tests/service/user/test_profile_onboarding.py
@@ -42,7 +42,7 @@ def test_profile_onboarding_config_roundtrip(app, monkeypatch) -> None:
         module, "load_profile_onboarding_config_payload", lambda: current_config
     )
 
-    def fake_save_config(_app, payload, *, updated_by):
+    def fake_save_config(_app, payload, *, updated_by) -> None:
         saved_payloads.append((payload, updated_by))
         current_config.update(payload)
 

--- a/src/api/tests/service/user/test_require_tmp_route.py
+++ b/src/api/tests/service/user/test_require_tmp_route.py
@@ -12,7 +12,9 @@ def test_require_tmp_passes_payload_source_to_temp_user(
 
     calls: list[dict[str, str | None]] = []
 
-    def fake_generate_temp_user(app, temp_id, source, wx_code=None, language="en-US"):
+    def fake_generate_temp_user(
+        app, temp_id, source, wx_code=None, language="en-US"
+    ) -> dict[str, str | dict[str, str]]:
         _ = app
         calls.append(
             {

--- a/src/api/tests/service/user/test_trial_credit_bootstrap.py
+++ b/src/api/tests/service/user/test_trial_credit_bootstrap.py
@@ -6,7 +6,7 @@ import importlib
 import json
 import uuid
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Never
 
 import pytest
 from flask import Flask
@@ -41,9 +41,10 @@ from tests.common.fixtures.fake_redis import FakeRedis
 
 if TYPE_CHECKING:
     from flask.testing import FlaskClient
+    from werkzeug.test import TestResponse
 
 
-def _load_user_route_handlers():
+def _load_user_route_handlers() -> tuple[object, object]:
     common_module = importlib.import_module("flaskr.route.common")
     user_module = importlib.import_module("flaskr.route.user")
     return user_module.register_user_handler, common_module.register_common_handler
@@ -52,7 +53,9 @@ def _load_user_route_handlers():
 register_user_handler, register_common_handler = _load_user_route_handlers()
 
 
-def _post_json(client, path: str, payload: dict, headers: dict | None = None):
+def _post_json(
+    client, path: str, payload: dict, headers: dict | None = None
+) -> TestResponse:
     return client.post(
         path,
         data=json.dumps(payload),
@@ -371,7 +374,7 @@ def test_post_auth_extension_failures_do_not_block_trial_bootstrap(
         token = generate_token(app, user_bid)
         dao.db.session.commit()
 
-    def _failing_post_auth_handler(_context, *, app):
+    def _failing_post_auth_handler(_context, *, app) -> Never:
         _ = app
         message = "boom"
         raise RuntimeError(message)

--- a/src/api/tests/service/user/test_user_identify.py
+++ b/src/api/tests/service/user/test_user_identify.py
@@ -8,15 +8,15 @@ class _FakeRedis:
         self.values = dict(values or {})
         self.deleted = []
 
-    def get(self, key):
+    def get(self, key) -> object:
         return self.values.get(key)
 
-    def delete(self, *keys: str):
+    def delete(self, *keys: str) -> int:
         self.deleted.extend(keys)
         return len(keys)
 
 
-def _reset_user_auth_tables():
+def _reset_user_auth_tables() -> None:
     from flaskr.dao import db
     from flaskr.service.user.models import (
         AuthCredential,
@@ -191,16 +191,16 @@ def test_send_email_code_stores_lowercase_identifier(app, monkeypatch) -> None:
         def __init__(self, *_args: object, **_kwargs: object) -> None:
             self.sent_to = None
 
-        def starttls(self):
+        def starttls(self) -> None:
             return None
 
-        def login(self, *_args: object):
+        def login(self, *_args: object) -> None:
             return None
 
-        def sendmail(self, _sender, recipient, _message):
+        def sendmail(self, _sender, recipient, _message) -> None:
             self.sent_to = recipient
 
-        def quit(self):
+        def quit(self) -> None:
             return None
 
     fake_redis = FakeRedis()

--- a/src/api/tests/service/user/test_user_repository.py
+++ b/src/api/tests/service/user/test_user_repository.py
@@ -30,10 +30,10 @@ def test_transactional_session_classifies_before_savepoint_rollback(
             self.rollbacks = 0
             self.commits = 0
 
-        def rollback(self):
+        def rollback(self) -> None:
             self.rollbacks += 1
 
-        def commit(self):
+        def commit(self) -> None:
             self.commits += 1
 
     nested = _Nested()

--- a/src/api/tests/service/user/test_validate_user.py
+++ b/src/api/tests/service/user/test_validate_user.py
@@ -1,5 +1,7 @@
 """Verify validate user behavior."""
 
+from typing import Never
+
 import jwt
 import pytest
 from flask import Flask
@@ -14,7 +16,7 @@ def test_validate_user_maps_invalid_algorithm_token_to_user_not_found(
     app.config["SECRET_KEY"] = "test-secret"
     app.config["ENVERIMENT"] = "prod"
 
-    def _raise_invalid_algorithm(*_args: object, **_kwargs: object):
+    def _raise_invalid_algorithm(*_args: object, **_kwargs: object) -> Never:
         message = "The specified alg value is not allowed"
         raise jwt.exceptions.InvalidAlgorithmError(message)
 

--- a/src/api/tests/test_edun.py
+++ b/src/api/tests/test_edun.py
@@ -1,6 +1,6 @@
 """Verify content-risk providers honor configuration and timeouts."""
 
-from typing import Self
+from typing import Never, Self
 
 import pytest
 
@@ -22,13 +22,13 @@ def test_yidun_check_uses_configured_timeout(app, monkeypatch) -> None:
     captured = {}
 
     class _Resp:
-        def json(self):
+        def json(self) -> dict[str, int | dict[str, dict[str, int]]]:
             return {
                 "code": 200,
                 "result": {"antispam": {"suggestion": 0, "label": 100}},
             }
 
-    def fake_post(url, data=None, headers=None, timeout=None):
+    def fake_post(url, data=None, headers=None, timeout=None) -> object:
         _ = (data, headers)
         captured["url"] = url
         captured["timeout"] = timeout
@@ -53,7 +53,7 @@ def test_ilivedata_send_wraps_oserror_as_urlerror(monkeypatch) -> None:
 
     from flaskr.api.check import ilivedata as ilivedata_module
 
-    def fake_urlopen(*_args: object, **_kwargs: object):
+    def fake_urlopen(*_args: object, **_kwargs: object) -> Never:
         message = "timed out"
         raise TimeoutError(message)
 
@@ -76,10 +76,10 @@ def test_ilivedata_check_uses_configured_timeout(app, monkeypatch) -> None:
         def __exit__(self, exc_type, exc, tb) -> bool | None:
             captured["closed"] = True
 
-        def read(self):
+        def read(self) -> bytes:
             return b'{"errorCode":0,"textSpam":{"result":0,"tags":[]}}'
 
-    def fake_urlopen(req, timeout=None):
+    def fake_urlopen(req, timeout=None) -> object:
         captured["host"] = req.full_url
         captured["timeout"] = timeout
         return _Resp()

--- a/src/api/tests/test_feishu.py
+++ b/src/api/tests/test_feishu.py
@@ -39,13 +39,13 @@ def test_send_order_feishu_formats_notification(app, monkeypatch) -> None:
             self._first_value = first_value
             self._count_value = count_value
 
-        def filter(self, *_args: object, **_kwargs: object):
+        def filter(self, *_args: object, **_kwargs: object) -> "FakeQuery":
             return self
 
-        def first(self):
+        def first(self) -> object:
             return self._first_value
 
-        def count(self):
+        def count(self) -> object:
             return self._count_value
 
     class FakeColumn:
@@ -71,7 +71,7 @@ def test_send_order_feishu_formats_notification(app, monkeypatch) -> None:
 
     captured = {}
 
-    def fake_send_notify(_app, title, msgs):
+    def fake_send_notify(_app, title, msgs) -> None:
         captured["title"] = title
         captured["msgs"] = msgs
 

--- a/src/api/tests/test_fix_discount.py
+++ b/src/api/tests/test_fix_discount.py
@@ -53,7 +53,7 @@ def test_use_coupon_code_applies_discount(app, monkeypatch) -> None:
 
     sent = {}
 
-    def fake_send_feishu_coupon_code(_app, user_id, code, _name, _value):
+    def fake_send_feishu_coupon_code(_app, user_id, code, _name, _value) -> None:
         sent["user_id"] = user_id
         sent["code"] = code
 

--- a/src/api/tests/test_gunicorn_worker_patch_guard.py
+++ b/src/api/tests/test_gunicorn_worker_patch_guard.py
@@ -8,9 +8,10 @@ actually selects the gevent worker.
 """
 
 import pathlib
+from typing import Never
 
 
-def _load_detector():
+def _load_detector() -> object:
     conf_path = pathlib.Path(__file__).resolve().parents[1] / "gunicorn.conf.py"
     source = conf_path.read_text()
     # Execute only the detector function, not the module (which would
@@ -64,7 +65,7 @@ def test_observer_skips_unpatched_processes(monkeypatch) -> None:
     monkeypatch.setattr(monkey, "is_module_patched", lambda _name: False)
 
     class _Logger:
-        def error(self, *args: object, **kwargs: object):
+        def error(self, *args: object, **kwargs: object) -> Never:
             _ = (args, kwargs)
             message = "must not log during a skipped install"
             raise AssertionError(message)

--- a/src/api/tests/test_langfuse_preload_deferral.py
+++ b/src/api/tests/test_langfuse_preload_deferral.py
@@ -20,7 +20,7 @@ class _RecordingLangfuse:
         _RecordingLangfuse.instances.append(kwargs)
 
 
-def _configure(app, monkeypatch):
+def _configure(app, monkeypatch) -> None:
     app.config["LANGFUSE_PUBLIC_KEY"] = "pk"
     app.config["LANGFUSE_SECRET_KEY"] = "sk"
     app.config["LANGFUSE_HOST"] = "https://langfuse.example"

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -8,9 +8,11 @@ import subprocess
 import sys
 import textwrap
 import types
+from collections.abc import Iterator
 from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
+from typing import Never
 
 import pytest
 
@@ -22,10 +24,10 @@ def _install_litellm_stub() -> None:
     litellm_stub = types.ModuleType("litellm")
     litellm_stub.model_cost = {}
 
-    def register_model(model_map):
+    def register_model(model_map) -> None:
         litellm_stub.model_cost.update(model_map)
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> Never:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -195,7 +197,7 @@ def _create_credit_rate(
     )
 
 
-def _configure_model_list(monkeypatch):
+def _configure_model_list(monkeypatch) -> None:
     available_models = [
         "qwen/deepseek-v4-flash",
         "ark/doubao-seed-2-0-lite-260428",
@@ -421,7 +423,7 @@ def test_get_current_models_keeps_list_when_credit_rate_lookup_fails(
 ) -> None:
     _configure_model_list(monkeypatch)
 
-    def raise_lookup(_app):
+    def raise_lookup(_app) -> Never:
         message = "db unavailable"
         raise RuntimeError(message)
 
@@ -440,7 +442,7 @@ def test_get_current_models_keeps_list_when_credit_rate_lookup_fails(
 def test_deepseek_model_loader_lists_models(monkeypatch) -> None:
     captured = {}
 
-    def fake_get(url, headers=None, timeout=None):
+    def fake_get(url, headers=None, timeout=None) -> FakeModelsResponse:
         captured["url"] = url
         captured["headers"] = headers
         captured["timeout"] = timeout
@@ -475,7 +477,7 @@ def test_deepseek_model_loader_lists_models(monkeypatch) -> None:
 
 
 def test_deepseek_model_loader_falls_back_when_list_models_fails(monkeypatch) -> None:
-    def fake_get(*args: object, **kwargs: object):
+    def fake_get(*args: object, **kwargs: object) -> Never:
         _ = args, kwargs
         message = "network unavailable"
         raise RuntimeError(message)
@@ -500,7 +502,9 @@ def test_deepseek_model_loader_falls_back_when_list_models_fails(monkeypatch) ->
 def test_qwen_prefixed_model_routes_without_fetched_alias(monkeypatch, app) -> None:
     captured = {}
 
-    def fake_completion(model, *args: object, **kwargs: object):
+    def fake_completion(
+        model, *args: object, **kwargs: object
+    ) -> Iterator[FakeResponse]:
         _ = args
         captured["model"] = model
         captured["kwargs"] = kwargs
@@ -508,7 +512,7 @@ def test_qwen_prefixed_model_routes_without_fetched_alias(monkeypatch, app) -> N
 
     monkeypatch.setattr(llm.litellm, "completion", fake_completion)
 
-    def reload_qwen_params(model_id, temperature):
+    def reload_qwen_params(model_id, temperature) -> object:
         captured["reload_model"] = model_id
         return llm._reload_qwen_params(model_id, temperature)
 
@@ -669,7 +673,7 @@ def test_stream_litellm_completion_applies_configured_limit_as_ceiling(
 def test_stream_litellm_completion_omits_unknown_limit(monkeypatch, app) -> None:
     captured = {}
 
-    def raise_unknown(_model):
+    def raise_unknown(_model) -> Never:
         message = "unknown model"
         raise ValueError(message)
 
@@ -766,7 +770,7 @@ def test_openai_params_use_litellm_reasoning_capabilities(
 ) -> None:
     captured = {}
 
-    def fake_get_model_info(*, model, custom_llm_provider):
+    def fake_get_model_info(*, model, custom_llm_provider) -> object:
         captured["model"] = model
         captured["custom_llm_provider"] = custom_llm_provider
         return model_info
@@ -788,7 +792,7 @@ def test_openai_params_use_litellm_reasoning_capabilities(
 def test_openai_params_fall_back_to_existing_policy_for_unknown_model(
     monkeypatch,
 ) -> None:
-    def raise_unknown(*args: object, **kwargs: object):
+    def raise_unknown(*args: object, **kwargs: object) -> Never:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -1259,7 +1263,7 @@ def test_litellm_195_native_adapter_contracts() -> None:
 def test_chat_llm_disables_deepseek_thinking(monkeypatch, app) -> None:
     captured_kwargs = {}
 
-    def fake_completion(*args: object, **kwargs: object):
+    def fake_completion(*args: object, **kwargs: object) -> Iterator[FakeResponse]:
         _ = args
         captured_kwargs["kwargs"] = kwargs
         return iter([FakeResponse("chunk-1", content="Hi", finish_reason="stop")])
@@ -1329,11 +1333,13 @@ def test_gemini_25_pro_params_use_lowest_supported_reasoning() -> None:
 def test_invoke_llm_uses_actual_model_for_provider_params(monkeypatch, app) -> None:
     captured = {}
 
-    def reload_params(model_id, temperature):
+    def reload_params(model_id, temperature) -> dict[str, object]:
         captured["reload_model"] = model_id
         return {"temperature": temperature}
 
-    def fake_completion(model, *args: object, **kwargs: object):
+    def fake_completion(
+        model, *args: object, **kwargs: object
+    ) -> Iterator[FakeResponse]:
         _ = args
         captured["completion_model"] = model
         captured["completion_kwargs"] = kwargs
@@ -1384,7 +1390,7 @@ def test_chat_llm_ends_partial_response_on_repeated_stream_chunk(
     class RepeatedChunkError(Exception):
         __module__ = "litellm.exceptions"
 
-    def fake_completion(*args: object, **kwargs: object):
+    def fake_completion(*args: object, **kwargs: object) -> Iterator[FakeResponse]:
         _ = (args, kwargs)
         yield FakeResponse("chunk-1", content="你好")
         message = "The model is repeating the same chunk = ！ ！ ."
@@ -1421,7 +1427,9 @@ def test_chat_llm_streams(monkeypatch, app) -> None:
     captured_kwargs = {}
     captured_usage = {}
 
-    def fake_completion(*args: object, **kwargs: object):
+    def fake_completion(
+        *args: object, **kwargs: object
+    ) -> Iterator[FakeResponse | SimpleNamespace]:
         _ = args
         captured_kwargs["kwargs"] = kwargs
         chunks = [
@@ -1491,7 +1499,7 @@ def test_chat_llm_streams(monkeypatch, app) -> None:
 def test_llm_sends_reasoning_output_to_langfuse_without_streaming_it(
     monkeypatch, app, llm_method
 ) -> None:
-    def fake_completion(*args: object, **kwargs: object):
+    def fake_completion(*args: object, **kwargs: object) -> Iterator[FakeResponse]:
         _ = args, kwargs
         return iter(
             [
@@ -1593,7 +1601,7 @@ def test_extract_reasoning_delta_supports_litellm_fallback_fields(
 
 
 def test_chat_llm_falls_back_to_request_trace_id(monkeypatch, app) -> None:
-    def fake_completion(*args: object, **kwargs: object):
+    def fake_completion(*args: object, **kwargs: object) -> Iterator[FakeResponse]:
         _ = args, kwargs
         return iter([FakeResponse("chunk-1", content="Hi", finish_reason="stop")])
 
@@ -1636,7 +1644,7 @@ class _FakeMidStreamFallbackError(Exception):
     """Stands in for litellm.exceptions.MidStreamFallbackError."""
 
 
-def _stream_chunk(content):
+def _stream_chunk(content) -> SimpleNamespace:
     return SimpleNamespace(
         choices=[
             SimpleNamespace(delta=SimpleNamespace(content=content), finish_reason=None)
@@ -1645,7 +1653,7 @@ def _stream_chunk(content):
     )
 
 
-def _reasoning_stream_chunk(reasoning_content):
+def _reasoning_stream_chunk(reasoning_content) -> SimpleNamespace:
     return SimpleNamespace(
         choices=[
             SimpleNamespace(
@@ -1659,7 +1667,7 @@ def _reasoning_stream_chunk(reasoning_content):
     )
 
 
-def _patch_retryable_stream_errors(monkeypatch):
+def _patch_retryable_stream_errors(monkeypatch) -> None:
     # Distinct classes per exception name: a resolver that silently drops one
     # of the names fails that class's parametrized retry test instead of
     # being masked by a shared class.
@@ -1674,15 +1682,15 @@ def _patch_retryable_stream_errors(monkeypatch):
     )
 
 
-def _patch_scripted_streams(monkeypatch, scripts):
+def _patch_scripted_streams(monkeypatch, scripts) -> dict[str, int]:
     """Each call to _stream_litellm_completion consumes the next script; a script is a list of chunks and/or exceptions raised in order."""
     calls = {"count": 0}
 
-    def _factory(_app, _requested, _invoke, _messages, _params, _kwargs):
+    def _factory(_app, _requested, _invoke, _messages, _params, _kwargs) -> object:
         script = scripts[min(calls["count"], len(scripts) - 1)]
         calls["count"] += 1
 
-        def _gen():
+        def _gen() -> Iterator[object]:
             for item in script:
                 if isinstance(item, BaseException):
                     raise item
@@ -1694,7 +1702,7 @@ def _patch_scripted_streams(monkeypatch, scripts):
     return calls
 
 
-def _collect_retry_stream(app):
+def _collect_retry_stream(app) -> list[object]:
     return list(
         llm._iter_stream_with_precontent_retry(
             app, "qwen/test-model", "test-model", [], {}, {}

--- a/src/api/tests/test_mdflow_adapter.py
+++ b/src/api/tests/test_mdflow_adapter.py
@@ -454,7 +454,7 @@ def test_save_shifu_mdflow_rereads_outline_after_risk_control_commit(
         position="0105",
     )
 
-    def _risk_check_and_reorder(_app, _check_id, _user_id, _content):
+    def _risk_check_and_reorder(_app, _check_id, _user_id, _content) -> None:
         with app.app_context():
             latest = (
                 DraftOutlineItem.query.filter_by(
@@ -629,7 +629,7 @@ def test_restore_shifu_mdflow_history_passes_base_revision(app, monkeypatch) -> 
         _outline_bid,
         _content,
         base_revision=None,
-    ):
+    ) -> dict[str, bool | dict[str, int]]:
         captured["base_revision"] = base_revision
         return {"conflict": True, "meta": {"revision": 99}}
 

--- a/src/api/tests/test_openai.py
+++ b/src/api/tests/test_openai.py
@@ -3,7 +3,9 @@
 
 import sys
 import types
+from collections.abc import Iterator
 from types import SimpleNamespace
+from typing import Never
 
 import pytest
 
@@ -14,7 +16,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> Never:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -130,7 +132,7 @@ class FakeUsage:
 def test_invoke_llm_streams_via_litellm(monkeypatch, app) -> None:
     captured_kwargs = {}
 
-    def fake_completion(*args: object, **kwargs: object):
+    def fake_completion(*args: object, **kwargs: object) -> Iterator[FakeResponse]:
         captured_kwargs["args"] = args
         captured_kwargs["kwargs"] = kwargs
         usage = FakeUsage(prompt_tokens=5, completion_tokens=4, total_tokens=9)

--- a/src/api/tests/test_order.py
+++ b/src/api/tests/test_order.py
@@ -89,13 +89,15 @@ def test_init_buy_record_refreshes_existing_unpaid_order_promotions(
     )
     apply_calls = {"count": 0}
 
-    def fake_apply_promo_campaigns(*_args: object, **_kwargs: object):
+    def fake_apply_promo_campaigns(*_args: object, **_kwargs: object) -> list[object]:
         apply_calls["count"] += 1
         if apply_calls["count"] == 1:
             return []
         return [promo_application]
 
-    def fake_query_promo_campaign_applications(_app, _order_id, recalc_discount):
+    def fake_query_promo_campaign_applications(
+        _app, _order_id, recalc_discount
+    ) -> list[object]:
         _ = recalc_discount
         if apply_calls["count"] >= 2:
             return [promo_application]

--- a/src/api/tests/test_pingpp.py
+++ b/src/api/tests/test_pingpp.py
@@ -10,7 +10,7 @@ def test_init_pingxx_uses_provider(app, monkeypatch) -> None:
         def __init__(self) -> None:
             self.called = False
 
-        def ensure_client(self, _app):
+        def ensure_client(self, _app) -> str:
             self.called = True
             return "client"
 
@@ -28,7 +28,7 @@ def test_create_pingxx_order_builds_request(app, monkeypatch) -> None:
     captured = {}
 
     class FakeProvider:
-        def create_payment(self, *, request, app):
+        def create_payment(self, *, request, app) -> PaymentCreationResult:
             _ = app
             captured["request"] = request
             return PaymentCreationResult(

--- a/src/api/tests/test_profile.py
+++ b/src/api/tests/test_profile.py
@@ -25,12 +25,12 @@ def test_add_profile_item_quick_creates_definition(app) -> None:
 def test_hide_unused_profile_items_no_unused(monkeypatch) -> None:
     calls = []
 
-    def fake_get_unused(app, parent_id):
+    def fake_get_unused(app, parent_id) -> list[object]:
         _ = app
         calls.append(("unused", parent_id))
         return []
 
-    def fake_get_defs(app, parent_id=None):
+    def fake_get_defs(app, parent_id=None) -> list[str]:
         _ = app
         calls.append(("defs", parent_id))
         return ["defs"]
@@ -52,12 +52,12 @@ def test_hide_unused_profile_items_no_unused(monkeypatch) -> None:
 def test_hide_unused_profile_items_updates_hidden(monkeypatch) -> None:
     calls = []
 
-    def fake_get_unused(app, parent_id):
+    def fake_get_unused(app, parent_id) -> list[str]:
         _ = app
         calls.append(("unused", parent_id))
         return ["v1", "v2"]
 
-    def fake_update(app, parent_id, profile_keys, hidden, user_id):
+    def fake_update(app, parent_id, profile_keys, hidden, user_id) -> list[str]:
         _ = app
         calls.append(("update", parent_id, tuple(profile_keys), hidden, user_id))
         return ["updated"]

--- a/src/api/tests/test_redislock.py
+++ b/src/api/tests/test_redislock.py
@@ -9,7 +9,7 @@ def test_run_with_redis_executes_once(app, monkeypatch) -> None:
     fake_redis = FakeRedis()
     monkeypatch.setattr(dao._redis_state, "client", fake_redis)
 
-    def add_one(value):
+    def add_one(value) -> object:
         return value + 1
 
     result = dao.run_with_redis(app, "lock-key", 10, add_one, [1])

--- a/src/api/tests/test_retry_on_deadlock.py
+++ b/src/api/tests/test_retry_on_deadlock.py
@@ -1,5 +1,6 @@
 """Verify transient database deadlocks are retried safely."""
 
+from typing import Never
 from unittest.mock import MagicMock
 
 import pytest
@@ -14,7 +15,7 @@ class _FakeOrigError(Exception):
         self.args = (errno, message)
 
 
-def _operational_error(errno):
+def _operational_error(errno) -> OperationalError:
     return OperationalError("SELECT 1", {}, _FakeOrigError(errno, "boom"))
 
 
@@ -22,7 +23,7 @@ def test_retries_deadlock_then_succeeds() -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def flaky():
+    def flaky() -> str:
         calls["n"] += 1
         if calls["n"] < 3:
             raise _operational_error(1213)
@@ -36,7 +37,7 @@ def test_retries_lock_wait_timeout() -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=2, backoff_seconds=0)
-    def flaky():
+    def flaky() -> str:
         calls["n"] += 1
         if calls["n"] < 2:
             raise _operational_error(1205)
@@ -50,7 +51,7 @@ def test_reraises_after_exhausting_attempts() -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def always_deadlock():
+    def always_deadlock() -> Never:
         calls["n"] += 1
         raise _operational_error(1213)
 
@@ -63,7 +64,7 @@ def test_does_not_retry_non_retryable_operational_error() -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def other_error():
+    def other_error() -> Never:
         calls["n"] += 1
         raise _operational_error(1146)  # table doesn't exist
 
@@ -78,7 +79,7 @@ def test_rolls_back_session_on_every_caught_error(monkeypatch) -> None:
     monkeypatch.setattr(dao, "db", fake_db)
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def always_deadlock():
+    def always_deadlock() -> Never:
         raise _operational_error(1213)
 
     with pytest.raises(OperationalError):
@@ -92,7 +93,7 @@ def test_rolls_back_session_on_non_retryable_error(monkeypatch) -> None:
     monkeypatch.setattr(dao, "db", fake_db)
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def other_error():
+    def other_error() -> Never:
         raise _operational_error(1146)
 
     with pytest.raises(OperationalError):
@@ -112,7 +113,7 @@ def test_protocol_interrupt_invalidates_and_does_not_retry(monkeypatch) -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def desynced():
+    def desynced() -> Never:
         calls["n"] += 1
         raise _operational_error(2014)
 
@@ -134,7 +135,7 @@ def test_rollback_db_failure_escalates_and_stops_retrying(monkeypatch) -> None:
     )
 
     class _BrokenSession:
-        def rollback(self):
+        def rollback(self) -> Never:
             message = "ROLLBACK"
             raise OperationalError(message, {}, Exception())
 
@@ -145,7 +146,7 @@ def test_rollback_db_failure_escalates_and_stops_retrying(monkeypatch) -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def deadlocked():
+    def deadlocked() -> Never:
         calls["n"] += 1
         raise _operational_error(1213)
 

--- a/src/api/tests/test_shifu_funcs.py
+++ b/src/api/tests/test_shifu_funcs.py
@@ -1,15 +1,17 @@
 """Verify course summaries isolate and report generation failures."""
 
+from typing import Never
+
 from flaskr.service.shifu import shifu_publish_funcs
 
 
 def test_run_summary_with_error_handling_logs_and_continues(app, monkeypatch) -> None:
     called = {"apply": False, "summary": False}
 
-    def fake_apply(_snapshot):
+    def fake_apply(_snapshot) -> None:
         called["apply"] = True
 
-    def fake_summary(_app, _shifu_id):
+    def fake_summary(_app, _shifu_id) -> Never:
         called["summary"] = True
         message = "boom"
         raise RuntimeError(message)

--- a/src/api/tests/test_sms_aliyun.py
+++ b/src/api/tests/test_sms_aliyun.py
@@ -13,7 +13,9 @@ def test_query_sms_template_list_caps_page_size_at_provider_limit(monkeypatch) -
         def __init__(self, _config) -> None:
             pass
 
-        def query_sms_template_list_with_options(self, request, _runtime):
+        def query_sms_template_list_with_options(
+            self, request, _runtime
+        ) -> SimpleNamespace:
             captured["page_index"] = request.page_index
             captured["page_size"] = request.page_size
             return SimpleNamespace(body=SimpleNamespace(code="OK"))

--- a/src/api/tests/test_wx_pub_order.py
+++ b/src/api/tests/test_wx_pub_order.py
@@ -42,7 +42,7 @@ def test_generate_charge_uses_pingxx_channel(app, monkeypatch) -> None:
 
     captured = {}
 
-    def fake_generate_pingxx_charge(**kwargs: object):
+    def fake_generate_pingxx_charge(**kwargs: object) -> BuyRecordDTO:
         captured.update(kwargs)
         return BuyRecordDTO(
             kwargs["buy_record"].order_bid,


### PR DESCRIPTION
## Stack

- Base: #2615 (`sunner/ruff-ann201`)
- Rule unit: ANN202 (`missing-return-type-private-function`)

## Summary

- enable ANN202 for mutable private callables
- add 1,509 reviewed return annotations across 276 Python files: 413 retained Ruff fixes and 1,096 manually reviewed contracts
- prefer concrete route, iterator, DTO, model, collection, protocol, and callable types; use `object` only at dynamic SDK, ORM, decorator, and test-double boundaries, with no new `Any` return annotations
- keep applied migration history unchanged and scope the only ANN202 exception to `f6b2a4d8c9e0_remove_legacy_timestamp_server_defaults.py`
- document the preferred ANN202 resolution policy for future contributors and coding agents

## Evidence

- semantic audit: 1,509 return annotations and 186 annotation-only import aliases; after stripping type scaffolding and normalizing four expected signature literals in one source-contract test, all 277 changed Python-file ASTs match the ANN201 parent
- configured ANN202: 1,510 findings to 0
- stable ALL census: 20,845 to 19,430
- isolated ALL census: 34,977 to 33,563, with exactly the one immutable migration helper remaining
- formatter-owned debt only: COM812 +94 and E501 +1; no enforced rule gained debt
- no files changed under `src/api/migrations/versions/`

## Verification

- `python3 /private/tmp/audit_ann202_ast.py`
- `/Users/sunner/src/ai-shifu/.venv/bin/python -m pytest -q tests/service/shifu/test_billing_debug_admission_contracts.py` (3 passed)
- `/Users/sunner/src/ai-shifu/.venv/bin/python -m pytest -q` (3,032 passed, 17 skipped, 733 existing warnings)
- `python3 -m compileall -q scripts src/api/flaskr src/api/scripts src/api/tests src/api/migrations/env.py`
- `python3 scripts/check_translations.py`
- `python3 scripts/check_repo_harness.py`
- `python3 scripts/check_architecture_boundaries.py`
- `uv run --with ruff==0.16.3 ruff check . --select ANN202`
- `uv run --with ruff==0.16.3 ruff check .`
- `uv run --with ruff==0.16.3 ruff format --check .`
- `uv run --with ruff==0.16.3 python scripts/check_dev_tools.py`
- `uv run --with ruff==0.16.3 lefthook run pre-commit --all-files`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->