### PR TITLE
fix: prevent cached tokens from double charging

### DIFF
--- a/src/api/flaskr/service/billing/charges.py
+++ b/src/api/flaskr/service/billing/charges.py
@@ -171,13 +171,17 @@ def build_usage_metric_charges(
 ) -> list[UsageMetricCharge]:
     usage_type = int(usage.usage_type or 0)
     if usage_type == BILL_USAGE_TYPE_LLM:
+        uncached_input = max(
+            int(usage.input or 0) - int(usage.input_cache or 0),
+            0,
+        )
         return [
             charge
             for charge in (
                 build_metric_charge(
                     usage,
                     billing_metric=BILLING_METRIC_LLM_INPUT_TOKENS,
-                    raw_amount=int(usage.input or 0),
+                    raw_amount=uncached_input,
                     settlement_at=settlement_at,
                 ),
                 build_metric_charge(

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -307,7 +307,7 @@ def test_settle_llm_usage_consumes_multi_metric_in_bucket_priority_order(
     )
 
     with billing_settlement_app.app_context():
-        wallet = _create_wallet("creator-1", "4.0000000000")
+        wallet = _create_wallet("creator-1", "3.0000000000")
         dao.db.session.add(wallet)
         dao.db.session.add(_create_active_subscription("creator-1"))
         dao.db.session.add_all(
@@ -318,7 +318,7 @@ def test_settle_llm_usage_consumes_multi_metric_in_bucket_priority_order(
                     bucket_bid="bucket-free",
                     category=CREDIT_BUCKET_CATEGORY_FREE,
                     priority=10,
-                    available_credits="2.0000000000",
+                    available_credits="1.0000000000",
                 ),
                 _create_bucket(
                     creator_bid="creator-1",
@@ -387,12 +387,12 @@ def test_settle_llm_usage_consumes_multi_metric_in_bucket_priority_order(
 
         assert payload["status"] == "settled"
         assert payload["entry_count"] == 1
-        assert payload["consumed_credits"] == 4
+        assert payload["consumed_credits"] == 3
         assert wallet.available_credits == Decimal("0E-10")
-        assert wallet.lifetime_consumed_credits == Decimal("4.0000000000")
+        assert wallet.lifetime_consumed_credits == Decimal("3.0000000000")
         assert len(entries) == 1
         assert entries[0].wallet_bucket_bid == ""
-        assert entries[0].amount == Decimal("-4.0000000000")
+        assert entries[0].amount == Decimal("-3.0000000000")
         assert entries[0].balance_after == Decimal("0E-10")
         assert [
             row["billing_metric"]
@@ -402,6 +402,9 @@ def test_settle_llm_usage_consumes_multi_metric_in_bucket_priority_order(
             "llm_cache_tokens",
             "llm_output_tokens",
         ]
+        assert [
+            row["raw_amount"] for row in entries[0].metadata_json["metric_breakdown"]
+        ] == [200, 1000, 1000]
         assert [
             row["wallet_bucket_bid"]
             for row in entries[0].metadata_json["bucket_breakdown"]


### PR DESCRIPTION
## Summary
- Exclude cached input tokens from the LLM input billing metric during usage settlement
- Keep cached input and output token metrics billed separately for future cache-specific rates
- Update settlement regression coverage to assert raw metric amounts are input minus cache, cache, and output

## Verification
- python scripts/check_dev_tools.py
- cd src/api && pytest tests/service/billing/test_usage_settlement.py tests/service/billing/test_billing_daily_usage_aggregates.py tests/service/billing/test_billing_daily_aggregate_rebuild.py -q
- cd src/api && python -m ruff check flaskr/service/billing/charges.py tests/service/billing/test_usage_settlement.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - LLM usage charges now calculate input costs using uncached tokens only, while cache and output charges remain unchanged.
  - Corrected credit settlement calculations and recorded usage amounts for multi-metric LLM billing.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->