### PR TITLE
chore: remove stale assert exception

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -379,6 +379,12 @@ ignore-name pattern. Preserve an external callback or override signature only
 when the caller truly owns the keyword contract, and explain that exception at
 the parameter.
 
+For `S101`, use `assert` only where assertion reporting is the interface, such
+as pytest tests and executable self-test fixtures. Production validation,
+authorization, and state guards must raise explicit exceptions because Python
+removes assertions under `-O`. Delete stale exact-file exceptions when the path
+disappears or an existing test pattern already owns it.
+
 For `N815`, keep Python DTO field names in snake_case even when the public JSON
 contract uses camelCase. Pydantic DTOs should declare the public name with
 `Field(alias="...")`, accept internal construction through `populate_by_name`,

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -208,6 +208,12 @@ plan's progress update for that rule.
   field contract and removing the only N803 suppression.
 - [ ] Merge or retarget N803 PR #2631 after N815 without combining it with the
   next rule unit.
+- [x] 2026-08-22: Rebuilt the S101 stage on `sunner/ruff-s101`, stacked on
+  N803. Removed the stale exact-file exception for the deleted
+  `src/api/conftest.py` path and documented the production/test assertion
+  boundary.
+- [ ] Merge or retarget S101 PR #2632 after N803 without combining it with the
+  next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/ruff.toml
+++ b/ruff.toml
@@ -270,7 +270,6 @@ runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 # These trees are input fixtures for check_architecture_boundaries.py, not
 # importable code.
 "scripts/testdata/**" = ["INP001"]
-"src/api/conftest.py" = ["S101"]
 "scripts/test_*.py" = ["S101"]
 "scripts/check_example_identifiers.py" = ["S101"]
 # These applied Alembic revisions are immutable history: their backfill


### PR DESCRIPTION
## Summary

- remove the obsolete src/api/conftest.py S101 exception
- document where assert is appropriate in tests and executable self-checks
- keep production validation on explicit exceptions

## Verification

- Ruff 0.16.3 configured repository check passed
- repository pre-commit hooks passed