### PR TITLE
refactor: use snake case in token constructor

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -371,6 +371,14 @@ provider payloads, protocol samples, and malformed inputs verbatim. Do not copy
 that exemption into production paths; add new tests under a `tests/` directory
 or use the conventional `test_*.py`, `*_test.py`, or `conftest.py` filename.
 
+For `N803`, keep Python function and method arguments in snake_case even when
+the corresponding serialized field uses camelCase. Translate from the Python
+argument to the wire-facing attribute inside the DTO and update internal
+keyword callers; do not copy JSON spelling into a Python signature or add an
+ignore-name pattern. Preserve an external callback or override signature only
+when the caller truly owns the keyword contract, and explain that exception at
+the parameter.
+
 For `N815`, keep Python DTO field names in snake_case even when the public JSON
 contract uses camelCase. Pydantic DTOs should declare the public name with
 `Field(alias="...")`, accept internal construction through `populate_by_name`,

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -202,6 +202,12 @@ plan's progress update for that rule.
   Swagger contract. Both file-wide N815 exceptions are removed.
 - [ ] Merge or retarget N815 PR #2630 after RUF001 without combining it with the
   next rule unit.
+- [x] 2026-08-22: Rebuilt the N803 stage on `sunner/ruff-n803`, stacked on
+  N815. Renamed the internal `UserToken` constructor argument and its keyword
+  callers to `user_info`, while preserving the `userInfo` JSON and Swagger
+  field contract and removing the only N803 suppression.
+- [ ] Merge or retarget N803 PR #2631 after N815 without combining it with the
+  next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -1122,7 +1122,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             refreshed_user = build_user_info_from_aggregate(refreshed)
             auth_result.user = refreshed_user
             auth_result.token = UserToken(
-                userInfo=refreshed_user,
+                user_info=refreshed_user,
                 token=auth_result.token.token,
             )
         db.session.commit()

--- a/src/api/flaskr/service/common/dtos.py
+++ b/src/api/flaskr/service/common/dtos.py
@@ -91,9 +91,9 @@ class UserToken:
     userInfo: UserInfo  # noqa: N815 - exact serialized and Swagger field name
     token: str
 
-    def __init__(self, userInfo: UserInfo, token) -> None:  # noqa: N803 - mirrors the serialized field name
+    def __init__(self, user_info: UserInfo, token) -> None:
         """Pair serialized user information with its access token."""
-        self.userInfo = userInfo
+        self.userInfo = user_info
         self.token = token
 
     def __json__(self) -> dict:

--- a/src/api/flaskr/service/user/auth/providers/google.py
+++ b/src/api/flaskr/service/user/auth/providers/google.py
@@ -391,7 +391,7 @@ class GoogleAuthProvider(AuthProvider):
                 raise RuntimeError(message)
             user_dto = build_user_info_from_aggregate(refreshed)
             token_value = generate_token(app, refreshed.user_bid)
-            user_token = UserToken(userInfo=user_dto, token=token_value)
+            user_token = UserToken(user_info=user_dto, token=token_value)
             snapshot = build_user_profile_snapshot_from_aggregate(refreshed)
 
         return AuthResult(

--- a/src/api/flaskr/service/user/email_flow.py
+++ b/src/api/flaskr/service/user/email_flow.py
@@ -221,7 +221,7 @@ def verify_email_code(
         snapshot = build_user_profile_snapshot_from_aggregate(refreshed)
 
     return (
-        UserToken(userInfo=user_dto, token=token),
+        UserToken(user_info=user_dto, token=token),
         created_new_user,
         {
             "course_id": course_id,

--- a/src/api/flaskr/service/user/phone_flow.py
+++ b/src/api/flaskr/service/user/phone_flow.py
@@ -460,7 +460,7 @@ def verify_phone_code(
         snapshot = build_user_profile_snapshot_from_aggregate(refreshed)
 
     return (
-        UserToken(userInfo=user_dto, token=token),
+        UserToken(user_info=user_dto, token=token),
         created_new_user,
         {
             "course_id": normalized_course_id,

--- a/src/api/tests/service/common/test_dto_base.py
+++ b/src/api/tests/service/common/test_dto_base.py
@@ -145,7 +145,7 @@ def test_user_token_keeps_camel_case_wire_and_swagger_field() -> None:
         wx_openid="openid-1",
         language="zh-CN",
     )
-    token = UserToken(userInfo=user_info, token="token-1")
+    token = UserToken(user_info=user_info, token="token-1")
 
     assert token.__json__() == {"userInfo": user_info, "token": "token-1"}
     schema = swagger_config["components"]["schemas"]["UserToken"]


### PR DESCRIPTION
## Summary

- rename the internal UserToken constructor argument to user_info
- update all keyword callers
- preserve the userInfo JSON and Swagger field contract
- remove the only N803 suppression

## Verification

- 20 focused DTO and authentication tests passed
- Ruff 0.16.3 configured check passed
- Ruff 0.16.3 isolated N803 check with --ignore-noqa passed
- repository pre-commit hooks passed