### PR TITLE
refactor: name fixed exception messages

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -367,15 +367,20 @@ cannot express exactly, pre-format only that field with `format(value, "spec")`
 and keep the rest of the message parameterized. Do not hide an f-string in a
 temporary variable merely to silence the rule.
 
-For `EM102`, assign a contextual f-string to a collision-free local immediately
-before raising it, normally `message` or `error_message`, and pass that local as
-the same constructor argument. Preserve the exception type, exact f-string,
-remaining positional and keyword arguments, and any explicit `raise ... from`
-cause. Do not evade the rule by concatenating strings, changing formatting, or
-dropping useful values from the error. Before introducing the local, check the
-whole function for that name so a new binding cannot shadow an existing local,
-free variable, or global lookup. For bulk changes, prove the rewrite is
-structurally reversible and run tests that exercise the affected error paths.
+For the Ruff `EM` family (`EM101`-`EM103`), assign a direct string literal,
+contextual f-string, or `.format()` expression to a collision-free local
+immediately before raising it, then pass that local as the same constructor
+argument. Prefer `message`; use `error_message` or `exception_message` when the
+whole function already uses that name. Preserve the exception type, exact
+message expression, remaining positional and keyword arguments, and any
+explicit `raise ... from` cause. Do not evade the rule by concatenating strings,
+changing formatting, or dropping useful values from the error. Scan the whole
+function, including nested scopes, before introducing the local so a new binding
+cannot shadow an existing local, free variable, or global lookup. For bulk
+changes, prove the rewrite is structurally reversible and run tests that exercise
+the affected error paths. A `pytest.raises` body must remain one simple statement:
+bind its fixed message immediately before the context-manager block and keep only
+the `raise` inside.
 
 For `D205`, put the complete summary on the first physical docstring line,
 then use exactly one blank line before details, sections, or embedded protocol

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -174,6 +174,11 @@ plan's progress update for that rule.
   branch after all local gates passed.
 - [ ] Merge or retarget D100 PR #2586 after its predecessors without combining
   it with the next rule unit.
+- [x] 2026-08-21: Prepared the EM101 stage on `sunner/ruff-em101`, stacked on
+  EM102. Assigned each ProviderPriceMappingError code to a local before raising,
+  preserving exception type, message, context, and all billing error contracts.
+- [ ] Merge or retarget EM101 PR #2628 after its predecessors without combining
+  it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/ruff.toml
+++ b/ruff.toml
@@ -103,10 +103,10 @@ select = [
     "TRY300",  # return at the end of a try body that belongs in `else`
     "TRY301",  # raise inside a try body that the same block then catches
     "TRY004",  # type check raising something other than TypeError
-    # Build contextual exception text immediately before raising it. Naming
-    # the message keeps the source line in the traceback concise without
-    # changing the exception type, rendered text, or explicit cause chain.
-    "EM102",   # f-string literal passed directly to an exception constructor
+    # Build exception text immediately before raising it. Naming the message
+    # keeps the source line in the traceback concise without changing the
+    # exception type, rendered text, remaining arguments, or cause chain.
+    "EM",      # flake8-errmsg (literal, f-string, and `.format()` messages)
 
     # --- Pylint subsets ---------------------------------------------------
     "PLE",     # pylint errors (yield/return in __init__, invalid dunders, ...)

--- a/scripts/check_example_identifiers.py
+++ b/scripts/check_example_identifiers.py
@@ -422,7 +422,8 @@ def _read_index_objects(object_ids: list[str]) -> dict[str, bytes]:
     for object_id in unique_object_ids:
         header_end = result.stdout.find(b"\n", offset)
         if header_end == -1:
-            raise OSError("git cat-file returned a truncated header")
+            error_message = "git cat-file returned a truncated header"
+            raise OSError(error_message)
         header = result.stdout[offset:header_end].split()
         if len(header) != 3 or header[1] != b"blob":
             message = f"git cat-file did not return blob {object_id}"
@@ -431,7 +432,8 @@ def _read_index_objects(object_ids: list[str]) -> dict[str, bytes]:
         content_start = header_end + 1
         content_end = content_start + size
         if result.stdout[content_end : content_end + 1] != b"\n":
-            raise OSError("git cat-file returned a truncated blob")
+            error_message = "git cat-file returned a truncated blob"
+            raise OSError(error_message)
         objects[object_id] = result.stdout[content_start:content_end]
         offset = content_end + 1
     return objects
@@ -455,7 +457,8 @@ def find_violations(
 
     violations: list[IdentifierViolation] = []
     if paths is not None and staged:
-        raise ValueError("explicit paths cannot be combined with staged content")
+        message = "explicit paths cannot be combined with staged content"
+        raise ValueError(message)
 
     if paths is not None:
         candidates = [

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -105,7 +105,8 @@ def create_app() -> Flask:
 
     plugin_manager = get_plugin_manager()
     if plugin_manager is None:
-        raise RuntimeError("Plugin manager is not enabled")
+        message = "Plugin manager is not enabled"
+        raise RuntimeError(message)
 
     load_plugins_from_dir(flask_app, str(Path("flaskr") / "service"))
     try:

--- a/src/api/flaskr/api/tts/aliyun_nls_token.py
+++ b/src/api/flaskr/api/tts/aliyun_nls_token.py
@@ -243,10 +243,11 @@ def get_aliyun_nls_token(
 
     access_key_id, access_key_secret = _get_access_keys()
     if not access_key_id or not access_key_secret:
-        raise ValueError(
+        message = (
             "Aliyun NLS token is not configured. Set ALIYUN_TTS_TOKEN, or set "
             "ALIYUN_AK_ID and ALIYUN_AK_SECRET to auto-fetch a temporary token."
         )
+        raise ValueError(message)
 
     lock = cache.lock(_get_lock_key(), timeout=15, blocking_timeout=2)
     acquired = False

--- a/src/api/flaskr/api/tts/aliyun_provider.py
+++ b/src/api/flaskr/api/tts/aliyun_provider.py
@@ -1250,7 +1250,8 @@ class AliyunTTSProvider(BaseTTSProvider):
 
         """
         if not text or not text.strip():
-            raise ValueError("Text cannot be empty")
+            exception_message = "Text cannot be empty"
+            raise ValueError(exception_message)
 
         # Check text length (300 characters limit)
         if len(text) > 300:
@@ -1269,9 +1270,10 @@ class AliyunTTSProvider(BaseTTSProvider):
         appkey, region = self._get_settings()
 
         if not appkey:
-            raise ValueError(
+            exception_message = (
                 "Aliyun TTS credentials are not configured. Set ALIYUN_TTS_APPKEY"
             )
+            raise ValueError(exception_message)
         token = get_aliyun_nls_token()
 
         # Get endpoint URL

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -799,7 +799,8 @@ class BaiduTTSProvider(BaseTTSProvider):
 
         """
         if not text or not text.strip():
-            raise ValueError("Text cannot be empty")
+            error_message = "Text cannot be empty"
+            raise ValueError(error_message)
 
         # Check text length (1024 bytes limit, per Baidu docs).
         # NOTE: `requests` will URL-encode query params using UTF-8; do not pre-encode `tex`,
@@ -823,10 +824,11 @@ class BaiduTTSProvider(BaseTTSProvider):
         api_key, secret_key = self._get_credentials()
 
         if not api_key or not secret_key:
-            raise ValueError(
+            error_message = (
                 "Baidu TTS credentials are not configured. "
                 "Set BAIDU_TTS_API_KEY and BAIDU_TTS_SECRET_KEY"
             )
+            raise ValueError(error_message)
 
         # Get access token
         access_token = _get_access_token(api_key, secret_key)

--- a/src/api/flaskr/api/tts/minimax_provider.py
+++ b/src/api/flaskr/api/tts/minimax_provider.py
@@ -376,7 +376,8 @@ class MinimaxTTSProvider(BaseTTSProvider):
 
         """
         if not text or not text.strip():
-            raise ValueError("Text cannot be empty")
+            message = "Text cannot be empty"
+            raise ValueError(message)
 
         # Call API with hex output format
         result = self._call_api(
@@ -392,7 +393,8 @@ class MinimaxTTSProvider(BaseTTSProvider):
         audio_hex = data.get("audio")
 
         if not audio_hex:
-            raise ValueError("No audio data in API response")
+            message = "No audio data in API response"
+            raise ValueError(message)
 
         # Decode hex to bytes
         audio_data = bytes.fromhex(audio_hex)
@@ -436,11 +438,13 @@ class MinimaxTTSProvider(BaseTTSProvider):
         decodable audio segments before sending them to the frontend.
         """
         if not text or not text.strip():
-            raise ValueError("Text cannot be empty")
+            error_message = "Text cannot be empty"
+            raise ValueError(error_message)
 
         api_key = get_config("MINIMAX_API_KEY")
         if not api_key:
-            raise ValueError("MINIMAX_API_KEY is not configured")
+            error_message = "MINIMAX_API_KEY is not configured"
+            raise ValueError(error_message)
 
         tts_model = _resolve_minimax_model(model)
         voice_settings = voice_settings or self.get_default_voice_settings()
@@ -503,9 +507,8 @@ class MinimaxTTSProvider(BaseTTSProvider):
             try:
                 message = json.loads(line)
             except json.JSONDecodeError as exc:
-                raise ValueError(
-                    "Invalid MiniMax HTTP streaming JSON response"
-                ) from exc
+                error_message = "Invalid MiniMax HTTP streaming JSON response"
+                raise ValueError(error_message) from exc
 
             _ensure_minimax_base_resp(message, "MiniMax HTTP streaming error")
             data = message.get("data") or {}
@@ -514,7 +517,8 @@ class MinimaxTTSProvider(BaseTTSProvider):
             try:
                 audio_data = bytes.fromhex(audio_hex) if audio_hex else b""
             except ValueError as exc:
-                raise ValueError("Invalid MiniMax HTTP streaming audio hex") from exc
+                error_message = "Invalid MiniMax HTTP streaming audio hex"
+                raise ValueError(error_message) from exc
 
             status = int(data.get("status") or 0)
             is_final = status == 2 or bool(extra_info) or bool(message.get("is_final"))
@@ -567,7 +571,8 @@ class MinimaxTTSProvider(BaseTTSProvider):
         tts_model = _resolve_minimax_model(model)
 
         if not api_key:
-            raise ValueError("MINIMAX_API_KEY is not configured")
+            error_message = "MINIMAX_API_KEY is not configured"
+            raise ValueError(error_message)
 
         if not voice_settings:
             voice_settings = self.get_default_voice_settings()

--- a/src/api/flaskr/api/tts/tencent_provider.py
+++ b/src/api/flaskr/api/tts/tencent_provider.py
@@ -297,7 +297,8 @@ def _export_tencent_pcm_to_mp3(audio_data: bytes, *, sample_rate: int) -> bytes:
     if not audio_data:
         return b""
     if PydubAudioSegment is None:
-        raise ValueError("pydub is required to convert Tencent TTS PCM audio to MP3")
+        message = "pydub is required to convert Tencent TTS PCM audio to MP3"
+        raise ValueError(message)
 
     segment = PydubAudioSegment(
         data=audio_data,
@@ -1118,7 +1119,8 @@ def parse_tencent_sse_message(
             base64.b64decode(audio_value, validate=True) if audio_value else b""
         )
     except ValueError as exc:
-        raise ValueError("Invalid Tencent TTS SSE audio base64") from exc
+        error_message = "Invalid Tencent TTS SSE audio base64"
+        raise ValueError(error_message) from exc
     if not audio_data and not subtitles and not has_final_field:
         return None
 
@@ -1154,7 +1156,8 @@ class TencentTTSProvider(BaseTTSProvider):
         secret_id = str(get_config("TENCENT_TTS_SECRET_ID", "") or "").strip()
         secret_key = str(get_config("TENCENT_TTS_SECRET_KEY", "") or "").strip()
         if not secret_id or not secret_key:
-            raise ValueError("Tencent TTS credentials are not configured")
+            message = "Tencent TTS credentials are not configured"
+            raise ValueError(message)
         return TencentTTSCredentials(
             app_id=_coerce_app_id(app_id),
             secret_id=secret_id,
@@ -1221,10 +1224,12 @@ class TencentTTSProvider(BaseTTSProvider):
         model: str | None = None,
     ):
         if not self.is_configured():
-            raise ValueError("Tencent TTS is not configured")
+            error_message = "Tencent TTS is not configured"
+            raise ValueError(error_message)
         request_text = str(text or "").strip()
         if not request_text:
-            raise ValueError("Text cannot be empty")
+            error_message = "Text cannot be empty"
+            raise ValueError(error_message)
 
         credentials = self.get_credentials()
         effective_voice_settings = voice_settings or self.get_default_voice_settings()
@@ -1282,19 +1287,22 @@ class TencentTTSProvider(BaseTTSProvider):
                 try:
                     message = json.loads(line)
                 except json.JSONDecodeError as exc:
-                    raise ValueError("Invalid Tencent TTS SSE JSON response") from exc
+                    error_message = "Invalid Tencent TTS SSE JSON response"
+                    raise ValueError(error_message) from exc
                 chunk = parse_tencent_sse_message(message, request_text=request_text)
                 if chunk is None:
                     continue
                 if chunk.audio_data:
                     received_audio = True
                 if chunk.is_final and not received_audio:
-                    raise ValueError("No audio data received from Tencent TTS")
+                    error_message = "No audio data received from Tencent TTS"
+                    raise ValueError(error_message)
                 yield chunk
                 if chunk.is_final:
                     break
             if not received_audio:
-                raise ValueError("No audio data received from Tencent TTS")
+                error_message = "No audio data received from Tencent TTS"
+                raise ValueError(error_message)
         finally:
             close = getattr(response, "close", None)
             if callable(close):
@@ -1308,10 +1316,12 @@ class TencentTTSProvider(BaseTTSProvider):
         model: str | None = None,
     ) -> TTSResult:
         if not self.is_configured():
-            raise ValueError("Tencent TTS is not configured")
+            message = "Tencent TTS is not configured"
+            raise ValueError(message)
         request_text = str(text or "").strip()
         if not request_text:
-            raise ValueError("Text cannot be empty")
+            message = "Text cannot be empty"
+            raise ValueError(message)
 
         effective_voice_settings = voice_settings or self.get_default_voice_settings()
         if not effective_voice_settings.voice_id:
@@ -1351,13 +1361,15 @@ class TencentTTSProvider(BaseTTSProvider):
                 segment for segment in chunk_pcm_segments if segment
             )
             if not chunk_pcm_audio:
-                raise ValueError("No audio data received from Tencent TTS")
+                message = "No audio data received from Tencent TTS"
+                raise ValueError(message)
             chunk_mp3_audio = _export_tencent_pcm_to_mp3(
                 chunk_pcm_audio,
                 sample_rate=sample_rate,
             )
             if not chunk_mp3_audio:
-                raise ValueError("No decodable audio data received from Tencent TTS")
+                message = "No decodable audio data received from Tencent TTS"
+                raise ValueError(message)
             audio_segments.append(chunk_mp3_audio)
 
             duration_ms = _tencent_pcm_duration_ms(
@@ -1396,7 +1408,8 @@ class TencentTTSProvider(BaseTTSProvider):
             audio_segments, output_format=output_format
         )
         if not final_audio:
-            raise ValueError("No decodable audio data received from Tencent TTS")
+            message = "No decodable audio data received from Tencent TTS"
+            raise ValueError(message)
         if duration_total_ms <= 0:
             decoded_duration_ms = try_get_audio_duration_ms(
                 final_audio,

--- a/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
+++ b/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
@@ -374,7 +374,8 @@ class TencentTextToVoiceProvider(BaseTTSProvider):
             raise ValueError(message)
         audio_base64 = result.get("Audio") or ""
         if not audio_base64:
-            raise ValueError("No audio data received from Tencent TextToVoice")
+            error_message = "No audio data received from Tencent TextToVoice"
+            raise ValueError(error_message)
         return base64.b64decode(audio_base64)
 
     def synthesize(
@@ -385,12 +386,14 @@ class TencentTextToVoiceProvider(BaseTTSProvider):
         model: str | None = None,
     ) -> TTSResult:
         if not text or not text.strip():
-            raise ValueError("Text cannot be empty")
+            error_message = "Text cannot be empty"
+            raise ValueError(error_message)
         if not self.is_configured():
-            raise ValueError(
+            error_message = (
                 "Tencent TextToVoice is not configured. "
                 "Set TENCENT_TTS_SECRET_ID and TENCENT_TTS_SECRET_KEY"
             )
+            raise ValueError(error_message)
 
         if not voice_settings:
             voice_settings = self.get_default_voice_settings()
@@ -408,7 +411,8 @@ class TencentTextToVoiceProvider(BaseTTSProvider):
 
         segments = _split_text(text)
         if not segments:
-            raise ValueError("Text cannot be empty")
+            error_message = "Text cannot be empty"
+            raise ValueError(error_message)
 
         logger.debug(
             "Calling Tencent TextToVoice: voice_type=%s, sample_rate=%s, "
@@ -425,7 +429,8 @@ class TencentTextToVoiceProvider(BaseTTSProvider):
         ]
         audio_data = concat_audio_best_effort(audio_segments, output_format="mp3")
         if not audio_data:
-            raise ValueError("No audio data received from Tencent TextToVoice")
+            error_message = "No audio data received from Tencent TextToVoice"
+            raise ValueError(error_message)
         duration_ms = try_get_audio_duration_ms(audio_data, audio_format="mp3") or 0
 
         return TTSResult(

--- a/src/api/flaskr/api/tts/volcengine_http_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_http_provider.py
@@ -182,15 +182,17 @@ class VolcengineHttpTTSProvider(BaseTTSProvider):
         model: str | None = None,
     ) -> TTSResult:
         if not text or not text.strip():
-            raise ValueError("Text cannot be empty")
+            exception_message = "Text cannot be empty"
+            raise ValueError(exception_message)
 
         app_id, token, cluster = self._get_credentials()
         if not app_id or not token or not cluster:
-            raise ValueError(
+            exception_message = (
                 "Volcengine HTTP TTS credentials are not configured. "
                 "Set VOLCENGINE_TTS_APP_KEY, VOLCENGINE_TTS_ACCESS_KEY, "
                 "and VOLCENGINE_TTS_CLUSTER_ID"
             )
+            raise ValueError(exception_message)
 
         if not voice_settings:
             voice_settings = self.get_default_voice_settings()
@@ -285,7 +287,8 @@ class VolcengineHttpTTSProvider(BaseTTSProvider):
                 response.headers.get("Content-Type", ""),
                 body_preview,
             )
-            raise ValueError("Volcengine HTTP TTS response is not valid JSON") from exc
+            exception_message = "Volcengine HTTP TTS response is not valid JSON"
+            raise ValueError(exception_message) from exc
 
         code = result.get("code")
         message = result.get("message") or ""
@@ -303,14 +306,14 @@ class VolcengineHttpTTSProvider(BaseTTSProvider):
 
         audio_base64 = result.get("data") or ""
         if not audio_base64:
-            raise ValueError("No audio data in Volcengine HTTP TTS response")
+            exception_message = "No audio data in Volcengine HTTP TTS response"
+            raise ValueError(exception_message)
 
         try:
             audio_data = base64.b64decode(audio_base64)
         except (ValueError, TypeError) as exc:
-            raise ValueError(
-                "Invalid base64 audio data from Volcengine HTTP TTS"
-            ) from exc
+            exception_message = "Invalid base64 audio data from Volcengine HTTP TTS"
+            raise ValueError(exception_message) from exc
 
         duration_ms = 0
         addition = result.get("addition")

--- a/src/api/flaskr/api/tts/volcengine_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_provider.py
@@ -448,12 +448,12 @@ class VolcengineTTSProvider(BaseTTSProvider):
 
         """
         if not WEBSOCKET_AVAILABLE:
-            raise ValueError(
-                "websocket-client package is not installed. Install with: pip install websocket-client"
-            )
+            exception_message = "websocket-client package is not installed. Install with: pip install websocket-client"
+            raise ValueError(exception_message)
 
         if not text or not text.strip():
-            raise ValueError("Text cannot be empty")
+            exception_message = "Text cannot be empty"
+            raise ValueError(exception_message)
 
         if not voice_settings:
             voice_settings = self.get_default_voice_settings()
@@ -481,10 +481,11 @@ class VolcengineTTSProvider(BaseTTSProvider):
         model_version = ""
 
         if not app_key or not access_key or not resource_id:
-            raise ValueError(
+            exception_message = (
                 "Volcengine TTS credentials are not configured. "
                 "Set VOLCENGINE_TTS_APP_KEY and VOLCENGINE_TTS_ACCESS_KEY."
             )
+            raise ValueError(exception_message)
 
         # Generate unique IDs
         connect_id = str(uuid.uuid4())
@@ -632,7 +633,8 @@ class VolcengineTTSProvider(BaseTTSProvider):
         try:
             # Wait for connection to be established
             if not connection_established.wait(timeout=10):
-                raise ValueError("Timeout waiting for connection")
+                exception_message = "Timeout waiting for connection"
+                raise ValueError(exception_message)
 
             if error_message:
                 raise ValueError(error_message)
@@ -659,7 +661,8 @@ class VolcengineTTSProvider(BaseTTSProvider):
             if not session_started.wait(timeout=10):
                 if error_message:
                     raise ValueError(error_message)
-                raise ValueError("Timeout waiting for TTS session to start")
+                exception_message = "Timeout waiting for TTS session to start"
+                raise ValueError(exception_message)
 
             if error_message:
                 raise ValueError(error_message)
@@ -676,7 +679,8 @@ class VolcengineTTSProvider(BaseTTSProvider):
 
             # Wait for session to finish
             if not session_finished.wait(timeout=60):
-                raise ValueError("Timeout waiting for TTS synthesis")
+                exception_message = "Timeout waiting for TTS synthesis"
+                raise ValueError(exception_message)
 
             if error_message:
                 raise ValueError(error_message)
@@ -700,7 +704,8 @@ class VolcengineTTSProvider(BaseTTSProvider):
                 session_id,
                 connect_id,
             )
-            raise ValueError("No audio data received")
+            exception_message = "No audio data received"
+            raise ValueError(exception_message)
 
         # Combine audio chunks
         audio_data = b"".join(audio_chunks)

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -176,7 +176,8 @@ def enable_commands(app: Flask):
                 migration_task.close()
 
         if migration_failed:
-            raise click.ClickException("Migration failed")
+            error_message = "Migration failed"
+            raise click.ClickException(error_message)
 
     @console.command(name="verify")
     def verify_command():

--- a/src/api/flaskr/command/import_user.py
+++ b/src/api/flaskr/command/import_user.py
@@ -23,7 +23,8 @@ def import_user(
     with app.app_context():
         normalized_mobile = normalize_phone_identifier(mobile)
         if not normalized_mobile:
-            raise RuntimeError("Mobile must not be empty for import_user")
+            message = "Mobile must not be empty for import_user"
+            raise RuntimeError(message)
 
         # Ensure there is a canonical user bound to this phone number, and that
         # the canonical record tracks the phone in ``user_identify`` together
@@ -42,7 +43,8 @@ def import_user(
         )
 
         if not aggregate:
-            raise RuntimeError("Failed to resolve user aggregate during import")
+            message = "Failed to resolve user aggregate during import"
+            raise RuntimeError(message)
 
         user_id = aggregate.user_bid
 

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -72,11 +72,13 @@ class _DynamicRedisCacheProvider:
         try:
             from flaskr.dao import get_redis_client
         except Exception as exc:  # pragma: no cover - defensive
-            raise CacheUnavailableError("Redis client import failed") from exc
+            message = "Redis client import failed"
+            raise CacheUnavailableError(message) from exc
 
         redis_client = get_redis_client()
         if redis_client is None:
-            raise CacheUnavailableError("Redis is not configured")
+            message = "Redis is not configured"
+            raise CacheUnavailableError(message)
         return redis_client
 
     def get(self, key: str):

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -119,24 +119,29 @@ def parse_llm_model_max_output_tokens(value: Any) -> dict[str, int]:
         try:
             candidate = json.loads(value)
         except (TypeError, ValueError) as exc:
-            raise ValueError("must be a JSON object") from exc
+            message = "must be a JSON object"
+            raise ValueError(message) from exc
     if not isinstance(candidate, dict):
         # ValueError is part of this parser's contract: callers only catch it.
-        raise ValueError("must be a JSON object")  # noqa: TRY004
+        message = "must be a JSON object"
+        raise ValueError(message)  # noqa: TRY004
 
     parsed: dict[str, int] = {}
     for model, max_output_tokens in candidate.items():
         if not isinstance(model, str) or not model.strip():
-            raise ValueError("model ids must be non-empty strings")
+            message = "model ids must be non-empty strings"
+            raise ValueError(message)
         normalized_model = model.strip()
         if normalized_model in parsed:
-            raise ValueError("model ids must be unique after trimming whitespace")
+            message = "model ids must be unique after trimming whitespace"
+            raise ValueError(message)
         if (
             isinstance(max_output_tokens, bool)
             or not isinstance(max_output_tokens, int)
             or max_output_tokens <= 0
         ):
-            raise ValueError("maximum output token values must be positive integers")
+            message = "maximum output token values must be positive integers"
+            raise ValueError(message)
         parsed[normalized_model] = max_output_tokens
     return parsed
 

--- a/src/api/flaskr/common/public_urls.py
+++ b/src/api/flaskr/common/public_urls.py
@@ -37,13 +37,11 @@ def _normalize_callback_url(value: str) -> str:
         return ""
     parsed = urlsplit(raw_value)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise RuntimeError(
-            "GOOGLE_OAUTH_REDIRECT_URI must include http(s) scheme and host"
-        )
+        message = "GOOGLE_OAUTH_REDIRECT_URI must include http(s) scheme and host"
+        raise RuntimeError(message)
     if parsed.query or parsed.fragment:
-        raise RuntimeError(
-            "GOOGLE_OAUTH_REDIRECT_URI must not carry a query or fragment"
-        )
+        message = "GOOGLE_OAUTH_REDIRECT_URI must not carry a query or fragment"
+        raise RuntimeError(message)
     path = parsed.path.rstrip("/") or GOOGLE_OAUTH_CALLBACK_PATH
     return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
 
@@ -79,7 +77,8 @@ def resolve_public_origin() -> str:
     if request_origin:
         return request_origin
 
-    raise RuntimeError("HOST_URL must be configured to build public callback URLs")
+    message = "HOST_URL must be configured to build public callback URLs"
+    raise RuntimeError(message)
 
 
 def _api_path(path: str) -> str:
@@ -131,11 +130,11 @@ def _normalize_origin(value: str) -> str:
 
     parsed = urlsplit(raw_value)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise RuntimeError("HOST_URL must include http(s) scheme and host")
+        message = "HOST_URL must include http(s) scheme and host"
+        raise RuntimeError(message)
     if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
-        raise RuntimeError(
-            "HOST_URL must be an origin without path, query, or fragment"
-        )
+        message = "HOST_URL must be an origin without path, query, or fragment"
+        raise RuntimeError(message)
     return urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
 
 

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -192,9 +192,8 @@ def _reject_desynced_connection_on_checkout(
         )
         # DisconnectionError makes the pool discard this connection and
         # transparently retry the checkout with another one.
-        raise DisconnectionError(
-            "pooled connection has unread protocol data (desynced stream)"
-        )
+        message = "pooled connection has unread protocol data (desynced stream)"
+        raise DisconnectionError(message)
     # Protected liveness ping, replacing pool_pre_ping. The stock pre_ping
     # path is the one wire operation with NO BaseException protection: a
     # GreenletExit landing in COM_PING's recv escapes every layer, leaks the
@@ -216,9 +215,8 @@ def _reject_desynced_connection_on_checkout(
         )
         if isinstance(ping_exc, Exception):
             # Dead connection: let the pool retry with a fresh one.
-            raise DisconnectionError(
-                "pooled connection failed the checkout liveness ping"
-            ) from ping_exc
+            message = "pooled connection failed the checkout liveness ping"
+            raise DisconnectionError(message) from ping_exc
         # GreenletExit and friends propagate; the record is already
         # invalidated so nothing dirty can reach the pool.
         raise
@@ -289,10 +287,11 @@ def _intercept_desync_before_execute(
         )
         with contextlib.suppress(Exception):
             conn.invalidate()
-        raise DisconnectionError(
+        message = (
             "connection has an unread response from a previous statement "
             "(interrupted exchange); refusing to execute on a desynced stream"
         )
+        raise DisconnectionError(message)
 
 
 @event.listens_for(Engine, "after_cursor_execute")

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -16,7 +16,8 @@ from .plugin_manager import get_plugin_manager
 def enable_plugins(app: Flask):
     plugin_manager = get_plugin_manager()
     if plugin_manager is None:
-        raise RuntimeError("Plugin manager is not enabled")
+        message = "Plugin manager is not enabled"
+        raise RuntimeError(message)
 
     @app.cli.group()
     def plugin():
@@ -32,7 +33,8 @@ def enable_plugins(app: Flask):
             return
         git_executable = shutil.which("git")
         if git_executable is None:
-            raise click.ClickException("git is not available on PATH")
+            message = "git is not available on PATH"
+            raise click.ClickException(message)
         # The repository URL is supplied by the operator running this CLI command.
         subprocess.run([git_executable, "clone", repo_url, dest_dir], check=False)  # noqa: S603
 

--- a/src/api/flaskr/framework/plugin/plugin_manager.py
+++ b/src/api/flaskr/framework/plugin/plugin_manager.py
@@ -126,7 +126,8 @@ def extension(target_func_name):
     def decorator(func):
         manager = get_plugin_manager()
         if manager is None:
-            raise RuntimeError("Plugin manager is not enabled")
+            message = "Plugin manager is not enabled"
+            raise RuntimeError(message)
         manager.register_extension(target_func_name, func)
         return func
 
@@ -137,7 +138,8 @@ def extensible_generic_register(func_name):
     def decorator(func):
         manager = get_plugin_manager()
         if manager is None:
-            raise RuntimeError("Plugin manager is not enabled")
+            message = "Plugin manager is not enabled"
+            raise RuntimeError(message)
         manager.register_extensible_generic(func_name, func)
         return func
 

--- a/src/api/flaskr/route/callback.py
+++ b/src/api/flaskr/route/callback.py
@@ -221,4 +221,5 @@ def _require_matching_integration(
         or order.creator_bid != creator_bid
         or order.payment_integration_bid != integration_bid
     ):
-        raise RuntimeError("Payment integration does not match order")
+        message = "Payment integration does not match order"
+        raise RuntimeError(message)

--- a/src/api/flaskr/service/billing/admin_ops_state.py
+++ b/src/api/flaskr/service/billing/admin_ops_state.py
@@ -69,15 +69,16 @@ def _admin_ops_lock(key: str) -> Iterator[None]:
             )
         )
     except Exception as exc:
-        raise RuntimeError(
-            "Admin billing operations state lock is unavailable"
-        ) from exc
+        message = "Admin billing operations state lock is unavailable"
+        raise RuntimeError(message) from exc
     if lock is None:
-        raise RuntimeError("Admin billing operations state lock is unavailable")
+        message = "Admin billing operations state lock is unavailable"
+        raise RuntimeError(message)
 
     acquired = lock.acquire(blocking=True, blocking_timeout=5)
     if not acquired:
-        raise RuntimeError("Admin billing operations state is busy")
+        message = "Admin billing operations state is busy"
+        raise RuntimeError(message)
     try:
         yield
     finally:

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -790,9 +790,8 @@ def register_billing_commands(console) -> None:
     ) -> None:
         """Grant the configured public trial plan to creators who still miss it."""
         if not str(creator_bid or "").strip() and not process_all:
-            raise click.ClickException(
-                "Pass --creator-bid or --all for trial plan backfill."
-            )
+            message = "Pass --creator-bid or --all for trial plan backfill."
+            raise click.ClickException(message)
 
         payload = backfill_missing_creator_trial_credits(
             current_app,
@@ -836,10 +835,11 @@ def register_billing_commands(console) -> None:
         has_course_scope = bool(str(course_bid or "").strip())
         has_user_scope = bool(str(user_bid or "").strip())
         if not has_course_scope and not has_user_scope and not process_all:
-            raise click.ClickException(
+            message = (
                 "Pass --user-bid, --course-bid, or --all for "
                 "authoring-permission creator backfill."
             )
+            raise click.ClickException(message)
 
         payload = backfill_authoring_permission_creators(
             current_app,
@@ -883,9 +883,10 @@ def register_billing_commands(console) -> None:
             and usage_id_end is None
             and not process_all
         ):
-            raise click.ClickException(
+            message = (
                 "Pass --usage-bid, a usage id range, or --all for settlement backfill."
             )
+            raise click.ClickException(message)
 
         payload = backfill_bill_usage_settlement(
             current_app,
@@ -925,9 +926,8 @@ def register_billing_commands(console) -> None:
             and not str(wallet_bid or "").strip()
             and not process_all
         ):
-            raise click.ClickException(
-                "Pass --creator-bid, --wallet-bid, or --all for wallet rebuild."
-            )
+            message = "Pass --creator-bid, --wallet-bid, or --all for wallet rebuild."
+            raise click.ClickException(message)
 
         payload = rebuild_credit_wallet_snapshots(
             current_app,
@@ -966,9 +966,8 @@ def register_billing_commands(console) -> None:
     ) -> None:
         """Run read-only billing credit invariant diagnostics."""
         if not str(creator_bid or "").strip() and not process_all:
-            raise click.ClickException(
-                "Pass --creator-bid or --all for credit state audit."
-            )
+            message = "Pass --creator-bid or --all for credit state audit."
+            raise click.ClickException(message)
 
         try:
             report = audit_credit_state(
@@ -1019,10 +1018,11 @@ def register_billing_commands(console) -> None:
             and not str(wallet_bucket_bid or "").strip()
             and not process_all
         ):
-            raise click.ClickException(
+            message = (
                 "Pass --creator-bid, --wallet-bucket-bid, or --all for "
                 "expire-ledger bucket drift repair."
             )
+            raise click.ClickException(message)
 
         payload = repair_expire_ledger_bucket_drift(
             current_app,
@@ -1062,9 +1062,8 @@ def register_billing_commands(console) -> None:
     ) -> None:
         """Repair lingering subscription or bucket state after cycle end."""
         if not str(creator_bid or "").strip() and not process_all:
-            raise click.ClickException(
-                "Pass --creator-bid or --all for renewal state drift repair."
-            )
+            message = "Pass --creator-bid or --all for renewal state drift repair."
+            raise click.ClickException(message)
 
         payload = repair_renewal_state_drift(
             current_app,
@@ -1080,7 +1079,8 @@ def register_billing_commands(console) -> None:
     def repair_topup_expiry_command(creator_bid: str) -> None:
         """Repair one creator's topup grant expiry against the active paid plan."""
         if not str(creator_bid or "").strip():
-            raise click.ClickException("Pass --creator-bid for topup expiry repair.")
+            message = "Pass --creator-bid for topup expiry repair."
+            raise click.ClickException(message)
 
         payload = repair_topup_grant_expiries(
             current_app,
@@ -1108,9 +1108,10 @@ def register_billing_commands(console) -> None:
     ) -> None:
         """Restore explicitly listed credit pack buckets expired by old logic."""
         if not any(str(bid or "").strip() for bid in bill_order_bids):
-            raise click.ClickException(
+            message = (
                 "Pass at least one --bill-order-bid for expired topup bucket restore."
             )
+            raise click.ClickException(message)
 
         payload = restore_wrongly_expired_credit_pack_buckets(
             current_app,
@@ -1132,9 +1133,8 @@ def register_billing_commands(console) -> None:
             not str(creator_bid or "").strip()
             and not str(subscription_bid or "").strip()
         ):
-            raise click.ClickException(
-                "Pass --creator-bid or --subscription-bid for subscription cycle repair."
-            )
+            message = "Pass --creator-bid or --subscription-bid for subscription cycle repair."
+            raise click.ClickException(message)
 
         payload = repair_subscription_cycle_mismatches(
             current_app,
@@ -1160,9 +1160,10 @@ def register_billing_commands(console) -> None:
             not str(creator_bid or "").strip()
             and not str(wallet_bucket_bid or "").strip()
         ):
-            raise click.ClickException(
+            message = (
                 "Pass --creator-bid or --wallet-bucket-bid for bucket status repair."
             )
+            raise click.ClickException(message)
 
         payload = repair_credit_bucket_runtime_statuses(
             current_app,
@@ -1194,9 +1195,8 @@ def register_billing_commands(console) -> None:
         normalized_date_from = str(date_from or "").strip()
         normalized_date_to = str(date_to or "").strip()
         if not process_all and not normalized_date_from and not normalized_date_to:
-            raise click.ClickException(
-                "Pass --date-from/--date-to or --all for daily aggregate rebuild."
-            )
+            message = "Pass --date-from/--date-to or --all for daily aggregate rebuild."
+            raise click.ClickException(message)
 
         if process_all:
             detected_date_from, detected_date_to = detect_daily_aggregate_rebuild_range(
@@ -1251,9 +1251,10 @@ def register_billing_commands(console) -> None:
             not str(bill_order_bid or "").strip()
             and not str(provider_reference_id or "").strip()
         ):
-            raise click.ClickException(
+            message = (
                 "Pass --bill-order-bid or --provider-reference-id for reconciliation."
             )
+            raise click.ClickException(message)
 
         payload = reconcile_billing_provider_reference(
             current_app,
@@ -1283,9 +1284,8 @@ def register_billing_commands(console) -> None:
                 str(creator_bid or "").strip(),
             )
         ):
-            raise click.ClickException(
-                "Pass a renewal event, subscription, or creator target."
-            )
+            message = "Pass a renewal event, subscription, or creator target."
+            raise click.ClickException(message)
 
         payload = run_billing_renewal_event(
             current_app,
@@ -1316,9 +1316,10 @@ def register_billing_commands(console) -> None:
                 str(bill_order_bid or "").strip(),
             )
         ):
-            raise click.ClickException(
+            message = (
                 "Pass a renewal event, subscription, creator, or bill order target."
             )
+            raise click.ClickException(message)
 
         payload = retry_billing_renewal_event(
             current_app,
@@ -1337,9 +1338,8 @@ def register_billing_commands(console) -> None:
     ) -> None:
         """Re-enqueue one pending or provider-failed subscription purchase SMS."""
         if not str(bill_order_bid or "").strip():
-            raise click.ClickException(
-                "Pass --bill-order-bid for subscription purchase SMS requeue."
-            )
+            message = "Pass --bill-order-bid for subscription purchase SMS requeue."
+            raise click.ClickException(message)
 
         payload = requeue_subscription_purchase_sms(
             current_app,
@@ -1374,10 +1374,11 @@ def seed_sample_exception_orders() -> dict[str, Any]:
     topup_product_bid = _load_first_active_product_bid(BILLING_PRODUCT_TYPE_TOPUP)
 
     if not plan_product_bid or not topup_product_bid:
-        raise click.ClickException(
+        message = (
             "Active billing plan/topup products are required before seeding "
             "sample exception orders."
         )
+        raise click.ClickException(message)
 
     creator_specs = [
         {
@@ -1945,13 +1946,17 @@ def upsert_billing_product(
     }
 
     if not payload["product_bid"]:
-        raise click.ClickException("--product-bid is required.")
+        message = "--product-bid is required."
+        raise click.ClickException(message)
     if not payload["product_code"]:
-        raise click.ClickException("--product-code is required.")
+        message = "--product-code is required."
+        raise click.ClickException(message)
     if not payload["display_name_i18n_key"]:
-        raise click.ClickException("--display-name-i18n-key is required.")
+        message = "--display-name-i18n-key is required."
+        raise click.ClickException(message)
     if not payload["description_i18n_key"]:
-        raise click.ClickException("--description-i18n-key is required.")
+        message = "--description-i18n-key is required."
+        raise click.ClickException(message)
 
     created = _upsert_bootstrap_row(
         model=BillingProduct,
@@ -2118,18 +2123,19 @@ def grant_billing_plan_by_identify(
 ) -> dict[str, Any]:
     normalized_identify = str(identify or "").strip()
     if not normalized_identify:
-        raise click.ClickException("--identify is required.")
+        error_message = "--identify is required."
+        raise click.ClickException(error_message)
 
     normalized_note = str(note or "").strip()
     if len(normalized_note) > 255:
-        raise click.ClickException("--note must be 255 characters or fewer.")
+        error_message = "--note must be 255 characters or fewer."
+        raise click.ClickException(error_message)
 
     normalized_product_bid = str(product_bid or "").strip()
     normalized_product_code = str(product_code or "").strip()
     if bool(normalized_product_bid) == bool(normalized_product_code):
-        raise click.ClickException(
-            "Pass exactly one of --product-bid or --product-code."
-        )
+        error_message = "Pass exactly one of --product-bid or --product-code."
+        raise click.ClickException(error_message)
     normalized_effective_to = str(effective_to or "").strip()
 
     with _rollback_on_error():
@@ -2143,7 +2149,8 @@ def grant_billing_plan_by_identify(
             product_code=normalized_product_code,
         )
         if product is None:
-            raise click.ClickException("Active billing plan not found.")
+            error_message = "Active billing plan not found."
+            raise click.ClickException(error_message)
 
         creator_role_granted = False
         if not bool(getattr(aggregate, "is_creator", False)):
@@ -2185,19 +2192,22 @@ def grant_billing_plan_by_identify(
             if not is_self_managed_billing_provider(
                 existing_subscription.billing_provider
             ):
-                raise click.ClickException(
+                error_message = (
                     "User already has an active provider-managed subscription. "
                     "Use the normal checkout upgrade flow or wait for the current cycle to expire."
                 )
+                raise click.ClickException(error_message)
             if current_product is None:
-                raise click.ClickException(
+                error_message = (
                     "Active billing plan not found for the current subscription."
                 )
+                raise click.ClickException(error_message)
             if int(product.sort_order or 0) <= int(current_product.sort_order or 0):
-                raise click.ClickException(
+                error_message = (
                     "The current subscription is still active. "
                     "Operator grant only supports upgrades to a higher-tier plan."
                 )
+                raise click.ClickException(error_message)
             order_type = BILLING_ORDER_TYPE_SUBSCRIPTION_UPGRADE
 
         granted_at = now_utc()
@@ -2210,11 +2220,13 @@ def grant_billing_plan_by_identify(
             )
         )
         if cycle_end_at is None:
-            raise click.ClickException(
+            error_message = (
                 "Target product does not support one-cycle manual activation."
             )
+            raise click.ClickException(error_message)
         if cycle_end_at <= granted_at:
-            raise click.ClickException("--effective-to must be later than now.")
+            error_message = "--effective-to must be later than now."
+            raise click.ClickException(error_message)
 
         subscription_metadata = {
             "manual_grant": True,
@@ -2292,9 +2304,8 @@ def grant_billing_plan_by_identify(
 
         granted = grant_paid_order_credits(current_app, order)
         if not granted:
-            raise click.ClickException(
-                "Manual plan grant did not create a new credit grant."
-            )
+            error_message = "Manual plan grant did not create a new credit grant."
+            raise click.ClickException(error_message)
 
         should_enqueue_subscription_purchase_sms = (
             stage_subscription_purchase_sms_for_paid_order(
@@ -2345,19 +2356,23 @@ def grant_operator_credits_by_cli(
     normalized_identify = str(identify or "").strip()
     normalized_user_bid = str(user_bid or "").strip()
     if bool(normalized_identify) == bool(normalized_user_bid):
-        raise click.ClickException("Pass exactly one of --identify or --user-bid.")
+        error_message = "Pass exactly one of --identify or --user-bid."
+        raise click.ClickException(error_message)
 
     normalized_request_id = str(request_id or "").strip()
     if len(normalized_request_id) > 100:
-        raise click.ClickException("--request-id must be 100 characters or fewer.")
+        error_message = "--request-id must be 100 characters or fewer."
+        raise click.ClickException(error_message)
 
     normalized_display_name = str(display_name or "").strip()
     if len(normalized_display_name) > 128:
-        raise click.ClickException("--name must be 128 characters or fewer.")
+        error_message = "--name must be 128 characters or fewer."
+        raise click.ClickException(error_message)
 
     normalized_note = str(note or "").strip()
     if len(normalized_note) > 255:
-        raise click.ClickException("--note must be 255 characters or fewer.")
+        error_message = "--note must be 255 characters or fewer."
+        raise click.ClickException(error_message)
 
     normalized_operator_user_bid = (
         str(operator_user_bid or "").strip() or _DEFAULT_CLI_OPERATOR_USER_BID
@@ -2607,9 +2622,8 @@ def _load_plan_product_by_bid(product_bid: str) -> BillingProduct | None:
 def _parse_effective_to_option(raw_value: str) -> datetime:
     parsed = coerce_datetime(raw_value)
     if parsed is None:
-        raise click.ClickException(
-            "--effective-to must be a valid ISO-8601 datetime or YYYY-MM-DD."
-        )
+        message = "--effective-to must be a valid ISO-8601 datetime or YYYY-MM-DD."
+        raise click.ClickException(message)
     return parsed
 
 

--- a/src/api/flaskr/service/billing/customization.py
+++ b/src/api/flaskr/service/billing/customization.py
@@ -889,7 +889,8 @@ def _probe_provider_credentials(
     if provider == "wechatpay":
         api_v3_key = str(secret_config.get("api_v3_key") or "").strip()
         if len(api_v3_key.encode("utf-8")) != 32:
-            raise ValueError("WeChat Pay API v3 key must be 32 bytes")
+            error_message = "WeChat Pay API v3 key must be 32 bytes"
+            raise ValueError(error_message)
         _parse_pem_private_key(secret_config.get("private_key"))
         _parse_x509_certificate(secret_config.get("platform_cert"))
         return
@@ -908,11 +909,14 @@ def _probe_stripe_credentials(
     secret_key = str(secret_config.get("secret_key") or "").strip()
     webhook_secret = str(secret_config.get("webhook_secret") or "").strip()
     if not publishable_key.startswith(("pk_live_", "pk_test_")):
-        raise ValueError("Stripe publishable key must start with pk_live_ or pk_test_")
+        message = "Stripe publishable key must start with pk_live_ or pk_test_"
+        raise ValueError(message)
     if not secret_key.startswith(("sk_live_", "sk_test_")):
-        raise ValueError("Stripe secret key must start with sk_live_ or sk_test_")
+        message = "Stripe secret key must start with sk_live_ or sk_test_"
+        raise ValueError(message)
     if not webhook_secret.startswith("whsec_"):
-        raise ValueError("Stripe webhook secret must start with whsec_")
+        message = "Stripe webhook secret must start with whsec_"
+        raise ValueError(message)
     if app.config.get("TESTING"):
         return
     try:
@@ -924,7 +928,8 @@ def _probe_stripe_credentials(
             request_options["stripe_version"] = api_version
         stripe.Account.retrieve(**request_options)
     except Exception as exc:
-        raise ValueError("Stripe credentials could not be verified") from exc
+        message = "Stripe credentials could not be verified"
+        raise ValueError(message) from exc
 
 
 def _parse_pem_private_key(value: Any) -> None:
@@ -932,7 +937,8 @@ def _parse_pem_private_key(value: Any) -> None:
     try:
         serialization.load_pem_private_key(pem, password=None)
     except (TypeError, ValueError) as exc:
-        raise ValueError("Private key is not a valid PEM key") from exc
+        message = "Private key is not a valid PEM key"
+        raise ValueError(message) from exc
 
 
 def _parse_pem_public_key(value: Any) -> None:
@@ -940,7 +946,8 @@ def _parse_pem_public_key(value: Any) -> None:
     try:
         serialization.load_pem_public_key(pem)
     except (TypeError, ValueError) as exc:
-        raise ValueError("Public key is not a valid PEM key") from exc
+        message = "Public key is not a valid PEM key"
+        raise ValueError(message) from exc
 
 
 def _parse_x509_certificate(value: Any) -> None:
@@ -948,7 +955,8 @@ def _parse_x509_certificate(value: Any) -> None:
     try:
         x509.load_pem_x509_certificate(pem)
     except ValueError as exc:
-        raise ValueError("Certificate is not a valid PEM certificate") from exc
+        message = "Certificate is not a valid PEM certificate"
+        raise ValueError(message) from exc
 
 
 def _normalize_pem(value: Any, label: str) -> bytes:
@@ -988,11 +996,13 @@ def _build_callback_token(app: Flask, integration_bid: str) -> str:
 def _require_creator_integration_secret_key(app: Flask) -> str:
     key = str(app.config.get("CREATOR_INTEGRATION_ENCRYPTION_KEY") or "").strip()
     if not key:
-        raise RuntimeError("CREATOR_INTEGRATION_ENCRYPTION_KEY must be configured")
+        message = "CREATOR_INTEGRATION_ENCRYPTION_KEY must be configured"
+        raise RuntimeError(message)
     try:
         Fernet(key.encode("ascii"))
     except (ValueError, TypeError) as exc:
-        raise RuntimeError("CREATOR_INTEGRATION_ENCRYPTION_KEY is invalid") from exc
+        message = "CREATOR_INTEGRATION_ENCRYPTION_KEY is invalid"
+        raise RuntimeError(message) from exc
     return key
 
 
@@ -1299,7 +1309,8 @@ def _saas_funcs(*, required: bool = True):
         if not str(exc.name or "").startswith("flaskr.plugins.ai_shifu_saas_plugin"):
             raise
         if required:
-            raise RuntimeError("SaaS config plugin is not installed") from exc
+            message = "SaaS config plugin is not installed"
+            raise RuntimeError(message) from exc
         return None
     # The plugin ships with the image even on deployments that never
     # configure its dedicated database. Plugin initialization then leaves
@@ -1308,7 +1319,8 @@ def _saas_funcs(*, required: bool = True):
     # installed" and let callers fall back to entitlement-backed storage.
     if has_app_context() and not current_app.config.get("SAAS_PLUGIN_ENABLED"):
         if required:
-            raise RuntimeError("SaaS config plugin is not enabled")
+            message = "SaaS config plugin is not enabled"
+            raise RuntimeError(message)
         return None
     return module
 

--- a/src/api/flaskr/service/billing/daily_aggregates.py
+++ b/src/api/flaskr/service/billing/daily_aggregates.py
@@ -640,7 +640,8 @@ def _resolve_stat_date_range(
     start_date = parse_naive_utc(start_value, "%Y-%m-%d")
     end_date = parse_naive_utc(end_value, "%Y-%m-%d")
     if end_date < start_date:
-        raise ValueError("date_to must be greater than or equal to date_from")
+        message = "date_to must be greater than or equal to date_from"
+        raise ValueError(message)
     return start_date, end_date
 
 

--- a/src/api/flaskr/service/billing/provider_catalog.py
+++ b/src/api/flaskr/service/billing/provider_catalog.py
@@ -131,8 +131,9 @@ class StripeCatalogReadAdapter:
         normalized_product_id = normalize_bid(provider_product_id)
         normalized_price_id = normalize_bid(provider_price_id)
         if not normalized_product_id or not normalized_price_id:
+            message = "stripe_catalog_reference_missing"
             raise ProviderCatalogReadError(
-                "stripe_catalog_reference_missing",
+                message,
                 "Stripe product and price identifiers are required",
             )
 
@@ -145,8 +146,9 @@ class StripeCatalogReadAdapter:
                 stripe.Price.retrieve(normalized_price_id, **request_options)
             )
         except Exception as exc:
+            message = "stripe_catalog_retrieve_failed"
             raise ProviderCatalogReadError(
-                "stripe_catalog_retrieve_failed",
+                message,
                 _build_safe_stripe_error_message(exc),
             ) from None
 

--- a/src/api/flaskr/service/billing/provider_price_mappings.py
+++ b/src/api/flaskr/service/billing/provider_price_mappings.py
@@ -156,8 +156,9 @@ def _select_single_active_mapping(
     product_bid: str,
 ) -> BillingProductProviderPrice | None:
     if len(rows) > 1:
+        error_code = "multiple_active_provider_prices"
         raise ProviderPriceMappingError(
-            "multiple_active_provider_prices",
+            error_code,
             "Multiple active provider price mappings found for the same product scope",
             {"product_bid": product_bid},
         )
@@ -196,8 +197,9 @@ def upsert_provider_price_mapping(
         )
         db.session.add(row)
     elif row.product_bid and row.product_bid != product.product_bid:
+        error_code = "provider_price_product_mismatch"
         raise ProviderPriceMappingError(
-            "provider_price_product_mismatch",
+            error_code,
             "Provider price mappings cannot be rebound to a different product",
             {
                 "provider_price_bid": row.provider_price_bid,
@@ -206,14 +208,16 @@ def upsert_provider_price_mapping(
             },
         )
     elif int(row.status or 0) == BILLING_PROVIDER_PRICE_STATUS_ACTIVE:
+        error_code = "active_mapping_cannot_be_rebound"
         raise ProviderPriceMappingError(
-            "active_mapping_cannot_be_rebound",
+            error_code,
             "Active provider price mappings cannot be rebound; retire them first",
             {"provider_price_bid": row.provider_price_bid},
         )
     elif int(row.status or 0) == BILLING_PROVIDER_PRICE_STATUS_RETIRED:
+        error_code = "retired_mapping_cannot_be_rebound"
         raise ProviderPriceMappingError(
-            "retired_mapping_cannot_be_rebound",
+            error_code,
             "Retired provider price mappings cannot be rebound; create a new provider price instead",
             {"provider_price_bid": row.provider_price_bid},
         )
@@ -352,8 +356,9 @@ def _load_product(product_bid: str) -> BillingProduct:
         BillingProduct.product_bid == normalized_product_bid,
     ).one_or_none()
     if product is None:
+        error_code = "billing_product_not_found"
         raise ProviderPriceMappingError(
-            "billing_product_not_found",
+            error_code,
             "Billing product not found",
             {"product_bid": normalized_product_bid},
         )
@@ -367,8 +372,9 @@ def _load_mapping(provider_price_bid: str) -> BillingProductProviderPrice:
         BillingProductProviderPrice.provider_price_bid == normalized_bid,
     ).one_or_none()
     if mapping is None:
+        error_code = "provider_price_mapping_not_found"
         raise ProviderPriceMappingError(
-            "provider_price_mapping_not_found",
+            error_code,
             "Provider price mapping not found",
             {"provider_price_bid": normalized_bid},
         )
@@ -466,8 +472,9 @@ def _serialize_validation_issues(issues) -> list[dict[str, str]]:
 def _normalize_provider(value: str) -> str:
     normalized = str(value or "").strip().lower()
     if normalized != PROVIDER_STRIPE:
+        error_code = "unsupported_provider"
         raise ProviderPriceMappingError(
-            "unsupported_provider",
+            error_code,
             "Only Stripe provider price mappings are supported",
             {"provider": normalized},
         )

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -579,7 +579,8 @@ def send_credit_notification_task(
         "provider_failed",
         "provider_exception",
     }:
-        raise CreditNotificationRetryableError("retrying credit notification")
+        message = "retrying credit notification"
+        raise CreditNotificationRetryableError(message)
     return payload
 
 

--- a/src/api/flaskr/service/billing/trials.py
+++ b/src/api/flaskr/service/billing/trials.py
@@ -440,7 +440,8 @@ def _bootstrap_trial_subscription(
 
     granted = _grant_paid_order_credits(app, order)
     if not granted:
-        raise RuntimeError("trial_order_credit_grant_failed")
+        message = "trial_order_credit_grant_failed"
+        raise RuntimeError(message)
 
     grant_notification = _stage_credit_granted_notification_for_order(
         app,

--- a/src/api/flaskr/service/billing/wallets.py
+++ b/src/api/flaskr/service/billing/wallets.py
@@ -887,7 +887,8 @@ def persist_credit_wallet_snapshot(
         CreditWallet.version == expected_version,
     ).update(values, synchronize_session=False)
     if updated_rows != 1:
-        raise RuntimeError("credit_wallet_version_conflict")
+        message = "credit_wallet_version_conflict"
+        raise RuntimeError(message)
 
     wallet.available_credits = values["available_credits"]
     wallet.reserved_credits = values["reserved_credits"]
@@ -2368,7 +2369,8 @@ def _build_expired_credit_pack_restore_records(
 
         wallet = _load_credit_wallet_by_wallet_bid(bucket.wallet_bid)
         if wallet is None:
-            raise RuntimeError("credit_pack_restore_wallet_missing")
+            message = "credit_pack_restore_wallet_missing"
+            raise RuntimeError(message)
         available_credits, reserved_credits = calculate_credit_wallet_snapshot_values(
             wallet,
             snapshot_at=repaired_at,

--- a/src/api/flaskr/service/billing/webhooks.py
+++ b/src/api/flaskr/service/billing/webhooks.py
@@ -471,7 +471,8 @@ def apply_billing_native_notification(
             actual_amount is not None
             and int(order.payable_amount or 0) != actual_amount
         ):
-            raise RuntimeError("Billing native payment amount mismatch")
+            message = "Billing native payment amount mismatch"
+            raise RuntimeError(message)
 
         target_status = _native_target_status(normalized_provider, trade_payload)
         order_update = _apply_billing_order_provider_update(

--- a/src/api/flaskr/service/common/oss_utils.py
+++ b/src/api/flaskr/service/common/oss_utils.py
@@ -102,7 +102,8 @@ def is_oss_profile_configured(profile: str = OSS_PROFILE_DEFAULT) -> bool:
 
 def create_oss_bucket(config: OSSConfig) -> oss2.Bucket:
     if oss2 is None:  # pragma: no cover
-        raise RuntimeError("oss2 dependency is not installed")
+        message = "oss2 dependency is not installed"
+        raise RuntimeError(message)
     auth = oss2.Auth(config.access_key_id, config.access_key_secret)
     return oss2.Bucket(auth, config.endpoint, config.bucket)
 

--- a/src/api/flaskr/service/common/storage.py
+++ b/src/api/flaskr/service/common/storage.py
@@ -71,11 +71,14 @@ def _resolve_provider(profile: str) -> str:
 def _normalize_object_key(object_key: str) -> str:
     key = (object_key or "").replace("\\", "/").strip()
     if not key:
-        raise ValueError("object_key is required")
+        message = "object_key is required"
+        raise ValueError(message)
     if key.startswith("/"):
-        raise ValueError("object_key must be a relative path")
+        message = "object_key must be a relative path"
+        raise ValueError(message)
     if ".." in key.split("/"):
-        raise ValueError("object_key must not contain '..'")
+        message = "object_key must not contain '..'"
+        raise ValueError(message)
     return key
 
 
@@ -94,7 +97,8 @@ def get_local_storage_path(profile: str, object_key: str) -> Path:
     root_abs = root.resolve()
     target_abs = target.resolve()
     if os.path.commonpath([str(root_abs), str(target_abs)]) != str(root_abs):
-        raise ValueError("Resolved path escapes LOCAL_STORAGE_ROOT")
+        message = "Resolved path escapes LOCAL_STORAGE_ROOT"
+        raise ValueError(message)
     return target
 
 
@@ -108,7 +112,8 @@ def build_local_storage_url(profile: str, object_key: str) -> str:
 
 def _coerce_to_binary_stream(file_content: Any) -> io.BufferedReader:
     if file_content is None:
-        raise ValueError("file_content is required")
+        message = "file_content is required"
+        raise ValueError(message)
 
     if isinstance(file_content, (bytes, bytearray)):
         return io.BufferedReader(io.BytesIO(file_content))
@@ -117,7 +122,8 @@ def _coerce_to_binary_stream(file_content: Any) -> io.BufferedReader:
         # Werkzeug FileStorage / BytesIO / file object.
         return file_content  # type: ignore[return-value]
 
-    raise TypeError("file_content must be bytes or a file-like object")
+    message = "file_content must be bytes or a file-like object"
+    raise TypeError(message)
 
 
 def _upload_to_local(

--- a/src/api/flaskr/service/common/stripe_client.py
+++ b/src/api/flaskr/service/common/stripe_client.py
@@ -19,16 +19,16 @@ def ensure_stripe_client(app: Flask):
         import stripe  # type: ignore[import-untyped]
     except ImportError as exc:  # pragma: no cover - surfaced during runtime
         app.logger.exception("Stripe SDK is not installed")
-        raise StripeClientConfigError(
-            "Stripe SDK is required for Stripe operations"
-        ) from exc
+        message = "Stripe SDK is required for Stripe operations"
+        raise StripeClientConfigError(message) from exc
     return stripe
 
 
 def build_stripe_request_options() -> dict[str, Any]:
     secret_key = get_config("STRIPE_SECRET_KEY")
     if not secret_key:
-        raise StripeClientConfigError("STRIPE_SECRET_KEY must be configured for Stripe")
+        message = "STRIPE_SECRET_KEY must be configured for Stripe"
+        raise StripeClientConfigError(message)
 
     request_options: dict[str, Any] = {"api_key": secret_key}
     api_version = get_config("STRIPE_API_VERSION")

--- a/src/api/flaskr/service/config/funcs.py
+++ b/src/api/flaskr/service/config/funcs.py
@@ -66,7 +66,8 @@ def _get_fernet_key(app: Flask) -> bytes:
     with app.app_context():
         secret_key = app.config.get("SECRET_KEY", "")
         if not secret_key:
-            raise ValueError("SECRET_KEY is not configured")
+            message = "SECRET_KEY is not configured"
+            raise ValueError(message)
 
         key_bytes = hashlib.sha256(secret_key.encode()).digest()
         return base64.urlsafe_b64encode(key_bytes)

--- a/src/api/flaskr/service/creator_analytics/engine.py
+++ b/src/api/flaskr/service/creator_analytics/engine.py
@@ -70,7 +70,8 @@ def get_analytics_engine(app: Flask) -> Engine:
                 previous_engine.dispose()
         engine = _engine_state.engine
         if engine is None:  # pragma: no cover - guarded by the branch above
-            raise RuntimeError("Analytics engine initialization failed")
+            message = "Analytics engine initialization failed"
+            raise RuntimeError(message)
         return engine
 
 

--- a/src/api/flaskr/service/learn/ask_provider_adapters/coze_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/coze_adapter.py
@@ -47,9 +47,8 @@ class CozeAskProviderAdapter:
         base_url = str(config.get("base_url") or DEFAULT_COZE_BASE_URL).strip()
         api_key = str(config.get("api_key") or "").strip()
         if not api_key:
-            raise AskProviderConfigError(
-                "coze api_key is required in ask_provider_config.config"
-            )
+            exception_message = "coze api_key is required in ask_provider_config.config"
+            raise AskProviderConfigError(exception_message)
 
         bot_id = str(config.get("bot_id") or "").strip()
         api_path = str(config.get("api_path") or "/v3/chat").strip() or "/v3/chat"
@@ -60,7 +59,8 @@ class CozeAskProviderAdapter:
         )
 
         if api_path == "/v3/chat" and not bot_id:
-            raise AskProviderConfigError("coze bot_id is required")
+            exception_message = "coze bot_id is required"
+            raise AskProviderConfigError(exception_message)
 
         payload: dict[str, Any] = {
             "stream": True,
@@ -72,9 +72,8 @@ class CozeAskProviderAdapter:
                     "content_type": "text",
                 }
             ],
+            **({"bot_id": bot_id} if bot_id else {}),
         }
-        if bot_id:
-            payload["bot_id"] = bot_id
 
         conversation_id = str(config.get("conversation_id") or "").strip()
         if conversation_id:
@@ -98,7 +97,8 @@ class CozeAskProviderAdapter:
                 timeout=(5, provider_timeout_seconds()),
             )
         except requests.Timeout as exc:
-            raise AskProviderTimeoutError("coze request timeout") from exc
+            exception_message = "coze request timeout"
+            raise AskProviderTimeoutError(exception_message) from exc
         except requests.RequestException as exc:
             message = f"coze request failed: {exc}"
             raise AskProviderError(message) from exc

--- a/src/api/flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/coze_workflow_adapter.py
@@ -200,9 +200,8 @@ class CozeWorkflowAskProviderAdapter:
         api_key = str(config.get("api_key") or "").strip()
         workflow_id = str(config.get("workflow_id") or "").strip()
         if not api_key or not workflow_id:
-            raise AskProviderConfigError(
-                "coze_workflow api_key/workflow_id are required in ask_provider_config.config"
-            )
+            error_message = "coze_workflow api_key/workflow_id are required in ask_provider_config.config"
+            raise AskProviderConfigError(error_message)
 
         query_key = str(config.get("query_key") or "query").strip() or "query"
         parameters = config.get("parameters")
@@ -232,7 +231,8 @@ class CozeWorkflowAskProviderAdapter:
                 timeout=(5, provider_timeout_seconds()),
             )
         except requests.Timeout as exc:
-            raise AskProviderTimeoutError("coze_workflow request timeout") from exc
+            error_message = "coze_workflow request timeout"
+            raise AskProviderTimeoutError(error_message) from exc
         except requests.RequestException as exc:
             message = f"coze_workflow request failed: {exc}"
             raise AskProviderError(message) from exc
@@ -242,10 +242,12 @@ class CozeWorkflowAskProviderAdapter:
         try:
             response_payload = response.json()
         except ValueError as exc:
-            raise AskProviderError("coze_workflow response is not valid json") from exc
+            error_message = "coze_workflow response is not valid json"
+            raise AskProviderError(error_message) from exc
 
         if not isinstance(response_payload, dict):
-            raise AskProviderError("coze_workflow response has invalid payload")
+            error_message = "coze_workflow response has invalid payload"
+            raise AskProviderError(error_message)
 
         response_code = response_payload.get("code")
         if response_code not in (0, "0"):
@@ -253,6 +255,7 @@ class CozeWorkflowAskProviderAdapter:
 
         text = _extract_workflow_text(response_payload)
         if not text:
-            raise AskProviderError("coze_workflow response has no retrievable text")
+            error_message = "coze_workflow response has no retrievable text"
+            raise AskProviderError(error_message)
 
         yield AskProviderChunk(content=text)

--- a/src/api/flaskr/service/learn/ask_provider_adapters/dify_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/dify_adapter.py
@@ -70,9 +70,10 @@ class DifyAskProviderAdapter:
         base_url = str(config.get("base_url") or "").strip()
         api_key = str(config.get("api_key") or "").strip()
         if not base_url or not api_key:
-            raise AskProviderConfigError(
+            exception_message = (
                 "dify base_url/api_key are required in ask_provider_config.config"
             )
+            raise AskProviderConfigError(exception_message)
 
         contextual_query = _build_dify_query(user_query, messages)
         payload: dict[str, Any] = {
@@ -104,7 +105,8 @@ class DifyAskProviderAdapter:
                 timeout=(5, provider_timeout_seconds()),
             )
         except requests.Timeout as exc:
-            raise AskProviderTimeoutError("dify request timeout") from exc
+            exception_message = "dify request timeout"
+            raise AskProviderTimeoutError(exception_message) from exc
         except requests.RequestException as exc:
             message = f"dify request failed: {exc}"
             raise AskProviderError(message) from exc

--- a/src/api/flaskr/service/learn/ask_provider_adapters/get_biji_knowledge_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/get_biji_knowledge_adapter.py
@@ -139,10 +139,11 @@ class GetBijiKnowledgeAskProviderAdapter:
         client_id = _normalize_text(config.get("client_id"))
         topic_id = _normalize_text(config.get("topic_id"))
         if not api_key or not client_id or not topic_id:
-            raise AskProviderConfigError(
+            error_message = (
                 "get_biji_knowledge api_key/client_id/topic_id are required "
                 "in ask_provider_config.config"
             )
+            raise AskProviderConfigError(error_message)
 
         payload = {
             "topic_id": topic_id,
@@ -163,7 +164,8 @@ class GetBijiKnowledgeAskProviderAdapter:
                 timeout=(5, provider_timeout_seconds()),
             )
         except requests.Timeout as exc:
-            raise AskProviderTimeoutError("get_biji_knowledge request timeout") from exc
+            error_message = "get_biji_knowledge request timeout"
+            raise AskProviderTimeoutError(error_message) from exc
         except requests.RequestException as exc:
             message = f"get_biji_knowledge request failed: {exc}"
             raise AskProviderError(message) from exc
@@ -178,7 +180,8 @@ class GetBijiKnowledgeAskProviderAdapter:
         _raise_for_api_error(payload_data)
         raise_for_provider_response(response, self.provider)
         if payload_data is None:
-            raise AskProviderError("get_biji_knowledge response is not valid json")
+            error_message = "get_biji_knowledge response is not valid json"
+            raise AskProviderError(error_message)
         results = _extract_results(payload_data)
         formatted_results = [
             formatted

--- a/src/api/flaskr/service/learn/ask_provider_adapters/llm_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/llm_adapter.py
@@ -29,7 +29,8 @@ class LlmAskProviderAdapter:
     ) -> Generator[AskProviderChunk, None, None]:
         _ = (app, user_id, user_query, messages, provider_config)
         if runtime is None or runtime.llm_stream_factory is None:
-            raise AskProviderConfigError("llm runtime is not configured")
+            message = "llm runtime is not configured"
+            raise AskProviderConfigError(message)
 
         for chunk in runtime.llm_stream_factory():
             current_content = getattr(chunk, "result", None)

--- a/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
@@ -217,9 +217,8 @@ class VolcKnowledgeAskProviderAdapter:
         sk = str(config.get("sk") or "").strip()
         collection_name = str(config.get("collection_name") or "").strip()
         if not account_id or not ak or not sk or not collection_name:
-            raise AskProviderConfigError(
-                "volc_knowledge account_id/ak/sk/collection_name are required in ask_provider_config.config"
-            )
+            exception_message = "volc_knowledge account_id/ak/sk/collection_name are required in ask_provider_config.config"
+            raise AskProviderConfigError(exception_message)
 
         domain = str(
             config.get("domain") or "api-knowledgebase.mlp.cn-beijing.volces.com"
@@ -289,7 +288,8 @@ class VolcKnowledgeAskProviderAdapter:
                 timeout=(5, request_timeout_seconds),
             )
         except requests.Timeout as exc:
-            raise AskProviderTimeoutError("volc_knowledge request timeout") from exc
+            exception_message = "volc_knowledge request timeout"
+            raise AskProviderTimeoutError(exception_message) from exc
         except requests.RequestException as exc:
             error_message = f"volc_knowledge request failed: {exc}"
             raise AskProviderError(error_message) from exc
@@ -299,7 +299,8 @@ class VolcKnowledgeAskProviderAdapter:
         try:
             payload_data = response.json()
         except ValueError as exc:
-            raise AskProviderError("volc_knowledge response is not valid json") from exc
+            exception_message = "volc_knowledge response is not valid json"
+            raise AskProviderError(exception_message) from exc
 
         if isinstance(payload_data, dict):
             code = payload_data.get("code")
@@ -315,7 +316,8 @@ class VolcKnowledgeAskProviderAdapter:
                 "volc_knowledge response contains no text chunks, payload=%s",
                 payload_data,
             )
-            raise AskProviderError("volc_knowledge response has no retrievable text")
+            exception_message = "volc_knowledge response has no retrievable text"
+            raise AskProviderError(exception_message)
 
         for chunk in chunks:
             yield AskProviderChunk(content=chunk)

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -319,7 +319,8 @@ class RUNLLMProvider(LLMProvider):
     ) -> str:
         # Extract the last message content as the main prompt
         if not messages:
-            raise ValueError("No messages provided")
+            message = "No messages provided"
+            raise ValueError(message)
         # Use provided model/temperature or fall back to settings
         actual_model = model or self.llm_settings.model
         actual_temperature = (
@@ -366,7 +367,8 @@ class RUNLLMProvider(LLMProvider):
     ) -> Generator[str, None, None]:
         # Extract the last message content as the main prompt
         if not messages:
-            raise ValueError("No messages provided")
+            message = "No messages provided"
+            raise ValueError(message)
 
         # Use provided model/temperature or fall back to settings
         actual_model = model or self.llm_settings.model
@@ -844,7 +846,8 @@ class RunScriptPreviewContextV2:
             outline.content if outline else ""
         )
         if not document:
-            raise ValueError("Markdown-Flow content is empty")
+            message = "Markdown-Flow content is empty"
+            raise ValueError(message)
 
         chapter_title = getattr(outline, "title", "") or outline_bid
         trace_scene = "lesson_preview"
@@ -1460,7 +1463,8 @@ class RunScriptPreviewContextV2:
                 model = allowed_available_models[0]
                 model_source = "allowlist"
             else:
-                raise ValueError("No allowed LLM models are available")
+                message = "No allowed LLM models are available"
+                raise ValueError(message)
 
         temperature = next(
             (t for t in temperature_candidates if t is not None),
@@ -1468,7 +1472,8 @@ class RunScriptPreviewContextV2:
         )
 
         if not model:
-            raise ValueError("LLM model is not configured")
+            message = "LLM model is not configured"
+            raise ValueError(message)
 
         self.app.logger.info(
             "preview resolved llm settings | model=%s | temperature=%s | source=%s",

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -869,14 +869,16 @@ def _yield_tts_segments(
 ):
     provider_name = (provider or "").strip().lower()
     if not provider_name:
-        raise ValueError("TTS provider is required")
+        error_message = "TTS provider is required"
+        raise ValueError(error_message)
     if not is_tts_configured(provider_name):
         message = f"TTS provider is not configured: {provider_name}"
         raise ValueError(message)
 
     segments = split_text_for_tts(text, provider_name=provider_name)
     if not segments:
-        raise ValueError("No speakable text after preprocessing")
+        error_message = "No speakable text after preprocessing"
+        raise ValueError(error_message)
 
     safe_audio_settings = replace(audio_settings, format="mp3")
     for index, segment_text in enumerate(segments):
@@ -957,7 +959,8 @@ def _finalize_tts_stream_audio(
 ) -> tuple[str, int]:
     final_audio = concat_audio_best_effort(audio_parts)
     if not final_audio:
-        raise ValueError("No audio data produced")
+        message = "No audio data produced"
+        raise ValueError(message)
 
     duration_ms = int(get_audio_duration_ms(final_audio, audio_format="mp3") or 0)
     oss_url, bucket_name = upload_audio_to_oss(app, final_audio, audio_bid)
@@ -1548,7 +1551,8 @@ def _yield_run_tts_audio_events(
         )
         yield event
     if not emitted_audio_complete:
-        raise RuntimeError("TTS stream finalized without audio_complete")
+        message = "TTS stream finalized without audio_complete"
+        raise RuntimeError(message)
 
 
 def _audio_stream_element_type(element) -> str:

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -149,10 +149,11 @@ def _ensure_healthy_db_connection(app: Flask) -> None:
         _discard_session_connection(app, source="db connection probe failure")
     if last_error is not None:
         raise last_error
-    raise RuntimeError(
+    message = (
         "db connection probe kept returning mismatched results; "
         "no healthy connection available"
     )
+    raise RuntimeError(message)
 
 
 def _get_max_parallel_ask_count(app: Flask) -> int:

--- a/src/api/flaskr/service/metering/consts.py
+++ b/src/api/flaskr/service/metering/consts.py
@@ -42,7 +42,8 @@ def normalize_usage_type(
 ) -> int:
     if value is None or value == "":
         if strict:
-            raise ValueError("usage_type is required")
+            message = "usage_type is required"
+            raise ValueError(message)
         return default
     try:
         numeric_value = int(value)
@@ -53,7 +54,8 @@ def normalize_usage_type(
     if numeric_value in _LEGACY_USAGE_TYPE_MAP:
         return _LEGACY_USAGE_TYPE_MAP[numeric_value]
     if strict:
-        raise ValueError("usage_type is invalid")
+        message = "usage_type is invalid"
+        raise ValueError(message)
     return default
 
 
@@ -62,7 +64,8 @@ def normalize_usage_scene(
 ) -> int:
     if value is None or value == "":
         if strict:
-            raise ValueError("usage_scene is required")
+            message = "usage_scene is required"
+            raise ValueError(message)
         return default
     try:
         numeric_value = int(value)
@@ -77,5 +80,6 @@ def normalize_usage_scene(
     if numeric_value in _LEGACY_USAGE_SCENE_MAP:
         return _LEGACY_USAGE_SCENE_MAP[numeric_value]
     if strict:
-        raise ValueError("usage_scene is invalid")
+        message = "usage_scene is invalid"
+        raise ValueError(message)
     return default

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -1839,7 +1839,8 @@ def success_buy_record_from_native(
                     actual_amount is not None
                     and int(native_order.amount or 0) != actual_amount
                 ):
-                    raise RuntimeError("Native payment amount mismatch")
+                    message = "Native payment amount mismatch"
+                    raise RuntimeError(message)
 
                 buy_record: Order = Order.query.filter(
                     Order.order_bid == native_order.order_bid,

--- a/src/api/flaskr/service/order/payment_providers/__init__.py
+++ b/src/api/flaskr/service/order/payment_providers/__init__.py
@@ -17,7 +17,8 @@ def register_payment_provider(provider_cls: type[PaymentProvider]) -> None:
     """Register a payment provider class keyed by its declared channel."""
     channel = provider_cls.channel
     if not channel:
-        raise ValueError("Payment provider must declare a non-empty channel")
+        message = "Payment provider must declare a non-empty channel"
+        raise ValueError(message)
     _PROVIDER_REGISTRY[channel] = provider_cls
 
 

--- a/src/api/flaskr/service/order/payment_providers/alipay.py
+++ b/src/api/flaskr/service/order/payment_providers/alipay.py
@@ -69,7 +69,8 @@ class AlipayProvider(PaymentProvider):
 
         qr_code = str(response_payload.get("qr_code") or "")
         if not qr_code:
-            raise RuntimeError("Alipay precreate response missing qr_code")
+            error_message = "Alipay precreate response missing qr_code"
+            raise RuntimeError(error_message)
 
         provider_payload = {
             "request": {
@@ -103,7 +104,8 @@ class AlipayProvider(PaymentProvider):
         del headers
         payload = _parse_form_payload(raw_body)
         if not self._verify_notification_signature(payload, app):
-            raise RuntimeError("Alipay notify signature verification failed")
+            message = "Alipay notify signature verification failed"
+            raise RuntimeError(message)
         return self._notification_from_payload(payload)
 
     def handle_notification(
@@ -117,7 +119,8 @@ class AlipayProvider(PaymentProvider):
                 app=app,
             )
         if not self._verify_notification_signature(normalized_payload, app):
-            raise RuntimeError("Alipay notify signature verification failed")
+            message = "Alipay notify signature verification failed"
+            raise RuntimeError(message)
         return self._notification_from_payload(normalized_payload)
 
     def sync_reference(
@@ -149,13 +152,15 @@ class AlipayProvider(PaymentProvider):
         self, *, request: PaymentRefundRequest, app: Flask
     ) -> PaymentRefundResult:
         del request, app
-        raise RuntimeError("Alipay refunds are not supported")
+        message = "Alipay refunds are not supported"
+        raise RuntimeError(message)
 
     def _ensure_client(self, app: Flask) -> Any:
         sdk = self._load_sdk(app)
         app_id = str(get_config("ALIPAY_APP_ID", "") or "").strip()
         if not app_id:
-            raise RuntimeError("ALIPAY_APP_ID must be configured for Alipay")
+            message = "ALIPAY_APP_ID must be configured for Alipay"
+            raise RuntimeError(message)
         private_key = _read_required_key(
             "ALIPAY_APP_PRIVATE_KEY_PATH", "ALIPAY_APP_PRIVATE_KEY"
         )
@@ -194,7 +199,8 @@ class AlipayProvider(PaymentProvider):
             )
         except Exception as exc:  # pragma: no cover - depends on runtime package
             app.logger.exception("Alipay SDK is not available")
-            raise RuntimeError("alipay-sdk-python is required for Alipay") from exc
+            message = "alipay-sdk-python is required for Alipay"
+            raise RuntimeError(message) from exc
 
         return {
             "AlipayClientConfig": AlipayClientConfig,
@@ -218,7 +224,8 @@ class AlipayProvider(PaymentProvider):
             )
         except Exception as exc:  # pragma: no cover - depends on runtime package
             app.logger.exception("Alipay signature utility is not available")
-            raise RuntimeError("Alipay signature utility is required") from exc
+            message = "Alipay signature utility is required"
+            raise RuntimeError(message) from exc
 
         public_key = _read_required_key("ALIPAY_PUBLIC_KEY_PATH", "ALIPAY_PUBLIC_KEY")
         sign = str(payload.get("sign") or "")
@@ -274,7 +281,8 @@ def _parse_alipay_response(raw_response: Any, response_key: str) -> dict[str, An
         raw_response = json.loads(raw_response)
     if not isinstance(raw_response, dict):
         # RuntimeError is this provider's uniform failure type.
-        raise RuntimeError("Invalid Alipay response")  # noqa: TRY004
+        message = "Invalid Alipay response"
+        raise RuntimeError(message)  # noqa: TRY004
     nested = raw_response.get(response_key)
     if isinstance(nested, dict):
         return nested

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -77,13 +77,15 @@ class PingxxProvider(PaymentProvider):
             client = _get_pingpp_client()
         except Exception as exc:  # pragma: no cover
             app.logger.exception("Pingxx dependency is not available")
-            raise RuntimeError("Pingxx dependency is not available") from exc
+            message = "Pingxx dependency is not available"
+            raise RuntimeError(message) from exc
 
         api_key = get_config("PINGXX_SECRET_KEY")
         private_key = str(get_config("PINGXX_PRIVATE_KEY", "") or "").strip()
         private_key_path = get_config("PINGXX_PRIVATE_KEY_PATH")
         if not private_key and not private_key_path:
-            raise RuntimeError("Pingxx private key is not configured")
+            message = "Pingxx private key is not configured"
+            raise RuntimeError(message)
         if not private_key and not Path(private_key_path).exists():
             app.logger.error("Pingxx private key not found at %s", private_key_path)
             raise FileNotFoundError(private_key_path)
@@ -163,17 +165,20 @@ class PingxxProvider(PaymentProvider):
     def create_subscription(
         self, *, request: PaymentRequest, app: Flask
     ) -> PaymentCreationResult:
-        raise RuntimeError("Pingxx does not support subscriptions")
+        message = "Pingxx does not support subscriptions"
+        raise RuntimeError(message)
 
     def cancel_subscription(
         self, *, subscription_bid: str, provider_subscription_id: str, app: Flask
     ) -> SubscriptionUpdateResult:
-        raise RuntimeError("Pingxx does not support subscriptions")
+        message = "Pingxx does not support subscriptions"
+        raise RuntimeError(message)
 
     def resume_subscription(
         self, *, subscription_bid: str, provider_subscription_id: str, app: Flask
     ) -> SubscriptionUpdateResult:
-        raise RuntimeError("Pingxx does not support subscriptions")
+        message = "Pingxx does not support subscriptions"
+        raise RuntimeError(message)
 
     def verify_webhook(
         self, *, headers: dict[str, str], raw_body: bytes | str, app: Flask
@@ -191,7 +196,8 @@ class PingxxProvider(PaymentProvider):
         if webhook_public_key:
             signature = normalized_headers.get("x-pingplusplus-signature", "")
             if not signature:
-                raise RuntimeError("Pingxx signature header missing")
+                message = "Pingxx signature header missing"
+                raise RuntimeError(message)
             public_key = serialization.load_pem_public_key(
                 webhook_public_key.encode("utf-8")
             )

--- a/src/api/flaskr/service/order/payment_providers/stripe.py
+++ b/src/api/flaskr/service/order/payment_providers/stripe.py
@@ -50,9 +50,8 @@ class StripeProvider(PaymentProvider):
             success_url = options.get("success_url")
             cancel_url = options.get("cancel_url")
             if not success_url or not cancel_url:
-                raise RuntimeError(
-                    "Stripe checkout session requires success and cancel URLs"
-                )
+                message = "Stripe checkout session requires success and cancel URLs"
+                raise RuntimeError(message)
 
             session_params = options.get("session_params", {})
             params: dict[str, Any] = {
@@ -64,7 +63,8 @@ class StripeProvider(PaymentProvider):
 
             line_items = options.get("line_items")
             if not line_items:
-                raise RuntimeError("Stripe checkout session requires line items")
+                message = "Stripe checkout session requires line items"
+                raise RuntimeError(message)
             params["line_items"] = line_items
             subscription_discount_amount = int(
                 options.get("subscription_one_time_discount_amount") or 0
@@ -254,7 +254,8 @@ class StripeProvider(PaymentProvider):
         webhook_secret = get_config("STRIPE_WEBHOOK_SECRET")
         if not webhook_secret:
             app.logger.error("STRIPE_WEBHOOK_SECRET configuration is missing")
-            raise RuntimeError("STRIPE_WEBHOOK_SECRET must be configured for Stripe")
+            message = "STRIPE_WEBHOOK_SECRET must be configured for Stripe"
+            raise RuntimeError(message)
 
         if isinstance(raw_body, bytes):
             raw_body_str = raw_body.decode("utf-8")
@@ -264,7 +265,8 @@ class StripeProvider(PaymentProvider):
             "stripe-signature", ""
         )
         if not sig_header:
-            raise RuntimeError("Stripe signature header missing")
+            message = "Stripe signature header missing"
+            raise RuntimeError(message)
 
         try:
             event = stripe.Webhook.construct_event(
@@ -368,9 +370,8 @@ class StripeProvider(PaymentProvider):
         elif charge_id:
             params["charge"] = charge_id
         else:
-            raise RuntimeError(
-                "Stripe refund requires payment_intent_id or charge_id metadata"
-            )
+            message = "Stripe refund requires payment_intent_id or charge_id metadata"
+            raise RuntimeError(message)
 
         refund = stripe.Refund.create(**params, **request_options)
         refund_dict = refund.to_dict()

--- a/src/api/flaskr/service/order/payment_providers/wechatpay.py
+++ b/src/api/flaskr/service/order/payment_providers/wechatpay.py
@@ -102,7 +102,8 @@ class WechatPayProvider(PaymentProvider):
         self, *, request: PaymentRefundRequest, app: Flask
     ) -> PaymentRefundResult:
         del request, app
-        raise RuntimeError("WeChat Pay refunds are not supported")
+        message = "WeChat Pay refunds are not supported"
+        raise RuntimeError(message)
 
     def _create_native_payment(
         self, *, request: PaymentRequest, app: Flask
@@ -116,7 +117,8 @@ class WechatPayProvider(PaymentProvider):
         )
         code_url = str(response_payload.get("code_url") or "")
         if not code_url:
-            raise RuntimeError("WeChat Native response missing code_url")
+            message = "WeChat Native response missing code_url"
+            raise RuntimeError(message)
         return PaymentCreationResult(
             provider_reference=request.order_bid,
             raw_response=response_payload,
@@ -132,7 +134,8 @@ class WechatPayProvider(PaymentProvider):
     ) -> PaymentCreationResult:
         open_id = str((request.extra or {}).get("open_id") or "").strip()
         if not open_id:
-            raise RuntimeError("WeChat JSAPI payment requires open_id")
+            message = "WeChat JSAPI payment requires open_id"
+            raise RuntimeError(message)
         body = self._build_transaction_body(request)
         body["payer"] = {"openid": open_id}
         response_payload = self._request(
@@ -143,7 +146,8 @@ class WechatPayProvider(PaymentProvider):
         )
         prepay_id = str(response_payload.get("prepay_id") or "")
         if not prepay_id:
-            raise RuntimeError("WeChat JSAPI response missing prepay_id")
+            message = "WeChat JSAPI response missing prepay_id"
+            raise RuntimeError(message)
         jsapi_params = self._build_jsapi_params(prepay_id=prepay_id)
         return PaymentCreationResult(
             provider_reference=request.order_bid,
@@ -264,7 +268,8 @@ class WechatPayProvider(PaymentProvider):
         nonce = normalized_headers.get("wechatpay-nonce", "")
         signature = normalized_headers.get("wechatpay-signature", "")
         if not timestamp or not nonce or not signature:
-            raise RuntimeError("WeChat Pay signature headers missing")
+            error_message = "WeChat Pay signature headers missing"
+            raise RuntimeError(error_message)
         public_key = _load_public_key_from_certificate()
         message = f"{timestamp}\n{nonce}\n{raw_body}\n".encode()
         public_key.verify(
@@ -279,7 +284,8 @@ class WechatPayProvider(PaymentProvider):
         resource: dict[str, Any],
     ) -> dict[str, Any]:
         if not resource:
-            raise RuntimeError("WeChat Pay notification resource missing")
+            error_message = "WeChat Pay notification resource missing"
+            raise RuntimeError(error_message)
         algorithm = str(resource.get("algorithm") or "")
         if algorithm and algorithm != "AEAD_AES_256_GCM":
             message = f"Unsupported WeChat Pay algorithm: {algorithm}"
@@ -299,7 +305,8 @@ def _wechatpay_app_id() -> str:
         get_config("WECHATPAY_APP_ID", "") or get_config("WECHAT_APP_ID", "") or ""
     ).strip()
     if not value:
-        raise RuntimeError("WECHATPAY_APP_ID must be configured for WeChat Pay")
+        message = "WECHATPAY_APP_ID must be configured for WeChat Pay"
+        raise RuntimeError(message)
     return value
 
 

--- a/src/api/flaskr/service/order/raw_snapshots.py
+++ b/src/api/flaskr/service/order/raw_snapshots.py
@@ -125,7 +125,8 @@ def upsert_native_snapshot(
         or order_bid_value
         or bill_order_bid_value
     ):
-        raise ValueError("Native payment snapshot requires a stable identifier")
+        message = "Native payment snapshot requires a stable identifier"
+        raise ValueError(message)
 
     query = model.query.filter(
         model.deleted == 0,

--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -286,7 +286,8 @@ def _create_invite_code_with_retry(
                 return existing
         else:
             return invite_code
-    raise RuntimeError("unable to generate referral invite code")
+    message = "unable to generate referral invite code"
+    raise RuntimeError(message)
 
 
 def _reward_count_for_rule(
@@ -336,7 +337,8 @@ def _resolve_public_origin() -> str:
             if normalized_origin:
                 return normalized_origin
         return _normalize_origin(f"{request.scheme}://{request.host}")
-    raise RuntimeError("HOST_URL must be configured to build referral invite URLs")
+    message = "HOST_URL must be configured to build referral invite URLs"
+    raise RuntimeError(message)
 
 
 def _normalize_origin(value: str) -> str:
@@ -345,11 +347,11 @@ def _normalize_origin(value: str) -> str:
         return ""
     parsed = urlsplit(raw_value)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise RuntimeError("HOST_URL must include http(s) scheme and host")
+        message = "HOST_URL must include http(s) scheme and host"
+        raise RuntimeError(message)
     if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
-        raise RuntimeError(
-            "HOST_URL must be an origin without path, query, or fragment"
-        )
+        message = "HOST_URL must be an origin without path, query, or fragment"
+        raise RuntimeError(message)
     return urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
 
 
@@ -395,7 +397,8 @@ def build_invite_profile(app: Flask, *, inviter_user_bid: str) -> InviteProfileD
     with _with_app_context(app):
         normalized_inviter = str(inviter_user_bid or "").strip()
         if not normalized_inviter:
-            raise ValueError("inviter_user_bid is required")
+            message = "inviter_user_bid is required"
+            raise ValueError(message)
         campaign = load_active_campaign()
         if campaign is None:
             return InviteProfileDTO.unavailable()
@@ -500,7 +503,8 @@ def record_invite_event(app: Flask, payload: InviteEventInput) -> InviteEventRes
     with _with_app_context(app):
         event_type = str(payload.event_type or "").strip()
         if event_type not in REFERRAL_INVITE_EVENT_TYPES:
-            raise ValueError("unsupported referral invite event type")
+            message = "unsupported referral invite event type"
+            raise ValueError(message)
         normalized_code = str(payload.invite_code or "").strip().upper()
         invite_code = _load_invite_code(normalized_code) if normalized_code else None
         campaign_bid = ""

--- a/src/api/flaskr/service/shifu/cli.py
+++ b/src/api/flaskr/service/shifu/cli.py
@@ -38,9 +38,8 @@ def register_shifu_commands(console, app) -> None:
     ) -> None:
         """Repair broken draft outline parent/position state and rebuild struct."""
         if not dry_run and not user_bid:
-            raise click.ClickException(
-                "Pass --user-bid for non-dry-run outline repair."
-            )
+            message = "Pass --user-bid for non-dry-run outline repair."
+            raise click.ClickException(message)
 
         payload = repair_shifu_outline_structure(
             app,

--- a/src/api/flaskr/service/shifu/repair.py
+++ b/src/api/flaskr/service/shifu/repair.py
@@ -289,7 +289,8 @@ def repair_shifu_outline_structure(
     dry_run: bool = False,
 ) -> OutlineStructureRepairResult:
     if not dry_run and not user_bid:
-        raise ValueError("user_bid is required when dry_run is False")
+        message = "user_bid is required when dry_run is False"
+        raise ValueError(message)
 
     with app.app_context():
         items = _load_latest_active_outline_items(shifu_bids)

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -1958,7 +1958,8 @@ def register_shifu_routes(app: Flask, path_prefix="/api/shifu"):
             NotImplementedError: This API endpoint is not yet implemented
 
         """
-        raise NotImplementedError("MDFlow run API is not yet implemented")
+        message = "MDFlow run API is not yet implemented"
+        raise NotImplementedError(message)
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/outlines", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)

--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -88,13 +88,15 @@ def concat_audio_mp3(
 
     """
     if not PYDUB_AVAILABLE:
-        raise ImportError(
+        error_message = (
             "pydub is required for audio concatenation. "
             "Install it with: pip install pydub"
         )
+        raise ImportError(error_message)
 
     if not segments:
-        raise ValueError("No audio segments to concatenate")
+        error_message = "No audio segments to concatenate"
+        raise ValueError(error_message)
 
     if len(segments) == 1:
         return segments[0]
@@ -132,7 +134,8 @@ def concat_audio_mp3(
             )
 
     if combined is None:
-        raise ValueError("Failed to concatenate audio segments")
+        error_message = "Failed to concatenate audio segments"
+        raise ValueError(error_message)
 
     if failed_segments:
         failed_segment_list = ", ".join(str(index) for index in failed_segments)

--- a/src/api/flaskr/service/tts/minimax_voice_clone.py
+++ b/src/api/flaskr/service/tts/minimax_voice_clone.py
@@ -22,7 +22,8 @@ except Exception:  # pragma: no cover - exercised only when pydub is missing.
 
         @staticmethod
         def from_file(*_args, **_kwargs) -> None:
-            raise RuntimeError("audio decoder is not available")
+            message = "audio decoder is not available"
+            raise RuntimeError(message)
 
 
 import contextlib
@@ -154,28 +155,35 @@ def normalize_audio_blob(
     normalized_filename = str(filename or "").strip()
     extension = _extract_extension(normalized_filename)
     if extension not in _ALLOWED_INPUT_EXTENSIONS:
-        raise ValueError("unsupported audio file type")
+        message = "unsupported audio file type"
+        raise ValueError(message)
     if not audio_bytes:
-        raise ValueError("audio file is empty")
+        message = "audio file is empty"
+        raise ValueError(message)
 
     try:
         segment = AudioSegment.from_file(io.BytesIO(audio_bytes), format=extension)
     except Exception as exc:
-        raise ValueError(
+        message = (
             "unable to decode audio; please record again or upload mp3, m4a, or wav"
-        ) from exc
+        )
+        raise ValueError(message) from exc
 
     duration_ms = len(segment)
     if purpose == "source":
         if duration_ms < _SOURCE_MIN_DURATION_MS:
-            raise ValueError("source audio must be at least 10 seconds")
+            message = "source audio must be at least 10 seconds"
+            raise ValueError(message)
         if duration_ms > _SOURCE_MAX_DURATION_MS:
-            raise ValueError("source audio must be no longer than 5 minutes")
+            message = "source audio must be no longer than 5 minutes"
+            raise ValueError(message)
     elif purpose == "prompt":
         if duration_ms > _PROMPT_MAX_DURATION_MS:
-            raise ValueError("prompt audio must be no longer than 8 seconds")
+            message = "prompt audio must be no longer than 8 seconds"
+            raise ValueError(message)
     else:
-        raise ValueError("invalid audio purpose")
+        message = "invalid audio purpose"
+        raise ValueError(message)
 
     output = io.BytesIO()
     segment.export(output, format="wav")
@@ -200,7 +208,8 @@ class MiniMaxVoiceCloneClient:
         self.api_key = str(get_config("MINIMAX_API_KEY") or "").strip()
         self.group_id = str(get_config("MINIMAX_GROUP_ID") or "").strip()
         if not self.api_key:
-            raise ValueError("MINIMAX_API_KEY is not configured")
+            message = "MINIMAX_API_KEY is not configured"
+            raise ValueError(message)
 
     def upload_clone_audio(
         self,
@@ -332,7 +341,8 @@ class MiniMaxVoiceCloneClient:
             or ""
         )
         if not file_id:
-            raise ValueError("MiniMax file upload did not return file_id")
+            error_message = "MiniMax file upload did not return file_id"
+            raise ValueError(error_message)
         extra_info = message.get("extra_info") or data.get("extra_info") or file_data
         return MiniMaxUploadedFile(
             file_id=file_id,
@@ -767,7 +777,8 @@ def _execute_clone_processing(
         prompt_file_id=prompt_file_id,
     )
     if clone_result.input_sensitive:
-        raise ValueError("MiniMax rejected the audio for sensitive content")
+        message = "MiniMax rejected the audio for sensitive content"
+        raise ValueError(message)
 
     with app.app_context():
         row = _load_voice_row(voice_bid)
@@ -1024,7 +1035,8 @@ def _delete_resource_object(app: Flask, resource_bid: str) -> None:
 def _read_resource_bytes(resource_bid: str) -> bytes:
     normalized = str(resource_bid or "").strip()
     if not normalized:
-        raise ValueError("audio resource is missing")
+        message = "audio resource is missing"
+        raise ValueError(message)
     if normalized in _PENDING_AUDIO_BLOBS:
         return _PENDING_AUDIO_BLOBS[normalized]
     temp_path = _temp_resource_path(normalized)
@@ -1039,7 +1051,8 @@ def _read_resource_bytes(resource_bid: str) -> bytes:
                 object_key=resource.oss_name,
                 bucket_name=resource.oss_bucket or "",
             )
-    raise ValueError("source audio is no longer available")
+    message = "source audio is no longer available"
+    raise ValueError(message)
 
 
 def _cleanup_raw_resources(app: Flask, row: TTSMiniMaxClonedVoice) -> None:
@@ -1073,7 +1086,8 @@ def _enqueue_minimax_clone_task(app: Flask, *, voice_bid: str) -> bool:
     celery_app = get_celery_app(flask_app=app)
     task = celery_app.tasks.get("tts.minimax_clone_voice")
     if task is None:
-        raise RuntimeError("tts.minimax_clone_voice task is unavailable")
+        message = "tts.minimax_clone_voice task is unavailable"
+        raise RuntimeError(message)
     task.apply_async(kwargs={"voice_bid": voice_bid})
     return True
 

--- a/src/api/flaskr/service/tts/pipeline.py
+++ b/src/api/flaskr/service/tts/pipeline.py
@@ -554,7 +554,8 @@ def _split_by_sentence_and_newline(text: str) -> list[str]:
 
 def _split_text_by_max_chars(units: Sequence[str], max_chars: int) -> list[str]:
     if max_chars <= 0:
-        raise ValueError("max_chars must be > 0")
+        message = "max_chars must be > 0"
+        raise ValueError(message)
 
     segments: list[str] = []
     current = ""
@@ -604,7 +605,8 @@ def _split_text_by_max_bytes(
     This is mainly required for providers like Baidu which enforce byte limits.
     """
     if max_bytes <= 0:
-        raise ValueError("max_bytes must be > 0")
+        message = "max_bytes must be > 0"
+        raise ValueError(message)
 
     output: list[str] = []
     for raw_segment in segments:
@@ -717,7 +719,8 @@ def synthesize_long_text_to_oss(
     """
     provider = (provider_name or "").strip().lower()
     if not provider:
-        raise ValueError("TTS provider is required")
+        error_message = "TTS provider is required"
+        raise ValueError(error_message)
 
     if not is_tts_configured(provider):
         message = f"TTS provider is not configured: {provider}"
@@ -729,7 +732,8 @@ def synthesize_long_text_to_oss(
         max_segment_chars=max_segment_chars,
     )
     if not segments:
-        raise ValueError("No speakable text after preprocessing")
+        error_message = "No speakable text after preprocessing"
+        raise ValueError(error_message)
 
     cleaned_text = preprocess_for_tts(text or "")
     raw_length = len(text or "")
@@ -765,7 +769,8 @@ def synthesize_long_text_to_oss(
     max_workers = max(1, int(max_workers or 1))
     sleep_between_segments = float(sleep_between_segments or 0.0)
     if sleep_between_segments < 0:
-        raise ValueError("sleep_between_segments must be >= 0")
+        error_message = "sleep_between_segments must be >= 0"
+        raise ValueError(error_message)
 
     if max_workers == 1:
         audio_parts: list[bytes] = []
@@ -873,7 +878,8 @@ def synthesize_long_text_to_oss(
 
     final_audio = concat_audio_best_effort(audio_parts)
     if not final_audio:
-        raise ValueError("No audio data produced")
+        error_message = "No audio data produced"
+        raise ValueError(error_message)
 
     duration_ms = get_audio_duration_ms(final_audio, audio_format="mp3")
 

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -151,7 +151,8 @@ def _acquire_local_slot(
         now = now_fn()
         scheduled_at = max(now, _LOCAL_STATE.get(scope_key, now))
         if scheduled_at > deadline:
-            raise TTSRpmQueueTimeoutError("TTS RPM local queue wait exceeded limit")
+            message = "TTS RPM local queue wait exceeded limit"
+            raise TTSRpmQueueTimeoutError(message)
 
         _LOCAL_STATE[scope_key] = scheduled_at + interval
         return TTSRpmGateResult(
@@ -165,7 +166,8 @@ def _get_redis_client():
 
     redis_client = get_redis_client()
     if redis_client is None:
-        raise RuntimeError("Redis is not configured")
+        message = "Redis is not configured"
+        raise RuntimeError(message)
     return redis_client
 
 

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -105,7 +105,8 @@ def _get_tts_executor() -> ThreadPoolExecutor:
         _tts_executor_state.pid = current_pid
     executor = _tts_executor_state.executor
     if executor is None:  # pragma: no cover - guarded by the branch above
-        raise RuntimeError("TTS executor initialization failed")
+        message = "TTS executor initialization failed"
+        raise RuntimeError(message)
     return executor
 
 
@@ -605,7 +606,8 @@ class StreamingTTSProcessor:
                     continue
                 raise
         if result is None:
-            raise ValueError("TTS synthesis returned no result")
+            message = "TTS synthesis returned no result"
+            raise ValueError(message)
         return result
 
     def _synthesize_in_thread(

--- a/src/api/flaskr/service/user/auth/factory.py
+++ b/src/api/flaskr/service/user/auth/factory.py
@@ -25,7 +25,8 @@ def register_provider(provider_cls: type[AuthProvider]) -> None:
     """Register a provider class with the global registry."""
     provider_name = getattr(provider_cls, "provider_name", None)
     if not provider_name:
-        raise ValueError("Auth providers must define a non-empty provider_name")
+        error_message = "Auth providers must define a non-empty provider_name"
+        raise ValueError(error_message)
 
     normalized = provider_name.lower()
     if normalized in _REGISTRY:

--- a/src/api/flaskr/service/user/auth/providers/email.py
+++ b/src/api/flaskr/service/user/auth/providers/email.py
@@ -60,7 +60,8 @@ class EmailAuthProvider(AuthProvider):
 
         aggregate = load_user_aggregate(user_token.userInfo.user_id)
         if not aggregate:
-            raise RuntimeError("User aggregate missing after email verification")
+            message = "User aggregate missing after email verification"
+            raise RuntimeError(message)
 
         credential = find_credential(
             provider_name="email",

--- a/src/api/flaskr/service/user/auth/providers/google.py
+++ b/src/api/flaskr/service/user/auth/providers/google.py
@@ -160,7 +160,8 @@ class GoogleAuthProvider(AuthProvider):
         return app.config.get("GOOGLE_OAUTH_USERINFO_ENDPOINT", USERINFO_ENDPOINT)
 
     def verify(self, app, request):
-        raise NotImplementedError("GoogleAuthProvider only supports OAuth flows")
+        message = "GoogleAuthProvider only supports OAuth flows"
+        raise NotImplementedError(message)
 
     def _create_session(self, app, redirect_uri: str) -> OAuth2Session:
         client_id = app.config.get("GOOGLE_OAUTH_CLIENT_ID")
@@ -272,7 +273,8 @@ class GoogleAuthProvider(AuthProvider):
         subject_id = profile.get("sub")
         email = profile.get("email")
         if not subject_id or not email:
-            raise RuntimeError("Google profile missing required identifiers")
+            message = "Google profile missing required identifiers"
+            raise RuntimeError(message)
 
         email = email.lower()
         email_verified = bool(profile.get("email_verified", False))
@@ -385,9 +387,8 @@ class GoogleAuthProvider(AuthProvider):
 
             refreshed = load_user_aggregate(aggregate.user_bid)
             if not refreshed:
-                raise RuntimeError(
-                    "Failed to refresh user aggregate after Google OAuth"
-                )
+                message = "Failed to refresh user aggregate after Google OAuth"
+                raise RuntimeError(message)
             user_dto = build_user_info_from_aggregate(refreshed)
             token_value = generate_token(app, refreshed.user_bid)
             user_token = UserToken(userInfo=user_dto, token=token_value)

--- a/src/api/flaskr/service/user/auth/providers/phone.py
+++ b/src/api/flaskr/service/user/auth/providers/phone.py
@@ -61,7 +61,8 @@ class PhoneAuthProvider(AuthProvider):
 
         aggregate = load_user_aggregate(user_token.userInfo.user_id)
         if not aggregate:
-            raise RuntimeError("User aggregate missing after phone verification")
+            message = "User aggregate missing after phone verification"
+            raise RuntimeError(message)
 
         credential = find_credential(
             provider_name="phone",

--- a/src/api/flaskr/service/user/user.py
+++ b/src/api/flaskr/service/user/user.py
@@ -218,7 +218,8 @@ def _wechat_identifiers(app: Flask, open_id: str, union_id: str) -> tuple[str, s
         return open_id, union_id
     app_id = str(custom_wechat.get("app_id") or "").strip()
     if not app_id:
-        raise RuntimeError("Custom WeChat OAuth integration is missing app_id")
+        message = "Custom WeChat OAuth integration is missing app_id"
+        raise RuntimeError(message)
     return (
         f"{app_id}:{open_id}" if open_id else "",
         f"{app_id}:{union_id}" if union_id else "",

--- a/src/api/scripts/check_mdflow_listen_adapter.py
+++ b/src/api/scripts/check_mdflow_listen_adapter.py
@@ -742,7 +742,8 @@ def main() -> int:
 
     samples = _load_samples(input_path, limit=args.limit)
     if not samples:
-        raise SystemExit("No samples loaded")
+        error_message = "No samples loaded"
+        raise SystemExit(error_message)
 
     app, temp_dir = _make_app()
     try:

--- a/src/api/scripts/check_sse_segmentation.py
+++ b/src/api/scripts/check_sse_segmentation.py
@@ -238,7 +238,8 @@ def main() -> int:
 
     samples = _load_samples(input_path, limit=args.limit)
     if not samples:
-        raise SystemExit("No samples loaded")
+        error_message = "No samples loaded"
+        raise SystemExit(error_message)
 
     abnormal: list[AnalysisResult] = []
     speakable_count = 0

--- a/src/api/scripts/evaluate_learner_profile_optimizer_prompt.py
+++ b/src/api/scripts/evaluate_learner_profile_optimizer_prompt.py
@@ -78,7 +78,8 @@ def _build_user_message(learner_profile: str) -> str:
 
 def _parse_model_output(raw_model_text: str) -> str:
     if not raw_model_text.strip():
-        raise EvaluationError("model output is empty")
+        message = "model output is empty"
+        raise EvaluationError(message)
     return raw_model_text
 
 
@@ -92,9 +93,11 @@ def _parse_codex_events(stdout: str) -> dict[str, Any]:
         try:
             event = json.loads(line)
         except json.JSONDecodeError as exc:
-            raise EvaluationError("codex CLI emitted a non-JSON event") from exc
+            exception_message = "codex CLI emitted a non-JSON event"
+            raise EvaluationError(exception_message) from exc
         if event.get("type") == "error":
-            raise EvaluationError("codex CLI emitted an error event")
+            exception_message = "codex CLI emitted an error event"
+            raise EvaluationError(exception_message)
         item = event.get("item")
         if isinstance(item, dict) and isinstance(item.get("type"), str):
             item_type = item["type"]
@@ -179,7 +182,8 @@ def _run_codex(
                 timeout=timeout_seconds,
             )
         except FileNotFoundError as exc:
-            raise EvaluationError("codex CLI is not installed") from exc
+            error_message = "codex CLI is not installed"
+            raise EvaluationError(error_message) from exc
         except subprocess.TimeoutExpired as exc:
             message = f"codex CLI exceeded the {timeout_seconds}s timeout"
             raise EvaluationError(message) from exc
@@ -190,7 +194,8 @@ def _run_codex(
             message = f"codex CLI exited with {completed.returncode}: {detail}"
             raise EvaluationError(message)
         if not output_path.exists():
-            raise EvaluationError("codex CLI did not write a final response")
+            error_message = "codex CLI did not write a final response"
+            raise EvaluationError(error_message)
         result = output_path.read_text(encoding="utf-8")
         event_metadata = _parse_codex_events(completed.stdout)
         metadata = {
@@ -210,9 +215,11 @@ def _codex_version() -> str:
             timeout=10,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-        raise EvaluationError("could not determine the codex CLI version") from exc
+        message = "could not determine the codex CLI version"
+        raise EvaluationError(message) from exc
     if completed.returncode != 0 or not completed.stdout.strip():
-        raise EvaluationError("could not determine the codex CLI version")
+        message = "could not determine the codex CLI version"
+        raise EvaluationError(message)
     return completed.stdout.strip()
 
 
@@ -245,11 +252,13 @@ def _load_cases(path: Path) -> tuple[dict[str, Any], list[dict[str, str]]]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     cases = payload.get("cases")
     if not isinstance(cases, list) or not cases:
-        raise EvaluationError("cases file must contain a non-empty cases array")
+        message = "cases file must contain a non-empty cases array"
+        raise EvaluationError(message)
     normalized_cases: list[dict[str, str]] = []
     for case in cases:
         if not isinstance(case, dict):
-            raise EvaluationError("every case must be an object")
+            message = "every case must be an object"
+            raise EvaluationError(message)
         case_id = case.get("id")
         learner_profile = case.get("learner_profile")
         observed_shape = case.get("observed_shape")
@@ -257,14 +266,16 @@ def _load_cases(path: Path) -> tuple[dict[str, Any], list[dict[str, str]]]:
             isinstance(value, str) and value.strip()
             for value in (case_id, learner_profile, observed_shape)
         ):
-            raise EvaluationError(
+            message = (
                 "every case requires non-empty id, observed_shape, and learner_profile"
             )
+            raise EvaluationError(message)
         normalized_profile = learner_profile.strip()
         if len(normalized_profile) > MAX_LEARNER_PROFILE_CHARS:
-            raise EvaluationError(
+            message = (
                 "learner_profile exceeds the production 1000-character input limit"
             )
+            raise EvaluationError(message)
         normalized_cases.append(
             {
                 "id": case_id.strip(),
@@ -368,18 +379,23 @@ def _build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     args = _build_parser().parse_args()
     if args.repeats < 1:
-        raise EvaluationError("--repeats must be at least 1")
+        error_message = "--repeats must be at least 1"
+        raise EvaluationError(error_message)
     if args.timeout_seconds < 1:
-        raise EvaluationError("--timeout-seconds must be at least 1")
+        error_message = "--timeout-seconds must be at least 1"
+        raise EvaluationError(error_message)
     if not 1 <= args.jobs <= 8:
-        raise EvaluationError("--jobs must be between 1 and 8")
+        error_message = "--jobs must be between 1 and 8"
+        raise EvaluationError(error_message)
 
     system_prompt = args.prompt.read_text(encoding="utf-8").strip()
     if not system_prompt:
-        raise EvaluationError("prompt file is empty")
+        error_message = "prompt file is empty"
+        raise EvaluationError(error_message)
     output_language = str(args.output_language or "").strip()
     if not output_language:
-        raise EvaluationError("--output-language must not be empty")
+        error_message = "--output-language must not be empty"
+        raise EvaluationError(error_message)
     system_prompt = (
         f"{system_prompt}\n\nOUTPUT LANGUAGE: {output_language}. "
         "Write every label and sentence in this language. "

--- a/src/api/tests/api/doc/test_feishu_notify.py
+++ b/src/api/tests/api/doc/test_feishu_notify.py
@@ -83,7 +83,8 @@ def test_send_notify_returns_none_for_request_error(monkeypatch):
     )
 
     def _raise(*args, **kwargs):
-        raise requests.RequestException("network down")
+        message = "network down"
+        raise requests.RequestException(message)
 
     monkeypatch.setattr(feishu.requests, "post", _raise)
 

--- a/src/api/tests/common/test_celery_fork_pool_dispose.py
+++ b/src/api/tests/common/test_celery_fork_pool_dispose.py
@@ -52,7 +52,8 @@ def test_one_failing_bind_does_not_block_the_rest(app, monkeypatch):
 
     class _BrokenEngine:
         def dispose(self, close):
-            raise RuntimeError("bind gone")
+            message = "bind gone"
+            raise RuntimeError(message)
 
     class _GoodEngine:
         def dispose(self, close):

--- a/src/api/tests/common/test_common_route.py
+++ b/src/api/tests/common/test_common_route.py
@@ -21,7 +21,8 @@ def test_common_handler_returns_translated_unexpected_error_for_unhandled_except
 
     @app.route("/boom")
     def _boom():
-        raise RuntimeError("unexpected failure")
+        message = "unexpected failure"
+        raise RuntimeError(message)
 
     with app.test_client() as client:
         response = client.get("/boom")
@@ -41,7 +42,8 @@ def test_common_handler_uses_request_language_for_unhandled_exceptions(monkeypat
 
     @app.route("/boom-zh")
     def _boom_zh():
-        raise RuntimeError("unexpected failure")
+        message = "unexpected failure"
+        raise RuntimeError(message)
 
     with app.test_client() as client:
         response = client.get(
@@ -88,7 +90,8 @@ def test_common_handler_uses_json_language_for_patch_requests(monkeypatch):
 
     @app.route("/boom-patch", methods=["PATCH"])
     def _boom_patch():
-        raise RuntimeError("unexpected failure")
+        message = "unexpected failure"
+        raise RuntimeError(message)
 
     with app.test_client() as client:
         response = client.patch(

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -135,7 +135,8 @@ def test_cleanup_escalates_to_invalidate_when_rollback_fails():
 
         def rollback(self):
             events.append("rollback")
-            raise RuntimeError("rollback broke")
+            message = "rollback broke"
+            raise RuntimeError(message)
 
     outcome = cleanup_session_after(ValueError("business"), source="t", session=_Fake())
     assert outcome == "invalidated"
@@ -180,8 +181,9 @@ def test_teardown_hook_ignores_ordinary_exceptions(app, monkeypatch):
         lambda *, source, session=None: invalidations.append(source) or True,
     )
 
+    message = "business"
     with pytest.raises(ValueError, match="business"), app.app_context():
-        raise ValueError("business")
+        raise ValueError(message)
 
     assert invalidations == []
 
@@ -246,7 +248,8 @@ def test_release_session_classified_ignores_ordinary_exceptions(app, monkeypatch
     with app.app_context():
         try:
             try:
-                raise ValueError("business")
+                message = "business"
+                raise ValueError(message)
             finally:
                 dao.release_session_classified(source="t-ordinary")
         except ValueError:

--- a/src/api/tests/common/test_gevent_hub_observer.py
+++ b/src/api/tests/common/test_gevent_hub_observer.py
@@ -68,7 +68,8 @@ def test_logger_failure_never_blocks_the_original_handler():
 
     class _BrokenLogger:
         def error(self, *args, **kwargs):
-            raise RuntimeError("logging backend down")
+            message = "logging backend down"
+            raise RuntimeError(message)
 
     install_hub_error_observer(_BrokenLogger(), hub=hub)
     result = _fire(hub)
@@ -84,7 +85,8 @@ def test_unreprable_context_is_still_logged(caplog):
 
     class _BadRepr:
         def __repr__(self) -> str:
-            raise ValueError("no repr for you")
+            message = "no repr for you"
+            raise ValueError(message)
 
     with caplog.at_level(logging.ERROR, logger="test-hub-observer-badrepr"):
         _fire(hub, context=_BadRepr())

--- a/src/api/tests/common/test_log.py
+++ b/src/api/tests/common/test_log.py
@@ -8,7 +8,8 @@ from flaskr.common.log import FeishuLogHandler
 
 class _FailingResponse:
     def raise_for_status(self):
-        raise requests.exceptions.HTTPError("400 Client Error")
+        message = "400 Client Error"
+        raise requests.exceptions.HTTPError(message)
 
 
 def test_feishu_log_handler_does_not_reemit_webhook_failures(monkeypatch):

--- a/src/api/tests/contract/test_sms_contract.py
+++ b/src/api/tests/contract/test_sms_contract.py
@@ -91,7 +91,8 @@ def test_send_sms_code_ali_returns_none_without_keys(monkeypatch):
     from flaskr.api.sms import aliyun as sms_aliyun
 
     def fake_client(_config):
-        raise AssertionError("client should not be created")
+        message = "client should not be created"
+        raise AssertionError(message)
 
     monkeypatch.setattr(sms_aliyun, "Dysmsapi20170525Client", fake_client)
 

--- a/src/api/tests/service/billing/test_billing_callbacks.py
+++ b/src/api/tests/service/billing/test_billing_callbacks.py
@@ -882,7 +882,8 @@ class TestBillingNativeCallbacks:
     ) -> None:
         class FakeWechatPayProvider:
             def verify_webhook(self, *, headers, raw_body, app):
-                raise RuntimeError("secret verification detail")
+                message = "secret verification detail"
+                raise RuntimeError(message)
 
         monkeypatch.setattr(
             "flaskr.route.callback.get_payment_provider",

--- a/src/api/tests/service/billing/test_billing_cycle_transitions.py
+++ b/src/api/tests/service/billing/test_billing_cycle_transitions.py
@@ -21,7 +21,8 @@ from flaskr.service.billing.cycle_transitions import (
 
 
 def _raise_unexpected_call(*_args, **_kwargs):
-    raise AssertionError("unexpected callback call")
+    message = "unexpected callback call"
+    raise AssertionError(message)
 
 
 def test_resolve_order_effective_from_prefers_order_cycle_metadata() -> None:

--- a/src/api/tests/service/billing/test_billing_error_specificity.py
+++ b/src/api/tests/service/billing/test_billing_error_specificity.py
@@ -26,7 +26,8 @@ class _UnavailableLock:
         return False
 
     def release(self) -> None:  # pragma: no cover - should not be called
-        raise AssertionError("unacquired lock should not be released")
+        message = "unacquired lock should not be released"
+        raise AssertionError(message)
 
 
 class _LockFactory:
@@ -37,12 +38,13 @@ class _LockFactory:
 def test_subscription_checkout_lock_conflict_returns_busy_error(app, monkeypatch):
     monkeypatch.setattr(checkout_module.cache_provider, "cache", _LockFactory())
 
+    message = "lock body should not execute"
     with (
         app.app_context(),
         pytest.raises(AppError) as exc_info,
         checkout_module._subscription_checkout_lock(app, "creator-busy"),
     ):
-        raise AssertionError("lock body should not execute")
+        raise AssertionError(message)
 
     assert exc_info.value.code == ERROR_CODE["server.billing.subscriptionCheckoutBusy"]
 

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -142,7 +142,8 @@ def _billing_paid_feishu_payload(
 
 
 def _raise_if_send_notify_called(*args, **kwargs):
-    raise AssertionError("billing paid Feishu delivery should run in a Celery task")
+    message = "billing paid Feishu delivery should run in a Celery task"
+    raise AssertionError(message)
 
 
 def _create_subscription(

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
@@ -1066,7 +1066,8 @@ def test_expire_credit_wallet_buckets_skips_bucket_on_wallet_version_conflict(
         def _persist_conflict_once(target_wallet, **kwargs):
             state["calls"] += 1
             if state["calls"] == 1:
-                raise RuntimeError("credit_wallet_version_conflict")
+                message = "credit_wallet_version_conflict"
+                raise RuntimeError(message)
             return real_persist(target_wallet, **kwargs)
 
         monkeypatch.setattr(

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_grants.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_grants.py
@@ -171,7 +171,8 @@ def test_grant_manual_credit_wallet_balance_returns_noop_existing_after_integrit
             dao.db.session.rollback()
             dao.db.session.add(existing)
             original_commit()
-            raise IntegrityError("duplicate", {}, Exception("duplicate"))
+            message = "duplicate"
+            raise IntegrityError(message, {}, Exception("duplicate"))
         return original_commit()
 
     monkeypatch.setattr(dao.db.session, "commit", _commit_once_with_duplicate)

--- a/src/api/tests/service/billing/test_creator_customization.py
+++ b/src/api/tests/service/billing/test_creator_customization.py
@@ -335,7 +335,8 @@ def test_expired_custom_payment_never_falls_back_to_platform(app, monkeypatch):
         except AppError:
             pass
         else:
-            raise AssertionError("expired custom payment must block new checkout")
+            message = "expired custom payment must block new checkout"
+            raise AssertionError(message)
 
 
 def test_callback_token_requires_valid_integration_secret_key(app):
@@ -691,9 +692,8 @@ def test_installed_but_disabled_saas_plugin_falls_back(app, monkeypatch):
 
     class _ExplodingModule:
         def __getattr__(self, name) -> Any:
-            raise AssertionError(
-                "SaaS plugin must not be used while SAAS_PLUGIN_ENABLED is false"
-            )
+            message = "SaaS plugin must not be used while SAAS_PLUGIN_ENABLED is false"
+            raise AssertionError(message)
 
     def fake_import(name):
         if name.startswith("flaskr.plugins.ai_shifu_saas_plugin"):
@@ -914,7 +914,8 @@ def test_creator_brand_logo_upload_rejects_invalid_or_oversized_image(app, monke
             except AppError:
                 pass
             else:
-                raise AssertionError("invalid logo content must be rejected")
+                message = "invalid logo content must be rejected"
+                raise AssertionError(message)
 
 
 def test_creator_brand_logo_upload_normalizes_square_variant(app, monkeypatch):

--- a/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
@@ -295,7 +295,8 @@ def test_scan_item_failure_is_isolated_from_neighbor_items(
     def staging_then_boom(app_arg, **kwargs):
         result = original_stage(app_arg, **kwargs)
         if kwargs.get("creator_bid") == "creator-uow-2":
-            raise RuntimeError("boom in creator-uow-2")
+            message = "boom in creator-uow-2"
+            raise RuntimeError(message)
         return result
 
     monkeypatch.setattr(
@@ -400,7 +401,8 @@ def test_failed_provider_marker_persists_and_stays_retryable(
     notification_bid = str(staged["notification_bid"])
 
     def crashing_send(*_args, **_kwargs):
-        raise RuntimeError("provider connection dropped")
+        message = "provider connection dropped"
+        raise RuntimeError(message)
 
     monkeypatch.setattr(credit_notifications, "send_sms_ali", crashing_send)
     failed = deliver_credit_notification(app, notification_bid=notification_bid)
@@ -456,7 +458,8 @@ def test_granted_dispatch_fires_after_commit_and_drops_on_rollback(
             )
             assert staged["status"] == CREDIT_NOTIFICATION_STATUS_PENDING
             assert enqueued == []  # not yet durable, must not dispatch
-            raise RuntimeError("outer boom")
+            message = "outer boom"
+            raise RuntimeError(message)
 
     with pytest.raises(RuntimeError, match="outer boom"):
         stage_then_fail()

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -854,7 +854,8 @@ def test_sync_credit_notification_template_records_provider_exception(
     )
 
     def raise_provider_error(app: Flask, *, template_code: str) -> None:
-        raise RuntimeError("provider down")
+        message = "provider down"
+        raise RuntimeError(message)
 
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.get_sms_template_ali",
@@ -2336,7 +2337,8 @@ def test_provider_exception_marks_notification_failed(
     _enable_policy(app)
 
     def raise_provider_error(*args, **kwargs) -> None:
-        raise RuntimeError("provider raised")
+        message = "provider raised"
+        raise RuntimeError(message)
 
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.send_sms_ali",

--- a/src/api/tests/service/billing/test_provider_catalog.py
+++ b/src/api/tests/service/billing/test_provider_catalog.py
@@ -87,7 +87,8 @@ class _FakeStripe:
 
 class _FailingStripeResource:
     def retrieve(self, *args, **kwargs):
-        raise RuntimeError("secret sk_test_should_not_leak")
+        message = "secret sk_test_should_not_leak"
+        raise RuntimeError(message)
 
 
 class _FailingStripe:

--- a/src/api/tests/service/billing/test_referral_plan_rewards.py
+++ b/src/api/tests/service/billing/test_referral_plan_rewards.py
@@ -965,7 +965,8 @@ def test_pingxx_renewal_event_preserves_paid_referral_reward_order(
     current_cycle_start = boundary_at - timedelta(days=30)
 
     def _fail_provider_sync(*_args, **_kwargs):
-        raise AssertionError("paid referral reward orders must not sync providers")
+        message = "paid referral reward orders must not sync providers"
+        raise AssertionError(message)
 
     monkeypatch.setattr(
         "flaskr.service.billing.renewal.sync_billing_order",

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -317,7 +317,8 @@ def test_renewal_order_persists_before_provider_sync_crash(
     dao.db.session.commit()
 
     def crashing_sync(*_args, **_kwargs):
-        raise RuntimeError("provider sync crash")
+        message = "provider sync crash"
+        raise RuntimeError(message)
 
     monkeypatch.setattr(billing_renewal, "_sync_billing_renewal_order", crashing_sync)
 
@@ -408,7 +409,8 @@ def test_expire_notification_fires_after_commit_and_drops_on_rollback(
                 renewal_uow_app, renewal_event_bid="renewal-uow-notify"
             )
             assert enqueued == []  # not yet durable, must not dispatch
-            raise RuntimeError("outer boom")
+            message = "outer boom"
+            raise RuntimeError(message)
 
     with pytest.raises(RuntimeError, match="outer boom"):
         run_then_fail()

--- a/src/api/tests/service/common/test_umami_client.py
+++ b/src/api/tests/service/common/test_umami_client.py
@@ -137,7 +137,8 @@ def test_get_course_visit_count_30d_caches_failures_briefly(app, monkeypatch):
 
     def _fake_get(url, params=None, headers=None, timeout=None):
         request_count["value"] += 1
-        raise requests.RequestException("umami unavailable")
+        message = "umami unavailable"
+        raise requests.RequestException(message)
 
     monkeypatch.setattr(umami_client.requests, "get", _fake_get)
 
@@ -196,7 +197,8 @@ def test_get_course_visit_count_30d_returns_fetched_value_when_cache_write_fails
             return self._cache.delete(*keys)
 
         def setex(self, key, ttl, value):
-            raise RuntimeError("cache unavailable")
+            message = "cache unavailable"
+            raise RuntimeError(message)
 
         def lock(self, key, timeout=None, blocking_timeout=None):
             return self._cache.lock(
@@ -240,7 +242,8 @@ def test_get_course_visit_count_30d_returns_zero_when_failure_cache_write_fails(
             return self._cache.delete(*keys)
 
         def setex(self, key, ttl, value):
-            raise RuntimeError("cache unavailable")
+            message = "cache unavailable"
+            raise RuntimeError(message)
 
         def lock(self, key, timeout=None, blocking_timeout=None):
             return self._cache.lock(
@@ -367,7 +370,8 @@ def test_login_for_access_token_returns_token_when_cache_write_fails(monkeypatch
             return self._cache.get(key)
 
         def setex(self, key, ttl, value):
-            raise RuntimeError("cache unavailable")
+            message = "cache unavailable"
+            raise RuntimeError(message)
 
         def lock(self, key, timeout=None, blocking_timeout=None):
             return self._cache.lock(

--- a/src/api/tests/service/common/test_uow.py
+++ b/src/api/tests/service/common/test_uow.py
@@ -36,7 +36,8 @@ def test_outermost_rolls_back_on_exception(app):
             with uow.unit_of_work():
                 dao.db.session.add(_make_shifu("uow-rollback-1"))
                 dao.db.session.flush()
-                raise RuntimeError("boom")
+                message = "boom"
+                raise RuntimeError(message)
 
         with pytest.raises(RuntimeError):
             write_then_fail()
@@ -54,7 +55,8 @@ def test_nested_block_joins_outer_transaction(app):
             with uow.unit_of_work():
                 helper()
                 dao.db.session.add(_make_shifu("uow-nested-outer-1"))
-                raise RuntimeError("outer fails after helper 'completed'")
+                message = "outer fails after helper 'completed'"
+                raise RuntimeError(message)
 
         with pytest.raises(RuntimeError):
             outer_fails_after_helper()
@@ -99,8 +101,9 @@ def test_depth_is_isolated_per_thread(app):
 
 def test_depth_resets_after_exception(app):
     with app.app_context():
+        message = "boom"
         with pytest.raises(RuntimeError), uow.unit_of_work():
-            raise RuntimeError("boom")
+            raise RuntimeError(message)
         assert not uow.in_unit_of_work()
 
 
@@ -129,7 +132,8 @@ def test_on_commit_dropped_on_rollback(app):
         def schedule_then_fail():
             with uow.unit_of_work():
                 uow.on_commit(lambda: calls.append("never"))
-                raise RuntimeError("boom")
+                message = "boom"
+                raise RuntimeError(message)
 
         with pytest.raises(RuntimeError):
             schedule_then_fail()
@@ -140,7 +144,8 @@ def test_on_commit_callback_exception_does_not_propagate(app):
     calls = []
 
     def boom():
-        raise RuntimeError("callback boom")
+        message = "callback boom"
+        raise RuntimeError(message)
 
     with app.app_context(), uow.unit_of_work():
         uow.on_commit(boom)

--- a/src/api/tests/service/learn/test_ask_provider_adapters.py
+++ b/src/api/tests/service/learn/test_ask_provider_adapters.py
@@ -115,7 +115,8 @@ def test_coze_adapter_timeout_raises_timeout_error(app, monkeypatch):
     )
 
     def _raise_timeout(*_args, **_kwargs):
-        raise requests.Timeout("timeout")
+        message = "timeout"
+        raise requests.Timeout(message)
 
     monkeypatch.setattr(coze_adapter.requests, "post", _raise_timeout)
 
@@ -359,6 +360,7 @@ def test_coze_adapter_uses_default_base_url_when_missing(app, monkeypatch):
 
     def _fake_post(url, **kwargs):
         request_state["url"] = url
+        request_state["json"] = kwargs["json"]
         return _FakeResponse(
             lines=[
                 'data: {"event":"message","content":"ok"}',
@@ -384,6 +386,7 @@ def test_coze_adapter_uses_default_base_url_when_missing(app, monkeypatch):
     )
 
     assert request_state["url"] == "https://api.coze.cn/v3/chat"
+    assert request_state["json"]["bot_id"] == "bot-1"
     assert [chunk.content for chunk in chunks] == ["ok"]
 
 
@@ -748,7 +751,8 @@ def test_get_biji_knowledge_adapter_timeout_raises_timeout_error(app, monkeypatc
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
 
     def _raise_timeout(*_args, **_kwargs):
-        raise requests.Timeout("timeout")
+        message = "timeout"
+        raise requests.Timeout(message)
 
     monkeypatch.setattr(get_biji_knowledge_adapter.requests, "post", _raise_timeout)
 

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -21,7 +21,8 @@ def _install_litellm_stub() -> None:
 
     def get_model_info(*args, **kwargs):
         _ = args, kwargs
-        raise ValueError("unknown model")
+        message = "unknown model"
+        raise ValueError(message)
 
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.get_model_info = get_model_info

--- a/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
+++ b/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
@@ -130,7 +130,8 @@ def test_tts_finalize_failure_runs_classified_cleanup(app, monkeypatch):
         next_element_index = 0
 
         def finalize(self, *, commit):
-            raise ResourceClosedError("desynced during finalize")
+            message = "desynced during finalize"
+            raise ResourceClosedError(message)
             yield  # pragma: no cover - generator marker
 
     stub = types.SimpleNamespace(app=app)

--- a/src/api/tests/service/learn/test_element_protocol.py
+++ b/src/api/tests/service/learn/test_element_protocol.py
@@ -2482,7 +2482,8 @@ class TestHandleAskAdapter:
             def _raise_provider_error(**_kwargs):
                 if False:
                     yield None
-                raise AskProviderError("provider failed")
+                message = "provider failed"
+                raise AskProviderError(message)
 
             monkeypatch.setattr(
                 module,

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -936,9 +936,8 @@ class TestGeneratedBlockListenTtsElementFirst:
         synthesized_texts = _patch_run_tts_processor(monkeypatch)
 
         def _fail_sem_acquire(*_args, **_kwargs):
-            raise AssertionError(
-                "cache fast-path should not acquire the synthesis semaphore"
-            )
+            message = "cache fast-path should not acquire the synthesis semaphore"
+            raise AssertionError(message)
 
         monkeypatch.setattr(
             "flaskr.service.learn.learn_funcs._tts_synth_sem_acquire",
@@ -1161,9 +1160,8 @@ class TestGeneratedBlockListenTtsElementFirst:
         synthesized_texts = _patch_run_tts_processor(monkeypatch)
 
         def _fail_sem_acquire(*_args, **_kwargs):
-            raise AssertionError(
-                "markup-only blocks should not acquire the synthesis semaphore"
-            )
+            message = "markup-only blocks should not acquire the synthesis semaphore"
+            raise AssertionError(message)
 
         monkeypatch.setattr(
             "flaskr.service.learn.learn_funcs._tts_synth_sem_acquire",

--- a/src/api/tests/service/learn/test_handle_input_ask_provider.py
+++ b/src/api/tests/service/learn/test_handle_input_ask_provider.py
@@ -13,7 +13,8 @@ def _install_litellm_stub() -> None:
 
     def get_model_info(*args, **kwargs):
         _ = args, kwargs
-        raise ValueError("unknown model")
+        message = "unknown model"
+        raise ValueError(message)
 
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.get_model_info = get_model_info
@@ -319,7 +320,8 @@ def test_handle_input_ask_provider_only_returns_provider_error_without_llm(
     def _raise_provider_error(**_kwargs):
         if False:
             yield None
-        raise AskProviderError("provider failed")
+        message = "provider failed"
+        raise AskProviderError(message)
 
     monkeypatch.setattr(module, "stream_ask_provider_response", _raise_provider_error)
 
@@ -390,7 +392,8 @@ def test_handle_input_ask_provider_then_llm_falls_back_to_llm(app, monkeypatch):
                 types.SimpleNamespace(content=chunk.result)
                 for chunk in runtime.llm_stream_factory()
             )
-        raise AskProviderError("provider failed")
+        message = "provider failed"
+        raise AskProviderError(message)
 
     monkeypatch.setattr(
         module,

--- a/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
+++ b/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
@@ -59,7 +59,8 @@ def test_sse_close_invalidates_session(app, invalidations):
 def test_sse_protocol_error_invalidates_session(app, invalidations):
     def factory():
         yield {"type": "chunk"}
-        raise ResourceClosedError("desynced")
+        message = "desynced"
+        raise ResourceClosedError(message)
 
     with app.test_request_context("/"):
         response = learn_routes._stream_sse_response(
@@ -79,7 +80,8 @@ def test_sse_protocol_error_invalidates_session(app, invalidations):
 def test_sse_business_error_does_not_invalidate(app, invalidations):
     def factory():
         yield {"type": "chunk"}
-        raise ValueError("business")
+        message = "business"
+        raise ValueError(message)
 
     with app.test_request_context("/"):
         response = learn_routes._stream_sse_response(
@@ -118,7 +120,8 @@ def test_passthrough_close_invalidates_session(app, invalidations):
 def test_passthrough_close_disguised_as_runtime_error(app, invalidations):
     def factory():
         yield "data: 1\n\n"
-        raise RuntimeError("generator ignored GeneratorExit")
+        message = "generator ignored GeneratorExit"
+        raise RuntimeError(message)
 
     with app.test_request_context("/"):
         response = learn_routes._stream_passthrough_response(

--- a/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
+++ b/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
@@ -15,7 +15,8 @@ def _install_litellm_stub() -> None:
 
     def get_model_info(*args, **kwargs):
         _ = args, kwargs
-        raise ValueError("unknown model")
+        message = "unknown model"
+        raise ValueError(message)
 
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.get_model_info = get_model_info

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -104,10 +104,11 @@ def test_find_active_element_row_ids_sees_rows_flushed_in_current_transaction(ap
 def test_find_active_element_row_ids_invalidates_desynced_connection(app, monkeypatch):
     class _DesyncedResult:
         def fetchall(self):
-            raise ResourceClosedError(
+            message = (
                 "This result object does not return rows. "
                 "It has been closed automatically."
             )
+            raise ResourceClosedError(message)
 
         def close(self):
             pass

--- a/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
+++ b/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
@@ -42,8 +42,9 @@ class _FakeSession:
         if behaviour == "ok":
             return _EchoResult(params["nonce"])
         if behaviour == "raise":
+            message = "SELECT :nonce"
             raise OperationalError(
-                "SELECT :nonce",
+                message,
                 params,
                 Exception("(2014, 'Command Out of Sync')"),
             )

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -297,7 +297,8 @@ def test_run_script_producer_done_survives_db_session_remove_failure(monkeypatch
 
         def _remove():
             remove_calls.append("remove")
-            raise RuntimeError("remove failed")
+            message = "remove failed"
+            raise RuntimeError(message)
 
         monkeypatch.setattr(
             runscript_v2,
@@ -691,7 +692,8 @@ def test_run_script_inner_rolls_back_on_unexpected_exception(monkeypatch):
 
     def _remove():
         remove_calls.append("remove")
-        raise RuntimeError("remove failed")
+        message = "remove failed"
+        raise RuntimeError(message)
 
     session_spy.commit = _commit
     session_spy.rollback = _rollback
@@ -743,7 +745,8 @@ def test_run_script_inner_rolls_back_on_unexpected_exception(monkeypatch):
             return False
 
         def run(self, _app):
-            raise RuntimeError("boom")
+            message = "boom"
+            raise RuntimeError(message)
 
     monkeypatch.setattr(runscript_v2, "RunScriptContextV2", FakeRunScriptContext)
 
@@ -1243,9 +1246,8 @@ def test_run_script_maps_llm_stream_connection_error_to_retryable_message(
         monkeypatch.setattr(runscript_v2, "_", lambda key: f"translated:{key}")
 
         def fake_run_script_inner(**_kwargs):
-            raise RuntimeError(
-                "litellm.APIConnectionError: APIConnectionError: OpenAIException - [SSL] record layer failure (_ssl.c:2590)"
-            )
+            message = "litellm.APIConnectionError: APIConnectionError: OpenAIException - [SSL] record layer failure (_ssl.c:2590)"
+            raise RuntimeError(message)
             yield  # pragma: no cover
 
         monkeypatch.setattr(runscript_v2, "run_script_inner", fake_run_script_inner)
@@ -1278,7 +1280,8 @@ def test_run_script_maps_standard_timeout_error_to_retryable_message(monkeypatch
         monkeypatch.setattr(runscript_v2, "_", lambda key: f"translated:{key}")
 
         def fake_run_script_inner(**_kwargs):
-            raise RuntimeError("stream failed") from TimeoutError(
+            message = "stream failed"
+            raise RuntimeError(message) from TimeoutError(
                 "The read operation timed out"
             )
             yield  # pragma: no cover

--- a/src/api/tests/service/learn/test_runtime_tts_admission.py
+++ b/src/api/tests/service/learn/test_runtime_tts_admission.py
@@ -21,7 +21,8 @@ def _install_litellm_stub() -> None:
 
     def get_model_info(*args, **kwargs):
         _ = args, kwargs
-        raise ValueError("unknown model")
+        message = "unknown model"
+        raise ValueError(message)
 
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.get_model_info = get_model_info
@@ -88,7 +89,8 @@ def _find_register_learn_routes() -> ast.FunctionDef:
     for node in _MODULE.body:
         if isinstance(node, ast.FunctionDef) and node.name == "register_learn_routes":
             return node
-    raise AssertionError("register_learn_routes not found")
+    message = "register_learn_routes not found"
+    raise AssertionError(message)
 
 
 def _find_nested_route(name: str) -> ast.FunctionDef:
@@ -177,7 +179,8 @@ def test_stream_passthrough_ignores_request_db_session_remove_failure(monkeypatc
 
     def _remove():
         calls.append("remove")
-        raise RuntimeError("remove failed")
+        message = "remove failed"
+        raise RuntimeError(message)
 
     monkeypatch.setattr(
         routes,
@@ -215,7 +218,8 @@ def test_stream_sse_logs_business_errors_as_warning(monkeypatch, caplog):
     )
 
     def _messages():
-        raise AppError("TTS provider quota exceeded", 45000292)
+        message = "TTS provider quota exceeded"
+        raise AppError(message, 45000292)
         yield  # pragma: no cover
 
     with app.test_request_context("/api/learn/shifu/s/generated-blocks/g/tts"):
@@ -246,7 +250,8 @@ def test_stream_sse_keeps_unexpected_errors_at_error_level(monkeypatch, caplog):
     )
 
     def _messages():
-        raise RuntimeError("tts worker crashed")
+        message = "tts worker crashed"
+        raise RuntimeError(message)
         yield  # pragma: no cover
 
     with app.test_request_context("/api/learn/shifu/s/generated-blocks/g/tts"):
@@ -277,7 +282,8 @@ def test_stream_sse_emits_error_event_for_business_error_with_factory(
     )
 
     def _messages():
-        raise AppError("TTS provider quota exceeded", 45000292)
+        message = "TTS provider quota exceeded"
+        raise AppError(message, 45000292)
         yield  # pragma: no cover
 
     with app.test_request_context("/api/learn/shifu/s/generated-blocks/g/tts"):

--- a/src/api/tests/service/learn/test_tts_error_mapping.py
+++ b/src/api/tests/service/learn/test_tts_error_mapping.py
@@ -10,7 +10,8 @@ from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeoutError
 
 def test_rpm_queue_timeout_maps_to_rate_limited_not_unknown(app, caplog):
     def _body():
-        raise TTSRpmQueueTimeoutError("TTS RPM queue wait exceeded 10.00s")
+        message = "TTS RPM queue wait exceeded 10.00s"
+        raise TTSRpmQueueTimeoutError(message)
         yield  # pragma: no cover
 
     with (
@@ -35,7 +36,8 @@ def test_rpm_queue_timeout_maps_to_rate_limited_not_unknown(app, caplog):
 
 def test_unexpected_error_still_maps_to_unknown_error(app, caplog):
     def _body():
-        raise RuntimeError("tts worker crashed")
+        message = "tts worker crashed"
+        raise RuntimeError(message)
         yield  # pragma: no cover
 
     with (

--- a/src/api/tests/service/learn/test_tts_synth_concurrency.py
+++ b/src/api/tests/service/learn/test_tts_synth_concurrency.py
@@ -44,7 +44,8 @@ class ExplodingRedis:
 
     def eval(self, *_args, **_kwargs):
         self.calls += 1
-        raise RuntimeError("redis down")
+        message = "redis down"
+        raise RuntimeError(message)
 
 
 def test_tts_synth_semaphore_caps_at_limit_and_releases(app, monkeypatch):

--- a/src/api/tests/service/metering/test_recording.py
+++ b/src/api/tests/service/metering/test_recording.py
@@ -357,7 +357,8 @@ def test_persist_cleanup_targets_failed_session_inside_context(app, monkeypatch)
             pass
 
         def commit(self):
-            raise ResourceClosedError("desynced")
+            message = "desynced"
+            raise ResourceClosedError(message)
 
     monkeypatch.setattr(
         recorder_module, "db", type("D", (), {"session": _FailingSession()})

--- a/src/api/tests/service/order/test_order_import_error_specificity.py
+++ b/src/api/tests/service/order/test_order_import_error_specificity.py
@@ -10,7 +10,8 @@ def test_import_activation_orders_unexpected_failure_returns_specific_message(
     app, monkeypatch
 ):
     def raise_unexpected(*_args, **_kwargs):
-        raise RuntimeError("boom")
+        message = "boom"
+        raise RuntimeError(message)
 
     monkeypatch.setattr(order_admin, "import_activation_order", raise_unexpected)
 
@@ -35,7 +36,8 @@ def test_import_activation_orders_from_entries_unexpected_failure_returns_specif
     app, monkeypatch
 ):
     def raise_unexpected(*_args, **_kwargs):
-        raise RuntimeError("boom")
+        message = "boom"
+        raise RuntimeError(message)
 
     monkeypatch.setattr(order_admin, "import_activation_order", raise_unexpected)
 

--- a/src/api/tests/service/order/test_order_init_lock.py
+++ b/src/api/tests/service/order/test_order_init_lock.py
@@ -62,7 +62,8 @@ def test_order_init_lock_uses_prefixed_key(monkeypatch):
 def test_order_init_lock_skips_when_cache_provider_errors(monkeypatch):
     class _BrokenCacheProvider:
         def lock(self, *args, **kwargs):
-            raise RuntimeError("lock unavailable")
+            message = "lock unavailable"
+            raise RuntimeError(message)
 
     monkeypatch.setattr(order_funs, "cache_provider", _BrokenCacheProvider())
     app = DummyApp(prefix="unit-test")

--- a/src/api/tests/service/order/test_provider_public_urls.py
+++ b/src/api/tests/service/order/test_provider_public_urls.py
@@ -230,7 +230,8 @@ def test_stripe_subscription_discount_coupon_is_cleaned_up_on_session_failure(
     class FakeSession:
         @staticmethod
         def create(**_kwargs) -> None:
-            raise RuntimeError("session failed")
+            message = "session failed"
+            raise RuntimeError(message)
 
     class FakeCheckout:
         Session = FakeSession

--- a/src/api/tests/service/order/test_uow_failure_paths.py
+++ b/src/api/tests/service/order/test_uow_failure_paths.py
@@ -102,7 +102,8 @@ def _fail_after_pricing_sync(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def failing_sync(*args, **kwargs):
         real_sync(*args, **kwargs)
-        raise RuntimeError("boom after pricing sync")
+        message = "boom after pricing sync"
+        raise RuntimeError(message)
 
     monkeypatch.setattr(order_funs, "_sync_order_campaign_pricing", failing_sync)
 
@@ -281,7 +282,8 @@ def test_success_buy_record_commits_alone_but_joins_outer_unit_of_work(
         with uow.unit_of_work():
             success_buy_record(order_app, order_bid)
             assert feishu_calls == []  # not yet durable, must not notify
-            raise RuntimeError("outer boom")
+            message = "outer boom"
+            raise RuntimeError(message)
 
     with pytest.raises(RuntimeError, match="outer boom"):
         flip_then_fail()

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -4813,7 +4813,8 @@ def test_registration_source_map_skips_user_query_when_users_argument_is_empty(
 ):
     class ForbiddenUserQuery:
         def filter(self, *_args, **_kwargs):
-            raise AssertionError("expected no user query when users=[] is provided")
+            message = "expected no user query when users=[] is provided"
+            raise AssertionError(message)
 
     with app.app_context():
         monkeypatch.setattr(
@@ -4866,7 +4867,8 @@ def test_registration_source_map_skips_unknown_provider_when_supported_one_exist
 def test_contact_map_skips_user_query_when_users_argument_is_empty(app, monkeypatch):
     class ForbiddenUserQuery:
         def filter(self, *_args, **_kwargs):
-            raise AssertionError("expected no user query when users=[] is provided")
+            message = "expected no user query when users=[] is provided"
+            raise AssertionError(message)
 
     with app.app_context():
         monkeypatch.setattr(

--- a/src/api/tests/service/shifu/test_archive.py
+++ b/src/api/tests/service/shifu/test_archive.py
@@ -329,7 +329,8 @@ def test_create_shifu_draft_skips_risk_check_for_default_outline_content(
     from flaskr.service.shifu import shifu_outline_funcs
 
     def fail_outline_risk(*_args, **_kwargs):
-        raise AssertionError("default outline content should not trigger risk check")
+        message = "default outline content should not trigger risk check"
+        raise AssertionError(message)
 
     monkeypatch.setattr(
         shifu_outline_funcs,
@@ -365,7 +366,8 @@ def test_create_shifu_draft_raises_when_default_outline_init_fails(app, monkeypa
     )
 
     def fail_default_outlines(*_args, **_kwargs):
-        raise AppError("outline init failed")
+        message = "outline init failed"
+        raise AppError(message)
 
     monkeypatch.setattr(
         draft_module,

--- a/src/api/tests/service/shifu/test_ask_preview_route.py
+++ b/src/api/tests/service/shifu/test_ask_preview_route.py
@@ -152,7 +152,8 @@ def test_ask_preview_route_fallbacks_to_llm(monkeypatch, test_client):
         _ = args
         provider = kwargs.get("provider", "")
         if provider == "dify":
-            raise AskProviderError("provider failed")
+            message = "provider failed"
+            raise AskProviderError(message)
         assert provider == "llm"
         yield SimpleNamespace(content="llm fallback")
 
@@ -357,9 +358,12 @@ def test_ask_preview_route_surfaces_friendly_provider_error(monkeypatch, test_cl
 
     def fake_stream_ask_provider_response(*args, **kwargs):
         _ = (args, kwargs)
-        raise AskProviderError(
+        message = (
             "get_biji_knowledge request failed: 401 Client Error for url: "
-            "https://openapi.biji.com/... | {raw json body}",
+            "https://openapi.biji.com/... | {raw json body}"
+        )
+        raise AskProviderError(
+            message,
             user_message="Knowledge base authentication failed.",
         )
         yield  # pragma: no cover
@@ -402,7 +406,8 @@ def test_ask_preview_route_falls_back_to_generic_provider_error(
 
     def fake_stream_ask_provider_response(*args, **kwargs):
         _ = (args, kwargs)
-        raise AskProviderError("dify request failed: 500 | {raw body}")
+        message = "dify request failed: 500 | {raw body}"
+        raise AskProviderError(message)
         yield  # pragma: no cover
 
     monkeypatch.setattr(

--- a/src/api/tests/service/shifu/test_operator_voice_clone_register.py
+++ b/src/api/tests/service/shifu/test_operator_voice_clone_register.py
@@ -184,7 +184,8 @@ def _mock_volcengine_status(monkeypatch, status: int) -> None:
 
 def _forbid_minimax_synthesis(monkeypatch) -> None:
     def _fail(*_args, **_kwargs):
-        raise AssertionError("synthesize_text must not be called for volcengine")
+        message = "synthesize_text must not be called for volcengine"
+        raise AssertionError(message)
 
     monkeypatch.setattr(
         "flaskr.service.shifu.admin_operations.voice_clones.synthesize_text",

--- a/src/api/tests/service/shifu/test_shifu_publish_funcs.py
+++ b/src/api/tests/service/shifu/test_shifu_publish_funcs.py
@@ -22,7 +22,8 @@ def _install_litellm_stub() -> None:
 
     def get_model_info(*args, **kwargs):
         _ = args, kwargs
-        raise ValueError("unknown model")
+        message = "unknown model"
+        raise ValueError(message)
 
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.get_model_info = get_model_info
@@ -211,10 +212,11 @@ def test_run_summary_downgrades_shutdown_race_to_warning(monkeypatch):
     monkeypatch.setattr(module, "apply_shifu_context_snapshot", lambda *_a, **_k: None)
 
     def _raise_shutdown(*_a, **_k):
-        raise RuntimeError(
+        message = (
             "litellm.MidStreamFallbackError: APIConnectionError: OpenAIException - "
             "cannot schedule new futures after shutdown"
         )
+        raise RuntimeError(message)
 
     monkeypatch.setattr(module, "get_shifu_summary", _raise_shutdown)
 
@@ -238,7 +240,8 @@ def test_run_summary_logs_error_for_other_failures(monkeypatch):
     monkeypatch.setattr(module, "apply_shifu_context_snapshot", lambda *_a, **_k: None)
 
     def _raise_other(*_a, **_k):
-        raise ValueError("boom")
+        message = "boom"
+        raise ValueError(message)
 
     monkeypatch.setattr(module, "get_shifu_summary", _raise_other)
 

--- a/src/api/tests/service/shifu/test_tts_preview_helper.py
+++ b/src/api/tests/service/shifu/test_tts_preview_helper.py
@@ -245,7 +245,8 @@ def test_build_tts_preview_response_guards_minimax_custom_voice(monkeypatch) -> 
                 "owner_user_bid": owner_user_bid,
             }
         )
-        raise AppError("voice unavailable", ERROR_CODE["server.common.paramsError"])
+        message = "voice unavailable"
+        raise AppError(message, ERROR_CODE["server.common.paramsError"])
 
     monkeypatch.setattr(
         "flaskr.service.shifu.tts_preview.assert_preview_cloned_voice_available",

--- a/src/api/tests/service/tts/test_aliyun_nls_token.py
+++ b/src/api/tests/service/tts/test_aliyun_nls_token.py
@@ -14,9 +14,8 @@ def test_get_aliyun_nls_token_uses_override_when_configured(monkeypatch):
     monkeypatch.setenv("ALIYUN_TTS_TOKEN", "override-token")
 
     def fake_get(*args, **kwargs):
-        raise AssertionError(
-            "requests.get should not be called when override token exists"
-        )
+        message = "requests.get should not be called when override token exists"
+        raise AssertionError(message)
 
     monkeypatch.setattr(requests, "get", fake_get)
 
@@ -98,7 +97,8 @@ def test_get_aliyun_nls_token_refresh_falls_back_to_cached_token(monkeypatch):
 
     def fake_get(*args, **kwargs):
         captured["calls"] += 1
-        raise requests.RequestException("network down")
+        message = "network down"
+        raise requests.RequestException(message)
 
     monkeypatch.setattr(requests, "get", fake_get)
 

--- a/src/api/tests/service/tts/test_audio_utils.py
+++ b/src/api/tests/service/tts/test_audio_utils.py
@@ -56,7 +56,8 @@ class _PartiallyBrokenAudioSegment:
     def from_mp3(segment_io: io.BytesIO) -> "_FakeSegment":
         payload = segment_io.getvalue()
         if payload == b"BAD":
-            raise ValueError("Decoding failed")
+            message = "Decoding failed"
+            raise ValueError(message)
         return _FakeSegment(int(payload.decode("utf-8")))
 
 

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -315,7 +315,8 @@ def test_run_minimax_voice_clone_success_captures_credit_once(
             return SimpleNamespace(file_id="file-source")
 
         def upload_prompt_audio(self, audio_bytes, filename, content_type):
-            raise AssertionError("prompt upload should not be called")
+            message = "prompt upload should not be called"
+            raise AssertionError(message)
 
         def clone_voice(self, **kwargs):
             assert kwargs["file_id"] == "file-source"
@@ -433,7 +434,8 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
             return SimpleNamespace(file_id="file-source")
 
         def upload_prompt_audio(self, audio_bytes, filename, content_type):
-            raise AssertionError("prompt upload should not be called")
+            message = "prompt upload should not be called"
+            raise AssertionError(message)
 
         def clone_voice(self, **kwargs):
             return SimpleNamespace(
@@ -599,7 +601,8 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(monkeypatch
             return SimpleNamespace(file_id="file-source")
 
         def upload_prompt_audio(self, audio_bytes, filename, content_type):
-            raise AssertionError("prompt upload should not be called")
+            message = "prompt upload should not be called"
+            raise AssertionError(message)
 
         def clone_voice(self, **kwargs):
             return SimpleNamespace(

--- a/src/api/tests/service/tts/test_provider_error_responses.py
+++ b/src/api/tests/service/tts/test_provider_error_responses.py
@@ -17,7 +17,8 @@ class _Response:
 
     def json(self):
         if self._payload is None:
-            raise ValueError("no json")
+            message = "no json"
+            raise ValueError(message)
         return self._payload
 
 

--- a/src/api/tests/service/tts/test_tts_executor_fork_isolation.py
+++ b/src/api/tests/service/tts/test_tts_executor_fork_isolation.py
@@ -24,10 +24,11 @@ def test_module_does_not_create_an_executor_at_import_time():
                 isinstance(value, ast.Call)
                 and getattr(value.func, "id", None) == "ThreadPoolExecutor"
             ):
-                raise AssertionError(
+                message = (
                     "module-level ThreadPoolExecutor recreates the "
                     "fork-inheritance hazard; use _get_tts_executor()"
                 )
+                raise AssertionError(message)
 
 
 def test_executor_is_cached_within_one_process(monkeypatch):

--- a/src/api/tests/service/tts/test_volcengine_voice_clone.py
+++ b/src/api/tests/service/tts/test_volcengine_voice_clone.py
@@ -101,7 +101,8 @@ def test_query_status_converts_transport_error_to_param_error(monkeypatch) -> No
     _patch_config(monkeypatch)
 
     def _raise_transport_error(*args, **kwargs):
-        raise requests_lib.exceptions.ConnectTimeout("connect timeout")
+        message = "connect timeout"
+        raise requests_lib.exceptions.ConnectTimeout(message)
 
     monkeypatch.setattr(volcengine_voice_clone.requests, "post", _raise_transport_error)
     with pytest.raises(AppError):
@@ -116,7 +117,8 @@ def test_query_status_converts_invalid_json_to_param_error(monkeypatch) -> None:
         text = "<html>gateway error</html>"
 
         def json(self):
-            raise ValueError("no json")
+            message = "no json"
+            raise ValueError(message)
 
     monkeypatch.setattr(
         volcengine_voice_clone.requests,

--- a/src/api/tests/service/user/test_learner_profile_optimizer.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer.py
@@ -451,7 +451,8 @@ def test_optimize_timeout_finalizes_trace_without_changing_state(app, monkeypatc
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
     def timeout_invoke(*_args, **_kwargs):
-        raise TimeoutError("provider timeout")
+        message = "provider timeout"
+        raise TimeoutError(message)
         yield  # pragma: no cover
 
     monkeypatch.setattr(optimizer, "invoke_llm", timeout_invoke)
@@ -482,9 +483,11 @@ def test_optimize_reports_a_wrapped_timeout_as_timeout(app, monkeypatch):
     def timeout_invoke(*_args, **_kwargs):
         try:
             # The wrapped-timeout shape is exactly what this test asserts.
-            raise TimeoutError("provider timeout")  # noqa: TRY301
+            message = "provider timeout"
+            raise TimeoutError(message)  # noqa: TRY301
         except TimeoutError as exc:
-            raise AppError("wrapped provider failure", 9999) from exc
+            message = "wrapped provider failure"
+            raise AppError(message, 9999) from exc
         yield  # pragma: no cover
 
     monkeypatch.setattr(optimizer, "invoke_llm", timeout_invoke)
@@ -548,7 +551,8 @@ def test_optimize_reports_moderation_failure_reason_without_calling_llm(
     invoked = False
 
     def failed_moderation(*_args):
-        raise RuntimeError("moderation unavailable")
+        message = "moderation unavailable"
+        raise RuntimeError(message)
 
     def unexpected_invoke(*_args, **_kwargs):
         nonlocal invoked

--- a/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
@@ -41,7 +41,8 @@ class ExplodingRedis:
     """Simulate a Redis failure for tests."""
 
     def eval(self, *_args, **_kwargs):
-        raise RuntimeError("redis unavailable")
+        message = "redis unavailable"
+        raise RuntimeError(message)
 
 
 @pytest.fixture(autouse=True)
@@ -54,6 +55,7 @@ def reset_local_admission_state():
 
 
 def _assert_admission_denied(app, *, user_id: str) -> None:
+    message = "denied admission must not enter the request body"
     with (
         pytest.raises(AppError) as raised,
         admission.learner_profile_optimization_admission(
@@ -61,7 +63,7 @@ def _assert_admission_denied(app, *, user_id: str) -> None:
             user_id=user_id,
         ),
     ):
-        raise AssertionError("denied admission must not enter the request body")
+        raise AssertionError(message)
     assert raised.value.code == 1023
 
 
@@ -99,6 +101,7 @@ def test_admission_releases_slot_after_request_error(app, monkeypatch):
     fake_redis = FakeRedis()
     monkeypatch.setattr(dao._redis_state, "client", fake_redis)
 
+    message = "provider failed"
     with (
         pytest.raises(RuntimeError, match="provider failed"),
         admission.learner_profile_optimization_admission(
@@ -106,7 +109,7 @@ def test_admission_releases_slot_after_request_error(app, monkeypatch):
             user_id="error-user",
         ),
     ):
-        raise RuntimeError("provider failed")
+        raise RuntimeError(message)
 
     with admission.learner_profile_optimization_admission(
         app,

--- a/src/api/tests/service/user/test_learner_profile_service.py
+++ b/src/api/tests/service/user/test_learner_profile_service.py
@@ -1252,7 +1252,8 @@ def test_complete_rolls_back_profile_and_state_together(app, monkeypatch):
         original_commit = db.session.commit
 
         def fail_commit():
-            raise RuntimeError("database unavailable")
+            message = "database unavailable"
+            raise RuntimeError(message)
 
         monkeypatch.setattr(db.session, "commit", fail_commit)
         with pytest.raises(RuntimeError, match="database unavailable"):
@@ -1296,7 +1297,8 @@ def test_clear_rolls_back_profile_and_state_together(app, monkeypatch):
         original_commit = db.session.commit
 
         def fail_commit():
-            raise RuntimeError("database unavailable")
+            message = "database unavailable"
+            raise RuntimeError(message)
 
         monkeypatch.setattr(db.session, "commit", fail_commit)
         with pytest.raises(RuntimeError, match="database unavailable"):

--- a/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
+++ b/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
@@ -583,7 +583,8 @@ def test_merge_helper_rolls_back_with_sign_in_transaction(app):
                     target_user_id=target.user_bid,
                 )
                 db.session.flush()
-                raise RuntimeError("abort sign-in")
+                message = "abort sign-in"
+                raise RuntimeError(message)
 
         with pytest.raises(RuntimeError, match="abort sign-in"):
             merge_then_fail()

--- a/src/api/tests/service/user/test_oauth_origins.py
+++ b/src/api/tests/service/user/test_oauth_origins.py
@@ -87,7 +87,8 @@ class TestIsAllowedOAuthOrigin:
 
     def test_lookup_failure_refuses_rather_than_allows(self, app, monkeypatch) -> None:
         def _boom(app, host):
-            raise RuntimeError("database is down")
+            message = "database is down"
+            raise RuntimeError(message)
 
         monkeypatch.setattr(oauth_origins, "_resolve_creator_bid_by_host", _boom)
         assert oauth_origins.is_allowed_oauth_origin(app, CUSTOM_ORIGIN) is False

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -614,7 +614,8 @@ def test_complete_onboarding_scene_handles_integrity_error(
     def flaky_commit():
         if not state["raised"]:
             state["raised"] = True
-            raise IntegrityError("duplicate", None, None)
+            message = "duplicate"
+            raise IntegrityError(message, None, None)
         return original_commit()
 
     monkeypatch.setattr(db.session, "commit", flaky_commit)

--- a/src/api/tests/service/user/test_trial_credit_bootstrap.py
+++ b/src/api/tests/service/user/test_trial_credit_bootstrap.py
@@ -368,7 +368,8 @@ def test_post_auth_extension_failures_do_not_block_trial_bootstrap(
         dao.db.session.commit()
 
     def _failing_post_auth_handler(_context, *, app):
-        raise RuntimeError("boom")
+        message = "boom"
+        raise RuntimeError(message)
 
     plugin_manager = get_plugin_manager()
     assert plugin_manager is not None

--- a/src/api/tests/service/user/test_user_repository.py
+++ b/src/api/tests/service/user/test_user_repository.py
@@ -39,18 +39,20 @@ def test_transactional_session_classifies_before_savepoint_rollback(app, monkeyp
     import pytest
 
     # Desync inside the body: invalidate only, savepoint untouched.
+    message = "desynced"
     with pytest.raises(ResourceClosedError), repo_module.transactional_session():
-        raise ResourceClosedError("desynced")
+        raise ResourceClosedError(message)
     assert events == [("invalidate", "transactional_session desync")]
     assert nested.rollbacks == 0
     events.clear()
 
     # Ordinary error: savepoint rollback then classified session cleanup.
+    message = "business"
     with (
         pytest.raises(ValueError, match="business"),
         repo_module.transactional_session(),
     ):
-        raise ValueError("business")
+        raise ValueError(message)
     assert events == [("cleanup", "transactional_session")]
     assert nested.rollbacks == 1
     events.clear()

--- a/src/api/tests/service/user/test_validate_user.py
+++ b/src/api/tests/service/user/test_validate_user.py
@@ -13,9 +13,8 @@ def test_validate_user_maps_invalid_algorithm_token_to_user_not_found(monkeypatc
     app.config["ENVERIMENT"] = "prod"
 
     def _raise_invalid_algorithm(*_args, **_kwargs):
-        raise jwt.exceptions.InvalidAlgorithmError(
-            "The specified alg value is not allowed"
-        )
+        message = "The specified alg value is not allowed"
+        raise jwt.exceptions.InvalidAlgorithmError(message)
 
     monkeypatch.setattr(jwt, "decode", _raise_invalid_algorithm)
 

--- a/src/api/tests/test_edun.py
+++ b/src/api/tests/test_edun.py
@@ -53,7 +53,8 @@ def test_ilivedata_send_wraps_oserror_as_urlerror(monkeypatch):
     from flaskr.api.check import ilivedata as ilivedata_module
 
     def fake_urlopen(*_args, **_kwargs):
-        raise TimeoutError("timed out")
+        message = "timed out"
+        raise TimeoutError(message)
 
     monkeypatch.setattr(ilivedata_module, "urlopen", fake_urlopen)
 

--- a/src/api/tests/test_gunicorn_worker_patch_guard.py
+++ b/src/api/tests/test_gunicorn_worker_patch_guard.py
@@ -65,6 +65,7 @@ def test_observer_skips_unpatched_processes(monkeypatch):
 
     class _Logger:
         def error(self, *args, **kwargs):
-            raise AssertionError("must not log during a skipped install")
+            message = "must not log during a skipped install"
+            raise AssertionError(message)
 
     assert install_hub_error_observer(_Logger()) is False

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -27,7 +27,8 @@ def _install_litellm_stub() -> None:
 
     def get_model_info(*args, **kwargs):
         _ = args, kwargs
-        raise ValueError("unknown model")
+        message = "unknown model"
+        raise ValueError(message)
 
     litellm_stub.register_model = register_model
     litellm_stub.get_max_tokens = lambda _model: 4096
@@ -417,7 +418,8 @@ def test_get_current_models_keeps_list_when_credit_rate_lookup_fails(monkeypatch
     _configure_model_list(monkeypatch)
 
     def raise_lookup(_app):
-        raise RuntimeError("db unavailable")
+        message = "db unavailable"
+        raise RuntimeError(message)
 
     monkeypatch.setattr(llm, "_load_llm_output_rate_rows", raise_lookup)
 
@@ -471,7 +473,8 @@ def test_deepseek_model_loader_lists_models(monkeypatch):
 def test_deepseek_model_loader_falls_back_when_list_models_fails(monkeypatch):
     def fake_get(*args, **kwargs):
         _ = args, kwargs
-        raise RuntimeError("network unavailable")
+        message = "network unavailable"
+        raise RuntimeError(message)
 
     monkeypatch.setattr(llm.requests, "get", fake_get)
     config = llm.ProviderConfig(
@@ -660,7 +663,8 @@ def test_stream_litellm_completion_omits_unknown_limit(monkeypatch, app):
     captured = {}
 
     def raise_unknown(_model):
-        raise ValueError("unknown model")
+        message = "unknown model"
+        raise ValueError(message)
 
     monkeypatch.setattr(llm, "MODEL_MAX_OUTPUT_TOKENS", {})
     monkeypatch.setattr(llm.litellm, "get_max_tokens", raise_unknown)
@@ -777,7 +781,8 @@ def test_openai_params_use_litellm_reasoning_capabilities(
 def test_openai_params_fall_back_to_existing_policy_for_unknown_model(monkeypatch):
     def raise_unknown(*args, **kwargs):
         _ = args, kwargs
-        raise ValueError("unknown model")
+        message = "unknown model"
+        raise ValueError(message)
 
     monkeypatch.setattr(llm.litellm, "get_model_info", raise_unknown)
 
@@ -1367,7 +1372,8 @@ def test_chat_llm_ends_partial_response_on_repeated_stream_chunk(monkeypatch, ap
 
     def fake_completion(*args, **kwargs):
         yield FakeResponse("chunk-1", content="你好")
-        raise RepeatedChunkError("The model is repeating the same chunk = ！ ！ .")
+        message = "The model is repeating the same chunk = ！ ！ ."
+        raise RepeatedChunkError(message)
 
     monkeypatch.setattr(llm.litellm, "completion", fake_completion)
     monkeypatch.setattr(llm, "record_llm_usage", lambda *args, **kwargs: None)

--- a/src/api/tests/test_openai.py
+++ b/src/api/tests/test_openai.py
@@ -16,7 +16,8 @@ def _install_litellm_stub() -> None:
 
     def get_model_info(*args, **kwargs):
         _ = args, kwargs
-        raise ValueError("unknown model")
+        message = "unknown model"
+        raise ValueError(message)
 
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.get_model_info = get_model_info

--- a/src/api/tests/test_retry_on_deadlock.py
+++ b/src/api/tests/test_retry_on_deadlock.py
@@ -135,7 +135,8 @@ def test_rollback_db_failure_escalates_and_stops_retrying(monkeypatch):
 
     class _BrokenSession:
         def rollback(self):
-            raise OperationalError("ROLLBACK", {}, Exception())
+            message = "ROLLBACK"
+            raise OperationalError(message, {}, Exception())
 
     class _FakeDb:
         session = _BrokenSession()

--- a/src/api/tests/test_shifu_funcs.py
+++ b/src/api/tests/test_shifu_funcs.py
@@ -11,7 +11,8 @@ def test_run_summary_with_error_handling_logs_and_continues(app, monkeypatch):
 
     def fake_summary(_app, _shifu_id):
         called["summary"] = True
-        raise RuntimeError("boom")
+        message = "boom"
+        raise RuntimeError(message)
 
     monkeypatch.setattr(shifu_publish_funcs, "apply_shifu_context_snapshot", fake_apply)
     monkeypatch.setattr(shifu_publish_funcs, "get_shifu_summary", fake_summary)

--- a/src/api/tests/test_uow.py
+++ b/src/api/tests/test_uow.py
@@ -38,7 +38,8 @@ def test_unit_of_work_classifies_desync_exceptions(app, monkeypatch):
 
     from sqlalchemy.exc import ResourceClosedError
 
+    message = "desynced"
     with app.app_context(), pytest.raises(ResourceClosedError), unit_of_work():
-        raise ResourceClosedError("desynced")
+        raise ResourceClosedError(message)
 
     assert outcomes == [("ResourceClosedError", "unit_of_work")]


### PR DESCRIPTION
## Summary
- Move all 388 fixed exception strings across 135 Python files into whole-function collision-free bindings while preserving exception types, rendered text, remaining arguments, and explicit cause chains.
- Keep `pytest.raises` bodies to one statement and consolidate the equivalent Coze payload construction so the rewrite adds no PT012 or PLR0915 debt.
- Promote the single EM102 selection to the complete Ruff `EM` family and document the preferred handling for future literal, f-string, and `.format()` exception messages.

## Verification
- Reversible semantic audit: restored all 388 literal arguments, including eight pytest-context bindings, and found zero unexpected executable AST differences after normalizing one equivalent Coze payload consolidation.
- Touched test modules: 918 passed, 14 skipped.
- Full backend suite: 3,019 passed, 17 skipped.
- Stable ALL census: 28,364 findings across 29 rules. EM101 falls by 388, TRY003 by 358, COM812 by 64, and ARG001 by one; no rule gains debt.
- Identifier and translation checks, affected script entry points, repository Ruff and format, generated collaboration/knowledge docs, repository harness, architecture boundaries, development-tool validation, and every pre-commit hook passed.

## Stack
- Base: #2626 (EM102)
- This PR contains only the EM101 rule unit; EM103 was already clean, allowing the family-level selection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->