### PR TITLE
chore: remove local naming exceptions

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -389,6 +389,15 @@ visible result. Keep a one-line contract when sufficient, and make test-double
 operators name the fake expression they build. Do not write filler such as
 "Implement `__json__`".
 
+For `N806`, distinguish a class declaration or module-level class import from
+a value bound inside a function. Keep real class names in CapWords, but bind a
+locally loaded model or constructor to a descriptive snake_case name such as
+`draft_shifu_model` or `session_factory`, then use that name consistently in
+the function. Preserve a deliberate lazy import instead of moving it to module
+scope merely for lint, and do not add a per-file exception for ordinary local
+bindings. Run the tests that exercise the local loader or factory so the rename
+cannot silently point queries or object creation at a different class.
+
 For `D100`, describe why the module exists at its ownership boundary. A
 production module names the service responsibility, protocol, or data contract
 it owns; a test module names the behavior group it protects; an executable

--- a/ruff.toml
+++ b/ruff.toml
@@ -265,12 +265,6 @@ runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 # These trees are input fixtures for check_architecture_boundaries.py, not
 # importable code.
 "scripts/testdata/**" = ["INP001"]
-# These suites bind SQLAlchemy model classes and session factories to local
-# names, where the CapWords spelling is the point.
-"src/api/tests/service/shifu/test_archive.py" = ["N806"]
-"src/api/tests/service/shifu/test_mdflow_history_routes.py" = ["N806"]
-"src/api/tests/service/shifu/test_permissions.py" = ["N806"]
-"src/api/tests/service/billing/test_renewal_uow_failure_paths.py" = ["N806"]
 "src/api/conftest.py" = ["S101"]
 "scripts/test_*.py" = ["S101"]
 "scripts/check_example_identifiers.py" = ["S101"]

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -1134,8 +1134,8 @@ def test_upsert_recovers_when_cross_session_insert_wins(
     ):
         calls.append(for_update)
         if len(calls) == 1:
-            Session = sessionmaker(bind=dao.db.engine)
-            other_session = Session()
+            session_factory = sessionmaker(bind=dao.db.engine)
+            other_session = session_factory()
             try:
                 winner = BillingRenewalEvent(
                     renewal_event_bid="renewal-uow-upsert-cross-session-winner",

--- a/src/api/tests/service/shifu/test_archive.py
+++ b/src/api/tests/service/shifu/test_archive.py
@@ -34,13 +34,13 @@ def _get_draft_module():
 def _seed_shifu(app, shifu_bid: str, owner_bid: str):
     """Create draft shifu row and clear archive state for testing."""
     with app.app_context():
-        _, DraftShifu, _, ShifuUserArchive = _get_models()
-        DraftShifu.query.filter_by(shifu_bid=shifu_bid).delete()
-        ShifuUserArchive.query.filter_by(
+        _, draft_shifu_model, _, shifu_user_archive_model = _get_models()
+        draft_shifu_model.query.filter_by(shifu_bid=shifu_bid).delete()
+        shifu_user_archive_model.query.filter_by(
             shifu_bid=shifu_bid, user_bid=owner_bid
         ).delete()
 
-        draft = DraftShifu(
+        draft = draft_shifu_model(
             shifu_bid=shifu_bid,
             title="Test Shifu",
             description="desc",
@@ -71,13 +71,13 @@ def test_archive_then_unarchive_updates_both_tables(app, monkeypatch):
     archive_shifu(app, owner_bid, shifu_bid)
 
     with app.app_context():
-        _, DraftShifu, _, ShifuUserArchive = _get_models()
+        _, draft_shifu_model, _, shifu_user_archive_model = _get_models()
         draft = (
-            DraftShifu.query.filter_by(shifu_bid=shifu_bid)
-            .order_by(DraftShifu.id.desc())
+            draft_shifu_model.query.filter_by(shifu_bid=shifu_bid)
+            .order_by(draft_shifu_model.id.desc())
             .first()
         )
-        archive = ShifuUserArchive.query.filter_by(
+        archive = shifu_user_archive_model.query.filter_by(
             shifu_bid=shifu_bid, user_bid=owner_bid
         ).first()
 
@@ -92,13 +92,13 @@ def test_archive_then_unarchive_updates_both_tables(app, monkeypatch):
     unarchive_shifu(app, owner_bid, shifu_bid)
 
     with app.app_context():
-        _, DraftShifu, _, ShifuUserArchive = _get_models()
+        _, draft_shifu_model, _, shifu_user_archive_model = _get_models()
         draft = (
-            DraftShifu.query.filter_by(shifu_bid=shifu_bid)
-            .order_by(DraftShifu.id.desc())
+            draft_shifu_model.query.filter_by(shifu_bid=shifu_bid)
+            .order_by(draft_shifu_model.id.desc())
             .first()
         )
-        archive = ShifuUserArchive.query.filter_by(
+        archive = shifu_user_archive_model.query.filter_by(
             shifu_bid=shifu_bid, user_bid=owner_bid
         ).first()
 
@@ -114,7 +114,7 @@ def test_create_shifu_draft_uses_now_utc_for_persisted_timestamps(app, monkeypat
     created_at = datetime(2026, 4, 21, 0, 0, 0)
     owner_bid = "owner-create-utc"
     draft_module = _get_draft_module()
-    _, DraftShifu, _, _ = _get_models()
+    _, draft_shifu_model, _, _ = _get_models()
 
     monkeypatch.setattr(draft_module, "now_utc", lambda: created_at)
     monkeypatch.setattr(draft_module, "generate_id", lambda _app: "shifu-create-utc")
@@ -144,7 +144,7 @@ def test_create_shifu_draft_uses_now_utc_for_persisted_timestamps(app, monkeypat
     )
 
     with app.app_context():
-        draft = DraftShifu.query.filter_by(shifu_bid=result.bid).first()
+        draft = draft_shifu_model.query.filter_by(shifu_bid=result.bid).first()
 
         assert draft is not None
         assert draft.created_at == created_at
@@ -154,7 +154,7 @@ def test_create_shifu_draft_uses_now_utc_for_persisted_timestamps(app, monkeypat
 def test_create_shifu_draft_initializes_default_chapter_and_lesson(app, monkeypatch):
     owner_bid = "owner-default-outline"
     draft_module = _get_draft_module()
-    DraftOutlineItem, _, LogDraftStruct, _ = _get_models()
+    draft_outline_model, _, draft_struct_model, _ = _get_models()
     from flaskr.service.shifu.shifu_history_manager import HistoryItem
 
     generated_ids = iter(
@@ -188,13 +188,13 @@ def test_create_shifu_draft_initializes_default_chapter_and_lesson(app, monkeypa
 
     with app.app_context():
         outline_items = (
-            DraftOutlineItem.query.filter_by(shifu_bid=result.bid, deleted=0)
-            .order_by(DraftOutlineItem.position.asc())
+            draft_outline_model.query.filter_by(shifu_bid=result.bid, deleted=0)
+            .order_by(draft_outline_model.position.asc())
             .all()
         )
         latest_struct = (
-            LogDraftStruct.query.filter_by(shifu_bid=result.bid, deleted=0)
-            .order_by(LogDraftStruct.id.desc())
+            draft_struct_model.query.filter_by(shifu_bid=result.bid, deleted=0)
+            .order_by(draft_struct_model.id.desc())
             .first()
         )
 
@@ -217,7 +217,7 @@ def test_default_outline_init_rebuilds_latest_struct_from_empty_history(
     owner_bid = "owner-empty-struct-rebuild"
     now_time = datetime(2026, 7, 13, 12, 0, 0)
     draft_module = _get_draft_module()
-    DraftOutlineItem, DraftShifu, LogDraftStruct, _ = _get_models()
+    draft_outline_model, draft_shifu_model, draft_struct_model, _ = _get_models()
     from flaskr.service.shifu.shifu_history_manager import HistoryItem
     from flaskr.service.shifu.shifu_outline_funcs import (
         create_default_outlines_for_new_shifu,
@@ -233,7 +233,7 @@ def test_default_outline_init_rebuilds_latest_struct_from_empty_history(
     )
 
     with app.app_context():
-        shifu = DraftShifu(
+        shifu = draft_shifu_model(
             shifu_bid="shifu-empty-struct",
             title="Draft",
             description="desc",
@@ -251,7 +251,7 @@ def test_default_outline_init_rebuilds_latest_struct_from_empty_history(
         dao.db.session.add(shifu)
         dao.db.session.flush()
 
-        empty_history = LogDraftStruct(
+        empty_history = draft_struct_model(
             struct_bid="empty-struct-bid",
             shifu_bid=shifu.shifu_bid,
             struct=HistoryItem(
@@ -280,13 +280,16 @@ def test_default_outline_init_rebuilds_latest_struct_from_empty_history(
         dao.db.session.commit()
 
         outline_items = (
-            DraftOutlineItem.query.filter_by(shifu_bid=shifu.shifu_bid, deleted=0)
-            .order_by(DraftOutlineItem.position.asc())
+            draft_outline_model.query.filter_by(
+                shifu_bid=shifu.shifu_bid,
+                deleted=0,
+            )
+            .order_by(draft_outline_model.position.asc())
             .all()
         )
         latest_struct = (
-            LogDraftStruct.query.filter_by(shifu_bid=shifu.shifu_bid, deleted=0)
-            .order_by(LogDraftStruct.id.desc())
+            draft_struct_model.query.filter_by(shifu_bid=shifu.shifu_bid, deleted=0)
+            .order_by(draft_struct_model.id.desc())
             .first()
         )
 

--- a/src/api/tests/service/shifu/test_mdflow_history_routes.py
+++ b/src/api/tests/service/shifu/test_mdflow_history_routes.py
@@ -35,13 +35,13 @@ def _seed_shifu_with_outline(
     content: str,
 ) -> int:
     with app.app_context():
-        DraftShifu, DraftOutlineItem = _get_models()
-        DraftOutlineItem.query.filter_by(
+        draft_shifu_model, draft_outline_model = _get_models()
+        draft_outline_model.query.filter_by(
             shifu_bid=shifu_bid, outline_item_bid=outline_bid
         ).delete()
-        DraftShifu.query.filter_by(shifu_bid=shifu_bid).delete()
+        draft_shifu_model.query.filter_by(shifu_bid=shifu_bid).delete()
 
-        draft = DraftShifu(
+        draft = draft_shifu_model(
             shifu_bid=shifu_bid,
             title="History Route Test",
             description="desc",
@@ -57,7 +57,7 @@ def _seed_shifu_with_outline(
         dao.db.session.add(draft)
         dao.db.session.flush()
 
-        outline = DraftOutlineItem(
+        outline = draft_outline_model(
             shifu_bid=shifu_bid,
             outline_item_bid=outline_bid,
             title="Unit A",
@@ -180,13 +180,13 @@ def test_restore_mdflow_history_route_returns_deleted_flag(
     _mock_user(monkeypatch, owner_bid)
 
     with app.app_context():
-        _, DraftOutlineItem = _get_models()
+        _, draft_outline_model = _get_models()
         latest = (
-            DraftOutlineItem.query.filter_by(
+            draft_outline_model.query.filter_by(
                 shifu_bid=shifu_bid,
                 outline_item_bid=outline_bid,
             )
-            .order_by(DraftOutlineItem.id.desc())
+            .order_by(draft_outline_model.id.desc())
             .first()
         )
         assert latest is not None

--- a/src/api/tests/service/shifu/test_permissions.py
+++ b/src/api/tests/service/shifu/test_permissions.py
@@ -25,11 +25,11 @@ def _get_models():
 
 def _seed_shifu(app, shifu_bid: str, owner_bid: str):
     with app.app_context():
-        DraftShifu, AiCourseAuth = _get_models()
-        DraftShifu.query.filter_by(shifu_bid=shifu_bid).delete()
-        AiCourseAuth.query.filter_by(course_id=shifu_bid).delete()
+        draft_shifu_model, course_auth_model = _get_models()
+        draft_shifu_model.query.filter_by(shifu_bid=shifu_bid).delete()
+        course_auth_model.query.filter_by(course_id=shifu_bid).delete()
 
-        draft = DraftShifu(
+        draft = draft_shifu_model(
             shifu_bid=shifu_bid,
             title="Test Shifu",
             description="desc",
@@ -75,9 +75,9 @@ def _allow_email_login(monkeypatch) -> None:
 
 def _add_auth(app, shifu_bid: str, user_id: str, status: int):
     with app.app_context():
-        _, AiCourseAuth = _get_models()
+        _, course_auth_model = _get_models()
         dao.db.session.add(
-            AiCourseAuth(
+            course_auth_model(
                 course_auth_id=f"auth-{user_id}",
                 course_id=shifu_bid,
                 user_id=user_id,
@@ -187,8 +187,8 @@ class TestShifuPermissions:
         assert payload["data"]["removed"] is True
 
         with app.app_context():
-            _, AiCourseAuth = _get_models()
-            auth = AiCourseAuth.query.filter_by(
+            _, course_auth_model = _get_models()
+            auth = course_auth_model.query.filter_by(
                 course_id=shifu_bid, user_id=target_user
             ).first()
             assert auth is not None
@@ -267,9 +267,9 @@ class TestShifuPermissions:
             assert payload["code"] == 0
 
         with app.app_context():
-            _, AiCourseAuth = _get_models()
+            _, course_auth_model = _get_models()
             user = UserEntity.query.filter_by(user_bid=target_user).one()
-            auth = AiCourseAuth.query.filter_by(
+            auth = course_auth_model.query.filter_by(
                 course_id=shifu_bid,
                 user_id=target_user,
                 status=1,


### PR DESCRIPTION
## Summary

- Replace 21 function-local CapWords bindings with descriptive snake_case model or factory names while preserving the existing lazy loaders and cross-session setup.
- Remove all four N806 per-file exceptions from Ruff configuration.
- Document the preferred N806 handling for future contributors and coding agents.

## Rule accounting

An isolated N806 scan exposed 21 findings that the four per-file exceptions hid from normal checks. The repository-wide isolated N806 scan is now clean and the exceptions are deleted. The stable ALL-rule census remains 29,964 findings across 33 rules because that census already honored the removed exceptions; every other finding count is unchanged.

## Verification

- 37 focused archive, MarkdownFlow history, permission, and renewal UoW tests passed
- Full backend: 3,019 passed, 17 skipped
- ruff check --isolated --select N806 .
- ruff check .
- ruff format --check .
- Stable ALL-rule census unchanged
- Generated collaboration and knowledge documents
- Repository harness and architecture boundary checks
- lefthook run pre-commit --all-files

## Stack

- Base: main
- Head: sunner/ruff-n806
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for consistent naming of locally loaded models and constructors, including lazy imports and focused testing.

* **Tests**
  * Updated service tests to use descriptive local model names.
  * Preserved existing test behavior and assertions while removing linting exceptions.
  * Improved coverage of session, archive, history, and permission test scenarios without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->