### PR TITLE
chore: enforce explicit dynamic boundaries

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -604,6 +604,19 @@ and type-import scaffolding. Applied Alembic revisions are immutable, including
 private migration helpers; keep only the exact migration-history exception and
 annotate every new or otherwise mutable private callable.
 
+For `ANN401`, do not let `Any` erase a function boundary's type contract.
+Prefer the concrete protocol, DTO, model, scalar, or collection type that the
+callable actually accepts or returns. At a genuinely heterogeneous JSON, SDK,
+ORM, decorator, compatibility, or test-double boundary, annotate the unknown
+value as `object` (or `object | None` when absence is distinct) and narrow it
+with the existing parser, validator, protocol check, or `isinstance` branch
+before using type-specific operations. This is intentionally stricter than
+`Any`: it makes the uncertainty visible to each consumer. Do not hide `Any`
+behind an alias, combine a known type with `Any` (the union still means
+`Any`), or use an unchecked cast merely to satisfy Ruff. Preserve applied
+Alembic history with an exact-file exception; all mutable function annotations
+must follow the typed-boundary contract.
+
 For `FIX002`, do not make an unresolved task invisible by renaming `TODO`,
 adding `noqa`, or turning the same promise into an untracked prose comment.
 Complete the work when it is part of the current change. When it genuinely

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -839,6 +839,38 @@ plan's progress update for that rule.
   audit.
 - [x] 2026-08-21 17:00 CST: Pinned Ruff 0.16.3 development-tool validation and
   every repository pre-commit hook pass across all files.
+- [x] 2026-08-21 17:08 CST: Ready ISC004 PR
+  [#2618](https://github.com/ai-shifu/ai-shifu/pull/2618) passed every GitHub
+  check, including the 3,032-test backend job and runtime harness. Selected
+  ANN401 next because it makes the uncertainty at the recently annotated
+  function boundaries explicit without changing executable behavior.
+- [x] 2026-08-21 17:27 CST: Enabled ANN401 and replaced all 489 mutable
+  function-boundary `Any` annotations across 109 Python files. Stable
+  contracts use their existing concrete annotations; genuinely heterogeneous
+  JSON, SDK, ORM, decorator, compatibility, and test-double values now use
+  `object` or `object | None`, requiring consumers to narrow them before
+  type-specific use. No alias, cast, or suppression hides mutable `Any` debt.
+- [x] 2026-08-21 17:27 CST: Retained the one pre-existing ANN401 finding in
+  exact applied migration
+  `0a7c4d8e9f12_backfill_billing_product_plan_tier.py`, with no migration-history
+  edits. A semantic audit accounts for 437 `Any` to `object`, 40 `Any | None`
+  to `object | None`, ten `Decimal | Any` to `object`, and two
+  `Decimal | Any | None` to `object | None` rewrites; after normalizing those
+  annotations and 28 removed `typing.Any` imports, all 109 executable ASTs
+  match the ISC004 parent.
+- [x] 2026-08-21 17:27 CST: The root trace harness test and 13 focused backend
+  observability, API golden, and Redis-contract tests pass. The complete
+  backend suite passes 3,032 tests with 17 skips and 733 existing warnings.
+  Configured ANN401, repository Ruff, and format pass. The stable census falls
+  from 19,038 to 18,553 and the isolated census falls from 33,171 to 32,687:
+  all 490 parent ANN401 findings disappear from the stable view, the isolated
+  view exposes only the immutable migration helper, and formatter-owned
+  COM812 rises by five where longer `object` signatures wrap.
+- [x] 2026-08-21 17:30 CST: Regenerated all 83 collaboration documents and six
+  repository knowledge documents with no generated-file drift, then passed
+  translation validation, the repository harness, architecture boundary
+  ratchet, compile checks, pinned Ruff 0.16.3 development-tool validation, and
+  every repository pre-commit hook across all files.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -1410,6 +1442,22 @@ The complete backend suite passes 3,032 tests with 17 skips, and repository
 generation, harness, architecture, translation, compile, Ruff, and format
 checks pass. Pinned development-tool validation and every repository
 pre-commit hook also pass.
+
+The ANN401 stage removes dynamically typed function annotations from every
+mutable boundary: 489 annotations across 109 production, contributor-tool, and
+test files now use `object` or `object | None` when the incoming JSON, SDK, ORM,
+decorator, compatibility, or test-double value is genuinely heterogeneous.
+This preserves the accepted runtime values while requiring future consumers to
+narrow the unknown value before type-specific use. One exact exception protects
+an applied migration and no migration file changes. A semantic audit accounts
+for every annotation and removed `typing.Any` import, then matches all 109
+executable ASTs to the ISC004 parent. Configured ANN401 is clean; the stable
+census falls to 18,553 and the isolated census to 32,687, where only the
+immutable migration finding remains. Five formatter-conflicting COM812 findings
+appear where the longer built-in annotation wraps a signature. The directly
+affected script and backend contract tests and the complete 3,032-test backend
+suite pass. Repository generation, harness, architecture, translation,
+compile, Ruff, format, development-tool, and pre-commit gates also pass.
 
 ## Context and Orientation
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,7 +15,7 @@
 #   below, so the rationale survives the next Ruff upgrade.
 #
 # Deliberately not selected:
-# - ANN (except ANN002/ANN003/ANN201/ANN202/ANN204/ANN205/ANN206, see `select`) / SLF001 /
+# - ANN (except ANN002/ANN003/ANN201/ANN202/ANN204/ANN205/ANN206/ANN401, see `select`) / SLF001 /
 #   PLC0415 / PLR2004
 #   (and D1xx, see the ignore block): thousands of violations each; enforcing
 #   them is a codebase-wide project, not a lint config change.
@@ -198,6 +198,11 @@ select = [
     "ANN204",  # missing return type on a special method
     "ANN205",  # missing return type on a staticmethod
     "ANN206",  # missing return type on a classmethod
+    # Unknown values enter through JSON, SDK, ORM, decorator, and test-double
+    # boundaries as `object`, which forces consumers to narrow them before use.
+    # Prefer a concrete protocol, DTO, model, or collection type whenever the
+    # boundary has a stable contract; do not disguise `Any` behind an alias.
+    "ANN401",  # dynamically typed function annotations
 
     # --- Boolean arguments ------------------------------------------------
     # flake8-boolean-trap is otherwise off: FBT001/FBT002 would rewrite the
@@ -276,6 +281,8 @@ runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 # Applied revision hooks are immutable public functions. New revisions inherit
 # Alembic's `upgrade` / `downgrade` contract instead of rewriting history.
 "src/api/migrations/versions/**" = ["ANN201"]
+# This applied backfill's value normalizer predates the typed-boundary policy.
+"src/api/migrations/versions/0a7c4d8e9f12_backfill_billing_product_plan_tier.py" = ["ANN401"]
 # This applied revision's private server-default helper is also immutable.
 "src/api/migrations/versions/f6b2a4d8c9e0_remove_legacy_timestamp_server_defaults.py" = ["ANN202"]
 # This applied no-op revision keeps a legacy `NOTE:` section in its module

--- a/scripts/harness/trace_run.py
+++ b/scripts/harness/trace_run.py
@@ -117,11 +117,11 @@ def read_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     return payload, None
 
 
-def collect_request_ids(value: Any) -> list[str]:
+def collect_request_ids(value: object) -> list[str]:
     """Collect request IDs."""
     found: list[str] = []
 
-    def visit(node: Any) -> None:
+    def visit(node: object) -> None:
         if isinstance(node, dict):
             for key, child in node.items():
                 normalized_key = str(key).replace("_", "").replace("-", "").lower()

--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -60,7 +60,7 @@ class MockClient:
     def __init__(self, *args: object, **kwargs: object) -> None:
         """Initialize the no-op Langfuse client."""
 
-    def __getattr__(self, name) -> Any:
+    def __getattr__(self, name) -> object:
         """Return a no-op callable for any Langfuse operation."""
 
         def method(*args: object, **kwargs: object) -> MockClient:
@@ -114,7 +114,7 @@ def get_request_trace_id() -> str:
     return coerce_langfuse_trace_id(get_request_id() or uuid.uuid4().hex)
 
 
-def resolve_langfuse_trace_id(observation: Any, trace_id: str | None = None) -> str:
+def resolve_langfuse_trace_id(observation: object, trace_id: str | None = None) -> str:
     # Only accept real string trace ids. When Langfuse is disabled the client is
     # a MockClient whose __getattr__ returns a method object for any attribute
     # (including ``trace_id``); using that object as the trace id later breaks the
@@ -130,7 +130,7 @@ def resolve_langfuse_trace_id(observation: Any, trace_id: str | None = None) -> 
 
 
 def build_langfuse_observation_link(
-    observation: Any, trace_id: str | None = None
+    observation: object, trace_id: str | None = None
 ) -> dict[str, str]:
     # Kept for logging/correlation. The handle classes drop these keys before
     # calling into SDK v3, where the span hierarchy already encodes the link.
@@ -182,7 +182,7 @@ def init_langfuse(app: Flask) -> None:
         _langfuse_state.client = MockClient()
 
 
-def _has_langfuse_value(value: Any) -> bool:
+def _has_langfuse_value(value: object) -> bool:
     if value is None:
         return False
     if isinstance(value, str):
@@ -201,7 +201,7 @@ def _looks_like_structured_text(value: str) -> bool:
     )
 
 
-def _parse_langfuse_text_value(value: str) -> Any:
+def _parse_langfuse_text_value(value: str) -> object:
     stripped = value.strip()
     if not _looks_like_structured_text(stripped):
         return value
@@ -213,7 +213,7 @@ def _parse_langfuse_text_value(value: str) -> Any:
         return value
 
 
-def normalize_langfuse_input_value(value: Any) -> str | None:
+def normalize_langfuse_input_value(value: object) -> str | None:
     """Normalize langfuse input value."""
     if value is None:
         return None
@@ -242,7 +242,7 @@ def normalize_langfuse_input_value(value: Any) -> str | None:
     return text if text.strip() else None
 
 
-def normalize_langfuse_output_value(value: Any) -> str | None:
+def normalize_langfuse_output_value(value: object) -> str | None:
     """Normalize langfuse output value."""
     if value is None:
         return None
@@ -280,7 +280,7 @@ def compact_langfuse_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
     return {key: value for key, value in payload.items() if _has_langfuse_value(value)}
 
 
-def _usage_to_details(usage: Any) -> dict[str, int] | None:
+def _usage_to_details(usage: object) -> dict[str, int] | None:
     if usage is None:
         return None
     if isinstance(usage, dict):
@@ -317,7 +317,7 @@ def _map_observation_kwargs(
 class LangfuseObservationHandle:
     """v2-style facade over a Langfuse SDK v3 span or generation."""
 
-    def __init__(self, delegate: Any, trace_id: str = "") -> None:
+    def __init__(self, delegate: object, trace_id: str = "") -> None:
         """Wrap a Langfuse observation and its trace identity."""
         self._delegate = delegate
         delegate_trace_id = getattr(delegate, "trace_id", "")
@@ -393,7 +393,7 @@ class LangfuseTraceHandle(LangfuseObservationHandle):
 
 def create_trace_with_root_span(
     *,
-    client: Any,
+    client: object,
     trace_payload: dict[str, Any],
     root_span_payload: dict[str, Any],
 ) -> tuple[LangfuseTraceHandle, LangfuseObservationHandle]:
@@ -415,7 +415,7 @@ def create_trace_with_root_span(
 
 
 def update_langfuse_trace(
-    trace: Any,
+    trace: object,
     payload: dict[str, Any] | None = None,
     **kwargs: object,
 ) -> object:
@@ -427,7 +427,7 @@ def update_langfuse_trace(
 
 
 def update_langfuse_observation(
-    observation: Any,
+    observation: object,
     payload: dict[str, Any] | None = None,
     **kwargs: object,
 ) -> object:
@@ -440,8 +440,8 @@ def update_langfuse_observation(
 
 def finalize_langfuse_trace(
     *,
-    trace: Any,
-    root_span: Any | None,
+    trace: object,
+    root_span: object | None,
     trace_payload: dict[str, Any] | None = None,
     root_span_payload: dict[str, Any] | None = None,
 ) -> object:

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -142,7 +142,7 @@ def _log_warning(message: str) -> None:
     _log("warning", message)
 
 
-def _extract_usage_value(usage: Any, key: str) -> int:
+def _extract_usage_value(usage: object, key: str) -> int:
     if usage is None:
         return 0
     if isinstance(usage, dict):
@@ -150,7 +150,7 @@ def _extract_usage_value(usage: Any, key: str) -> int:
     return int(getattr(usage, key, 0) or 0)
 
 
-def _extract_input_cache(usage: Any) -> int:
+def _extract_input_cache(usage: object) -> int:
     if usage is None:
         return 0
     if isinstance(usage, dict):
@@ -190,15 +190,15 @@ def _attach_usage_output_text(
     return next_metadata
 
 
-def _extract_reasoning_delta(delta: Any) -> str:
+def _extract_reasoning_delta(delta: object) -> str:
     """Return provider reasoning from a normalized LiteLLM stream delta."""
 
-    def _get(value: Any, key: str) -> Any:
+    def _get(value: object, key: str) -> object:
         if isinstance(value, dict):
             return value.get(key)
         return getattr(value, key, None)
 
-    def _normalize(value: Any) -> str | None:
+    def _normalize(value: object) -> str | None:
         if isinstance(value, str) and value.strip():
             return value
         return normalize_langfuse_output_value(value)
@@ -249,7 +249,7 @@ def _build_langfuse_llm_output(
     }
 
 
-def _normalize_model_config(value: Any) -> list[str]:
+def _normalize_model_config(value: object) -> list[str]:
     if not value:
         return []
     if isinstance(value, str):

--- a/src/api/flaskr/api/tts/aliyun_nls_token.py
+++ b/src/api/flaskr/api/tts/aliyun_nls_token.py
@@ -60,7 +60,7 @@ class AliyunNlsToken:
         return self.expire_time <= int(now_ts)
 
 
-def _percent_encode(value: Any) -> str:
+def _percent_encode(value: object) -> str:
     """RFC3986 percent encoding compatible with Aliyun POP signing rules."""
     if value is None:
         value = ""
@@ -110,7 +110,7 @@ def _get_lock_key() -> str:
     return f"{prefix}tts:aliyun:nls_token:lock"
 
 
-def _decode_cache_value(raw: Any) -> AliyunNlsToken | None:
+def _decode_cache_value(raw: object) -> AliyunNlsToken | None:
     if raw is None:
         return None
     if isinstance(raw, bytes):

--- a/src/api/flaskr/api/tts/minimax_provider.py
+++ b/src/api/flaskr/api/tts/minimax_provider.py
@@ -277,7 +277,7 @@ def _looks_like_subtitle_item(value: dict[str, Any]) -> bool:
     )
 
 
-def _collect_subtitle_items(value: Any) -> list[dict[str, Any]]:
+def _collect_subtitle_items(value: object) -> list[dict[str, Any]]:
     if isinstance(value, list):
         return [item for item in value if isinstance(item, dict)]
     if isinstance(value, dict):

--- a/src/api/flaskr/api/tts/tencent_provider.py
+++ b/src/api/flaskr/api/tts/tencent_provider.py
@@ -242,7 +242,7 @@ class TencentTTSError(ValueError):
     def __init__(
         self,
         *,
-        code: Any,
+        code: object,
         message: str = "",
         request_id: str = "",
         message_id: str = "",
@@ -260,7 +260,7 @@ class TencentTTSError(ValueError):
         self.message_id = message_id
 
 
-def _tencent_codec(value: Any = None) -> str:
+def _tencent_codec(value: object = None) -> str:
     codec = str(value or TENCENT_DEFAULT_CODEC).lower()
     if codec != TENCENT_DEFAULT_CODEC:
         logger.warning(
@@ -309,7 +309,7 @@ def _export_tencent_pcm_to_mp3(audio_data: bytes, *, sample_rate: int) -> bytes:
     return output.getvalue()
 
 
-def _coerce_app_id(app_id: Any) -> int:
+def _coerce_app_id(app_id: object) -> int:
     try:
         return int(app_id)
     except (TypeError, ValueError) as exc:
@@ -321,7 +321,7 @@ def _clamp_float(value: float, minimum: float, maximum: float) -> float:
     return min(max(float(value), minimum), maximum)
 
 
-def _tencent_flow_speed(value: Any) -> float:
+def _tencent_flow_speed(value: object) -> float:
     try:
         legacy_speed = float(value or 0)
     except (TypeError, ValueError):
@@ -333,7 +333,7 @@ def _tencent_flow_speed(value: Any) -> float:
     return round(_clamp_float(mapped, 0.5, 2.0), 2)
 
 
-def _tencent_flow_volume(value: Any) -> float:
+def _tencent_flow_volume(value: object) -> float:
     try:
         volume = float(value or 0)
     except (TypeError, ValueError):
@@ -351,7 +351,7 @@ def _tencent_voice_language(voice_id: str) -> str:
     return "zh"
 
 
-def _normalize_tencent_voice_id(voice_id: Any) -> str:
+def _normalize_tencent_voice_id(voice_id: object) -> str:
     normalized_voice_id = str(voice_id or "").strip()
     if not normalized_voice_id:
         return TENCENT_DEFAULT_VOICE_ID
@@ -366,7 +366,7 @@ def _resolve_tencent_model(model: str | None, emotion: str = "") -> str:
     return TENCENT_DEFAULT_MODEL
 
 
-def _normalize_tencent_emotion(emotion: Any) -> str:
+def _normalize_tencent_emotion(emotion: object) -> str:
     normalized = str(emotion or "").strip()
     emotion_aliases = {
         "fear": "fearful",
@@ -384,7 +384,7 @@ def _normalize_tencent_emotion(emotion: Any) -> str:
 
 def build_tencent_sse_payload(
     *,
-    app_id: Any,
+    app_id: object,
     text: str,
     voice_settings: VoiceSettings,
     audio_settings: AudioSettings,
@@ -960,14 +960,14 @@ def _group_tencent_subtitle_cues_by_sentence(
     return normalize_subtitle_cues(grouped)
 
 
-def _coerce_int(value: Any, default: int = 0) -> int:
+def _coerce_int(value: object, default: int = 0) -> int:
     try:
         return int(value)
     except (TypeError, ValueError):
         return int(default or 0)
 
 
-def _coerce_bool(value: Any) -> bool:
+def _coerce_bool(value: object) -> bool:
     if isinstance(value, bool):
         return value
     if value is None:
@@ -977,14 +977,14 @@ def _coerce_bool(value: Any) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes", "y"}
 
 
-def _get_first_present(payload: dict[str, Any], *keys: str) -> Any:
+def _get_first_present(payload: dict[str, Any], *keys: str) -> object:
     for key in keys:
         if key in payload:
             return payload.get(key)
     return None
 
 
-def _is_nonzero_tencent_code(value: Any) -> bool:
+def _is_nonzero_tencent_code(value: object) -> bool:
     if value is None:
         return False
     if isinstance(value, (int, float)):
@@ -1000,7 +1000,7 @@ def _unwrap_tencent_sse_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
-def _decode_tencent_sse_line(raw_line: Any) -> str:
+def _decode_tencent_sse_line(raw_line: object) -> str:
     if isinstance(raw_line, bytes):
         return raw_line.decode("utf-8", errors="replace").strip()
     return str(raw_line or "").strip()

--- a/src/api/flaskr/api/tts/volcengine_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_provider.py
@@ -45,7 +45,7 @@ logger = AppLoggerProxy(logging.getLogger(__name__))
 VOLCENGINE_TTS_WS_URL = "wss://openspeech.bytedance.com/api/v3/tts/bidirection"
 
 
-def _timestamp_seconds_to_ms(value: Any) -> int:
+def _timestamp_seconds_to_ms(value: object) -> int:
     try:
         return max(round(float(value) * 1000), 0)
     except (TypeError, ValueError):
@@ -103,7 +103,7 @@ def _volcengine_words_to_sentence_cue(
 
 
 def _extract_volcengine_subtitle_cues(
-    payload: Any,
+    payload: object,
     *,
     segment_index: int = 0,
 ) -> list[dict[str, Any]]:

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 
 @runtime_checkable
@@ -40,7 +40,7 @@ class CacheProvider(Protocol):
     def set(
         self,
         key: str,
-        value: Any,
+        value: object,
         ex: int | None = None,
         px: int | None = None,
         nx: bool = False,
@@ -51,7 +51,7 @@ class CacheProvider(Protocol):
         """Store a value under a cache key."""
         raise NotImplementedError
 
-    def setex(self, key: str, time_in_seconds: int, value: Any) -> bool:
+    def setex(self, key: str, time_in_seconds: int, value: object) -> bool:
         """Store a cached value with an expiration."""
         raise NotImplementedError
 
@@ -106,7 +106,7 @@ class _DynamicRedisCacheProvider:
     def set(
         self,
         key: str,
-        value: Any,
+        value: object,
         ex: int | None = None,
         px: int | None = None,
         nx: bool = False,
@@ -119,7 +119,7 @@ class _DynamicRedisCacheProvider:
             args = ()
         return self._client().set(key, value, ex=ex, px=px, nx=nx, xx=xx, **kwargs)
 
-    def setex(self, key: str, time_in_seconds: int, value: Any) -> bool:
+    def setex(self, key: str, time_in_seconds: int, value: object) -> bool:
         return self._client().setex(key, time_in_seconds, value)
 
     def delete(self, *keys: str) -> int:
@@ -183,7 +183,7 @@ class InMemoryCacheProvider:
     def _now(self) -> float:
         return time.time()
 
-    def _encode(self, value: Any) -> bytes:
+    def _encode(self, value: object) -> bytes:
         if isinstance(value, bytes):
             return value
         if isinstance(value, (int, float, bool)):
@@ -228,7 +228,7 @@ class InMemoryCacheProvider:
     def set(
         self,
         key: str,
-        value: Any,
+        value: object,
         ex: int | None = None,
         px: int | None = None,
         nx: bool = False,
@@ -256,7 +256,7 @@ class InMemoryCacheProvider:
             )
             return True
 
-    def setex(self, key: str, time_in_seconds: int, value: Any) -> bool:
+    def setex(self, key: str, time_in_seconds: int, value: object) -> bool:
         """Store a cached value with an expiration."""
         return self.set(key, value, ex=time_in_seconds)
 
@@ -344,7 +344,7 @@ class FallbackCacheProvider:
     def set(
         self,
         key: str,
-        value: Any,
+        value: object,
         ex: int | None = None,
         px: int | None = None,
         nx: bool = False,
@@ -365,7 +365,7 @@ class FallbackCacheProvider:
             **kwargs,
         )
 
-    def setex(self, key: str, time_in_seconds: int, value: Any) -> bool:
+    def setex(self, key: str, time_in_seconds: int, value: object) -> bool:
         """Store a cached value with an expiration."""
         return self._call("setex", key, time_in_seconds, value)
 

--- a/src/api/flaskr/common/celery_app.py
+++ b/src/api/flaskr/common/celery_app.py
@@ -66,7 +66,7 @@ def create_celery_app(flask_app: Flask | None = None) -> Celery:
     resolved_flask_app = flask_app or _load_flask_app()
 
     @worker_process_init.connect(weak=False)
-    def _dispose_db_pools_after_fork(**_kwargs: Any) -> None:
+    def _dispose_db_pools_after_fork(**_kwargs: object) -> None:
         try:
             dispose_inherited_db_pools(resolved_flask_app)
         except Exception:  # pragma: no cover - never kill a booting worker
@@ -77,7 +77,7 @@ def create_celery_app(flask_app: Flask | None = None) -> Celery:
     class FlaskTask(Task):
         abstract = True
 
-        def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        def __call__(self, *args: object, **kwargs: object) -> object:
             with resolved_flask_app.app_context():
                 return self.run(*args, **kwargs)
 
@@ -255,7 +255,7 @@ def _register_default_tasks() -> None:
     importlib.import_module("flaskr.service.billing.tasks")
 
 
-def _to_bool(value: Any) -> bool:
+def _to_bool(value: object) -> bool:
     if isinstance(value, bool):
         return value
     if isinstance(value, str):

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -44,13 +44,13 @@ class EnvVar:
             )
             raise ValueError(message)
 
-    def validate_value(self, value: Any) -> bool:
+    def validate_value(self, value: object) -> bool:
         """Validate the environment variable value."""
         if self.validator:
             return self.validator(value)
         return True
 
-    def convert_type(self, value: Any) -> Any:
+    def convert_type(self, value: object) -> object:
         """Convert string value to the specified type."""
         # Trim whitespace from string values before conversion
         if isinstance(value, str):
@@ -84,7 +84,7 @@ class EnvVar:
             return str(value)
 
 
-def _is_valid_rpm_limits_json(value: Any) -> bool:
+def _is_valid_rpm_limits_json(value: object) -> bool:
     """Validate the MINIMAX_TTS_RPM_LIMITS override map.
 
     Empty is allowed (no overrides). A non-empty value must be a JSON object
@@ -109,7 +109,7 @@ def _is_valid_rpm_limits_json(value: Any) -> bool:
     return True
 
 
-def parse_llm_model_max_output_tokens(value: Any) -> dict[str, int]:
+def parse_llm_model_max_output_tokens(value: object) -> dict[str, int]:
     """Parse a routed model id -> maximum output token JSON map."""
     if value in (None, ""):
         return {}
@@ -146,7 +146,7 @@ def parse_llm_model_max_output_tokens(value: Any) -> dict[str, int]:
     return parsed
 
 
-def _is_valid_llm_model_max_output_tokens_json(value: Any) -> bool:
+def _is_valid_llm_model_max_output_tokens_json(value: object) -> bool:
     try:
         parse_llm_model_max_output_tokens(value)
     except ValueError:
@@ -1903,7 +1903,7 @@ class EnhancedConfig:
             raise EnvironmentConfigError("\n\n".join(errors))
         self._validated = True
 
-    def get(self, key: str) -> Any:
+    def get(self, key: str) -> object:
         """Get configuration value with type conversion."""
         if key in self._cache:
             return self._cache[key]
@@ -2021,7 +2021,7 @@ class EnhancedConfig:
         """
 
         # Format values for .env output, handling lists as comma-separated strings
-        def format_value(env_var: EnvVar, value: Any) -> str:
+        def format_value(env_var: EnvVar, value: object) -> str:
             if value is None:
                 return ""
             if env_var.type is list:
@@ -2159,11 +2159,11 @@ class Config(FlaskConfig):
             raise
         self._populate_redis_prefixes()
 
-    def __getitem__(self, key: Any) -> Any:
+    def __getitem__(self, key: object) -> object:
         """Get configuration value using enhanced config first, with fallback to parent."""
         return self.get(key)
 
-    def __getattr__(self, key: Any) -> Any:
+    def __getattr__(self, key: object) -> object:
         """Get configuration attribute using enhanced config first."""
         try:
             return self.enhanced.get(key)
@@ -2173,7 +2173,7 @@ class Config(FlaskConfig):
         except Exception:
             return getattr(self.parent, key)
 
-    def __setitem__(self, key: Any, value: Any) -> None:
+    def __setitem__(self, key: object, value: object) -> None:
         """Set configuration value."""
         self.parent.__setitem__(key, value)
         os.environ[key] = str(value)
@@ -2193,7 +2193,7 @@ class Config(FlaskConfig):
             )
             self.parent.setdefault(key, derived_value)
 
-    def get(self, key: Any, default: Any = None) -> Any:
+    def get(self, key: object, default: object = None) -> object:
         """Get configuration value with fallback to parent and optional default.
 
         This method maintains compatibility with Flask's Config.get() API.
@@ -2259,11 +2259,11 @@ class Config(FlaskConfig):
         """Get list configuration value."""
         return self.enhanced.get_list(key)
 
-    def __call__(self, *args: Any, **kwds: Any) -> Any:
+    def __call__(self, *args: object, **kwds: object) -> object:
         """Resolve a configuration value by key."""
         return self.parent.__call__(*args, **kwds)
 
-    def setdefault(self, key: Any, default: Any = None) -> Any:
+    def setdefault(self, key: object, default: object = None) -> object:
         """Set default value if key doesn't exist.
 
         This method maintains compatibility with Flask's Config.setdefault() API.
@@ -2280,7 +2280,7 @@ class Config(FlaskConfig):
         return self.parent.setdefault(key, default)
 
 
-def get_config(key: str, default: Any = None) -> Any:
+def get_config(key: str, default: object = None) -> object:
     """Get configuration value.
 
     Args:

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -8,7 +8,6 @@ import uuid
 from datetime import datetime
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
-from typing import Any
 
 import colorlog
 import pytz
@@ -36,7 +35,7 @@ class AppLoggerProxy:
         except Exception:
             return self._fallback
 
-    def __getattr__(self, name: str) -> Any:
+    def __getattr__(self, name: str) -> object:
         """Delegate attribute access to the active application logger."""
         return getattr(self._resolve(), name)
 

--- a/src/api/flaskr/common/umami_client.py
+++ b/src/api/flaskr/common/umami_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import requests
@@ -44,7 +44,7 @@ def build_course_visit_event_name(shifu_bid: str) -> str:
     return COURSE_VISIT_EVENT_PREFIX + normalized[:suffix_limit]
 
 
-def _decode_cache_bytes(raw: Any) -> str:
+def _decode_cache_bytes(raw: object) -> str:
     if raw is None:
         return ""
     if isinstance(raw, bytes):
@@ -104,7 +104,7 @@ def _get_access_token_cache_key() -> str:
 def _cache_setex_best_effort(
     cache_key: str,
     ttl_seconds: int,
-    value: Any,
+    value: object,
     *,
     operation: str,
 ) -> None:

--- a/src/api/flaskr/service/billing/admin_ops_state.py
+++ b/src/api/flaskr/service/billing/admin_ops_state.py
@@ -104,7 +104,7 @@ def _write_map(app: Flask, key: str, value: dict[str, Any]) -> None:
     )
 
 
-def _load_json(value: Any) -> dict[str, Any]:
+def _load_json(value: object) -> dict[str, Any]:
     try:
         payload = json.loads(str(value or "{}"))
     except (TypeError, ValueError, json.JSONDecodeError):

--- a/src/api/flaskr/service/billing/admin_target_users.py
+++ b/src/api/flaskr/service/billing/admin_target_users.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from importlib import import_module
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from flaskr.service.common.contact_identifiers import (
     resolve_contact_lookup_providers,
@@ -139,13 +139,13 @@ def _resolve_creator_contact(creator_contact: str) -> tuple[str, str]:
     return contact_type, normalized_creator_contact
 
 
-def _user_repository() -> Any:
+def _user_repository() -> object:
     return import_module("flaskr.service.user.repository")
 
 
-def _user_utils() -> Any:
+def _user_utils() -> object:
     return import_module("flaskr.service.user.utils")
 
 
-def _user_consts() -> Any:
+def _user_consts() -> object:
     return import_module("flaskr.service.user.consts")

--- a/src/api/flaskr/service/billing/admission.py
+++ b/src/api/flaskr/service/billing/admission.py
@@ -51,7 +51,7 @@ class CreatorUsageAdmission:
             "priority_class": self.priority_class,
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a response field by key."""
         return self.to_response_dict()[key]
 

--- a/src/api/flaskr/service/billing/bucket_categories.py
+++ b/src/api/flaskr/service/billing/bucket_categories.py
@@ -78,7 +78,7 @@ def resolve_runtime_credit_bucket_category(
     bucket_category: int | None = None,
     source_type: int | None = None,
     source_bid: str = "",
-    metadata: Any | None = None,
+    metadata: object | None = None,
     load_order_type: OrderTypeLoader | None = None,
 ) -> int:
     """Resolve runtime credit bucket category."""
@@ -184,7 +184,7 @@ def load_billing_order_type_by_bid(bill_order_bid: str) -> int | None:
 
 def _resolve_refund_bucket_category(
     *,
-    metadata: Any | None = None,
+    metadata: object | None = None,
     load_order_type: OrderTypeLoader | None = None,
 ) -> int:
     return resolve_bucket_category_from_order_type(
@@ -198,7 +198,7 @@ def _resolve_refund_bucket_category(
 def _resolve_gift_bucket_category(
     *,
     source_bid: str,
-    metadata: Any | None = None,
+    metadata: object | None = None,
     load_order_type: OrderTypeLoader | None = None,
 ) -> int:
     normalized_source_bid = _normalize_bid(source_bid)
@@ -225,7 +225,7 @@ def _resolve_gift_bucket_category(
 
 def _resolve_origin_order_type(
     *,
-    metadata: Any | None = None,
+    metadata: object | None = None,
     load_order_type: OrderTypeLoader | None = None,
 ) -> int | None:
     metadata_map = _normalize_json_object(metadata)
@@ -263,7 +263,7 @@ def _resolve_bucket_category_hint(metadata: dict[str, Any]) -> int | None:
     return None
 
 
-def _parse_order_type(value: Any) -> int | None:
+def _parse_order_type(value: object) -> int | None:
     if isinstance(value, bool) or value in (None, ""):
         return None
     if isinstance(value, (int, float)):
@@ -277,7 +277,7 @@ def _parse_order_type(value: Any) -> int | None:
     return _ORDER_TYPE_BY_LABEL.get(normalized_value)
 
 
-def _parse_bucket_category(value: Any) -> int | None:
+def _parse_bucket_category(value: object) -> int | None:
     if isinstance(value, bool) or value in (None, ""):
         return None
     if isinstance(value, (int, float)):

--- a/src/api/flaskr/service/billing/campaigns.py
+++ b/src/api/flaskr/service/billing/campaigns.py
@@ -649,7 +649,7 @@ def _dedupe_campaign_product_drafts(
     return ordered
 
 
-def _coerce_discount_amount(value: Any) -> int:
+def _coerce_discount_amount(value: object) -> int:
     try:
         discount_amount = max(int(value or 0), 0)
     except (TypeError, ValueError):
@@ -659,7 +659,7 @@ def _coerce_discount_amount(value: Any) -> int:
     return discount_amount
 
 
-def _coerce_discount_percent(value: Any) -> Decimal:
+def _coerce_discount_percent(value: object) -> Decimal:
     try:
         discount_percent = to_decimal(value)
     except Exception:
@@ -669,7 +669,7 @@ def _coerce_discount_percent(value: Any) -> Decimal:
     return discount_percent.quantize(Decimal("0.01"))
 
 
-def _coerce_campaign_price_amount(value: Any) -> int:
+def _coerce_campaign_price_amount(value: object) -> int:
     try:
         campaign_price_amount = int(value or 0)
     except (TypeError, ValueError):
@@ -679,7 +679,7 @@ def _coerce_campaign_price_amount(value: Any) -> int:
     return campaign_price_amount
 
 
-def _coerce_bonus_credit_amount(value: Any) -> Decimal:
+def _coerce_bonus_credit_amount(value: object) -> Decimal:
     try:
         bonus_credit_amount = quantize_credit_amount(value)
     except Exception:
@@ -690,7 +690,7 @@ def _coerce_bonus_credit_amount(value: Any) -> Decimal:
 
 
 def _coerce_required_datetime(
-    value: Any,
+    value: object,
     *,
     required: bool,
     parameter_name: str,
@@ -701,7 +701,7 @@ def _coerce_required_datetime(
     return parsed
 
 
-def _resolve_product_type_filter(value: Any) -> int | None:
+def _resolve_product_type_filter(value: object) -> int | None:
     normalized = str(value or "").strip().lower()
     if not normalized:
         return None
@@ -715,7 +715,7 @@ def _resolve_product_type_filter(value: Any) -> int | None:
     return None
 
 
-def _resolve_benefit_type(value: Any, *, required: bool) -> int | None:
+def _resolve_benefit_type(value: object, *, required: bool) -> int | None:
     normalized = str(value or "").strip().lower()
     if not normalized:
         if required:
@@ -728,7 +728,7 @@ def _resolve_benefit_type(value: Any, *, required: bool) -> int | None:
     return None
 
 
-def _resolve_discount_type(value: Any, *, required: bool) -> int | None:
+def _resolve_discount_type(value: object, *, required: bool) -> int | None:
     normalized = str(value or "").strip().lower()
     if not normalized:
         if required:

--- a/src/api/flaskr/service/billing/charges.py
+++ b/src/api/flaskr/service/billing/charges.py
@@ -72,7 +72,7 @@ class UsageMetricCharge:
     rounded_units: Decimal
     consumed_credits: Decimal
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return an attribute value by key."""
         return getattr(self, key)
 

--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -204,7 +204,7 @@ class ProviderReferenceReconcileResult:
             "payment_provider": self.payment_provider,
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
@@ -1751,11 +1751,11 @@ def _persist_billing_stripe_raw_snapshot(
     order: BillingOrder,
     *,
     create_if_missing: bool,
-    metadata: Any | None = None,
+    metadata: object | None = None,
     checkout_session_id: str = "",
-    checkout_object: Any | None = None,
+    checkout_object: object | None = None,
     payment_intent_id: str = "",
-    payment_object: Any | None = None,
+    payment_object: object | None = None,
     latest_charge_id: str = "",
     receipt_url: str = "",
     payment_method: str = "",
@@ -1795,14 +1795,14 @@ def _persist_billing_pingxx_raw_snapshot(
     *,
     create_if_missing: bool,
     charge_id: str = "",
-    charge_object: Any | None = None,
+    charge_object: object | None = None,
     transaction_no: str = "",
     app_id: str = "",
     channel: str = "",
     subject: str = "",
     body: str = "",
     client_ip: str = "",
-    extra: Any | None = None,
+    extra: object | None = None,
 ) -> None:
     raw_status = _RAW_SNAPSHOT_STATUS_BY_BILLING_STATUS.get(
         int(order.status or BILLING_ORDER_STATUS_INIT), 0
@@ -1843,10 +1843,10 @@ def _persist_billing_native_raw_snapshot(
     transaction_id: str = "",
     raw_status: str = "",
     raw_snapshot_status: int | None = None,
-    raw_request: Any | None = None,
-    raw_response: Any | None = None,
-    raw_notification: Any | None = None,
-    metadata: Any | None = None,
+    raw_request: object | None = None,
+    raw_response: object | None = None,
+    raw_notification: object | None = None,
+    metadata: object | None = None,
 ) -> None:
     resolved_raw_snapshot_status = (
         int(raw_snapshot_status)
@@ -1956,7 +1956,7 @@ def _interpolate_checkout_product_name(
     )
 
 
-def _format_checkout_credit_amount(amount: Any) -> str:
+def _format_checkout_credit_amount(amount: object) -> str:
     credit_amount = _to_decimal(amount)
     if credit_amount == credit_amount.to_integral_value():
         return str(int(credit_amount))

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -2403,7 +2403,7 @@ def _enforce_manual_subscription_expire_event(
     db.session.add(expire_event)
 
 
-def _serialize_cli_payload(payload: Any) -> Any:
+def _serialize_cli_payload(payload: object) -> object:
     if hasattr(payload, "to_task_payload"):
         return payload.to_task_payload()
     if hasattr(payload, "to_payload"):
@@ -2415,7 +2415,7 @@ def _serialize_cli_payload(payload: Any) -> Any:
     return payload
 
 
-def _echo_payload(payload: Any) -> None:
+def _echo_payload(payload: object) -> None:
     click.echo(
         json.dumps(
             _serialize_cli_payload(payload),
@@ -2426,7 +2426,7 @@ def _echo_payload(payload: Any) -> None:
     )
 
 
-def _serialize_json_value(value: Any) -> Any:
+def _serialize_json_value(value: object) -> object:
     if isinstance(value, datetime):
         return value.isoformat()
     if isinstance(value, Decimal):

--- a/src/api/flaskr/service/billing/consts.py
+++ b/src/api/flaskr/service/billing/consts.py
@@ -6,7 +6,6 @@ import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any
 
 from flaskr.service.metering.consts import (
     BILL_USAGE_SCENE_DEBUG,
@@ -438,7 +437,7 @@ class CreditUsageRateSeed:
     effective_to: datetime | None
     status: int
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return an attribute value by key."""
         return getattr(self, key)
 

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -190,7 +190,7 @@ def _deep_merge(defaults: dict[str, Any], override: dict[str, Any]) -> dict[str,
     return merged
 
 
-def _coerce_bool(value: Any) -> bool:
+def _coerce_bool(value: object) -> bool:
     if isinstance(value, bool):
         return value
     if isinstance(value, (int, float)):
@@ -200,7 +200,7 @@ def _coerce_bool(value: Any) -> bool:
     return bool(value)
 
 
-def _coerce_positive_int(value: Any, default: int = 0) -> int:
+def _coerce_positive_int(value: object, default: int = 0) -> int:
     try:
         parsed = int(value)
     except (TypeError, ValueError):
@@ -208,7 +208,7 @@ def _coerce_positive_int(value: Any, default: int = 0) -> int:
     return max(0, parsed)
 
 
-def _normalize_positive_int(value: Any, field_name: str) -> int:
+def _normalize_positive_int(value: object, field_name: str) -> int:
     try:
         parsed = int(value)
     except (TypeError, ValueError):
@@ -218,7 +218,7 @@ def _normalize_positive_int(value: Any, field_name: str) -> int:
     return parsed
 
 
-def _decimal_from_policy(value: Any, default: Decimal = _ZERO) -> Decimal:
+def _decimal_from_policy(value: object, default: Decimal = _ZERO) -> Decimal:
     try:
         parsed = _quantize_credit_amount(Decimal(str(value or "0").strip()))
     except (InvalidOperation, TypeError, ValueError, ArithmeticError):
@@ -226,7 +226,7 @@ def _decimal_from_policy(value: Any, default: Decimal = _ZERO) -> Decimal:
     return parsed if parsed.is_finite() else default
 
 
-def _normalize_policy_decimal(value: Any, field_name: str) -> Decimal:
+def _normalize_policy_decimal(value: object, field_name: str) -> Decimal:
     try:
         parsed = _quantize_credit_amount(Decimal(str(value or "0").strip()))
     except (InvalidOperation, TypeError, ValueError, ArithmeticError):
@@ -236,20 +236,20 @@ def _normalize_policy_decimal(value: Any, field_name: str) -> Decimal:
     return parsed
 
 
-def _require_mapping(value: Any, field_name: str) -> dict[str, Any]:
+def _require_mapping(value: object, field_name: str) -> dict[str, Any]:
     if isinstance(value, dict):
         return value
     raise_param_error(field_name)
     return None
 
 
-def _normalize_string_list(value: Any, field_name: str) -> list[str]:
+def _normalize_string_list(value: object, field_name: str) -> list[str]:
     if not isinstance(value, list):
         raise_param_error(field_name)
     return [str(item or "").strip() for item in value if str(item or "").strip()]
 
 
-def _validate_hhmm(value: Any, field_name: str) -> str:
+def _validate_hhmm(value: object, field_name: str) -> str:
     normalized = str(value or "").strip()
     parts = normalized.split(":")
     if len(parts) != 2:
@@ -264,7 +264,7 @@ def _validate_hhmm(value: Any, field_name: str) -> str:
     return f"{hour:02d}:{minute:02d}"
 
 
-def _normalize_fixed_thresholds(value: Any, field_name: str) -> list[dict[str, str]]:
+def _normalize_fixed_thresholds(value: object, field_name: str) -> list[dict[str, str]]:
     if not isinstance(value, list):
         raise_param_error(field_name)
     thresholds: list[dict[str, str]] = []
@@ -282,7 +282,7 @@ def _normalize_fixed_thresholds(value: Any, field_name: str) -> list[dict[str, s
 
 
 def _normalize_low_balance_thresholds(
-    value: Any, field_name: str
+    value: object, field_name: str
 ) -> list[dict[str, Any]]:
     if not isinstance(value, list):
         raise_param_error(field_name)
@@ -343,7 +343,9 @@ def _normalize_low_balance_thresholds(
     return thresholds
 
 
-def _normalize_policy_list_group(value: Any, field_name: str) -> dict[str, list[str]]:
+def _normalize_policy_list_group(
+    value: object, field_name: str
+) -> dict[str, list[str]]:
     current = _require_mapping(value, field_name)
     return {
         "creator_bids": _normalize_string_list(
@@ -654,12 +656,12 @@ def _supported_template_placeholders(notification_type: str) -> set[str]:
     return set(placeholders)
 
 
-def _extract_template_placeholders(template_content: Any) -> list[str]:
+def _extract_template_placeholders(template_content: object) -> list[str]:
     content = str(template_content or "")
     return sorted(set(_TEMPLATE_PLACEHOLDER_PATTERN.findall(content)))
 
 
-def _json_safe(value: Any) -> Any:
+def _json_safe(value: object) -> object:
     try:
         json.dumps(value, ensure_ascii=False)
     except (TypeError, ValueError):
@@ -674,12 +676,12 @@ def _aliyun_sms_credentials_configured(app: Flask) -> bool:
     )
 
 
-def _template_body_value(body: Any, field_name: str) -> str:
+def _template_body_value(body: object, field_name: str) -> str:
     return str(getattr(body, field_name, "") or "").strip()
 
 
 def _provider_template_response_payload(
-    response: Any,
+    response: object,
     *,
     requested_template_code: str,
 ) -> dict[str, Any]:
@@ -696,7 +698,7 @@ def _provider_template_response_payload(
     }
 
 
-def _template_list_body_value(item: Any, field_name: str) -> str:
+def _template_list_body_value(item: object, field_name: str) -> str:
     return str(getattr(item, field_name, "") or "").strip()
 
 
@@ -1231,7 +1233,7 @@ def build_low_balance_estimated_days_dedupe_key(
     )
 
 
-def _provider_response_payload(response: Any) -> dict[str, Any]:
+def _provider_response_payload(response: object) -> dict[str, Any]:
     body = getattr(response, "body", None)
     if body is None:
         return {}
@@ -1243,7 +1245,7 @@ def _provider_response_payload(response: Any) -> dict[str, Any]:
     }
 
 
-def _format_sms_datetime(app: Flask, value: Any) -> str:
+def _format_sms_datetime(app: Flask, value: object) -> str:
     if value is None:
         return ""
     if isinstance(value, datetime):
@@ -1272,7 +1274,7 @@ def _normalize_sms_template_params(
     return normalized
 
 
-def _amount_text(value: Any) -> str:
+def _amount_text(value: object) -> str:
     try:
         return str(_quantize_credit_amount(value))
     except Exception:
@@ -1719,7 +1721,7 @@ def stage_credit_granted_notification_for_order(
     )
 
 
-def _parse_window_days(window: Any) -> int | None:
+def _parse_window_days(window: object) -> int | None:
     normalized = str(window or "").strip().lower()
     if not normalized.endswith("d"):
         return None
@@ -2587,7 +2589,7 @@ def _is_quiet_hours(policy: dict[str, Any], now: datetime | None = None) -> bool
     return current_value >= start_value or current_value < end_value
 
 
-def _resolve_policy_creator_bids(items: Any) -> set[str]:
+def _resolve_policy_creator_bids(items: object) -> set[str]:
     creator_bids: set[str] = set()
     if not isinstance(items, list):
         return creator_bids
@@ -3089,7 +3091,7 @@ def requeue_credit_notification(
     return enqueue_result
 
 
-def _parse_positive_int(value: Any, default: int) -> int:
+def _parse_positive_int(value: object, default: int) -> int:
     try:
         parsed = int(value)
     except (TypeError, ValueError):

--- a/src/api/flaskr/service/billing/customization.py
+++ b/src/api/flaskr/service/billing/customization.py
@@ -944,7 +944,7 @@ def _probe_stripe_credentials(
         raise ValueError(message) from exc
 
 
-def _parse_pem_private_key(value: Any) -> None:
+def _parse_pem_private_key(value: object) -> None:
     pem = _normalize_pem(value, "PRIVATE KEY")
     try:
         serialization.load_pem_private_key(pem, password=None)
@@ -953,7 +953,7 @@ def _parse_pem_private_key(value: Any) -> None:
         raise ValueError(message) from exc
 
 
-def _parse_pem_public_key(value: Any) -> None:
+def _parse_pem_public_key(value: object) -> None:
     pem = _normalize_pem(value, "PUBLIC KEY")
     try:
         serialization.load_pem_public_key(pem)
@@ -962,7 +962,7 @@ def _parse_pem_public_key(value: Any) -> None:
         raise ValueError(message) from exc
 
 
-def _parse_x509_certificate(value: Any) -> None:
+def _parse_x509_certificate(value: object) -> None:
     pem = _normalize_pem(value, "CERTIFICATE")
     try:
         x509.load_pem_x509_certificate(pem)
@@ -971,7 +971,7 @@ def _parse_x509_certificate(value: Any) -> None:
         raise ValueError(message) from exc
 
 
-def _normalize_pem(value: Any, label: str) -> bytes:
+def _normalize_pem(value: object, label: str) -> bytes:
     text = str(value or "").strip()
     if not text:
         message = f"{label.title()} is required"
@@ -1029,14 +1029,14 @@ def _verify_callback_token(app: Flask, token: str) -> str:
     return integration_bid
 
 
-def _normalize_provider(value: Any) -> str:
+def _normalize_provider(value: object) -> str:
     provider = normalize_bid(value).lower()
     if provider not in INTEGRATION_PROVIDERS:
         raise_param_error("provider")
     return provider
 
 
-def _normalize_config(provider: str, value: Any, secret: bool) -> dict[str, Any]:
+def _normalize_config(provider: str, value: object, secret: bool) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise_param_error("secret_config" if secret else "public_config")
     public_fields, secret_fields = _PROVIDER_FIELDS[provider]
@@ -1077,7 +1077,7 @@ def _require_capability(
         raise_error("server.shifu.noPermission")
 
 
-def _normalize_logo_url(value: Any, field: str) -> str:
+def _normalize_logo_url(value: object, field: str) -> str:
     raw = str(value or "").strip()
     if not raw:
         return ""
@@ -1104,7 +1104,7 @@ def _normalize_logo_url(value: Any, field: str) -> str:
     return raw
 
 
-def _normalize_home_url(value: Any) -> str:
+def _normalize_home_url(value: object) -> str:
     raw = str(value or "").strip()
     if not raw:
         return ""
@@ -1116,7 +1116,7 @@ def _normalize_home_url(value: Any) -> str:
     return raw
 
 
-def _normalize_home_url_lenient(value: Any) -> str:
+def _normalize_home_url_lenient(value: object) -> str:
     """Draft-side variant: drop invalid values instead of raising, so the admin draft autosave never fails on a partially typed URL."""
     try:
         return _normalize_home_url(value)
@@ -1217,7 +1217,7 @@ def _read_validated_brand_image(
     )
 
 
-def _normalize_logo_target(value: Any) -> str:
+def _normalize_logo_target(value: object) -> str:
     normalized = str(value or "wide").strip().lower()
     if normalized not in _LOGO_VARIANTS:
         raise_param_error("target")
@@ -1343,7 +1343,7 @@ def _saas_model() -> type[object]:
     ).SaasUserConfig
 
 
-def _load_json(value: Any) -> dict[str, Any]:
+def _load_json(value: object) -> dict[str, Any]:
     try:
         payload = json.loads(str(value or "{}"))
     except (TypeError, ValueError, json.JSONDecodeError):
@@ -1355,7 +1355,7 @@ def _dump_json(value: dict[str, Any]) -> str:
     return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
 
 
-def _to_bool(value: Any) -> bool:
+def _to_bool(value: object) -> bool:
     if isinstance(value, bool):
         return value
     return str(value or "").strip().lower() in {"1", "true", "yes", "on"}

--- a/src/api/flaskr/service/billing/cycle_transitions.py
+++ b/src/api/flaskr/service/billing/cycle_transitions.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 def resolve_order_effective_from(
     *,
-    order: Any,
+    order: object,
     default_effective_from: datetime,
     load_subscription_by_bid: Callable[[str], Any | None],
 ) -> datetime:
@@ -47,8 +47,8 @@ def resolve_order_effective_from(
 
 def resolve_order_effective_to(
     *,
-    order: Any,
-    product: Any,
+    order: object,
+    product: object,
     effective_from: datetime,
     load_subscription_by_bid: Callable[[str], Any | None],
     resolve_topup_effective_to: Callable[[str, datetime], datetime | None],

--- a/src/api/flaskr/service/billing/daily_aggregates.py
+++ b/src/api/flaskr/service/billing/daily_aggregates.py
@@ -71,7 +71,7 @@ class DailyAggregateJobResult:
             payload["reason"] = self.reason
         return payload
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
@@ -119,7 +119,7 @@ class RebuildDailyAggregatesResult:
             },
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
@@ -647,5 +647,5 @@ def _resolve_stat_date_range(
     return start_date, end_date
 
 
-def _quantize_decimal(value: Any) -> Decimal:
+def _quantize_decimal(value: object) -> Decimal:
     return _quantize_credit_amount(value)

--- a/src/api/flaskr/service/billing/domains.py
+++ b/src/api/flaskr/service/billing/domains.py
@@ -69,7 +69,7 @@ class DomainVerificationResult:
             "binding": self.binding.__json__(),
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
@@ -168,8 +168,8 @@ def verify_domain_binding(
     *,
     creator_bid: str = "",
     domain_binding_bid: str = "",
-    host: Any = "",
-    verification_token: Any = "",
+    host: object = "",
+    verification_token: object = "",
 ) -> DomainVerificationResult:
     """Verify one domain binding by business id or host for background tasks."""
     normalized_creator_bid = _normalize_bid(creator_bid)
@@ -206,7 +206,7 @@ def verify_domain_binding(
         )
 
 
-def resolve_creator_bid_by_host(app: Flask, host: Any) -> str | None:
+def resolve_creator_bid_by_host(app: Flask, host: object) -> str | None:
     """Resolve a verified creator custom domain back to creator_bid."""
     normalized_host = normalize_domain_host(host, strict=False)
     if not normalized_host:
@@ -233,7 +233,7 @@ def resolve_creator_bid_by_host(app: Flask, host: Any) -> str | None:
         return _normalize_bid(binding.creator_bid) or None
 
 
-def resolve_effective_custom_origin(app: Flask, creator_bid: Any) -> str | None:
+def resolve_effective_custom_origin(app: Flask, creator_bid: object) -> str | None:
     """Return the creator's effective custom-domain origin for building links.
 
     A binding is effective only when it is verified and the creator still has
@@ -269,7 +269,7 @@ def resolve_effective_custom_origin(app: Flask, creator_bid: Any) -> str | None:
 
 def resolve_runtime_domain_result(
     app: Flask,
-    host: Any,
+    host: object,
     *,
     creator_bid: str = "",
 ) -> RuntimeBillingDomainDTO:
@@ -333,7 +333,7 @@ def resolve_runtime_domain_result(
         )
 
 
-def normalize_domain_host(value: Any, *, strict: bool = True) -> str:
+def normalize_domain_host(value: object, *, strict: bool = True) -> str:
     """Normalize a host string into a lowercase custom-domain host."""
     raw = str(value or "").strip()
     if not raw:
@@ -372,7 +372,7 @@ def _bind_creator_domain(
     creator_bid: str,
     host: str,
     domain_binding_bid: str,
-    verification_method: Any,
+    verification_method: object,
 ) -> BillingDomainBinding:
     if not host:
         raise_param_error("host")
@@ -442,7 +442,7 @@ def _verify_creator_domain(
     creator_bid: str,
     host: str,
     domain_binding_bid: str,
-    verification_token: Any,
+    verification_token: object,
 ) -> BillingDomainBinding:
     binding = _load_creator_domain_binding(
         creator_bid=creator_bid,
@@ -630,14 +630,14 @@ def _serialize_domain_binding(
     )
 
 
-def _normalize_action(value: Any) -> str:
+def _normalize_action(value: object) -> str:
     normalized = _normalize_bid(value) or "bind"
     if normalized not in _DOMAIN_BINDING_ACTIONS:
         raise_param_error("action")
     return normalized
 
 
-def _normalize_verification_method(value: Any) -> int:
+def _normalize_verification_method(value: object) -> int:
     normalized = _normalize_bid(value)
     if not normalized:
         return BILLING_DOMAIN_VERIFICATION_METHOD_DNS_TXT
@@ -673,7 +673,7 @@ def _is_invalid_host(host: str) -> bool:
     return any(_DOMAIN_LABEL_RE.fullmatch(label) is None for label in labels)
 
 
-def _as_dict(value: Any) -> JsonObjectMap:
+def _as_dict(value: object) -> JsonObjectMap:
     if isinstance(value, dict):
         return JsonObjectMap(values={str(key): item for key, item in value.items()})
     return JsonObjectMap()

--- a/src/api/flaskr/service/billing/dtos.py
+++ b/src/api/flaskr/service/billing/dtos.py
@@ -20,7 +20,7 @@ class BillingBaseDTO(BaseModel):
         """Return aliased model fields as JSON-compatible data."""
         return self.model_dump(mode="python", by_alias=True)
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a serialized DTO field by key."""
         return self.__json__()[key]
 

--- a/src/api/flaskr/service/billing/entitlements.py
+++ b/src/api/flaskr/service/billing/entitlements.py
@@ -63,7 +63,7 @@ class CreatorEntitlementState:
             "support_tier": self.support_tier,
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a serialized entitlement field by key."""
         if key == "feature_payload":
             return self.feature_payload.to_metadata_json()
@@ -392,7 +392,7 @@ def _apply_entitlement_payload(
 
 
 def _resolve_labeled_value(
-    value: Any,
+    value: object,
     *,
     labels: dict[int, str],
     default: str,
@@ -412,7 +412,7 @@ def _resolve_labeled_value(
         return default
 
 
-def _normalize_feature_payload(value: Any) -> JsonObjectMap:
+def _normalize_feature_payload(value: object) -> JsonObjectMap:
     if not isinstance(value, dict):
         return JsonObjectMap()
     return JsonObjectMap(values={str(key): item for key, item in value.items()})
@@ -425,7 +425,7 @@ def _coalesce_datetime(
     return value or fallback
 
 
-def _to_bool(value: Any, *, default: bool = False) -> bool:
+def _to_bool(value: object, *, default: bool = False) -> bool:
     if value is None:
         return default
     if isinstance(value, bool):

--- a/src/api/flaskr/service/billing/grant_results.py
+++ b/src/api/flaskr/service/billing/grant_results.py
@@ -41,7 +41,7 @@ class ManualCreditGrantResult:
             "metadata_json": self.metadata_json,
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a serialized payload field by key."""
         return self.to_payload()[key]
 

--- a/src/api/flaskr/service/billing/manual_credit_grants.py
+++ b/src/api/flaskr/service/billing/manual_credit_grants.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from decimal import Decimal, InvalidOperation
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.util.datetime import now_utc
@@ -52,7 +52,7 @@ MANUAL_CREDIT_VALIDITY_PRESETS = (
 )
 
 
-def _normalize_credit_amount(value: Any) -> Decimal:
+def _normalize_credit_amount(value: object) -> Decimal:
     normalized = str(value or "").strip()
     if not normalized:
         raise_param_error("amount")

--- a/src/api/flaskr/service/billing/notifications.py
+++ b/src/api/flaskr/service/billing/notifications.py
@@ -489,7 +489,7 @@ def _load_notification_product(order: BillingOrder) -> BillingProduct | None:
     )
 
 
-def _format_minor_currency_amount(currency: str | None, amount: Any) -> str:
+def _format_minor_currency_amount(currency: str | None, amount: object) -> str:
     try:
         major_amount = Decimal(str(amount or 0)) / Decimal(100)
     except (InvalidOperation, TypeError, ValueError):
@@ -497,7 +497,7 @@ def _format_minor_currency_amount(currency: str | None, amount: Any) -> str:
     return f"{_normalize_bid(currency) or 'CNY'} {major_amount:.2f}"
 
 
-def _format_credit_amount(amount: Any) -> str:
+def _format_credit_amount(amount: object) -> str:
     try:
         credit_amount = Decimal(str(amount or 0))
     except (InvalidOperation, TypeError, ValueError):
@@ -556,7 +556,7 @@ def _build_billing_paid_feishu_message(
     app: Flask,
     order: BillingOrder,
     *,
-    aggregate: Any,
+    aggregate: object,
     product: BillingProduct | None,
     product_name: str,
 ) -> tuple[str, list[str]]:

--- a/src/api/flaskr/service/billing/operation_credits.py
+++ b/src/api/flaskr/service/billing/operation_credits.py
@@ -618,5 +618,5 @@ def _iter_hold_buckets(
     return []
 
 
-def _credit_to_string(value: Any) -> str:
+def _credit_to_string(value: object) -> str:
     return str(billing_primitives.quantize_credit_amount(value))

--- a/src/api/flaskr/service/billing/ownership.py
+++ b/src/api/flaskr/service/billing/ownership.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from flaskr.service.metering.consts import BILL_USAGE_SCENE_DEBUG, normalize_usage_scene
 from flaskr.service.shifu.utils import get_shifu_creator_bid
@@ -19,7 +19,7 @@ def resolve_shifu_creator_bid(app: Flask, shifu_bid: str) -> str | None:
     return get_shifu_creator_bid(app, normalized_shifu_bid)
 
 
-def resolve_usage_creator_bid(app: Flask, usage: Any) -> str | None:
+def resolve_usage_creator_bid(app: Flask, usage: object) -> str | None:
     """Resolve the owning creator from a metering usage record or payload."""
     shifu_bid = _extract_usage_field(usage, "shifu_bid")
     if shifu_bid:
@@ -36,7 +36,7 @@ def resolve_usage_creator_bid(app: Flask, usage: Any) -> str | None:
     return None
 
 
-def _extract_usage_field(usage: Any, field_name: str) -> str:
+def _extract_usage_field(usage: object, field_name: str) -> str:
     if isinstance(usage, dict):
         value = usage.get(field_name, "")
     else:

--- a/src/api/flaskr/service/billing/preorders.py
+++ b/src/api/flaskr/service/billing/preorders.py
@@ -35,7 +35,7 @@ _ACTIVE_PREORDER_STATES = {PREORDER_STATE_PENDING_EFFECTIVE}
 _ACTIVE_PREORDER_ORDER_STATUSES = {BILLING_ORDER_STATUS_PAID}
 
 
-def normalize_checkout_action(value: Any) -> str:
+def normalize_checkout_action(value: object) -> str:
     """Normalize checkout action."""
     return str(value or CHECKOUT_ACTION_UPGRADE_IMMEDIATE).strip().lower()
 

--- a/src/api/flaskr/service/billing/primitives.py
+++ b/src/api/flaskr/service/billing/primitives.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
-from typing import Any
 
 from flask import has_app_context
 from flaskr.common.config import get_config as get_common_config
@@ -29,12 +28,12 @@ MAX_BILL_CREDIT_PRECISION = 10
 DEFAULT_BILL_ENABLED = False
 
 
-def normalize_bid(value: Any) -> str:
+def normalize_bid(value: object) -> str:
     """Normalize BID."""
     return str(value or "").strip()
 
 
-def to_decimal(value: Any) -> Decimal:
+def to_decimal(value: object) -> Decimal:
     """Convert a value to the billing Decimal representation."""
     if isinstance(value, Decimal):
         return value
@@ -43,7 +42,7 @@ def to_decimal(value: Any) -> Decimal:
     return Decimal(str(value))
 
 
-def safe_int(value: Any) -> int | None:
+def safe_int(value: object) -> int | None:
     """Convert a value to an integer, returning None when invalid."""
     try:
         return int(value)
@@ -52,7 +51,7 @@ def safe_int(value: Any) -> int | None:
 
 
 def clamp_billing_credit_precision(
-    value: Any,
+    value: object,
     *,
     default: int = DEFAULT_BILL_CREDIT_PRECISION,
 ) -> int:
@@ -94,7 +93,7 @@ def build_credit_quantizer(*, precision: int | None = None) -> Decimal:
 
 
 def quantize_credit_amount(
-    value: Any,
+    value: object,
     *,
     precision: int | None = None,
 ) -> Decimal:
@@ -106,7 +105,7 @@ def quantize_credit_amount(
 
 
 def credit_decimal_to_number(
-    value: Any,
+    value: object,
     *,
     precision: int | None = None,
 ) -> int | float:
@@ -117,7 +116,7 @@ def credit_decimal_to_number(
     return float(normalized)
 
 
-def decimal_to_number(value: Any) -> int | float:
+def decimal_to_number(value: object) -> int | float:
     """Convert a numeric value to an API-safe integer or float."""
     if value is None:
         return 0
@@ -136,7 +135,7 @@ def decimal_to_number(value: Any) -> int | float:
     return float(normalized)
 
 
-def coerce_bool(value: Any, *, default: bool = False) -> bool:
+def coerce_bool(value: object, *, default: bool = False) -> bool:
     """Coerce bool."""
     if value in (None, ""):
         return default
@@ -148,7 +147,7 @@ def coerce_bool(value: Any, *, default: bool = False) -> bool:
     return normalized in {"1", "true", "yes", "on"}
 
 
-def safe_to_positive_int(value: Any, *, default: int) -> int:
+def safe_to_positive_int(value: object, *, default: int) -> int:
     """Return a positive integer or the supplied default."""
     candidate = safe_int(value)
     if candidate is None or candidate <= 0:
@@ -156,7 +155,7 @@ def safe_to_positive_int(value: Any, *, default: int) -> int:
     return candidate
 
 
-def coerce_datetime(value: Any) -> datetime | None:
+def coerce_datetime(value: object) -> datetime | None:
     """Coerce datetime."""
     if value in (None, ""):
         return None
@@ -190,7 +189,7 @@ def normalize_mysql_datetime(value: datetime) -> datetime:
     return value.replace(microsecond=0)
 
 
-def normalize_json_value(value: Any) -> Any:
+def normalize_json_value(value: object) -> object:
     """Normalize JSON value."""
     if isinstance(value, Decimal):
         return decimal_to_number(value)
@@ -223,7 +222,7 @@ def normalize_json_value(value: Any) -> Any:
     return value
 
 
-def normalize_json_object(value: Any) -> JsonObjectMap:
+def normalize_json_object(value: object) -> JsonObjectMap:
     """Normalize JSON object."""
     normalized = normalize_json_value(value)
     if isinstance(normalized, JsonObjectMap):

--- a/src/api/flaskr/service/billing/provider_catalog.py
+++ b/src/api/flaskr/service/billing/provider_catalog.py
@@ -479,7 +479,7 @@ def _expected_plan_tier_metadata(product: BillingProduct) -> str:
     return ""
 
 
-def _product_type_label(value: Any) -> str:
+def _product_type_label(value: object) -> str:
     return BILLING_PRODUCT_TYPE_LABELS.get(int(value or 0), "")
 
 
@@ -489,11 +489,11 @@ def _expected_price_billing_interval_metadata(product: BillingProduct) -> str:
     return _billing_interval_label(product.billing_interval)
 
 
-def _billing_interval_label(value: Any) -> str:
+def _billing_interval_label(value: object) -> str:
     return BILLING_INTERVAL_LABELS.get(int(value or BILLING_INTERVAL_NONE), "")
 
 
-def _format_metadata_decimal(value: Any) -> str:
+def _format_metadata_decimal(value: object) -> str:
     try:
         normalized = to_decimal(value)
     except (InvalidOperation, ValueError):
@@ -503,7 +503,7 @@ def _format_metadata_decimal(value: Any) -> str:
     return format(normalized.normalize(), "f").rstrip("0").rstrip(".")
 
 
-def _normalize_metadata_compare_value(value: Any) -> str:
+def _normalize_metadata_compare_value(value: object) -> str:
     if isinstance(value, Decimal):
         return _format_metadata_decimal(value)
     text = str(value or "").strip()
@@ -576,7 +576,7 @@ def _normalize_stripe_price(payload: dict[str, Any]) -> ProviderPriceSnapshot:
     )
 
 
-def _normalize_stripe_reference_id(value: Any) -> str:
+def _normalize_stripe_reference_id(value: object) -> str:
     if isinstance(value, dict):
         return str(value.get("id") or "").strip()
     if hasattr(value, "to_dict"):
@@ -584,12 +584,12 @@ def _normalize_stripe_reference_id(value: Any) -> str:
     return str(value or "").strip()
 
 
-def _normalize_metadata(value: Any) -> dict[str, Any]:
+def _normalize_metadata(value: object) -> dict[str, Any]:
     payload = _to_plain_dict(value or {})
     return payload if isinstance(payload, dict) else {}
 
 
-def _to_plain_dict(value: Any) -> dict[str, Any]:
+def _to_plain_dict(value: object) -> dict[str, Any]:
     if hasattr(value, "to_dict"):
         value = value.to_dict()
     elif hasattr(value, "to_dict_recursive"):
@@ -599,7 +599,7 @@ def _to_plain_dict(value: Any) -> dict[str, Any]:
     return {}
 
 
-def _coerce_optional_bool(value: Any) -> bool | None:
+def _coerce_optional_bool(value: object) -> bool | None:
     if value is None:
         return None
     return bool(value)

--- a/src/api/flaskr/service/billing/provider_state.py
+++ b/src/api/flaskr/service/billing/provider_state.py
@@ -509,7 +509,7 @@ def _record_subscription_provider_event(
 
 def _merge_provider_metadata(
     *,
-    existing: Any,
+    existing: object,
     provider: str,
     source: str,
     event_type: str,
@@ -531,7 +531,7 @@ def _merge_provider_metadata(
     return _normalize_json_object(metadata)
 
 
-def _extract_provider_event_time(payload: Any) -> datetime | None:
+def _extract_provider_event_time(payload: object) -> datetime | None:
     if not isinstance(payload, dict):
         return None
     for key in ("created", "time_paid", "current_period_end", "current_period_start"):

--- a/src/api/flaskr/service/billing/queries.py
+++ b/src/api/flaskr/service/billing/queries.py
@@ -73,7 +73,7 @@ _DOMAIN_BINDING_STATUS_CODES_BY_LABEL = {
 }
 
 
-def normalize_stat_date_filter(value: Any, *, parameter_name: str) -> str:
+def normalize_stat_date_filter(value: object, *, parameter_name: str) -> str:
     """Normalize stat date filter."""
     normalized_value = normalize_bid(value)
     if not normalized_value:
@@ -85,7 +85,7 @@ def normalize_stat_date_filter(value: Any, *, parameter_name: str) -> str:
     return normalized_value
 
 
-def normalize_payment_provider_hint(value: Any) -> str:
+def normalize_payment_provider_hint(value: object) -> str:
     """Normalize payment provider hint."""
     provider = str(value or "").strip().lower()
     if not provider:
@@ -148,7 +148,7 @@ def load_latest_subscription_renewal_order(
     ).first()
 
 
-def extract_order_metadata_datetime(metadata: Any, key: str) -> datetime | None:
+def extract_order_metadata_datetime(metadata: object, key: str) -> datetime | None:
     """Extract order metadata datetime."""
     if not isinstance(metadata, dict):
         return None
@@ -162,7 +162,7 @@ def serialize_order_metadata_datetime(value: datetime | None) -> str | None:
     return value.isoformat()
 
 
-def extract_resolved_order_cycle_start_at(metadata: Any) -> datetime | None:
+def extract_resolved_order_cycle_start_at(metadata: object) -> datetime | None:
     """Extract resolved order cycle start at."""
     return extract_order_metadata_datetime(
         metadata,
@@ -170,7 +170,7 @@ def extract_resolved_order_cycle_start_at(metadata: Any) -> datetime | None:
     ) or extract_order_metadata_datetime(metadata, "renewal_cycle_start_at")
 
 
-def extract_resolved_order_cycle_end_at(metadata: Any) -> datetime | None:
+def extract_resolved_order_cycle_end_at(metadata: object) -> datetime | None:
     """Extract resolved order cycle end at."""
     return extract_order_metadata_datetime(
         metadata,

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -1184,7 +1184,7 @@ def _is_independent_entitlement_row(row) -> bool:
     )
 
 
-def _payload_bool(value: Any) -> bool:
+def _payload_bool(value: object) -> bool:
     if isinstance(value, bool):
         return value
     normalized = str(value or "").strip().lower()
@@ -1215,8 +1215,8 @@ def build_operator_credit_orders_page(
     status: str = "",
     has_available_credits: bool = False,
     payment_provider: str = "",
-    start_time: Any = "",
-    end_time: Any = "",
+    start_time: object = "",
+    end_time: object = "",
 ) -> OperatorCreditOrdersPageDTO:
     """Return paginated operator-facing creator credit orders."""
     safe_page_index, safe_page_size = normalize_pagination(page_index, page_size)

--- a/src/api/flaskr/service/billing/referral_plan_rewards.py
+++ b/src/api/flaskr/service/billing/referral_plan_rewards.py
@@ -204,7 +204,7 @@ def _calculate_self_managed_billing_cycle_end_after_boundary(
     )
 
 
-def _extract_order_metadata_datetime(metadata: Any, key: str) -> datetime | None:
+def _extract_order_metadata_datetime(metadata: object, key: str) -> datetime | None:
     from .queries import extract_order_metadata_datetime
 
     return extract_order_metadata_datetime(metadata, key)

--- a/src/api/flaskr/service/billing/referral_reward_grants.py
+++ b/src/api/flaskr/service/billing/referral_reward_grants.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from decimal import Decimal, InvalidOperation
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from flaskr.dao import db
 from flaskr.service.common.models import raise_param_error
@@ -59,7 +59,7 @@ REFERRAL_REWARD_GRANT_SOURCE = "reward"
 REFERRAL_REWARD_VALIDITY_PRESET = "1m"
 
 
-def _normalize_referral_reward_amount(value: Any) -> Decimal:
+def _normalize_referral_reward_amount(value: object) -> Decimal:
     normalized = str(value or "").strip()
     if not normalized or not normalized.isdigit():
         raise_param_error("amount")
@@ -76,7 +76,7 @@ def _serialize_metadata_datetime(value: datetime | None) -> str:
     return value.isoformat() if value is not None else ""
 
 
-def _is_referral_reward_metadata(metadata: Any) -> bool:
+def _is_referral_reward_metadata(metadata: object) -> bool:
     if not isinstance(metadata, dict):
         return False
     return str(metadata.get("grant_type") or "").strip() == REFERRAL_REWARD_GRANT_TYPE

--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -270,7 +270,7 @@ class RenewalEventSnapshot:
             "payload": self.payload,
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
@@ -315,7 +315,7 @@ class RenewalEventResult:
             payload["order_status"] = self.order_status
         return payload
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 

--- a/src/api/flaskr/service/billing/serializers.py
+++ b/src/api/flaskr/service/billing/serializers.py
@@ -189,8 +189,8 @@ def serialize_admin_campaign(
     has_custom_product_rules: bool = False,
     discount_type_code: int | None = None,
     discount_amount: int | None = None,
-    discount_percent: Any | None = None,
-    bonus_credit_amount: Any | None = None,
+    discount_percent: object | None = None,
+    bonus_credit_amount: object | None = None,
 ) -> AdminBillingCampaignDTO:
     """Serialize admin campaign."""
     _ = app
@@ -554,7 +554,7 @@ def serialize_ledger_entry(
     app: Flask,
     row: CreditLedgerEntry,
     *,
-    metadata: Any | None = None,
+    metadata: object | None = None,
     credit_asset_kind: str = "unknown",
 ) -> BillingLedgerItemDTO:
     """Serialize ledger entry."""

--- a/src/api/flaskr/service/billing/settlement.py
+++ b/src/api/flaskr/service/billing/settlement.py
@@ -93,7 +93,7 @@ class SettlementResult:
             payload["reason"] = self.reason
         return payload
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
@@ -118,7 +118,7 @@ class BackfillSettlementItem:
             "requested_creator_bid": self.requested_creator_bid,
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
@@ -151,7 +151,7 @@ class BackfillSettlementResult:
             "backfill": self.backfill,
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 

--- a/src/api/flaskr/service/billing/subscriptions.py
+++ b/src/api/flaskr/service/billing/subscriptions.py
@@ -225,7 +225,7 @@ class TopupExpiryRepairResult:
             "skipped_bucket_bids": list(self.skipped_bucket_bids),
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
@@ -283,7 +283,7 @@ class SubscriptionCycleRepairResult:
             "skipped_subscription_bids": list(self.skipped_subscription_bids),
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
@@ -374,7 +374,7 @@ def _load_topup_expiry_subscription_for_bucket(
 
 def _merge_provider_metadata(
     *,
-    existing: Any,
+    existing: object,
     provider: str,
     source: str,
     event_type: str,

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -154,7 +154,7 @@ class LowBalanceAlertTaskResult:
         }
 
 
-def _serialize_task_payload(result: Any) -> Any:
+def _serialize_task_payload(result: object) -> object:
     if isinstance(result, dict):
         return dict(result)
     if hasattr(result, "to_task_payload"):
@@ -187,7 +187,7 @@ def _load_renewal_task_config() -> dict[str, Any]:
 
 
 def _coerce_positive_int(
-    value: Any,
+    value: object,
     default: int,
     *,
     minimum: int = 0,
@@ -199,7 +199,7 @@ def _coerce_positive_int(
     return max(minimum, normalized)
 
 
-def _normalize_optional_queue(value: Any, *, enabled: Any = False) -> str:
+def _normalize_optional_queue(value: object, *, enabled: object = False) -> str:
     if not _coerce_bool(enabled):
         return ""
     return str(value or "").strip()
@@ -351,7 +351,7 @@ def _expire_pending_billing_orders(
     app,
     *,
     creator_bid: str = "",
-    expire_before: Any = None,
+    expire_before: object = None,
 ) -> dict[str, Any]:
     normalized_creator_bid = _normalize_bid(creator_bid)
     resolved_expire_before = _coerce_datetime(expire_before) or now_utc()
@@ -467,7 +467,7 @@ def replay_usage_settlement_task(
 def expire_wallet_buckets_task(
     *,
     creator_bid: str = "",
-    expire_before: Any = None,
+    expire_before: object = None,
 ) -> dict[str, Any]:
     """Scan expiring wallet buckets and write expire ledger entries."""
     app = _create_task_app()
@@ -485,7 +485,7 @@ def expire_wallet_buckets_task(
 def expire_pending_orders_task(
     *,
     creator_bid: str = "",
-    expire_before: Any = None,
+    expire_before: object = None,
 ) -> dict[str, Any]:
     """Scan expired pending package orders and sync them into terminal state."""
     app = _create_task_app()
@@ -727,7 +727,7 @@ def aggregate_daily_usage_metrics_task(
     *,
     stat_date: str = "",
     creator_bid: str = "",
-    finalize: Any = False,
+    finalize: object = False,
 ) -> dict[str, Any]:
     """Rebuild one creator/day usage aggregate slice from usage + ledger rows."""
     app = _create_task_app()
@@ -747,7 +747,7 @@ def aggregate_daily_ledger_summary_task(
     *,
     stat_date: str = "",
     creator_bid: str = "",
-    finalize: Any = False,
+    finalize: object = False,
 ) -> dict[str, Any]:
     """Rebuild one creator/day ledger summary slice from ledger entries."""
     app = _create_task_app()

--- a/src/api/flaskr/service/billing/trials.py
+++ b/src/api/flaskr/service/billing/trials.py
@@ -106,7 +106,9 @@ class TrialOfferState:
         )
 
 
-def _trial_product_field(product_ref: Any, field: str, default: Any = "") -> Any:
+def _trial_product_field(
+    product_ref: object, field: str, default: object = ""
+) -> object:
     if isinstance(product_ref, BillingProduct):
         return getattr(product_ref, field, default)
     if isinstance(product_ref, dict):
@@ -114,7 +116,7 @@ def _trial_product_field(product_ref: Any, field: str, default: Any = "") -> Any
     return default
 
 
-def _trial_product_metadata(product_ref: Any) -> dict[str, Any]:
+def _trial_product_metadata(product_ref: object) -> dict[str, Any]:
     if isinstance(product_ref, BillingProduct):
         payload = product_ref.metadata_json
     elif isinstance(product_ref, dict):
@@ -126,7 +128,7 @@ def _trial_product_metadata(product_ref: Any) -> dict[str, Any]:
     return dict(payload) if isinstance(payload, dict) else {}
 
 
-def _resolve_trial_valid_days(product_ref: Any) -> int:
+def _resolve_trial_valid_days(product_ref: object) -> int:
     metadata = _trial_product_metadata(product_ref)
     return _safe_to_positive_int(
         metadata.get(BILLING_TRIAL_PRODUCT_METADATA_VALID_DAYS),
@@ -134,7 +136,7 @@ def _resolve_trial_valid_days(product_ref: Any) -> int:
     )
 
 
-def _resolve_trial_highlights(product_ref: Any) -> tuple[str, ...]:
+def _resolve_trial_highlights(product_ref: object) -> tuple[str, ...]:
     metadata = _trial_product_metadata(product_ref)
     highlights = metadata.get("highlights")
     if not isinstance(highlights, list):
@@ -142,7 +144,7 @@ def _resolve_trial_highlights(product_ref: Any) -> tuple[str, ...]:
     return tuple(str(item) for item in highlights if str(item or "").strip())
 
 
-def _trial_product_public_enabled(product_ref: Any) -> bool:
+def _trial_product_public_enabled(product_ref: object) -> bool:
     metadata = _trial_product_metadata(product_ref)
     return _coerce_bool(
         metadata.get(BILLING_TRIAL_PRODUCT_METADATA_PUBLIC_FLAG),

--- a/src/api/flaskr/service/billing/value_objects.py
+++ b/src/api/flaskr/service/billing/value_objects.py
@@ -30,7 +30,7 @@ class PageWindow(Generic[T]):
         }
 
 
-def _serialize_json_value(value: Any) -> Any:
+def _serialize_json_value(value: object) -> object:
     if isinstance(value, JsonObjectMap):
         return value.to_metadata_json()
     if isinstance(value, list):
@@ -44,11 +44,11 @@ class JsonObjectMap(MutableMapping[str, Any]):
 
     values: dict[str, Any] = field(default_factory=dict)
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a stored JSON value by key."""
         return self.values[key]
 
-    def __setitem__(self, key: str, value: Any) -> None:
+    def __setitem__(self, key: str, value: object) -> None:
         """Store a JSON value under the normalized string key."""
         self.values[str(key)] = value
 
@@ -64,7 +64,7 @@ class JsonObjectMap(MutableMapping[str, Any]):
         """Return the number of stored JSON keys."""
         return len(self.values)
 
-    def get(self, key: str, default: Any = None) -> Any:
+    def get(self, key: str, default: object = None) -> object:
         """Return the stored value for a key."""
         return self.values.get(key, default)
 

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -102,7 +102,7 @@ class WalletSnapshotRecord:
             "changed": self.changed,
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
@@ -131,7 +131,7 @@ class WalletSnapshotRebuildResult:
             "wallets": [wallet.to_payload() for wallet in self.wallets],
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
@@ -158,7 +158,7 @@ class RefundReturnCreditsResult:
             "ledger_bid": self.ledger_bid,
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
@@ -181,7 +181,7 @@ class WalletExpirationResult:
             "expired_credits": self.expired_credits,
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
@@ -251,7 +251,7 @@ class ExpireLedgerBucketDriftRepairResult:
             "buckets": [bucket.to_payload() for bucket in self.buckets],
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
@@ -323,7 +323,7 @@ class ExpiredCreditPackBucketRestoreResult:
             "buckets": [bucket.to_payload() for bucket in self.buckets],
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
@@ -354,7 +354,7 @@ class ManualCreditGrantResult:
             "metadata_json": self.metadata_json,
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
@@ -385,7 +385,7 @@ class ReservedGrantRepairRecord:
             "renewal_event_bids": list(self.renewal_event_bids),
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a serialized payload field by key."""
         return self.to_payload()[key]
 
@@ -446,7 +446,7 @@ class RenewalStateDriftRepairResult:
             ],
         }
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a task-payload field by key."""
         return self.to_task_payload()[key]
 
@@ -464,7 +464,7 @@ def _normalize_json_dict(payload: object) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-def _json_extract_text(column: Any, path: str) -> Any:
+def _json_extract_text(column: object, path: str) -> object:
     bind = db.session.get_bind()
     dialect_name = bind.dialect.name.lower() if bind is not None else ""
     extracted = func.json_extract(column, path)
@@ -473,7 +473,7 @@ def _json_extract_text(column: Any, path: str) -> Any:
     return extracted
 
 
-def _sql_null_if_empty_or_json_null(value: Any) -> Any:
+def _sql_null_if_empty_or_json_null(value: object) -> object:
     text = func.trim(func.coalesce(value, ""))
     return case(
         (func.lower(text) == "null", None),
@@ -618,7 +618,7 @@ def _load_overdue_reserved_paid_order_records(
     return records
 
 
-def _normalize_bucket_credit_state(value: Any) -> str:
+def _normalize_bucket_credit_state(value: object) -> str:
     state = str(value or "").strip().lower()
     return "" if state == "null" else state
 
@@ -863,10 +863,10 @@ def refresh_credit_wallet_snapshot(
 def persist_credit_wallet_snapshot(
     wallet: CreditWallet,
     *,
-    available_credits: Decimal | Any,
-    reserved_credits: Decimal | Any,
-    lifetime_granted_credits: Decimal | Any | None = None,
-    lifetime_consumed_credits: Decimal | Any | None = None,
+    available_credits: object,
+    reserved_credits: object,
+    lifetime_granted_credits: object | None = None,
+    lifetime_consumed_credits: object | None = None,
     last_settled_usage_id: int | None = None,
     updated_at: datetime | None = None,
 ) -> CreditWallet:
@@ -1485,7 +1485,7 @@ def grant_refund_return_credits(
     app: Flask,
     *,
     creator_bid: str,
-    amount: Decimal | Any,
+    amount: object,
     refund_bid: str,
     metadata: dict[str, Any] | None = None,
     effective_from: datetime | None = None,
@@ -1628,7 +1628,7 @@ def adjust_credit_wallet_balance(
     app: Flask,
     *,
     creator_bid: str,
-    amount: Decimal | Any,
+    amount: object,
     note: str = "",
     operator_user_bid: str = "",
 ) -> BillingLedgerAdjustResultDTO:
@@ -1803,7 +1803,7 @@ def grant_manual_credit_wallet_balance(
     app: Flask,
     *,
     creator_bid: str,
-    amount: Decimal | Any,
+    amount: object,
     source_bid: str = "",
     effective_from: datetime | None = None,
     effective_to: datetime | None = None,
@@ -2456,13 +2456,13 @@ def _build_expired_credit_pack_restore_record(
     creator_bid: str | None = None,
     wallet_bid: str | None = None,
     wallet_bucket_bid: str | None = None,
-    previous_available_credits: Decimal | Any = _ZERO,
-    available_credits: Decimal | Any = _ZERO,
-    previous_expired_credits: Decimal | Any = _ZERO,
-    expired_credits: Decimal | Any = _ZERO,
+    previous_available_credits: object = _ZERO,
+    available_credits: object = _ZERO,
+    previous_expired_credits: object = _ZERO,
+    expired_credits: object = _ZERO,
     previous_status: int | None = None,
     status: int | None = None,
-    restored_credits: Decimal | Any = _ZERO,
+    restored_credits: object = _ZERO,
     repair_action: str,
     repair_reason: str,
     changed: bool = False,

--- a/src/api/flaskr/service/billing/webhooks.py
+++ b/src/api/flaskr/service/billing/webhooks.py
@@ -131,7 +131,7 @@ class BillingWebhookResult:
             payload["message"] = self.message
         return payload
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> object:
         """Return a response field by key."""
         return self.to_response_dict()[key]
 

--- a/src/api/flaskr/service/common/dto_base.py
+++ b/src/api/flaskr/service/common/dto_base.py
@@ -31,10 +31,10 @@ How per-class output is reproduced:
 
 from __future__ import annotations
 
-from typing import Any, ClassVar
+from typing import ClassVar
 
 
-def _json_field_value(value: Any, annotation: Any) -> Any:
+def _json_field_value(value: object, annotation: object) -> object:
     """Convert one field value the same way hand-written ``__json__`` did."""
     if annotation is int:
         return int(value)

--- a/src/api/flaskr/service/common/oss_utils.py
+++ b/src/api/flaskr/service/common/oss_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import requests
 
@@ -129,7 +129,7 @@ def get_image_content_type(filename: str) -> str:
     return None
 
 
-def warm_up_cdn(app: Any, url: str, config: OSSConfig) -> bool:
+def warm_up_cdn(app: object, url: str, config: OSSConfig) -> bool:
     """Warm up a CDN URL."""
     try:
         from aliyunsdkcdn.request.v20180510.DescribeRefreshTasksRequest import (
@@ -216,9 +216,9 @@ def warm_up_cdn(app: Any, url: str, config: OSSConfig) -> bool:
 
 
 def upload_to_oss(
-    app: Any,
+    app: object,
     *,
-    file_content: Any,
+    file_content: object,
     file_id: str,
     content_type: str,
     profile: str = OSS_PROFILE_DEFAULT,

--- a/src/api/flaskr/service/common/profile_onboarding.py
+++ b/src/api/flaskr/service/common/profile_onboarding.py
@@ -38,7 +38,7 @@ def _default_config_payload() -> dict[str, Any]:
     }
 
 
-def normalize_profile_onboarding_config_payload(payload: Any) -> dict[str, Any]:
+def normalize_profile_onboarding_config_payload(payload: object) -> dict[str, Any]:
     """Normalize profile onboarding config payload."""
     base = _default_config_payload()
     if isinstance(payload, dict):

--- a/src/api/flaskr/service/common/storage.py
+++ b/src/api/flaskr/service/common/storage.py
@@ -7,7 +7,7 @@ import os
 import shutil
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from flaskr.service.common.oss_utils import (
     OSS_PROFILE_COURSES,
@@ -113,7 +113,7 @@ def build_local_storage_url(profile: str, object_key: str) -> str:
     return f"{path_prefix}/storage/{resolved_profile}/{resolved_key}"
 
 
-def _coerce_to_binary_stream(file_content: Any) -> io.BufferedReader:
+def _coerce_to_binary_stream(file_content: object) -> io.BufferedReader:
     if file_content is None:
         message = "file_content is required"
         raise ValueError(message)
@@ -131,7 +131,7 @@ def _coerce_to_binary_stream(file_content: Any) -> io.BufferedReader:
 
 def _upload_to_local(
     *,
-    file_content: Any,
+    file_content: object,
     object_key: str,
     profile: str,
 ) -> StorageUploadResult:
@@ -158,7 +158,7 @@ def _upload_to_local(
 def _upload_to_oss(
     app: Flask,
     *,
-    file_content: Any,
+    file_content: object,
     object_key: str,
     content_type: str,
     profile: str,
@@ -186,7 +186,7 @@ def _upload_to_oss(
 def upload_to_storage(
     app: Flask,
     *,
-    file_content: Any,
+    file_content: object,
     object_key: str,
     content_type: str,
     profile: str = OSS_PROFILE_DEFAULT,

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -80,7 +80,7 @@ _ALLOWED_USAGE_TYPES = frozenset({1101, 1102})
 _DEFAULT_LIMIT = 100
 
 
-def run(app: Flask, user_id: str, payload: Any) -> dict[str, Any]:
+def run(app: Flask, user_id: str, payload: object) -> dict[str, Any]:
     """Execute the credit-detail query for ``user_id``.
 
     Validates the payload, enforces the per-shifu permission check, then
@@ -180,7 +180,7 @@ class _Params:
         self.offset = offset
 
 
-def _parse_payload(payload: Any, limit_max: int) -> _Params:
+def _parse_payload(payload: object, limit_max: int) -> _Params:
     if not isinstance(payload, dict):
         _raise(ERR_INVALID_DSL, "payload must be a JSON object")
 
@@ -219,7 +219,7 @@ def _parse_payload(payload: Any, limit_max: int) -> _Params:
     )
 
 
-def _parse_optional_date(raw: Any, field_name: str) -> date | None:
+def _parse_optional_date(raw: object, field_name: str) -> date | None:
     if raw is None or raw == "":
         return None
     if not isinstance(raw, str):
@@ -236,7 +236,7 @@ def _parse_optional_date(raw: Any, field_name: str) -> date | None:
 
 
 def _parse_int_set(
-    raw: Any, field_name: str, allowed: Iterable[int]
+    raw: object, field_name: str, allowed: Iterable[int]
 ) -> tuple[int, ...] | None:
     if raw is None:
         return None
@@ -261,7 +261,7 @@ def _parse_int_set(
     return tuple(out)
 
 
-def _parse_int(raw: Any, field_name: str, *, default: int) -> int:
+def _parse_int(raw: object, field_name: str, *, default: int) -> int:
     if raw is None:
         return default
     if isinstance(raw, bool) or not isinstance(raw, int):
@@ -393,7 +393,7 @@ def _row_to_dict(columns: Sequence[str], values: Sequence[Any]) -> dict[str, Any
     return row
 
 
-def _summary_row_to_dict(summary_row: Any) -> dict[str, Any]:
+def _summary_row_to_dict(summary_row: object) -> dict[str, Any]:
     if summary_row is None:
         return {
             "total_records": 0,
@@ -421,7 +421,7 @@ def _summary_row_to_dict(summary_row: Any) -> dict[str, Any]:
     }
 
 
-def _coerce_value(value: Any) -> Any:
+def _coerce_value(value: object) -> object:
     """Coerce non-JSON-friendly values (Decimal, datetime) to strings.
 
     The HTTP response wrapper turns the dict into JSON; SQLAlchemy returns

--- a/src/api/flaskr/service/creator_analytics/dsl.py
+++ b/src/api/flaskr/service/creator_analytics/dsl.py
@@ -155,7 +155,7 @@ class QueryDSL:
 # ---------------------------------------------------------------------------
 
 
-def parse_dsl(payload: Any, limit_max: int, user_id: str = "") -> QueryDSL:
+def parse_dsl(payload: object, limit_max: int, user_id: str = "") -> QueryDSL:
     """Validate ``payload`` and return a :class:`QueryDSL`.
 
     ``limit_max`` is the upper bound for the DSL ``limit`` field (typically
@@ -236,7 +236,7 @@ def parse_dsl(payload: Any, limit_max: int, user_id: str = "") -> QueryDSL:
 # ---------------------------------------------------------------------------
 
 
-def _parse_select(raw: Any, spec: TableSpec) -> list[str]:
+def _parse_select(raw: object, spec: TableSpec) -> list[str]:
     if raw is None:
         return []
     if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
@@ -254,7 +254,7 @@ def _parse_select(raw: Any, spec: TableSpec) -> list[str]:
     return list(raw)
 
 
-def _parse_group_by(raw: Any, spec: TableSpec) -> list[str]:
+def _parse_group_by(raw: object, spec: TableSpec) -> list[str]:
     if raw is None:
         return []
     if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
@@ -270,7 +270,7 @@ def _parse_group_by(raw: Any, spec: TableSpec) -> list[str]:
     return list(raw)
 
 
-def _parse_aggregates(raw: Any, spec: TableSpec) -> list[Aggregate]:
+def _parse_aggregates(raw: object, spec: TableSpec) -> list[Aggregate]:
     if raw is None:
         return []
     if not isinstance(raw, list):
@@ -336,7 +336,7 @@ def _parse_aggregates(raw: Any, spec: TableSpec) -> list[Aggregate]:
     return aggregates
 
 
-def _parse_filters(raw: Any, spec: TableSpec) -> list[Filter]:
+def _parse_filters(raw: object, spec: TableSpec) -> list[Filter]:
     if raw is None:
         return []
     if not isinstance(raw, list):
@@ -364,7 +364,7 @@ def _parse_filters(raw: Any, spec: TableSpec) -> list[Filter]:
 
 
 def _parse_order_by(
-    raw: Any,
+    raw: object,
     select: Sequence[str],
     aggregates: Sequence[Aggregate],
     group_by: Sequence[str],
@@ -391,7 +391,9 @@ def _parse_order_by(
     return out
 
 
-def _parse_paging(raw_limit: Any, raw_offset: Any, limit_max: int) -> tuple[int, int]:
+def _parse_paging(
+    raw_limit: object, raw_offset: object, limit_max: int
+) -> tuple[int, int]:
     limit = raw_limit if raw_limit is not None else min(100, limit_max)
     if not isinstance(limit, int) or isinstance(limit, bool):
         _raise(ERR_INVALID_LIMIT, "'limit' must be an integer")
@@ -411,7 +413,7 @@ def _parse_paging(raw_limit: Any, raw_offset: Any, limit_max: int) -> tuple[int,
 # ---------------------------------------------------------------------------
 
 
-def _validate_filter_value(index: int, op: str, value: Any) -> None:
+def _validate_filter_value(index: int, op: str, value: object) -> None:
     if op in _OPS_REQUIRING_NO_VALUE:
         if value is not None:
             _raise(ERR_INVALID_DSL, f"where[{index}] '{op}' must not carry a value")

--- a/src/api/flaskr/service/creator_analytics/funcs.py
+++ b/src/api/flaskr/service/creator_analytics/funcs.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 ERR_NO_PERMISSION = "server.creatorAnalytics.noPermission"
 
 
-def run_dsl(app: Flask, user_id: str, payload: Any) -> dict[str, Any]:
+def run_dsl(app: Flask, user_id: str, payload: object) -> dict[str, Any]:
     """Execute a DSL query on behalf of ``user_id``.
 
     Steps:

--- a/src/api/flaskr/service/learn/ask_provider_adapters/common.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/common.py
@@ -140,7 +140,7 @@ def iter_sse_payloads(response: requests.Response) -> Iterable[str]:
             yield normalized
 
 
-def extract_text(payload: Any) -> str:
+def extract_text(payload: object) -> str:
     """Extract text."""
     if isinstance(payload, str):
         return payload

--- a/src/api/flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py
@@ -50,7 +50,7 @@ def _parse_output_fields(raw_text: str) -> dict[str, str]:
     return fields
 
 
-def _format_workflow_item(item: Any) -> str:
+def _format_workflow_item(item: object) -> str:
     if isinstance(item, str):
         return item.strip()
 
@@ -79,7 +79,7 @@ def _format_workflow_item(item: Any) -> str:
     return title or summary or json.dumps(item, ensure_ascii=False)
 
 
-def _format_workflow_payload(payload: Any) -> str:
+def _format_workflow_payload(payload: object) -> str:
     if isinstance(payload, str):
         return payload.strip()
 

--- a/src/api/flaskr/service/learn/ask_provider_adapters/get_biji_knowledge_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/get_biji_knowledge_adapter.py
@@ -33,11 +33,11 @@ DEFAULT_TOP_K = 5
 MAX_TOP_K = 10
 
 
-def _normalize_text(value: Any) -> str:
+def _normalize_text(value: object) -> str:
     return str(value or "").strip()
 
 
-def _top_k_value(value: Any) -> int:
+def _top_k_value(value: object) -> int:
     try:
         parsed = int(value)
     except (TypeError, ValueError):
@@ -61,7 +61,7 @@ def _user_message_for_error(code: str, reason: str) -> str | None:
     return None
 
 
-def _raise_for_api_error(payload: Any) -> None:
+def _raise_for_api_error(payload: object) -> None:
     if not isinstance(payload, dict):
         return
     if payload.get("success") is not False:
@@ -85,7 +85,7 @@ def _raise_for_api_error(payload: Any) -> None:
     )
 
 
-def _extract_results(payload: Any) -> list[Any]:
+def _extract_results(payload: object) -> list[Any]:
     if not isinstance(payload, dict):
         return []
     data = payload.get("data")
@@ -94,7 +94,7 @@ def _extract_results(payload: Any) -> list[Any]:
     return []
 
 
-def _format_result(index: int, result: Any) -> str:
+def _format_result(index: int, result: object) -> str:
     if not isinstance(result, dict):
         content = extract_text(result) or _normalize_text(result)
         return f"{index}. {content}".strip() if content else ""

--- a/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
@@ -47,7 +47,7 @@ def _normalize_query(params: dict[str, Any] | None) -> str:
     return "&".join(encoded_parts)
 
 
-def _normalize_header_value(value: Any) -> str:
+def _normalize_header_value(value: object) -> str:
     return " ".join(str(value).strip().split())
 
 
@@ -113,7 +113,7 @@ def _build_volc_signature_headers(
     }
 
 
-def _to_positive_int(value: Any, default: int) -> int:
+def _to_positive_int(value: object, default: int) -> int:
     try:
         parsed = int(value)
     except (TypeError, ValueError):
@@ -124,7 +124,7 @@ def _to_positive_int(value: Any, default: int) -> int:
 
 
 def _normalize_pre_processing(
-    config_value: Any, user_query: str
+    config_value: object, user_query: str
 ) -> dict[str, Any] | None:
     if not isinstance(config_value, dict):
         return None
@@ -150,11 +150,11 @@ def _normalize_pre_processing(
     return pre_processing
 
 
-def _collect_text_chunks(payload: Any) -> list[str]:
+def _collect_text_chunks(payload: object) -> list[str]:
     chunks: list[str] = []
     seen: set[str] = set()
 
-    def _append(value: Any) -> None:
+    def _append(value: object) -> None:
         text = extract_text(value)
         if text and text not in seen:
             seen.add(text)

--- a/src/api/flaskr/service/learn/ask_provider_langfuse.py
+++ b/src/api/flaskr/service/learn/ask_provider_langfuse.py
@@ -33,7 +33,9 @@ def _is_sensitive_provider_config_key(key: str) -> bool:
     return normalized.endswith(("_key", "_secret", "_token", "_password"))
 
 
-def sanitize_provider_config_for_langfuse(value: Any, key: str | None = None) -> Any:
+def sanitize_provider_config_for_langfuse(
+    value: object, key: str | None = None
+) -> object:
     """Redact provider secrets before recording configuration in Langfuse."""
     if key and _is_sensitive_provider_config_key(key):
         return "[REDACTED]"
@@ -83,7 +85,7 @@ def _build_provider_generation_metadata(
 def stream_provider_with_langfuse(
     *,
     provider_stream: Iterable[Any],
-    span: Any,
+    span: object,
     app: Flask | None,
     provider_name: str,
     generation_name: str,

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -147,7 +147,7 @@ def _find_outline_path_or_raise(
     return path
 
 
-def _normalize_stream_number(value: Any) -> int | None:
+def _normalize_stream_number(value: object) -> int | None:
     try:
         return int(value) if value is not None else None
     except (TypeError, ValueError):
@@ -155,7 +155,7 @@ def _normalize_stream_number(value: Any) -> int | None:
 
 
 def _iter_llm_result_content_parts(
-    llm_result: Any,
+    llm_result: object,
 ) -> Generator[tuple[str, str, int | None], None, None]:
     if llm_result is None:
         return
@@ -268,7 +268,7 @@ class RUNLLMProvider(LLMProvider):
         app: Flask,
         llm_settings: LLMSettings,
         trace: LangfuseTraceHandle,
-        parent_observation: Any,
+        parent_observation: object,
         trace_args: dict,
         usage_context: UsageContext,
         usage_scene: int,
@@ -1254,7 +1254,7 @@ class RunScriptPreviewContextV2:
         generated_block_bid: str,
         content: str,
         stream_type: str,
-        stream_number: Any,
+        stream_number: object,
     ) -> RunMarkdownFlowDTO:
         event = RunMarkdownFlowDTO(
             outline_bid=outline_bid,
@@ -1714,7 +1714,7 @@ class RunScriptContextV2:
             return None
         return context_local.current_context
 
-    def append_langfuse_output(self, value: Any) -> None:
+    def append_langfuse_output(self, value: object) -> None:
         """Append output content to the active Langfuse trace."""
         if not hasattr(self, "_langfuse_output_chunks"):
             self._langfuse_output_chunks = []

--- a/src/api/flaskr/service/learn/handle_input_ask.py
+++ b/src/api/flaskr/service/learn/handle_input_ask.py
@@ -259,7 +259,7 @@ def _run_guardrail(
     return chunks
 
 
-def _append_context_langfuse_output(context: Any, value: str) -> None:
+def _append_context_langfuse_output(context: object, value: str) -> None:
     append_output = getattr(context, "append_langfuse_output", None)
     if callable(append_output) and value:
         append_output(value)
@@ -267,10 +267,10 @@ def _append_context_langfuse_output(context: Any, value: str) -> None:
 
 def _finalize_ask_trace(
     *,
-    context: Any,
+    context: object,
     trace: LangfuseTraceHandle,
-    parent_observation: Any | None,
-    span: Any,
+    parent_observation: object | None,
+    span: object,
     trace_args: dict,
     response_text: str,
 ) -> None:
@@ -301,7 +301,7 @@ def handle_input_ask(
     is_preview: bool = False,
     last_position: int = -1,
     anchor_element_bid: str = "",
-    parent_observation: Any | None = None,
+    parent_observation: object | None = None,
 ) -> Generator[str, None, None]:
     """Handle user Q&A input.
 

--- a/src/api/flaskr/service/learn/legacy_record_builder.py
+++ b/src/api/flaskr/service/learn/legacy_record_builder.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
 
 from flaskr.service.learn.block_type_mapping import (
     CONTENT_LIKE_BLOCK_TYPES,
@@ -65,12 +64,12 @@ class LegacyLearnRecord:
         }
 
 
-def _set_stat(stats: Any | None, field_name: str, value: int) -> None:
+def _set_stat(stats: object | None, field_name: str, value: int) -> None:
     if stats is not None and hasattr(stats, field_name):
         setattr(stats, field_name, int(value))
 
 
-def _inc_stat(stats: Any | None, field_name: str, delta: int = 1) -> None:
+def _inc_stat(stats: object | None, field_name: str, delta: int = 1) -> None:
     if stats is not None and hasattr(stats, field_name):
         current = int(getattr(stats, field_name, 0) or 0)
         setattr(stats, field_name, current + int(delta))
@@ -86,7 +85,7 @@ def build_legacy_record_for_progress(
     dedupe_blocks_by_bid: bool = False,
     dedupe_audio_by_block_position: bool = False,
     skip_empty_content: bool = False,
-    stats: Any | None = None,
+    stats: object | None = None,
 ) -> LegacyLearnRecord:
     """Build legacy record for progress."""
     filters = [

--- a/src/api/flaskr/service/learn/listen_element_audio_binding.py
+++ b/src/api/flaskr/service/learn/listen_element_audio_binding.py
@@ -19,7 +19,7 @@ def _normalized_stream_audio_target_type(stream_element_type: str | None) -> str
 
 
 def _stream_element_matches_audio_target(
-    stream_state: Any,
+    stream_state: object,
     stream_element_number: int,
     stream_element_type: str | None = None,
 ) -> bool:
@@ -41,7 +41,7 @@ def _stream_element_matches_audio_target(
     )
 
 
-def _ordered_stream_audio_targets(state: Any) -> list[Any]:
+def _ordered_stream_audio_targets(state: object) -> list[Any]:
     return [
         stream_state
         for stream_state in state.stream_elements.values()
@@ -51,8 +51,8 @@ def _ordered_stream_audio_targets(state: Any) -> list[Any]:
 
 
 def _resolve_pending_audio_for_stream_element(
-    state: Any,
-    stream_state: Any,
+    state: object,
+    stream_state: object,
 ) -> tuple[ElementAudioDTO | None, list[dict[str, Any]] | None]:
     if not _stream_element_accepts_audio_target(stream_state.element_type):
         return None, None
@@ -104,7 +104,7 @@ def _resolve_pending_audio_for_stream_element(
 
 
 def _resolve_stream_audio_for_element_bid(
-    state: Any,
+    state: object,
     element_bid: str,
 ) -> tuple[ElementAudioDTO | None, list[dict[str, Any]]]:
     matched_positions = [
@@ -161,7 +161,7 @@ def _resolve_stream_audio_for_element_bid(
 
 
 def _resolve_audio_target_element_bid_for_stream_number(
-    state: Any,
+    state: object,
     stream_element_number: int,
     stream_element_type: str | None = None,
 ) -> str | None:
@@ -193,7 +193,7 @@ def _resolve_audio_target_element_bid_for_stream_number(
 
 
 def _resolve_audio_target_element_bid(
-    state: Any,
+    state: object,
     position: int,
 ) -> str | None:
     existing_target = state.audio_target_element_bid_by_position.get(position)

--- a/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
+++ b/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
@@ -330,7 +330,7 @@ def _count_current_run_active_rows(
     ).count()
 
 
-def _reset_adapter_runtime(adapter: Any, generated_block_bid: str) -> None:
+def _reset_adapter_runtime(adapter: object, generated_block_bid: str) -> None:
     adapter._block_states.pop(generated_block_bid, None)
     adapter._current_element_bid = None
     adapter._current_ask_anchor_bid = None
@@ -360,7 +360,7 @@ def _latest_anchor_bid_from_messages(messages: list[Any]) -> str:
 
 
 def _emit_content_group(
-    adapter: Any,
+    adapter: object,
     block: LearnGeneratedBlock,
 ) -> list[Any]:
     messages: list[Any] = []
@@ -378,7 +378,7 @@ def _emit_content_group(
 
 
 def _emit_interaction_group(
-    adapter: Any,
+    adapter: object,
     block: LearnGeneratedBlock,
 ) -> list[Any]:
     event = RunMarkdownFlowDTO(
@@ -391,7 +391,7 @@ def _emit_interaction_group(
 
 
 def _emit_follow_up_group(
-    adapter: Any,
+    adapter: object,
     *,
     ask_block: LearnGeneratedBlock,
     answer_block: LearnGeneratedBlock,

--- a/src/api/flaskr/service/learn/listen_element_run_stream.py
+++ b/src/api/flaskr/service/learn/listen_element_run_stream.py
@@ -69,7 +69,7 @@ class ListenElementRunStreamMixin:
     """Provide streaming operations for listen-mode element runs."""
 
     @staticmethod
-    def _normalize_live_audio_position(position: Any) -> int:
+    def _normalize_live_audio_position(position: object) -> int:
         try:
             return max(int(position or 0), 0)
         except (TypeError, ValueError):
@@ -335,7 +335,7 @@ class ListenElementRunStreamMixin:
         state: BlockState,
         *,
         position: int,
-        stream_element_number: Any = None,
+        stream_element_number: object = None,
         stream_element_type: str | None = None,
     ) -> str | None:
         existing_target = state.audio_target_element_bid_by_position.get(position)

--- a/src/api/flaskr/service/learn/listen_element_types.py
+++ b/src/api/flaskr/service/learn/listen_element_types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from flaskr.service.learn.const import ROLE_STUDENT, ROLE_UI
 from flaskr.service.learn.learn_dtos import ElementChangeType, ElementType
@@ -48,13 +48,13 @@ LEGACY_ELEMENT_TYPE_MAP = {
 }
 
 
-def _normalize_bool(raw: Any) -> bool:
+def _normalize_bool(raw: object) -> bool:
     if isinstance(raw, str):
         return raw.strip().lower() == "true"
     return bool(raw)
 
 
-def _role_value_to_name(role_value: Any) -> str:
+def _role_value_to_name(role_value: object) -> str:
     if role_value == ROLE_STUDENT:
         return "student"
     if role_value == ROLE_UI:

--- a/src/api/flaskr/service/learn/listen_source_span_utils.py
+++ b/src/api/flaskr/service/learn/listen_source_span_utils.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
 
-
-def normalize_source_span(raw: Any) -> list[int]:
+def normalize_source_span(raw: object) -> list[int]:
     """Normalize source span."""
     if not isinstance(raw, list) or len(raw) < 2:
         return []

--- a/src/api/flaskr/service/learn/stream_tts_finalize.py
+++ b/src/api/flaskr/service/learn/stream_tts_finalize.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import queue
 import threading
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from flaskr.common.shifu_context import (
     apply_shifu_context_snapshot,
@@ -34,7 +34,7 @@ class _StreamTTSFinalizeJob:
 class StreamTTSFinalizeDrainer:
     """Finalize switched-out text TTS without blocking mdflow visual chunks."""
 
-    def __init__(self, run_context: Any, *, log_prefix: str) -> None:
+    def __init__(self, run_context: object, *, log_prefix: str) -> None:
         """Configure deferred TTS finalization for a run."""
         self._run_context = run_context
         self._app = run_context.app

--- a/src/api/flaskr/service/metering/consts.py
+++ b/src/api/flaskr/service/metering/consts.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from flaskr.i18n import _
 
 # Use 4-digit numeric codes starting with "1" to distinguish from legacy enums.
@@ -38,7 +36,7 @@ _LEGACY_USAGE_SCENE_MAP = {
 
 
 def normalize_usage_type(
-    value: Any, *, default: int = BILL_USAGE_TYPE_LLM, strict: bool = False
+    value: object, *, default: int = BILL_USAGE_TYPE_LLM, strict: bool = False
 ) -> int:
     """Normalize usage type."""
     if value is None or value == "":
@@ -61,7 +59,7 @@ def normalize_usage_type(
 
 
 def normalize_usage_scene(
-    value: Any, *, default: int = BILL_USAGE_SCENE_PROD, strict: bool = False
+    value: object, *, default: int = BILL_USAGE_SCENE_PROD, strict: bool = False
 ) -> int:
     """Normalize usage scene."""
     if value is None or value == "":

--- a/src/api/flaskr/service/order/__init__.py
+++ b/src/api/flaskr/service/order/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from importlib import import_module
-from typing import Any
 
 from flaskr.service.common.dicts import register_dict
 
@@ -13,7 +12,7 @@ register_dict("order_status", "订单状态", ORDER_STATUS_TYPES)  # noqa: F405
 register_dict("learn_status", "学习状态", LEARN_STATUS_TYPES)  # noqa: F405
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> object:
     """Lazy-export symbols from order helpers to avoid circular imports."""
     funs = import_module(".funs", __name__)
     if hasattr(funs, name):

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -233,7 +233,7 @@ def _parse_datetime(value: str, is_end: bool = False) -> datetime | None:
     return None
 
 
-def _normalize_order_status_filter(value: Any) -> int | None:
+def _normalize_order_status_filter(value: object) -> int | None:
     if isinstance(value, bool):
         return None
     if isinstance(value, int):
@@ -245,7 +245,7 @@ def _normalize_order_status_filter(value: Any) -> int | None:
 
 
 def _normalize_order_datetime_filter(
-    value: Any, *, is_end: bool = False
+    value: object, *, is_end: bool = False
 ) -> datetime | None:
     if isinstance(value, datetime):
         return value

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -1360,7 +1360,7 @@ def _is_stripe_payment_successful(
 
 def _apply_native_snapshot_update(
     *,
-    snapshot: Any,
+    snapshot: object,
     provider: str,
     notification: PaymentNotificationResult,
     source: str,
@@ -1463,7 +1463,7 @@ def _inject_order_query(url: str, order_id: str) -> str:
     )
 
 
-def _stringify_payload(payload: Any) -> str:
+def _stringify_payload(payload: object) -> str:
     if not payload:
         return "{}"
     if hasattr(payload, "to_dict"):
@@ -1471,7 +1471,7 @@ def _stringify_payload(payload: Any) -> str:
     return json.dumps(payload)
 
 
-def _parse_json_payload(value: Any) -> Any:
+def _parse_json_payload(value: object) -> object:
     if not value:
         return {}
     if isinstance(value, (dict, list)):

--- a/src/api/flaskr/service/order/payment_providers/alipay.py
+++ b/src/api/flaskr/service/order/payment_providers/alipay.py
@@ -161,7 +161,7 @@ class AlipayProvider(PaymentProvider):
         message = "Alipay refunds are not supported"
         raise RuntimeError(message)
 
-    def _ensure_client(self, app: Flask) -> Any:
+    def _ensure_client(self, app: Flask) -> object:
         sdk = self._load_sdk(app)
         app_id = str(get_config("ALIPAY_APP_ID", "") or "").strip()
         if not app_id:
@@ -280,7 +280,7 @@ def _format_cny_amount(amount: int) -> str:
     return format(yuan, "f")
 
 
-def _parse_alipay_response(raw_response: Any, response_key: str) -> dict[str, Any]:
+def _parse_alipay_response(raw_response: object, response_key: str) -> dict[str, Any]:
     if hasattr(raw_response, "to_dict"):
         raw_response = raw_response.to_dict()
     if isinstance(raw_response, str):

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -51,7 +51,7 @@ def _serialized_pingpp_config(func) -> Callable[..., object]:
     return wrapped
 
 
-def _get_pingpp_client() -> Any:
+def _get_pingpp_client() -> object:
     with _pingpp_client_state.lock:
         if _pingpp_client_state.client is not None:
             return _pingpp_client_state.client
@@ -73,7 +73,7 @@ class PingxxProvider(PaymentProvider):
 
     channel = "pingxx"
 
-    def _ensure_client(self, app: Flask) -> Any:
+    def _ensure_client(self, app: Flask) -> object:
         """Configure pingpp for the current owner context."""
         try:
             client = _get_pingpp_client()
@@ -98,7 +98,7 @@ class PingxxProvider(PaymentProvider):
         app.logger.info("Pingxx client initialized")
         return client
 
-    def ensure_client(self, app: Flask) -> Any:
+    def ensure_client(self, app: Flask) -> object:
         """Public wrapper for configuring the pingpp client."""
         return self._ensure_client(app)
 

--- a/src/api/flaskr/service/order/raw_snapshots.py
+++ b/src/api/flaskr/service/order/raw_snapshots.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from typing import Any
 
 from .models import AlipayOrder, PingxxOrder, StripeOrder, WechatPayOrder
 
@@ -117,10 +116,10 @@ def upsert_native_snapshot(
     shifu_bid: str = "",
     transaction_id: str = "",
     channel: str = "",
-    raw_request: Any | None = None,
-    raw_response: Any | None = None,
-    raw_notification: Any | None = None,
-    metadata: Any | None = None,
+    raw_request: object | None = None,
+    raw_response: object | None = None,
+    raw_notification: object | None = None,
+    metadata: object | None = None,
 ) -> AlipayOrder | WechatPayOrder:
     """Create or update native snapshot."""
     model = native_snapshot_model(payment_provider)
@@ -242,11 +241,11 @@ def upsert_billing_stripe_snapshot(
     amount: int,
     currency: str,
     raw_status: int,
-    metadata: Any | None = None,
+    metadata: object | None = None,
     checkout_session_id: str = "",
-    checkout_object: Any | None = None,
+    checkout_object: object | None = None,
     payment_intent_id: str = "",
-    payment_object: Any | None = None,
+    payment_object: object | None = None,
     latest_charge_id: str = "",
     receipt_url: str = "",
     payment_method: str = "",
@@ -331,14 +330,14 @@ def upsert_billing_pingxx_snapshot(
     currency: str,
     raw_status: int,
     charge_id: str = "",
-    charge_object: Any | None = None,
+    charge_object: object | None = None,
     transaction_no: str = "",
     app_id: str = "",
     channel: str = "",
     subject: str = "",
     body: str = "",
     client_ip: str = "",
-    extra: Any | None = None,
+    extra: object | None = None,
 ) -> PingxxOrder:
     """Create or update billing pingxx snapshot."""
     snapshot = (
@@ -410,7 +409,7 @@ def upsert_billing_pingxx_snapshot(
     return snapshot
 
 
-def _extract_object_id(payload: Any, *, prefix: str) -> str:
+def _extract_object_id(payload: object, *, prefix: str) -> str:
     if not isinstance(payload, dict):
         return ""
     value = str(payload.get("id") or "")
@@ -419,13 +418,13 @@ def _extract_object_id(payload: Any, *, prefix: str) -> str:
     return ""
 
 
-def _extract_order_no(payload: Any) -> str:
+def _extract_order_no(payload: object) -> str:
     if not isinstance(payload, dict):
         return ""
     return str(payload.get("order_no") or "")
 
 
-def _extract_pingxx_app_id(payload: Any) -> str:
+def _extract_pingxx_app_id(payload: object) -> str:
     if not isinstance(payload, dict):
         return ""
     value = payload.get("app")
@@ -434,13 +433,13 @@ def _extract_pingxx_app_id(payload: Any) -> str:
     return str(value or "")
 
 
-def _extract_object_value(payload: Any, key: str) -> str:
+def _extract_object_value(payload: object, key: str) -> str:
     if not isinstance(payload, dict):
         return ""
     return str(payload.get(key) or "")
 
 
-def _parse_json_payload(value: Any) -> Any:
+def _parse_json_payload(value: object) -> object:
     if not value:
         return {}
     if isinstance(value, (dict, list)):
@@ -453,7 +452,7 @@ def _parse_json_payload(value: Any) -> Any:
     return value
 
 
-def _stringify_payload(payload: Any) -> str:
+def _stringify_payload(payload: object) -> str:
     if not payload:
         return "{}"
     if hasattr(payload, "to_dict"):

--- a/src/api/flaskr/service/profile/learner_profile.py
+++ b/src/api/flaskr/service/profile/learner_profile.py
@@ -92,7 +92,7 @@ def load_learner_profile_user(
     return user
 
 
-def normalize_learner_profile(raw_profile: Any) -> str:
+def normalize_learner_profile(raw_profile: object) -> str:
     """Normalize learner profile."""
     if not isinstance(raw_profile, str):
         raise_param_error("learner_profile")
@@ -102,7 +102,7 @@ def normalize_learner_profile(raw_profile: Any) -> str:
     return normalized
 
 
-def normalize_learner_profile_nickname(raw_nickname: Any) -> str:
+def normalize_learner_profile_nickname(raw_nickname: object) -> str:
     """Normalize learner profile nickname."""
     if not isinstance(raw_nickname, str):
         raise_param_error("nickname")
@@ -128,7 +128,7 @@ def serialize_learner_profile(user: UserEntity) -> dict[str, Any]:
     }
 
 
-def _identifier_variants(value: Any) -> set[str]:
+def _identifier_variants(value: object) -> set[str]:
     normalized = str(value or "").strip()
     if not normalized:
         return set()

--- a/src/api/flaskr/service/profile/onboarding.py
+++ b/src/api/flaskr/service/profile/onboarding.py
@@ -89,7 +89,7 @@ def get_profile_onboarding_status(app: Flask, *, user_id: str) -> dict[str, Any]
     }
 
 
-def _normalize_submitted_variables(raw_variables: Any) -> dict[str, str]:
+def _normalize_submitted_variables(raw_variables: object) -> dict[str, str]:
     if raw_variables is None:
         return {}
     if not isinstance(raw_variables, dict):

--- a/src/api/flaskr/service/referral/admin.py
+++ b/src/api/flaskr/service/referral/admin.py
@@ -66,7 +66,7 @@ def _serialize_decimal(value: Decimal | None) -> str | None:
     return str(value) if value is not None else None
 
 
-def _user_bid_or_identifier_filter(column: Any, value: str) -> Any:
+def _user_bid_or_identifier_filter(column: object, value: str) -> object:
     normalized = _normalize_text(value)
     candidates = {normalized}
     phone_normalized = normalize_phone_identifier(normalized)

--- a/src/api/flaskr/service/referral/auth_hooks.py
+++ b/src/api/flaskr/service/referral/auth_hooks.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from flaskr.framework.plugin.plugin_manager import extension
 
@@ -14,10 +14,10 @@ if TYPE_CHECKING:
 
 @extension("run_post_auth_extensions")
 def bind_referral_invite_post_auth(
-    context: Any,
+    context: object,
     *,
     app: Flask,
-) -> Any:
+) -> object:
     """Best-effort referral binding for new SMS-created users."""
     try:
         process_referral_post_auth(app, context)

--- a/src/api/flaskr/service/referral/reward_queue.py
+++ b/src/api/flaskr/service/referral/reward_queue.py
@@ -44,11 +44,11 @@ def _serialize_decimal(value: Decimal | None) -> str | None:
     return str(value) if value is not None else None
 
 
-def _normalize_dict(value: Any) -> dict[str, Any]:
+def _normalize_dict(value: object) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
-def _parse_metadata_datetime(value: Any) -> datetime | None:
+def _parse_metadata_datetime(value: object) -> datetime | None:
     if isinstance(value, datetime):
         return value
     normalized = _normalize_text(value)

--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -777,7 +777,7 @@ def retry_pending_referral_rewards(
 
 def process_referral_post_auth(
     app: Flask,
-    context: Any,
+    context: object,
 ) -> ReferralPostAuthResult:
     """Process referral post auth."""
     with _with_app_context(app):

--- a/src/api/flaskr/service/shifu/admin_operations/config_rates.py
+++ b/src/api/flaskr/service/shifu/admin_operations/config_rates.py
@@ -75,7 +75,7 @@ def _rate_effective_now() -> datetime:
     return now_utc().replace(microsecond=0)
 
 
-def _decimal(value: Any, *, field_name: str) -> Decimal:
+def _decimal(value: object, *, field_name: str) -> Decimal:
     try:
         result = Decimal(str(value).strip())
     except (InvalidOperation, AttributeError, TypeError, ValueError):
@@ -557,7 +557,7 @@ def get_operator_rate_config(app: Flask) -> dict[str, Any]:
         }
 
 
-def _normalize_usage_type(value: Any) -> int:
+def _normalize_usage_type(value: object) -> int:
     if isinstance(value, str):
         normalized = value.strip().lower()
         if normalized in _USAGE_TYPE_CODES:
@@ -571,7 +571,7 @@ def _normalize_usage_type(value: Any) -> int:
     return numeric
 
 
-def _normalize_metric(value: Any, *, usage_type: int) -> int:
+def _normalize_metric(value: object, *, usage_type: int) -> int:
     if isinstance(value, str):
         normalized = value.strip()
         if normalized in _METRIC_CODES:

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
@@ -133,7 +133,7 @@ def _resolve_course_credit_usage_scene_filter(value: str) -> str:
     return ""
 
 
-def _build_course_credit_usage_scene_filter(value: str) -> Any | None:
+def _build_course_credit_usage_scene_filter(value: str) -> object | None:
     if value == COURSE_CREDIT_USAGE_SCENE_LEARNING:
         return BillUsageRecord.usage_scene == BILL_USAGE_SCENE_PROD
     if value == COURSE_CREDIT_USAGE_SCENE_PREVIEW:
@@ -304,7 +304,7 @@ def _build_course_credit_usage_group_key(
 def _build_operator_course_credit_usage_item(
     *,
     usage_row: BillUsageRecord,
-    ledger_amount: Any,
+    ledger_amount: object,
     user_map: dict[str, dict[str, Any]],
     outline_context_map: dict[str, dict[str, str]],
     group_key: str = "",
@@ -314,8 +314,8 @@ def _build_operator_course_credit_usage_item(
     model: str = "",
     model_label: str = "",
     model_variant_count: int = 0,
-    consumed_credits: Any = None,
-    created_at: Any = None,
+    consumed_credits: object = None,
+    created_at: object = None,
 ) -> AdminOperationCourseCreditUsageItemDTO:
     user_bid = str(getattr(usage_row, "user_bid", "") or "").strip()
     outline_item_bid = str(getattr(usage_row, "outline_item_bid", "") or "").strip()
@@ -372,11 +372,13 @@ def _build_operator_course_credit_usage_item(
     )
 
 
-def _build_course_credit_usage_generation_name_expr() -> Any:
+def _build_course_credit_usage_generation_name_expr() -> object:
     return db.func.lower(BillUsageRecord.extra["generation_name"].as_string())
 
 
-def _build_course_credit_usage_ask_filter(generation_name: Any | None = None) -> Any:
+def _build_course_credit_usage_ask_filter(
+    generation_name: object | None = None,
+) -> object:
     generation_name = (
         generation_name
         if generation_name is not None
@@ -390,8 +392,8 @@ def _build_course_credit_usage_ask_filter(generation_name: Any | None = None) ->
 
 
 def _build_course_credit_usage_learn_filter(
-    generation_name: Any | None = None,
-) -> Any:
+    generation_name: object | None = None,
+) -> object:
     generation_name = (
         generation_name
         if generation_name is not None
@@ -592,7 +594,7 @@ def _load_course_credit_usage_output_summary_map(
     if not generated_block_bids:
         return {}
 
-    def context_key(row: Any) -> tuple[str, str, str, str]:
+    def context_key(row: object) -> tuple[str, str, str, str]:
         return (
             str(getattr(row, "generated_block_bid", "") or "").strip(),
             str(getattr(row, "shifu_bid", "") or "").strip(),
@@ -715,7 +717,7 @@ def _load_course_credit_usage_output_summary_map(
 
 def _build_operator_course_credit_usage_detail_item(
     usage_row: BillUsageRecord,
-    ledger_amount: Any,
+    ledger_amount: object,
     model_label_resolver: _CourseCreditUsageModelLabelResolver,
     output_summary: str | None = None,
 ) -> AdminOperationCourseCreditUsageDetailItemDTO:
@@ -745,7 +747,7 @@ def _build_operator_course_credit_usage_detail_item(
     )
 
 
-def _apply_course_credit_usage_filters(query: Any, filters: dict) -> Any:
+def _apply_course_credit_usage_filters(query: object, filters: dict) -> object:
     keyword = str(filters.get("keyword", "") or "").strip()
     mode_filter = _resolve_course_credit_usage_mode_filter(
         str(filters.get("mode", "") or "")
@@ -923,8 +925,8 @@ def _build_operator_course_credit_metrics(
 
 
 def _build_credit_usage_user_keyword_filter(
-    user_bid_column: Any, keyword: str
-) -> Any | None:
+    user_bid_column: object, keyword: str
+) -> object | None:
     normalized = _normalize_identifier(keyword)
     if not normalized:
         return None

--- a/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
@@ -91,8 +91,8 @@ def _build_course_follow_up_base_subquery(shifu_bid: str) -> object:
 
 
 def _build_follow_up_user_keyword_filter(
-    user_bid_column: Any, keyword: str
-) -> Any | None:
+    user_bid_column: object, keyword: str
+) -> object | None:
     normalized = _normalize_identifier(keyword)
     if not normalized:
         return None

--- a/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
@@ -1055,11 +1055,11 @@ def _find_operator_course_bids_by_name(course_name: str) -> set[str]:
 
 
 def _build_operator_course_query_filter(
-    shifu_bid_column: Any,
+    shifu_bid_column: object,
     course_query: str,
     *,
     matching_course_bids: set[str] | None = None,
-) -> Any | None:
+) -> object | None:
     normalized_course_query = str(course_query or "").strip()
     if not normalized_course_query:
         return None

--- a/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
@@ -308,7 +308,7 @@ USER_STATE_TO_OPERATOR_STATUS = {
 }
 
 
-def _get_legacy_admin_symbol(name: str, fallback: Any) -> Any:
+def _get_legacy_admin_symbol(name: str, fallback: object) -> object:
     admin_module = sys.modules.get("flaskr.service.shifu.admin")
     if admin_module is None:
         return fallback
@@ -324,7 +324,7 @@ def _format_decimal(value: Decimal | None) -> str:
     return normalized
 
 
-def _coerce_operator_datetime(value: Any) -> datetime | None:
+def _coerce_operator_datetime(value: object) -> datetime | None:
     if value is None:
         return None
     if isinstance(value, datetime):
@@ -361,7 +361,7 @@ def _format_average_score(value: Decimal | None) -> str:
     return f"{value:.1f}"
 
 
-def _normalize_metadata_json(value: Any) -> dict[str, Any]:
+def _normalize_metadata_json(value: object) -> dict[str, Any]:
     if isinstance(value, dict):
         return value
     return {}

--- a/src/api/flaskr/service/shifu/admin_operations/shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/shared.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from flask import current_app
 from flaskr.service.user.models import AuthCredential
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
-def coerce_operator_datetime(value: Any) -> datetime | None:
+def coerce_operator_datetime(value: object) -> datetime | None:
     """Coerce operator datetime."""
     if value is None:
         return None
@@ -46,7 +46,7 @@ def coerce_operator_datetime(value: Any) -> datetime | None:
     return None
 
 
-def format_operator_datetime(value: Any) -> str:
+def format_operator_datetime(value: object) -> str:
     """Format operator datetime."""
     normalized_value = coerce_operator_datetime(value)
     if not normalized_value:

--- a/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
+++ b/src/api/flaskr/service/shifu/admin_operations/voice_clones.py
@@ -64,7 +64,7 @@ def _normalize_text(value: object) -> str:
     return str(value or "").strip()
 
 
-def _decimal_to_str(value: Any) -> str:
+def _decimal_to_str(value: object) -> str:
     if value is None:
         return "0"
     if isinstance(value, Decimal):

--- a/src/api/flaskr/service/shifu/admin_shared.py
+++ b/src/api/flaskr/service/shifu/admin_shared.py
@@ -289,7 +289,7 @@ def _format_decimal(value: Decimal | None) -> str:
     return normalized
 
 
-def _coerce_operator_datetime(value: Any) -> datetime | None:
+def _coerce_operator_datetime(value: object) -> datetime | None:
     if value is None:
         return None
     if isinstance(value, datetime):
@@ -320,7 +320,7 @@ def _coerce_operator_datetime(value: Any) -> datetime | None:
     return None
 
 
-def _normalize_metadata_json(value: Any) -> dict[str, Any]:
+def _normalize_metadata_json(value: object) -> dict[str, Any]:
     if isinstance(value, dict):
         return value
     return {}

--- a/src/api/flaskr/service/shifu/admin_user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_user_credits.py
@@ -185,7 +185,7 @@ def _resolve_course_credit_usage_scene_filter(value: str) -> str:
     return ""
 
 
-def _build_course_credit_usage_scene_filter(value: str) -> Any | None:
+def _build_course_credit_usage_scene_filter(value: str) -> object | None:
     if value == COURSE_CREDIT_USAGE_SCENE_LEARNING:
         return BillUsageRecord.usage_scene == BILL_USAGE_SCENE_PROD
     if value == COURSE_CREDIT_USAGE_SCENE_PREVIEW:
@@ -239,7 +239,7 @@ def _build_course_credit_usage_group_key(
 def _build_operator_course_credit_usage_item(
     *,
     usage_row: BillUsageRecord,
-    ledger_amount: Any,
+    ledger_amount: object,
     user_map: dict[str, dict[str, Any]],
     outline_context_map: dict[str, dict[str, str]],
     group_key: str = "",
@@ -248,8 +248,8 @@ def _build_operator_course_credit_usage_item(
     provider: str = "",
     model: str = "",
     model_variant_count: int = 0,
-    consumed_credits: Any = None,
-    created_at: Any = None,
+    consumed_credits: object = None,
+    created_at: object = None,
 ) -> AdminOperationCourseCreditUsageItemDTO:
     user_bid = str(getattr(usage_row, "user_bid", "") or "").strip()
     outline_item_bid = str(getattr(usage_row, "outline_item_bid", "") or "").strip()
@@ -305,11 +305,13 @@ def _build_operator_course_credit_usage_item(
     )
 
 
-def _build_course_credit_usage_generation_name_expr() -> Any:
+def _build_course_credit_usage_generation_name_expr() -> object:
     return db.func.lower(BillUsageRecord.extra["generation_name"].as_string())
 
 
-def _build_course_credit_usage_ask_filter(generation_name: Any | None = None) -> Any:
+def _build_course_credit_usage_ask_filter(
+    generation_name: object | None = None,
+) -> object:
     generation_name = (
         generation_name
         if generation_name is not None
@@ -323,8 +325,8 @@ def _build_course_credit_usage_ask_filter(generation_name: Any | None = None) ->
 
 
 def _build_course_credit_usage_learn_filter(
-    generation_name: Any | None = None,
-) -> Any:
+    generation_name: object | None = None,
+) -> object:
     generation_name = (
         generation_name
         if generation_name is not None
@@ -525,7 +527,7 @@ def _load_course_credit_usage_output_summary_map(
     if not generated_block_bids:
         return {}
 
-    def context_key(row: Any) -> tuple[str, str, str, str]:
+    def context_key(row: object) -> tuple[str, str, str, str]:
         return (
             str(getattr(row, "generated_block_bid", "") or "").strip(),
             str(getattr(row, "shifu_bid", "") or "").strip(),
@@ -648,7 +650,7 @@ def _load_course_credit_usage_output_summary_map(
 
 def _build_operator_course_credit_usage_detail_item(
     usage_row: BillUsageRecord,
-    ledger_amount: Any,
+    ledger_amount: object,
     output_summary: str | None = None,
 ) -> AdminOperationCourseCreditUsageDetailItemDTO:
     return AdminOperationCourseCreditUsageDetailItemDTO(
@@ -670,7 +672,7 @@ def _build_operator_course_credit_usage_detail_item(
     )
 
 
-def _apply_course_credit_usage_filters(query: Any, filters: dict) -> Any:
+def _apply_course_credit_usage_filters(query: object, filters: dict) -> object:
     keyword = str(filters.get("keyword", "") or "").strip()
     mode_filter = _resolve_course_credit_usage_mode_filter(
         str(filters.get("mode", "") or "")
@@ -980,7 +982,7 @@ def _resolve_operator_credit_usage_scene(metadata: dict[str, Any]) -> int:
         return 0
 
 
-def _operator_credit_int(value: Any, default: int = 0) -> int:
+def _operator_credit_int(value: object, default: int = 0) -> int:
     candidate = _safe_int(value)
     return candidate if candidate is not None else default
 

--- a/src/api/flaskr/service/shifu/ask_provider_registry.py
+++ b/src/api/flaskr/service/shifu/ask_provider_registry.py
@@ -526,7 +526,7 @@ def get_ask_provider_schema_registry() -> dict[str, dict[str, Any]]:
 
 
 def validate_ask_provider_specific_config(
-    provider: str, config: Any
+    provider: str, config: object
 ) -> tuple[bool, str | None]:
     """Lightweight validation against provider schema required fields."""
     registry = get_ask_provider_schema_registry()
@@ -569,7 +569,7 @@ def validate_ask_provider_specific_config(
     return True, None
 
 
-def get_effective_ask_provider_config(raw_config: Any) -> dict[str, Any]:
+def get_effective_ask_provider_config(raw_config: object) -> dict[str, Any]:
     """Normalize persisted ask provider config."""
     return normalize_ask_provider_config(raw_config)
 

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -69,7 +69,7 @@ SUPPORTED_ASK_ENABLED_STATUSES = {
 }
 
 
-def normalize_ask_provider_config(raw_config: Any) -> dict[str, Any]:
+def normalize_ask_provider_config(raw_config: object) -> dict[str, Any]:
     """Normalize ask_provider_config into a stable object shape."""
     parsed: dict[str, Any] = {}
     if isinstance(raw_config, dict):
@@ -103,7 +103,7 @@ def normalize_ask_provider_config(raw_config: Any) -> dict[str, Any]:
     }
 
 
-def serialize_ask_provider_config(raw_config: Any) -> str:
+def serialize_ask_provider_config(raw_config: object) -> str:
     """Serialize ask_provider_config into canonical JSON for persistence."""
     normalized = normalize_ask_provider_config(raw_config)
     return json.dumps(normalized, ensure_ascii=False, sort_keys=True)
@@ -409,7 +409,7 @@ def save_shifu_draft_info(
     ask_model: str | None = None,
     ask_temperature: float | None = None,
     ask_system_prompt: str | None = None,
-    ask_provider_config: Any = None,
+    ask_provider_config: object = None,
 ) -> ShifuDto:
     """Save shifu draft info.
 

--- a/src/api/flaskr/service/shifu/tts_preview.py
+++ b/src/api/flaskr/service/shifu/tts_preview.py
@@ -6,7 +6,7 @@ import base64
 import json
 import uuid
 from dataclasses import replace
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from flask import Response, current_app, stream_with_context
 from flaskr.api.tts import (
@@ -34,8 +34,8 @@ if TYPE_CHECKING:
 
 
 def _build_tts_preview_usage_metadata(
-    voice_settings: Any,
-    audio_settings: Any,
+    voice_settings: object,
+    audio_settings: object,
 ) -> dict[str, object]:
     return {
         "voice_id": getattr(voice_settings, "voice_id", "") or "",

--- a/src/api/flaskr/service/tts/audio_record_utils.py
+++ b/src/api/flaskr/service/tts/audio_record_utils.py
@@ -24,7 +24,7 @@ def build_completed_audio_record(
     oss_object_key: str,
     duration_ms: int,
     file_size: int,
-    voice_settings: Any,
+    voice_settings: object,
     tts_model: str,
     text_length: int,
     segment_count: int,

--- a/src/api/flaskr/service/tts/minimax_voice_clone.py
+++ b/src/api/flaskr/service/tts/minimax_voice_clone.py
@@ -1188,5 +1188,5 @@ def _normalize_required(value: str, field_name: str) -> str:
     return normalized
 
 
-def _zero() -> Any:
+def _zero() -> object:
     return quantize_credit_amount(0)

--- a/src/api/flaskr/service/tts/validation.py
+++ b/src/api/flaskr/service/tts/validation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from flaskr.api.tts import get_tts_provider
 from flaskr.service.common.models import raise_error_with_args
@@ -43,14 +43,14 @@ def _raise_param_error(message: str) -> None:
     raise_error_with_args("server.common.paramsError", param_message=message)
 
 
-def _to_float(value: Any, field_name: str) -> float:
+def _to_float(value: object, field_name: str) -> float:
     try:
         return float(value)
     except (TypeError, ValueError):
         _raise_param_error(f"Invalid {field_name}: {value!r}")
 
 
-def _to_int(value: Any, field_name: str) -> int:
+def _to_int(value: object, field_name: str) -> int:
     try:
         return int(value)
     except (TypeError, ValueError):
@@ -62,8 +62,8 @@ def validate_tts_settings_strict(
     provider: str,
     model: str,
     voice_id: str,
-    speed: Any,
-    pitch: Any,
+    speed: object,
+    pitch: object,
     emotion: str,
 ) -> StrictTTSSettings:
     """Validate strict, DB-driven TTS settings.

--- a/src/api/flaskr/service/user/auth/base.py
+++ b/src/api/flaskr/service/user/auth/base.py
@@ -100,7 +100,7 @@ class AuthProvider(ABC):
     def verify(self, app: Flask, request: VerificationRequest) -> AuthResult:
         """Validate a user based on the incoming verification request."""
 
-    def begin_oauth(self, app: Flask, metadata: dict[str, Any]) -> Any:
+    def begin_oauth(self, app: Flask, metadata: dict[str, Any]) -> object:
         """Initiate an OAuth flow (optional)."""
         message = f"Provider '{self.provider_name}' does not support OAuth begin"
         raise NotImplementedError(message)

--- a/src/api/flaskr/service/user/auth/oauth_origins.py
+++ b/src/api/flaskr/service/user/auth/oauth_origins.py
@@ -10,7 +10,7 @@ checked against domains we actually serve, which is what this module does.
 from __future__ import annotations
 
 from importlib import import_module
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from urllib.parse import urlsplit, urlunsplit
 
 from flaskr.common.public_urls import (
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 DEFAULT_PORTS = {"http": 80, "https": 443}
 
 
-def normalize_origin(value: Any) -> str:
+def normalize_origin(value: object) -> str:
     """Reduce a URL to a bare ``scheme://host`` origin, or "" if unusable.
 
     Credentials and non-default ports are refused rather than carried through:
@@ -56,7 +56,7 @@ def normalize_origin(value: Any) -> str:
     return urlunsplit((parsed.scheme, hostname, "", "", ""))
 
 
-def is_allowed_oauth_origin(app: Flask, origin: Any) -> bool:
+def is_allowed_oauth_origin(app: Flask, origin: object) -> bool:
     """Return whether the browser may be handed back to this origin.
 
     Allowed are the deployment's own origin, the origin of the configured
@@ -84,7 +84,7 @@ def is_allowed_oauth_origin(app: Flask, origin: Any) -> bool:
         return False
 
 
-def resolve_oauth_return_origin(app: Flask, origin: Any) -> str:
+def resolve_oauth_return_origin(app: Flask, origin: object) -> str:
     """Return the origin to hand back to, or "" when it is not allowed."""
     normalized_origin = normalize_origin(origin)
     if not normalized_origin:

--- a/src/api/flaskr/service/user/captcha.py
+++ b/src/api/flaskr/service/user/captcha.py
@@ -65,7 +65,7 @@ def _normalize_code(value: str | None) -> str:
     return str(value or "").strip().upper()
 
 
-def _decode_cache_value(value: Any) -> str | None:
+def _decode_cache_value(value: object) -> str | None:
     if value is None:
         return None
     if isinstance(value, bytes):

--- a/src/api/flaskr/service/user/onboarding.py
+++ b/src/api/flaskr/service/user/onboarding.py
@@ -59,7 +59,7 @@ def _serialize_datetime(value: datetime | None) -> str | None:
     return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
-def _parse_rollout_threshold(value: Any) -> datetime | None:
+def _parse_rollout_threshold(value: object) -> datetime | None:
     text = str(value or "").strip()
     if not text:
         return None

--- a/src/api/scripts/observability_consistency_probes.py
+++ b/src/api/scripts/observability_consistency_probes.py
@@ -86,7 +86,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def json_safe(value: Any) -> Any:
+def json_safe(value: object) -> object:
     """Convert a probe value to a JSON-compatible scalar."""
     if isinstance(value, datetime):
         return value.isoformat()
@@ -95,12 +95,12 @@ def json_safe(value: Any) -> Any:
     return value
 
 
-def row_to_dict(row: Any) -> dict[str, Any]:
+def row_to_dict(row: object) -> dict[str, Any]:
     """Convert a database result row to a dictionary."""
     return {key: json_safe(value) for key, value in dict(row).items()}
 
 
-def table_has_columns(inspector: Any, table_name: str, columns: set[str]) -> bool:
+def table_has_columns(inspector: object, table_name: str, columns: set[str]) -> bool:
     """Return whether a database table exposes every required column."""
     if table_name not in set(inspector.get_table_names()):
         return False
@@ -140,7 +140,7 @@ def rows_probe(
     }
 
 
-def execute_rows(db: Any, sql: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+def execute_rows(db: object, sql: str, params: dict[str, Any]) -> list[dict[str, Any]]:
     """Execute rows."""
     statement = text(sql)
     decimal_params = [
@@ -155,8 +155,8 @@ def execute_rows(db: Any, sql: str, params: dict[str, Any]) -> list[dict[str, An
 
 
 def probe_usage_ledger(
-    db: Any,
-    inspector: Any,
+    db: object,
+    inspector: object,
     args: argparse.Namespace,
     now: datetime,
     since: datetime,
@@ -218,8 +218,8 @@ def probe_usage_ledger(
 
 
 def probe_wallet_snapshot(
-    db: Any,
-    inspector: Any,
+    db: object,
+    inspector: object,
     args: argparse.Namespace,
     now: datetime,
     since: datetime,
@@ -357,8 +357,8 @@ def probe_wallet_snapshot(
 
 
 def probe_bucket_expiration(
-    db: Any,
-    inspector: Any,
+    db: object,
+    inspector: object,
     args: argparse.Namespace,
     now: datetime,
     since: datetime,
@@ -421,8 +421,8 @@ def probe_bucket_expiration(
 
 
 def probe_model_override_inventory(
-    db: Any,
-    inspector: Any,
+    db: object,
+    inspector: object,
     args: argparse.Namespace,
     now: datetime,
     since: datetime,
@@ -500,8 +500,8 @@ def probe_model_override_inventory(
 
 
 def probe_sms_send_failures(
-    db: Any,
-    inspector: Any,
+    db: object,
+    inspector: object,
     args: argparse.Namespace,
     now: datetime,
     since: datetime,
@@ -542,8 +542,8 @@ def probe_sms_send_failures(
 
 
 def probe_notification_template_sync(
-    db: Any,
-    inspector: Any,
+    db: object,
+    inspector: object,
     args: argparse.Namespace,
     now: datetime,
     since: datetime,

--- a/src/api/scripts/tts_test_report.py
+++ b/src/api/scripts/tts_test_report.py
@@ -18,7 +18,6 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 # Ensure `/app` (repo root for src/api) is on sys.path when executed as a file path.
 _API_ROOT = Path(__file__).resolve().parents[1]
@@ -86,7 +85,7 @@ class ReportRow:
         return f'<audio controls preload="none" src="{url}"></audio>'
 
 
-def _safe_str(value: Any) -> str:
+def _safe_str(value: object) -> str:
     return ("" if value is None else str(value)).strip()
 
 
@@ -254,7 +253,7 @@ def _render_html(rows: list[ReportRow], *, output_path: str) -> str:
     return str(out.resolve())
 
 
-def _escape_markdown_cell(value: Any) -> str:
+def _escape_markdown_cell(value: object) -> str:
     cell = _safe_str(value)
     if not cell:
         return ""

--- a/src/api/tests/common/fixtures/fake_redis.py
+++ b/src/api/tests/common/fixtures/fake_redis.py
@@ -41,7 +41,7 @@ class FakeRedis:
     def _now(self) -> float:
         return time.time()
 
-    def _encode(self, value: Any) -> bytes:
+    def _encode(self, value: object) -> bytes:
         if isinstance(value, bytes):
             return value
         if isinstance(value, (int, float, bool)):
@@ -86,7 +86,7 @@ class FakeRedis:
     def set(
         self,
         key: str,
-        value: Any,
+        value: object,
         ex: int | None = None,
         px: int | None = None,
         nx: bool = False,
@@ -110,7 +110,7 @@ class FakeRedis:
             self._expires.pop(key, None)
         return True
 
-    def setex(self, key: str, time_in_seconds: int, value: Any) -> bool:
+    def setex(self, key: str, time_in_seconds: int, value: object) -> bool:
         return self.set(key, value, ex=time_in_seconds)
 
     def delete(self, *keys: str) -> int:

--- a/src/api/tests/golden/normalize.py
+++ b/src/api/tests/golden/normalize.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
 
 HEX_ID_RE = re.compile(r"\b[0-9a-f]{32}\b")
 UUID_RE = re.compile(
@@ -70,7 +69,7 @@ class IdNormalizer:
         value = HEX_ID_RE.sub(self._replace_match, value)
         return ISO_TS_RE.sub("<TS>", value)
 
-    def normalize_value(self, value: Any, field_name: str | None = None) -> Any:
+    def normalize_value(self, value: object, field_name: str | None = None) -> object:
         if isinstance(value, str):
             return self.normalize_string(value)
         if isinstance(value, bool):
@@ -115,7 +114,9 @@ def normalize_sse_transcript(
     return "\n".join(lines) + "\n"
 
 
-def normalize_json_payload(payload: Any, normalizer: IdNormalizer | None = None) -> str:
+def normalize_json_payload(
+    payload: object, normalizer: IdNormalizer | None = None
+) -> str:
     """Normalize a JSON response payload into a stable pretty-printed string."""
     normalizer = normalizer or IdNormalizer()
     normalized = normalizer.normalize_value(payload)

--- a/src/api/tests/service/billing/test_creator_customization.py
+++ b/src/api/tests/service/billing/test_creator_customization.py
@@ -4,7 +4,6 @@ import hashlib
 from importlib import import_module
 from io import BytesIO
 from types import SimpleNamespace
-from typing import Any
 
 import pytest
 from cryptography.fernet import Fernet
@@ -696,7 +695,7 @@ def test_installed_but_disabled_saas_plugin_falls_back(app, monkeypatch) -> None
     """A deployment can ship the plugin package without configuring its database; SAAS_PLUGIN_ENABLED then stays false and the plugin bind points at an unreachable host, so customization reads must not touch it."""
 
     class _ExplodingModule:
-        def __getattr__(self, name) -> Any:
+        def __getattr__(self, name) -> object:
             message = "SaaS plugin must not be used while SAAS_PLUGIN_ENABLED is false"
             raise AssertionError(message)
 

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Never, Self
+from typing import TYPE_CHECKING, Never, Self
 
 import pytest
 from flask import Flask
@@ -544,7 +544,7 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(
             self.billing_reservation_bid = ""
             self.estimated_credits = Decimal(0)
 
-        def __getattribute__(self, name) -> Any:
+        def __getattribute__(self, name) -> object:
             protected = {
                 "voice_bid",
                 "voice_id",


### PR DESCRIPTION
## Summary

- Stack this PR on #2618.
- Enable Ruff `ANN401` and replace all 489 mutable function-boundary `Any` annotations across 109 Python files with `object` or `object | None`, preserving every accepted runtime value while requiring consumers to narrow unknown data before type-specific use.
- Remove 28 now-unused `typing.Any` imports and retain one exact exception for the already-applied `0a7c4d8e9f12_backfill_billing_product_plan_tier.py` migration; no migration history is edited.
- Document the preferred future treatment: use concrete protocols, DTOs, models, scalars, or collections for stable contracts; reserve `object` for genuinely heterogeneous JSON, SDK, ORM, decorator, compatibility, and test-double boundaries; never hide `Any` behind aliases or unchecked casts.

## Verification

- Semantic audit: 489 reviewed annotation rewrites across 109 files, 28 removed `typing.Any` imports, and executable AST equality with the ISC004 parent.
- Focused tests: 1 trace-harness test and 13 observability, API-golden, and Redis-contract tests passed.
- Full backend: 3,032 passed, 17 skipped, 733 existing warnings.
- Regenerated 83 collaboration documents and six repository knowledge documents with no generated-file drift.
- Translation, repository harness, architecture boundary, compile, configured Ruff, format, pinned development-tool, and full pre-commit gates passed.

## Ruff census

- Stable: 19,038 -> 18,553. ANN401: 490 -> 0; formatter-conflicting COM812 rises by five where longer `object` signatures wrap.
- Isolated: 33,171 -> 32,687. ANN401: 490 -> 1, the exact immutable migration finding; COM812 rises by the same five.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->