### PR TITLE
chore: enforce Unicode confusable checks

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -358,6 +358,19 @@ configuration quieter. For a finding in new or changed code:
    fundamentally conflicts with the rule. Do not weaken `select` or `ignore`
    to make an unrelated PR pass.
 
+For `RUF001`, retain intentional fullwidth Chinese punctuation (`，`, `：`,
+`！`, `？`, and `；`) in Chinese prose, notification formatting, TTS boundary
+patterns, and regression fixtures. Suppress each audited source line with
+`# noqa: RUF001` and an English reason; do not add characters to
+`allowed-confusables`, because that option also weakens the distinct RUF002 and
+RUF003 checks. Treat every other confusable as suspicious and replace it with
+the intended code point unless an exact external protocol or regression fixture
+requires it. Python test modules and test
+configuration files are exempt from RUF001 because they must preserve user text,
+provider payloads, protocol samples, and malformed inputs verbatim. Do not copy
+that exemption into production paths; add new tests under a `tests/` directory
+or use the conventional `test_*.py`, `*_test.py`, or `conftest.py` filename.
+
 For `G004`, keep log message construction lazy: pass a constant message and
 its values as positional logging arguments, preserving the message text,
 argument order, and log level. Use `%s` for normal or `!s` interpolation,

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -188,6 +188,11 @@ plan's progress update for that rule.
   Conventional Python test modules and test configuration are exempt so they
   can preserve user text, provider payloads, protocol samples, and malformed
   inputs verbatim without weakening production enforcement.
+- [x] 2026-08-22 CST: Addressed the remaining PR #2629 review by removing the
+  test-only `--select RUF001` override from the RUF001 policy test. The test now
+  exercises `ruff.toml` as CI does: test paths must omit RUF001 while a production
+  path must report it, so moving RUF001 back to a global ignore would fail the
+  regression. The focused test and `ruff check .` pass.
 - [ ] Merge or retarget RUF001 PR #2629 after its predecessors without combining
   it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -179,6 +179,17 @@ plan's progress update for that rule.
   preserving exception type, message, context, and all billing error contracts.
 - [ ] Merge or retarget EM101 PR #2628 after its predecessors without combining
   it with the next rule unit.
+- [x] 2026-08-21: Prepared the RUF001 stage on `sunner/ruff-ruf001`, stacked on
+  EM101. The isolated audit identified 162 deliberately fullwidth punctuation
+  findings across 106 Chinese-message, TTS-boundary, and regression-fixture
+  lines. The stage enables RUF001 and records 96 newly required, explained
+  line-level suppressions; it intentionally removes the global
+  `allowed-confusables` list so RUF002 and RUF003 remain fully enforced.
+  Conventional Python test modules and test configuration are exempt so they
+  can preserve user text, provider payloads, protocol samples, and malformed
+  inputs verbatim without weakening production enforcement.
+- [ ] Merge or retarget RUF001 PR #2629 after its predecessors without combining
+  it with the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable
@@ -248,11 +259,15 @@ plan's progress update for that rule.
   annotations, while SQLAlchemy model classes used for executable query
   construction stayed available at runtime. The exact import-movement audit
   makes that boundary explicit.
-- RUF001 is not the next safe exception-removal stage: its 162 findings are
-  deliberate full-width Chinese punctuation in customer messages, TTS boundary
-  patterns, and tests that freeze those language semantics. Replacing them with
-  ASCII punctuation would change product and speech behavior merely to shorten
-  configuration.
+- The isolated RUF001 audit reported 162 occurrences on 106 source lines. They
+  are deliberate fullwidth Chinese punctuation in customer messages, TTS
+  boundary patterns, and regression fixtures. Replacing them with ASCII
+  punctuation would change product and speech behavior merely to shorten
+  configuration. The correct production exception is an explained
+  `# noqa: RUF001` on each audited line, not `allowed-confusables`, which would
+  also relax RUF002 and RUF003. Test modules and test configuration are exempt
+  because they must preserve user text, provider payloads, protocol samples,
+  and malformed inputs verbatim.
 - D100 included one zero-byte, unreferenced `test_rag.py` placeholder. Removing
   it was more honest than inventing a module purpose and also removed one
   CPY001 finding; every documented module otherwise differs from its parent

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -182,7 +182,7 @@ plan's progress update for that rule.
 - [x] 2026-08-21: Prepared the RUF001 stage on `sunner/ruff-ruf001`, stacked on
   EM101. The isolated audit identified 162 deliberately fullwidth punctuation
   findings across 106 Chinese-message, TTS-boundary, and regression-fixture
-  lines. The stage enables RUF001 and records 96 newly required, explained
+  lines. The stage enables RUF001 and records 43 newly required, explained
   line-level suppressions; it intentionally removes the global
   `allowed-confusables` list so RUF002 and RUF003 remain fully enforced.
   Conventional Python test modules and test configuration are exempt so they

--- a/ruff.toml
+++ b/ruff.toml
@@ -214,10 +214,9 @@ select = [
     "UP",
 
     # --- Ruff-native rules ------------------------------------------------
-    # RUF001 (ambiguous unicode in a string) is ignored below.
-    # RUF100 is enforced, so a `# noqa` may only name a rule this file
-    # selects: reasons for exceptions to non-selected rules (BLE001,
-    # DTZ001, SLF001) are written as plain comments instead.
+    # RUF100 is enforced, so a `# noqa` may only name a rule this file selects:
+    # reasons for exceptions to non-selected rules (BLE001, DTZ001, SLF001)
+    # are written as plain comments instead.
     "RUF",
 ]
 ignore = [
@@ -231,10 +230,6 @@ ignore = [
     "D213",    # summary on the second line -- conflicts with D212
     "DTZ001",  # naive datetime() -- naive UTC is the house convention
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)
-    # INP001 is enforced; see per-file-ignores for the entrypoints, Alembic
-    # revisions and boundary-check fixtures that are loaded by path rather
-    # than imported.
-    "RUF001",  # ambiguous unicode in a string -- CJK punctuation is intended
 ]
 
 [lint.flake8-type-checking]
@@ -244,6 +239,13 @@ ignore = [
 runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 
 [lint.per-file-ignores]
+# Tests intentionally freeze user text, provider payloads, protocol samples,
+# and malformed-input regressions verbatim. RUF001 would make those fixtures
+# less faithful, so it remains enforced in production code but not test files.
+"**/tests/**" = ["RUF001"]
+"**/test_*.py" = ["RUF001"]
+"**/*_test.py" = ["RUF001"]
+"**/conftest.py" = ["RUF001"]
 # `assert` is the point of a test, and both scripts below are test code: one is
 # a pytest module, the other keeps its regex fixtures in a `run_self_test()`.
 # Developer tooling (repo scripts, backend scripts, test harnesses) also shells

--- a/src/api/flaskr/api/tts/tencent_provider.py
+++ b/src/api/flaskr/api/tts/tencent_provider.py
@@ -154,7 +154,7 @@ TENCENT_SSE_REQUEST_CODEC = "pcm"
 TENCENT_ENABLE_SUBTITLE = True
 TENCENT_MAX_SESSION_CHARS = 255
 
-_TERMINAL_PUNCTUATION = set(".!?;。！？；")
+_TERMINAL_PUNCTUATION = set(".!?;。！？；")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
 
 TENCENT_EMOTIONS = [
     {

--- a/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
+++ b/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
@@ -73,7 +73,7 @@ _LARGE_MODEL_SAMPLE_RATE = 24000
 # cap at 140 to keep a safety margin below the documented limit.
 _SEGMENT_WEIGHT_LIMIT = 140.0
 _NON_CJK_CHAR_WEIGHT = 0.3
-_TERMINAL_PUNCTUATION = "。！？!?；;\n"
+_TERMINAL_PUNCTUATION = "。！？!?；;\n"  # noqa: RUF001 - intentional fullwidth Chinese punctuation
 
 
 def _texttovoice_voice(

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -110,7 +110,7 @@ class FeishuLogHandler(logging.Handler):
         self._delivering = threading.local()
 
     def _build_message_text(self, log_entry: str) -> str:
-        text = f"SHIFU ERROR!\n{log_entry}\n"
+        text = f"师傅出错啦！\n{log_entry}\n"  # noqa: RUF001 - intentional fullwidth Chinese punctuation
         if len(text) <= self.MAX_TEXT_LENGTH:
             return text
         omitted = len(text) - self.MAX_TEXT_LENGTH

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -110,7 +110,7 @@ class FeishuLogHandler(logging.Handler):
         self._delivering = threading.local()
 
     def _build_message_text(self, log_entry: str) -> str:
-        text = f"师傅出错啦！\n{log_entry}\n"
+        text = f"SHIFU ERROR!\n{log_entry}\n"
         if len(text) <= self.MAX_TEXT_LENGTH:
             return text
         omitted = len(text) - self.MAX_TEXT_LENGTH

--- a/src/api/flaskr/service/billing/notifications.py
+++ b/src/api/flaskr/service/billing/notifications.py
@@ -548,7 +548,7 @@ def _append_subscription_user_count_line(msgs: list[str]) -> None:
         .distinct()
         .count()
     )
-    msgs.append(f"订阅用户数：{subscription_user_count}")
+    msgs.append(f"订阅用户数：{subscription_user_count}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
 
 
 def _build_billing_paid_feishu_message(
@@ -570,24 +570,24 @@ def _build_billing_paid_feishu_message(
     )
 
     msgs = [
-        "手机号：{}".format(getattr(aggregate, "mobile", "")),
-        "昵称：{}".format(getattr(aggregate, "name", "")),
-        f"{product_label}：{product_name}",
-        f"实付金额：{amount_text}",
-        f"订单来源：{_resolve_feishu_channel_label(order)}",
-        f"渠道：{_resolve_user_conversion_source(order.creator_bid)}",
+        "手机号：{}".format(getattr(aggregate, "mobile", "")),  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+        "昵称：{}".format(getattr(aggregate, "name", "")),  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+        f"{product_label}：{product_name}",  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+        f"实付金额：{amount_text}",  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+        f"订单来源：{_resolve_feishu_channel_label(order)}",  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+        f"渠道：{_resolve_user_conversion_source(order.creator_bid)}",  # noqa: RUF001 - intentional fullwidth Chinese punctuation
         f"{order_type_label}-{product_name}-{amount_text}",
     ]
     if product is not None:
-        msgs.append(f"积分数量：{_format_credit_amount(product.credit_amount)}")
+        msgs.append(f"积分数量：{_format_credit_amount(product.credit_amount)}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
     paid_at_text = format_with_app_timezone(
         app,
         order.paid_at,
         "%Y-%m-%d %H:%M:%S",
     )
     if paid_at_text:
-        msgs.append(f"支付时间：{paid_at_text}")
-    msgs.append(f"订单号：{order.bill_order_bid}")
+        msgs.append(f"支付时间：{paid_at_text}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+    msgs.append(f"订单号：{order.bill_order_bid}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
     _append_subscription_user_count_line(msgs)
     return title, msgs
 

--- a/src/api/flaskr/service/feedback/funs.py
+++ b/src/api/flaskr/service/feedback/funs.py
@@ -17,17 +17,17 @@ def submit_feedback(app: Flask, user_id: str, feedback: str, mail: str):
                 app,
                 "有用户提交反馈,注意跟进",
                 [
-                    f"用户ID：{user_id}",
-                    f"用户昵称：{user.name}",
-                    f"用户手机：{user.mobile}",
-                    f"用户反馈：{feedback}",
+                    f"用户ID：{user_id}",  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+                    f"用户昵称：{user.name}",  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+                    f"用户手机：{user.mobile}",  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+                    f"用户反馈：{feedback}",  # noqa: RUF001 - intentional fullwidth Chinese punctuation
                 ],
             )
         else:
             send_notify(
                 app,
                 "有用户提交登录反馈,注意跟进",
-                [f"E-mail：{mail}", f"反馈：{feedback}"],
+                [f"E-mail：{mail}", f"反馈：{feedback}"],  # noqa: RUF001 - intentional fullwidth Chinese punctuation
             )
         db.session.add(feedback_item)
         db.session.commit()

--- a/src/api/flaskr/service/order/coupon_funcs.py
+++ b/src/api/flaskr/service/order/coupon_funcs.py
@@ -123,18 +123,18 @@ def send_feishu_coupon_code(
                 "feishu coupon notify skipped: user aggregate missing for %s", user_id
             )
             return
-        msgs.append(f"手机号：{user_info.mobile}")
-        msgs.append(f"昵称：{user_info.name}")
-        msgs.append(f"优惠码：{discount_code}")
-        msgs.append(f"优惠名称：{discount_name}")
-        msgs.append(f"优惠额度：{discount_value}")
+        msgs.append(f"手机号：{user_info.mobile}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+        msgs.append(f"昵称：{user_info.name}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+        msgs.append(f"优惠码：{discount_code}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+        msgs.append(f"优惠名称：{discount_name}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+        msgs.append(f"优惠额度：{discount_value}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
         user_convertion = UserConversion.query.filter(
             UserConversion.user_id == user_id
         ).first()
         channel = ""
         if user_convertion:
             channel = user_convertion.conversion_source
-        msgs.append(f"渠道：{channel}")
+        msgs.append(f"渠道：{channel}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
         send_notify(app, title, msgs)
 
 

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -210,34 +210,34 @@ def send_order_feishu(app: Flask, record_id: str):
     }
     title = "购买课程通知"
     msgs = []
-    msgs.append(f"手机号：{aggregate.mobile}")
-    msgs.append(f"昵称：{aggregate.name}")
-    msgs.append(f"课程名称：{shifu_info.title}")
-    msgs.append(f"实付金额：{order_info.price}")
+    msgs.append(f"手机号：{aggregate.mobile}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+    msgs.append(f"昵称：{aggregate.name}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+    msgs.append(f"课程名称：{shifu_info.title}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+    msgs.append(f"实付金额：{order_info.price}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
     channel = getattr(order_info, "payment_channel", "") or ""
     source_label = channel_labels.get(channel, channel or "未知")
-    msgs.append(f"订单来源：{source_label}")
+    msgs.append(f"订单来源：{source_label}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
     user_convertion = UserConversion.query.filter(
         UserConversion.user_id == order_info.user_id
     ).first()
     channel = ""
     if user_convertion:
         channel = user_convertion.conversion_source
-    msgs.append(f"渠道：{channel}")
+    msgs.append(f"渠道：{channel}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
     for item in order_info.price_item:
         msgs.append(f"{item.name}-{item.price_name}-{item.price}")
         if item.is_discount:
-            msgs.append(f"优惠码：{item.discount_code}")
+            msgs.append(f"优惠码：{item.discount_code}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
     user_count = UserEntity.query.filter(
         UserEntity.state == USER_STATE_PAID, UserEntity.deleted == 0
     ).count()
-    msgs.append(f"总付费用户数：{user_count}")
+    msgs.append(f"总付费用户数：{user_count}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
     user_reg_count = UserEntity.query.filter(
         UserEntity.state >= USER_STATE_REGISTERED, UserEntity.deleted == 0
     ).count()
-    msgs.append(f"总注册用户数：{user_reg_count}")
+    msgs.append(f"总注册用户数：{user_reg_count}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
     user_total_count = UserEntity.query.filter(UserEntity.deleted == 0).count()
-    msgs.append(f"总访客数：{user_total_count}")
+    msgs.append(f"总访客数：{user_total_count}")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
     send_notify(app, title, msgs)
 
 
@@ -250,10 +250,10 @@ def send_revoke_feishu(app: Flask, order_bid: str, user_identify: str):
     )
     title = "取消课程授权通知"
     msgs = [
-        f"用户标识：{user_identify}",
-        f"课程名称：{shifu_info.title if shifu_info else order.shifu_bid}",
-        f"订单号：{order_bid}",
-        "来源：Open API",
+        f"用户标识：{user_identify}",  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+        f"课程名称：{shifu_info.title if shifu_info else order.shifu_bid}",  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+        f"订单号：{order_bid}",  # noqa: RUF001 - intentional fullwidth Chinese punctuation
+        "来源：Open API",  # noqa: RUF001 - intentional fullwidth Chinese punctuation
     ]
     send_notify(app, title, msgs)
 

--- a/src/api/flaskr/service/shifu/tts_preview.py
+++ b/src/api/flaskr/service/shifu/tts_preview.py
@@ -61,7 +61,7 @@ def build_tts_preview_response(
     emotion = ""
     text = payload.get(
         "text",
-        "你好，这是语音合成的试听效果。Hello, this is a preview of text-to-speech.",
+        "你好，这是语音合成的试听效果。Hello, this is a preview of text-to-speech.",  # noqa: RUF001 - intentional fullwidth Chinese punctuation
     )
 
     validated = validate_tts_settings_strict(

--- a/src/api/flaskr/service/tts/minimax_voice_clone.py
+++ b/src/api/flaskr/service/tts/minimax_voice_clone.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
 
 MINIMAX_FILE_UPLOAD_URL = "https://api.minimaxi.com/v1/files/upload"
 MINIMAX_VOICE_CLONE_URL = "https://api.minimaxi.com/v1/voice_clone"
-MINIMAX_CLONE_PREVIEW_TEXT = "你好，这是音色复制后的试听效果。"
+MINIMAX_CLONE_PREVIEW_TEXT = "你好，这是音色复制后的试听效果。"  # noqa: RUF001 - intentional fullwidth Chinese punctuation
 MINIMAX_CLONE_PREVIEW_MODEL = "speech-2.8-turbo"
 
 _ALLOWED_INPUT_EXTENSIONS = {"mp3", "m4a", "wav", "webm", "ogg", "mp4"}

--- a/src/api/flaskr/service/tts/patterns.py
+++ b/src/api/flaskr/service/tts/patterns.py
@@ -88,7 +88,7 @@ FIXED_MARKER_TAIL = re.compile(r"^[\s!=]*$")
 # ---------------------------------------------------------------------------
 # Streaming TTS
 # ---------------------------------------------------------------------------
-SENTENCE_ENDINGS = re.compile(r"[.!?。！？；;]")
+SENTENCE_ENDINGS = re.compile(r"[.!?。！？；;]")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
 
 # ---------------------------------------------------------------------------
 # HTML tag extraction helpers

--- a/src/api/flaskr/service/tts/pipeline.py
+++ b/src/api/flaskr/service/tts/pipeline.py
@@ -74,7 +74,7 @@ _AV_LATEX_BLOCK = AV_LATEX_BLOCK
 logger = AppLoggerProxy(logging.getLogger(__name__))
 
 
-_DEFAULT_SENTENCE_ENDINGS = set(".!?。！？；;")
+_DEFAULT_SENTENCE_ENDINGS = set(".!?。！？；;")  # noqa: RUF001 - intentional fullwidth Chinese punctuation
 
 _AV_SPEAKABLE_SANDBOX_ROOT_TAGS = {"div", "section", "article", "main", "template"}
 

--- a/src/api/scripts/tts_test_report.py
+++ b/src/api/scripts/tts_test_report.py
@@ -49,7 +49,7 @@ ZH_TEXT = """在辅导过几十家企业、上万人用 AI 提升业绩、效率
 
 在实现这个目标的过程中，我慢慢发现，用好 AI 的前提是用户需要知道如何调教 AI，发挥 AI 的长处，弥补 AI 的短处。调教好了，可以一句话就让 AI 帮你完成繁琐的工作。
 
-这门课就是专门讲如何调教 AI 的，帮你成为 AI 的主人。而且，调教的思路非常符合人的直觉，最核心的只需要理解三件事："""
+这门课就是专门讲如何调教 AI 的，帮你成为 AI 的主人。而且，调教的思路非常符合人的直觉，最核心的只需要理解三件事："""  # noqa: RUF001 - intentional fullwidth Chinese punctuation
 
 
 EN_TEXT = """I appreciate your insight in disagreeing with all three misconceptions! Your critical thinking shows real promise. Given your current understanding, this course might offer limited comprehensive help, but there could be some valuable insights in specific areas. Feel free to decide whether to continue based on your needs.

--- a/src/api/tests/scripts/test_ruff_test_file_policy.py
+++ b/src/api/tests/scripts/test_ruff_test_file_policy.py
@@ -1,0 +1,70 @@
+"""Verify that RUF001 is limited to non-test Python files."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONFUSABLE_SOURCE = 'value = "（"\n'
+
+
+class RuffTestFilePolicyTest(unittest.TestCase):
+    """Protect the test-only RUF001 exemption boundary."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Resolve the same Ruff executable used by local and CI checks."""
+        cls.ruff = os.environ.get("RUFF_BIN") or shutil.which("ruff")
+        if cls.ruff is None:
+            message = "ruff is not installed"
+            raise unittest.SkipTest(message)
+
+    def run_ruff(self, filename: str) -> subprocess.CompletedProcess[str]:
+        """Run RUF001 against source presented under one repository path."""
+        return subprocess.run(
+            [
+                self.ruff,
+                "check",
+                "--config",
+                str(REPO_ROOT / "ruff.toml"),
+                "--select",
+                "RUF001",
+                "--stdin-filename",
+                filename,
+                "-",
+            ],
+            cwd=REPO_ROOT,
+            input=CONFUSABLE_SOURCE,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_test_module_allows_confusable_fixture_text(self) -> None:
+        """Allow verbatim fixtures under every supported test convention."""
+        test_filenames = (
+            "example/tests/fixture.py",
+            "example/test_fixture.py",
+            "example/fixture_test.py",
+            "example/conftest.py",
+        )
+
+        for filename in test_filenames:
+            with self.subTest(filename=filename):
+                result = self.run_ruff(filename)
+                assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_production_module_still_rejects_confusable_text(self) -> None:
+        """Keep RUF001 enforced outside test paths."""
+        result = self.run_ruff("src/api/flaskr/confusable_fixture.py")
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "RUF001" in result.stdout
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/api/tests/scripts/test_ruff_test_file_policy.py
+++ b/src/api/tests/scripts/test_ruff_test_file_policy.py
@@ -24,15 +24,13 @@ class RuffTestFilePolicyTest(unittest.TestCase):
             raise unittest.SkipTest(message)
 
     def run_ruff(self, filename: str) -> subprocess.CompletedProcess[str]:
-        """Run RUF001 against source presented under one repository path."""
+        """Run the configured Ruff policy against source at one repository path."""
         return subprocess.run(
             [
                 self.ruff,
                 "check",
                 "--config",
                 str(REPO_ROOT / "ruff.toml"),
-                "--select",
-                "RUF001",
                 "--stdin-filename",
                 filename,
                 "-",
@@ -45,7 +43,7 @@ class RuffTestFilePolicyTest(unittest.TestCase):
         )
 
     def test_test_module_allows_confusable_fixture_text(self) -> None:
-        """Allow verbatim fixtures under every supported test convention."""
+        """Allow verbatim fixtures without an RUF001 diagnostic under test paths."""
         test_filenames = (
             "example/tests/fixture.py",
             "example/test_fixture.py",
@@ -56,7 +54,7 @@ class RuffTestFilePolicyTest(unittest.TestCase):
         for filename in test_filenames:
             with self.subTest(filename=filename):
                 result = self.run_ruff(filename)
-                assert result.returncode == 0, result.stdout + result.stderr
+                assert "RUF001" not in result.stdout, result.stdout + result.stderr
 
     def test_production_module_still_rejects_confusable_text(self) -> None:
         """Keep RUF001 enforced outside test paths."""

--- a/src/api/tests/scripts/test_ruff_test_file_policy.py
+++ b/src/api/tests/scripts/test_ruff_test_file_policy.py
@@ -9,7 +9,10 @@ import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
-CONFUSABLE_SOURCE = 'value = "（"\n'
+CONFUSABLE_SOURCE = '''"""Fixture module used to verify the RUF001 policy."""
+# ruff: noqa: INP001
+value = "（"
+'''
 
 
 class RuffTestFilePolicyTest(unittest.TestCase):
@@ -54,6 +57,7 @@ class RuffTestFilePolicyTest(unittest.TestCase):
         for filename in test_filenames:
             with self.subTest(filename=filename):
                 result = self.run_ruff(filename)
+                assert result.returncode == 0, result.stdout + result.stderr
                 assert "RUF001" not in result.stdout, result.stdout + result.stderr
 
     def test_production_module_still_rejects_confusable_text(self) -> None:


### PR DESCRIPTION
## Summary

- remove the repository-wide `RUF001` ignore
- preserve audited production punctuation with narrow `# noqa: RUF001` suppressions without weakening RUF002/RUF003
- exempt conventional Python test modules and `conftest.py` files from RUF001 so fixtures can remain verbatim
- document the production/test boundary and cover all supported test path conventions

## Policy boundary

Production Python remains subject to RUF001. Test files are recognized by a `tests/` directory, `test_*.py`, `*_test.py`, or `conftest.py`. The exemption exists for user text, provider payloads, protocol samples, and malformed-input regressions; it must not be copied to production paths.

## Verification

- `ruff check --select RUF001 .`
- focused Ruff check and format check for `test_ruff_test_file_policy.py`
- executable policy regression: four test path conventions pass while a production path reports RUF001
- repository harness
- architecture boundary check
- commit-time lefthook checks

## Stack

- Base: `sunner/ruff-em101`
- Predecessor: #2628

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Content Updates**
  * Feishu error notifications now begin with the Chinese prefix “师傅出错啦！”
  * Completed the Chinese text in the TTS test report with its closing explanation of AI training and its three core concepts.

* **Quality Improvements**
  * Improved linting guidance and validation for intentional multilingual punctuation.
  * Preserved notification, feedback, order, and text-to-speech message formatting.
  * Added validation to ensure punctuation rules are applied consistently across production and test code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->