### PR TITLE
refactor: keep runtime config fields in snake case

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -371,6 +371,14 @@ provider payloads, protocol samples, and malformed inputs verbatim. Do not copy
 that exemption into production paths; add new tests under a `tests/` directory
 or use the conventional `test_*.py`, `*_test.py`, or `conftest.py` filename.
 
+For `N815`, keep Python DTO field names in snake_case even when the public JSON
+contract uses camelCase. Pydantic DTOs should declare the public name with
+`Field(alias="...")`, accept internal construction through `populate_by_name`,
+and serialize with `by_alias=True`; tests must lock both the Python attribute
+and exact wire keys. A non-Pydantic DTO whose annotated name directly drives
+both JSON and generated Swagger may use one explained inline suppression for
+that field. Do not exempt the containing file or rename the external contract.
+
 For `G004`, keep log message construction lazy: pass a constant message and
 its values as positional logging arguments, preserving the message text,
 argument order, and log level. Use `%s` for normal or `!s` interpolation,

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -195,6 +195,13 @@ plan's progress update for that rule.
   regression. The focused test and `ruff check .` pass.
 - [ ] Merge or retarget RUF001 PR #2629 after its predecessors without combining
   it with the next rule unit.
+- [x] 2026-08-22: Rebuilt the N815 stage on `sunner/ruff-n815`, stacked directly
+  on RUF001. Replaced 26 Pydantic camelCase attributes with snake_case Python
+  names and explicit wire aliases, and retained one explained field-level
+  suppression where the annotated name itself defines the `UserToken` JSON and
+  Swagger contract. Both file-wide N815 exceptions are removed.
+- [ ] Merge or retarget N815 PR #2630 after RUF001 without combining it with the
+  next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/ruff.toml
+++ b/ruff.toml
@@ -282,11 +282,6 @@ runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 "src/api/migrations/versions/6b956399315e_backfill_profile_variable_tables.py" = ["S608"]
 "src/api/migrations/versions/e1b2c3d4e5f6_add_ask_provider_config_to_shifu.py" = ["S608"]
 "src/api/migrations/versions/ef7dbc5a8be3_backfill_promo_campaign_tables.py" = ["S608"]
-# Every field in these two DTOs is serialized verbatim into an API response and
-# read by the frontend under that exact key, so the camelCase spelling is the
-# wire contract, not a naming slip.
-"src/api/flaskr/service/billing/dtos.py" = ["N815"]
-"src/api/flaskr/service/common/dtos.py" = ["N815"]
 # Developer scripts and the backend inventory/harness tooling are console
 # programs: printing to stdout is their interface.
 "scripts/**" = ["S603", "S607", "T20"]

--- a/src/api/flaskr/common/swagger.py
+++ b/src/api/flaskr/common/swagger.py
@@ -70,7 +70,8 @@ def parse_comments(cls):
 
                     if "#" in line:
                         comment = line.split("#", 1)[1].strip()
-                        comments[field_name] = comment
+                        if not comment.lower().startswith("noqa"):
+                            comments[field_name] = comment
                     elif item.value and isinstance(item.value, (ast.Str, ast.Constant)):
                         if isinstance(item.value, ast.Str):
                             comments[field_name] = item.value.s

--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -216,59 +216,59 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
         ) or get_config("STRIPE_PUBLISHABLE_KEY", "")
 
         config = RuntimeConfigDTO(
-            defaultLlmModel=get_config("DEFAULT_LLM_MODEL", ""),
-            wechatAppId=wechat_app_id,
-            enableWechatCode=bool(wechat_app_id),
-            billingEnabled=billing_enabled,
-            billingCreditPrecision=get_billing_credit_precision(),
-            stripePublishableKey=stripe_publishable_key,
-            stripeEnabled=(
+            default_llm_model=get_config("DEFAULT_LLM_MODEL", ""),
+            wechat_app_id=wechat_app_id,
+            enable_wechat_code=bool(wechat_app_id),
+            billing_enabled=billing_enabled,
+            billing_credit_precision=get_billing_credit_precision(),
+            stripe_publishable_key=stripe_publishable_key,
+            stripe_enabled=(
                 "stripe" in custom_payment_channels
                 if custom_payment_enabled
                 else _to_bool(
                     get_config("STRIPE_ENABLED", default=False), default=False
                 )
             ),
-            paymentChannels=payment_channels,
-            payOrderExpireSeconds=_to_int(
+            payment_channels=payment_channels,
+            pay_order_expire_seconds=_to_int(
                 get_config("PAY_ORDER_EXPIRE_TIME", 600),
                 600,
             ),
-            alwaysShowLessonTree=_to_bool(
+            always_show_lesson_tree=_to_bool(
                 get_config("UI_ALWAYS_SHOW_LESSON_TREE", default=False),
                 default=False,
             ),
-            logoWideUrl=logo_wide_url,
-            logoSquareUrl=logo_square_url,
-            faviconUrl=favicon_url,
-            umamiScriptSrc=get_config(
+            logo_wide_url=logo_wide_url,
+            logo_square_url=logo_square_url,
+            favicon_url=favicon_url,
+            umami_script_src=get_config(
                 "ANALYTICS_UMAMI_SCRIPT",
                 "",
             ),
-            umamiWebsiteId=get_config(
+            umami_website_id=get_config(
                 "ANALYTICS_UMAMI_SITE_ID",
                 "",
             ),
-            enableEruda=_to_bool(
+            enable_eruda=_to_bool(
                 get_config("DEBUG_ERUDA_ENABLED", default=False),
                 default=False,
             ),
-            loginMethodsEnabled=_to_list(
+            login_methods_enabled=_to_list(
                 get_config("LOGIN_METHODS_ENABLED", "phone"),
                 ["phone"],
             ),
-            defaultLoginMethod=get_config("DEFAULT_LOGIN_METHOD", "phone"),
-            googleOauthRedirect=build_google_oauth_callback_url(),
-            homeUrl=home_url,
-            contactUsUrl=contact_us_url,
-            officialSiteUrl=official_site_url,
-            currencySymbol=get_config("CURRENCY_SYMBOL", "¥"),
-            legalUrls=legal_urls,
+            default_login_method=get_config("DEFAULT_LOGIN_METHOD", "phone"),
+            google_oauth_redirect=build_google_oauth_callback_url(),
+            home_url=home_url,
+            contact_us_url=contact_us_url,
+            official_site_url=official_site_url,
+            currency_symbol=get_config("CURRENCY_SYMBOL", "¥"),
+            legal_urls=legal_urls,
             entitlements=runtime_billing.entitlements,
             branding=runtime_billing.branding,
             domain=runtime_billing.domain,
-            customizationCapabilities=customization_capabilities,
-            paymentConfigurationReady=(
+            customization_capabilities=customization_capabilities,
+            payment_configuration_ready=(
                 custom_payment_enabled and bool(custom_payment_channels)
             ),
         )

--- a/src/api/flaskr/service/billing/dtos.py
+++ b/src/api/flaskr/service/billing/dtos.py
@@ -902,32 +902,38 @@ class RuntimeBillingContextDTO(BillingBaseDTO):
 class RuntimeConfigDTO(BillingBaseDTO):
     """Represent the runtime config API payload."""
 
-    defaultLlmModel: str
-    wechatAppId: str
-    enableWechatCode: bool
-    billingEnabled: bool
-    billingCreditPrecision: int
-    stripePublishableKey: str
-    stripeEnabled: bool
-    paymentChannels: list[str]
-    payOrderExpireSeconds: int
-    alwaysShowLessonTree: bool
-    logoWideUrl: str
-    logoSquareUrl: str
-    faviconUrl: str
-    umamiScriptSrc: str
-    umamiWebsiteId: str
-    enableEruda: bool
-    loginMethodsEnabled: list[str]
-    defaultLoginMethod: str
-    googleOauthRedirect: str
-    homeUrl: str
-    contactUsUrl: str
-    officialSiteUrl: str
-    currencySymbol: str
-    legalUrls: RuntimeLegalUrlsDTO
+    default_llm_model: str = Field(alias="defaultLlmModel")
+    wechat_app_id: str = Field(alias="wechatAppId")
+    enable_wechat_code: bool = Field(alias="enableWechatCode")
+    billing_enabled: bool = Field(alias="billingEnabled")
+    billing_credit_precision: int = Field(alias="billingCreditPrecision")
+    stripe_publishable_key: str = Field(alias="stripePublishableKey")
+    stripe_enabled: bool = Field(alias="stripeEnabled")
+    payment_channels: list[str] = Field(alias="paymentChannels")
+    pay_order_expire_seconds: int = Field(alias="payOrderExpireSeconds")
+    always_show_lesson_tree: bool = Field(alias="alwaysShowLessonTree")
+    logo_wide_url: str = Field(alias="logoWideUrl")
+    logo_square_url: str = Field(alias="logoSquareUrl")
+    favicon_url: str = Field(alias="faviconUrl")
+    umami_script_src: str = Field(alias="umamiScriptSrc")
+    umami_website_id: str = Field(alias="umamiWebsiteId")
+    enable_eruda: bool = Field(alias="enableEruda")
+    login_methods_enabled: list[str] = Field(alias="loginMethodsEnabled")
+    default_login_method: str = Field(alias="defaultLoginMethod")
+    google_oauth_redirect: str = Field(alias="googleOauthRedirect")
+    home_url: str = Field(alias="homeUrl")
+    contact_us_url: str = Field(alias="contactUsUrl")
+    official_site_url: str = Field(alias="officialSiteUrl")
+    currency_symbol: str = Field(alias="currencySymbol")
+    legal_urls: RuntimeLegalUrlsDTO = Field(alias="legalUrls")
     entitlements: RuntimeBillingEntitlementsDTO
     branding: RuntimeBillingBrandingDTO
     domain: RuntimeBillingDomainDTO
-    customizationCapabilities: dict[str, bool] = Field(default_factory=dict)
-    paymentConfigurationReady: bool = False
+    customization_capabilities: dict[str, bool] = Field(
+        default_factory=dict,
+        alias="customizationCapabilities",
+    )
+    payment_configuration_ready: bool = Field(
+        default=False,
+        alias="paymentConfigurationReady",
+    )

--- a/src/api/flaskr/service/common/dtos.py
+++ b/src/api/flaskr/service/common/dtos.py
@@ -88,7 +88,7 @@ class UserInfo:
 class UserToken:
     """Represent an issued user token in API responses."""
 
-    userInfo: UserInfo
+    userInfo: UserInfo  # noqa: N815 - exact serialized and Swagger field name
     token: str
 
     def __init__(self, userInfo: UserInfo, token) -> None:  # noqa: N803 - mirrors the serialized field name

--- a/src/api/tests/service/billing/test_billing_dtos.py
+++ b/src/api/tests/service/billing/test_billing_dtos.py
@@ -188,30 +188,30 @@ def test_billing_dto_json_serializes_metric_breakdowns_and_bucket_lists() -> Non
 
 def test_runtime_config_dto_json_uses_public_aliases() -> None:
     dto = RuntimeConfigDTO(
-        defaultLlmModel="gpt-5.4",
-        wechatAppId="wechat-app-1",
-        enableWechatCode=True,
-        billingEnabled=True,
-        billingCreditPrecision=2,
-        stripePublishableKey="pk_test_123",
-        stripeEnabled=True,
-        paymentChannels=["stripe", "pingxx"],
-        payOrderExpireSeconds=600,
-        alwaysShowLessonTree=False,
-        logoWideUrl="https://cdn.example.com/logo-wide.png",
-        logoSquareUrl="https://cdn.example.com/logo-square.png",
-        faviconUrl="https://cdn.example.com/favicon.ico",
-        umamiScriptSrc="",
-        umamiWebsiteId="",
-        enableEruda=False,
-        loginMethodsEnabled=["phone"],
-        defaultLoginMethod="phone",
-        googleOauthRedirect="https://example.com/login/google-callback",
-        homeUrl="/",
-        contactUsUrl="https://ai-shifu.cn/contact.html",
-        officialSiteUrl="https://official.example.com",
-        currencySymbol="¥",
-        legalUrls=RuntimeLegalUrlsDTO(
+        default_llm_model="gpt-5.4",
+        wechat_app_id="wechat-app-1",
+        enable_wechat_code=True,
+        billing_enabled=True,
+        billing_credit_precision=2,
+        stripe_publishable_key="pk_test_123",
+        stripe_enabled=True,
+        payment_channels=["stripe", "pingxx"],
+        pay_order_expire_seconds=600,
+        always_show_lesson_tree=False,
+        logo_wide_url="https://cdn.example.com/logo-wide.png",
+        logo_square_url="https://cdn.example.com/logo-square.png",
+        favicon_url="https://cdn.example.com/favicon.ico",
+        umami_script_src="",
+        umami_website_id="",
+        enable_eruda=False,
+        login_methods_enabled=["phone"],
+        default_login_method="phone",
+        google_oauth_redirect="https://example.com/login/google-callback",
+        home_url="/",
+        contact_us_url="https://ai-shifu.cn/contact.html",
+        official_site_url="https://official.example.com",
+        currency_symbol="¥",
+        legal_urls=RuntimeLegalUrlsDTO(
             agreement=RuntimeLocalizedUrlDTO(
                 **{
                     "zh-CN": "/legal/agreement/zh",
@@ -270,6 +270,39 @@ def test_runtime_config_dto_json_uses_public_aliases() -> None:
     assert payload["branding"]["home_url"] == "https://creator.example.com"
     assert payload["contactUsUrl"] == "https://ai-shifu.cn/contact.html"
     assert payload["officialSiteUrl"] == "https://official.example.com"
+    assert dto.billing_enabled is True
+    assert dto.official_site_url == "https://official.example.com"
+    assert set(payload) == {
+        "defaultLlmModel",
+        "wechatAppId",
+        "enableWechatCode",
+        "billingEnabled",
+        "billingCreditPrecision",
+        "stripePublishableKey",
+        "stripeEnabled",
+        "paymentChannels",
+        "payOrderExpireSeconds",
+        "alwaysShowLessonTree",
+        "logoWideUrl",
+        "logoSquareUrl",
+        "faviconUrl",
+        "umamiScriptSrc",
+        "umamiWebsiteId",
+        "enableEruda",
+        "loginMethodsEnabled",
+        "defaultLoginMethod",
+        "googleOauthRedirect",
+        "homeUrl",
+        "contactUsUrl",
+        "officialSiteUrl",
+        "currencySymbol",
+        "legalUrls",
+        "entitlements",
+        "branding",
+        "domain",
+        "customizationCapabilities",
+        "paymentConfigurationReady",
+    }
     assert (
         payload["branding"]["contact_us_url"] == "https://creator.example.com/contact"
     )

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -444,8 +444,8 @@ def test_runtime_billing_builder_and_route_config_use_dto_outputs(
     config = RuntimeConfigDTO(**route_payload)
 
     assert isinstance(config, RuntimeConfigDTO)
-    assert config.billingEnabled is True
-    assert config.officialSiteUrl == "https://official.example.com"
+    assert config.billing_enabled is True
+    assert config.official_site_url == "https://official.example.com"
     assert config.__json__()["legalUrls"]["privacy"] == {
         "zh-CN": "/legal/privacy/zh",
         "en-US": "/legal/privacy/en",

--- a/src/api/tests/service/common/test_dto_base.py
+++ b/src/api/tests/service/common/test_dto_base.py
@@ -7,8 +7,10 @@ from decimal import Decimal
 from typing import get_args
 
 import pytest
+from flaskr.common.swagger import swagger_config
 from flaskr.route.common import fmt
 from flaskr.service.common.dto_base import AutoJsonMixin
+from flaskr.service.common.dtos import UserInfo, UserToken
 from pydantic import BaseModel, Field
 
 
@@ -129,6 +131,27 @@ def test_key_overrides_and_exclusions():
     assert payload == {"page": 2, "items": ["a", "b"]}
     assert list(payload.keys()) == ["page", "items"]
     assert "internal_state" not in payload
+
+
+def test_user_token_keeps_camel_case_wire_and_swagger_field() -> None:
+    """Keep the intentional N815 exception aligned with both public contracts."""
+    user_info = UserInfo(
+        user_id="user-1",
+        username="learner",
+        name="Learner",
+        email="learner@example.com",
+        mobile="13800138000",
+        user_state=1,
+        wx_openid="openid-1",
+        language="zh-CN",
+    )
+    token = UserToken(userInfo=user_info, token="token-1")
+
+    assert token.__json__() == {"userInfo": user_info, "token": "token-1"}
+    schema = swagger_config["components"]["schemas"]["UserToken"]
+    assert list(schema["properties"]) == ["userInfo", "token"]
+    assert schema["required"] == ["userInfo", "token"]
+    assert "description" not in schema["properties"]["userInfo"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- remove the two file-wide N815 exceptions
- use snake_case Python attributes with explicit aliases for the existing runtime-config wire keys
- retain one explained field-level suppression where the annotated UserToken name defines the JSON and Swagger contract
- keep Ruff directives out of generated Swagger descriptions

## Verification

- 28 focused DTO, runtime-config, alias, and Swagger tests passed
- 761 billing/common service tests passed, 10 skipped
- Ruff 0.16.3 configured check passed
- Ruff 0.16.3 isolated N815 check passed
- repository pre-commit hooks passed for the commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime configuration handling while preserving existing camelCase API responses.
  * Prevented inline lint annotations from appearing incorrectly as Swagger field descriptions.
  * Preserved correct user information fields and schema metadata in API documentation.

* **Documentation**
  * Added guidance for consistent field naming and API serialization practices.

* **Tests**
  * Expanded coverage for runtime configuration attributes, serialized responses, and Swagger schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->