### PR TITLE
refactor: make method compatibility arguments explicit

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -385,6 +385,11 @@ authorization, and state guards must raise explicit exceptions because Python
 removes assertions under `-O`. Delete stale exact-file exceptions when the path
 disappears or an existing test pattern already owns it.
 
+For `ARG002`, remove method parameters only when the repository owns the
+signature and all callers. Keep externally owned framework, protocol, fixture,
+and test-double signatures intact; explicitly consume compatibility values near
+the boundary so keyword contracts remain visible and lint-clean.
+
 For `N815`, keep Python DTO field names in snake_case even when the public JSON
 contract uses camelCase. Pydantic DTOs should declare the public name with
 `Field(alias="...")`, accept internal construction through `populate_by_name`,

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -214,6 +214,12 @@ plan's progress update for that rule.
   boundary.
 - [ ] Merge or retarget S101 PR #2632 after N803 without combining it with the
   next rule unit.
+- [x] 2026-08-22: Rebuilt the ARG002 stage on `sunner/ruff-arg002`, stacked on
+  S101. Removed repository-owned unused method parameters and explicitly
+  consumed externally owned protocol, fixture, and test-double compatibility
+  values without renaming keyword contracts.
+- [ ] Merge or retarget ARG002 PR #2633 after S101 without combining it with the
+  next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/ruff.toml
+++ b/ruff.toml
@@ -29,8 +29,8 @@
 #   patterns here (moderation, logging, notification side channels).
 # - C901 / PLR09xx: complexity and argument-count budgets that the existing
 #   service and route modules exceed by design.
-# - ARG001 / ARG002 / ARG005: unused arguments are pervasive in framework
-#   callbacks, fixtures and test doubles.
+# - ARG001 / ARG005: unused function and lambda arguments are pervasive in
+#   framework callbacks, fixtures and test doubles.
 # - TD003 / FIX002: the remaining TODOs have no tracking issue to link, and
 #   inventing one (or downgrading the comment) would hide real pending work.
 
@@ -127,6 +127,10 @@ select = [
     # --- Paths, suppressions, shadowing, security -------------------------
     "PTH",     # os.path calls that should use pathlib
     "PGH",     # blanket noqa / type: ignore, invalid suppressions
+    # Remove unused private method parameters. When a framework, protocol,
+    # fixture or test double owns the signature, preserve its keyword names and
+    # explicitly consume the compatibility-only values in the method body.
+    "ARG002",  # unused method argument
     "ARG003",  # unused classmethod argument
     "ARG004",  # unused staticmethod argument
     "A001",    # local variable shadowing a builtin

--- a/src/api/flaskr/api/tts/aliyun_provider.py
+++ b/src/api/flaskr/api/tts/aliyun_provider.py
@@ -1249,6 +1249,7 @@ class AliyunTTSProvider(BaseTTSProvider):
             ValueError: If synthesis fails
 
         """
+        _ = model
         if not text or not text.strip():
             exception_message = "Text cannot be empty"
             raise ValueError(exception_message)

--- a/src/api/flaskr/api/tts/baidu_provider.py
+++ b/src/api/flaskr/api/tts/baidu_provider.py
@@ -798,6 +798,7 @@ class BaiduTTSProvider(BaseTTSProvider):
             ValueError: If synthesis fails
 
         """
+        _ = model
         if not text or not text.strip():
             error_message = "Text cannot be empty"
             raise ValueError(error_message)

--- a/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
+++ b/src/api/flaskr/api/tts/tencent_texttovoice_provider.py
@@ -385,6 +385,7 @@ class TencentTextToVoiceProvider(BaseTTSProvider):
         audio_settings: AudioSettings | None = None,
         model: str | None = None,
     ) -> TTSResult:
+        _ = audio_settings
         if not text or not text.strip():
             error_message = "Text cannot be empty"
             raise ValueError(error_message)

--- a/src/api/flaskr/api/tts/volcengine_protocol.py
+++ b/src/api/flaskr/api/tts/volcengine_protocol.py
@@ -175,6 +175,7 @@ class VolcengineProtocol:
             Encoded binary frame
 
         """
+        _ = pitch
         self.session_id = session_id
 
         # Build audio params

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -214,6 +214,7 @@ class InMemoryCacheProvider:
         *args,
         **kwargs,
     ):
+        _ = kwargs
         with self._mu:
             self._purge_if_expired(key)
             if nx and key in self._store:
@@ -274,6 +275,7 @@ class InMemoryCacheProvider:
         timeout: int | None = None,
         blocking_timeout: int | None = None,
     ):
+        _ = (timeout, blocking_timeout)
         with self._mu:
             lock = self._locks.get(key)
             if lock is None:

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -2114,9 +2114,7 @@ class Config(FlaskConfig):
 
     _instance: Config | None = None
 
-    def __init__(
-        self, parent: FlaskConfig, app: Flask, defaults: dict | None = None
-    ) -> None:
+    def __init__(self, parent: FlaskConfig, app: Flask) -> None:
         """Bind parent and environment config, then populate Redis prefixes."""
         self.parent = parent
         self.app = app

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -655,7 +655,6 @@ def build_billing_overview(
     normalized_creator_bid = _normalize_bid(creator_bid)
     with app.app_context():
         trial_offer = _resolve_new_creator_trial_offer(
-            app,
             normalized_creator_bid,
             trigger="billing_overview",
         )

--- a/src/api/flaskr/service/billing/trials.py
+++ b/src/api/flaskr/service/billing/trials.py
@@ -85,7 +85,7 @@ class TrialOfferState:
     expires_at: datetime | None = None
     welcome_dialog_acknowledged_at: datetime | None = None
 
-    def to_dto(self, app: Flask) -> BillingTrialOfferDTO:
+    def to_dto(self) -> BillingTrialOfferDTO:
         return BillingTrialOfferDTO(
             enabled=bool(self.enabled),
             status=str(self.status),
@@ -689,7 +689,6 @@ def _backfill_missing_creator_trial_credits(
 
 
 def _resolve_new_creator_trial_offer(
-    app: Flask,
     creator_bid: str,
     *,
     trigger: str,
@@ -720,7 +719,6 @@ def _resolve_new_creator_trial_offer(
             legacy_entry=legacy_entry,
         )
         return _serialize_trial_offer(
-            app,
             _build_trial_offer_state(
                 product_ref,
                 enabled=enabled,
@@ -733,7 +731,6 @@ def _resolve_new_creator_trial_offer(
 
     if not enabled:
         return _serialize_trial_offer(
-            app,
             _build_trial_offer_state(
                 product_ref,
                 enabled=False,
@@ -744,7 +741,6 @@ def _resolve_new_creator_trial_offer(
     creator = get_user_entity_by_bid(normalized_creator_bid)
     if creator is None or not bool(creator.is_creator):
         return _serialize_trial_offer(
-            app,
             _build_trial_offer_state(
                 product_ref,
                 enabled=True,
@@ -755,7 +751,6 @@ def _resolve_new_creator_trial_offer(
     current_subscription = _load_active_creator_subscription(normalized_creator_bid)
     if current_subscription is not None:
         return _serialize_trial_offer(
-            app,
             _build_trial_offer_state(
                 product_ref,
                 enabled=True,
@@ -764,7 +759,6 @@ def _resolve_new_creator_trial_offer(
         )
 
     return _serialize_trial_offer(
-        app,
         _build_trial_offer_state(
             product_ref,
             enabled=True,
@@ -773,11 +767,8 @@ def _resolve_new_creator_trial_offer(
     )
 
 
-def _serialize_trial_offer(
-    app: Flask,
-    state: TrialOfferState,
-) -> BillingTrialOfferDTO:
-    return state.to_dto(app)
+def _serialize_trial_offer(state: TrialOfferState) -> BillingTrialOfferDTO:
+    return state.to_dto()
 
 
 def _acknowledge_trial_welcome_dialog(

--- a/src/api/flaskr/service/learn/ask_provider_adapters/coze_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/coze_adapter.py
@@ -39,7 +39,7 @@ class CozeAskProviderAdapter:
         provider_config: dict[str, Any],
         runtime: AskProviderRuntime | None = None,
     ) -> Generator[AskProviderChunk, None, None]:
-        _ = runtime
+        _ = (messages, runtime)
         config = provider_config.get("config") or {}
         if not isinstance(config, dict):
             config = {}

--- a/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
+++ b/src/api/flaskr/service/learn/ask_provider_adapters/volc_knowledge_adapter.py
@@ -207,7 +207,7 @@ class VolcKnowledgeAskProviderAdapter:
         provider_config: dict[str, Any],
         runtime: AskProviderRuntime | None = None,
     ) -> Generator[AskProviderChunk, None, None]:
-        _ = (messages, runtime)
+        _ = (user_id, messages, runtime)
         config = provider_config.get("config") or {}
         if not isinstance(config, dict):
             config = {}

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -2241,7 +2241,7 @@ class RunScriptContextV2:
             self._current_attend, is_ask=self._input_type == "ask"
         )
         if run_script_info is None:
-            yield from self._phase_completion_when_script_missing(app)
+            yield from self._phase_completion_when_script_missing()
             return
         llm_settings = self.get_llm_settings(run_script_info.outline_bid)
         system_prompt = self.get_system_prompt(run_script_info.outline_bid)
@@ -2335,7 +2335,7 @@ class RunScriptContextV2:
         return True
 
     def _phase_completion_when_script_missing(
-        self, app: Flask
+        self,
     ) -> Generator[RunMarkdownFlowDTO, None, None]:
         """Completion tail for a step whose run-script info resolved to None."""
         self.app.logger.warning("run script is none")
@@ -2562,7 +2562,7 @@ class RunScriptContextV2:
         if handled:
             return True
         handled = yield from self._phase_validate_input_and_advance(
-            app, state, generated_block, parsed_interaction, user_input_param
+            app, state, generated_block, user_input_param
         )
         return handled
 
@@ -2948,7 +2948,6 @@ class RunScriptContextV2:
         app: Flask,
         state: _RunStepState,
         generated_block: LearnGeneratedBlock,
-        parsed_interaction: dict,
         user_input_param: dict,
     ) -> Generator[RunMarkdownFlowDTO, None, bool]:
         """Validate the interaction input, save variables, advance the cursor.

--- a/src/api/flaskr/service/order/payment_providers/base.py
+++ b/src/api/flaskr/service/order/payment_providers/base.py
@@ -133,6 +133,7 @@ class PaymentProvider(ABC):
         self, *, order_bid: str, provider_reference: str, app
     ) -> PaymentNotificationResult:
         """Synchronize payment status with the provider if supported."""
+        _ = order_bid
         return self.sync_reference(
             provider_reference=provider_reference,
             reference_type="payment",

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -165,24 +165,28 @@ class PingxxProvider(PaymentProvider):
     def create_subscription(
         self, *, request: PaymentRequest, app: Flask
     ) -> PaymentCreationResult:
+        _ = (request, app)
         message = "Pingxx does not support subscriptions"
         raise RuntimeError(message)
 
     def cancel_subscription(
         self, *, subscription_bid: str, provider_subscription_id: str, app: Flask
     ) -> SubscriptionUpdateResult:
+        _ = (subscription_bid, provider_subscription_id, app)
         message = "Pingxx does not support subscriptions"
         raise RuntimeError(message)
 
     def resume_subscription(
         self, *, subscription_bid: str, provider_subscription_id: str, app: Flask
     ) -> SubscriptionUpdateResult:
+        _ = (subscription_bid, provider_subscription_id, app)
         message = "Pingxx does not support subscriptions"
         raise RuntimeError(message)
 
     def verify_webhook(
         self, *, headers: dict[str, str], raw_body: bytes | str, app: Flask
     ) -> PaymentNotificationResult:
+        _ = app
         normalized_headers = {
             str(key).lower(): str(value) for key, value in (headers or {}).items()
         }

--- a/src/api/flaskr/service/order/payment_providers/wechatpay.py
+++ b/src/api/flaskr/service/order/payment_providers/wechatpay.py
@@ -55,6 +55,7 @@ class WechatPayProvider(PaymentProvider):
     def verify_webhook(
         self, *, headers: dict[str, str], raw_body: bytes | str, app: Flask
     ) -> PaymentNotificationResult:
+        _ = app
         raw_body_text = (
             raw_body.decode("utf-8") if isinstance(raw_body, bytes) else str(raw_body)
         )

--- a/src/api/flaskr/service/shifu/dtos.py
+++ b/src/api/flaskr/service/shifu/dtos.py
@@ -69,7 +69,6 @@ class ShifuDto(BaseModel):
         can_manage_permissions: bool = False,
         created_user_bid: str = "",
         is_guide_course: bool = False,
-        **kwargs,
     ) -> None:
         """Build the shifu payload."""
         super().__init__(

--- a/src/api/tests/api/doc/test_feishu_notify.py
+++ b/src/api/tests/api/doc/test_feishu_notify.py
@@ -11,12 +11,15 @@ class _Logger:
         self.exceptions = []
 
     def info(self, *args, **kwargs):
+        _ = kwargs
         self.infos.append(args)
 
     def warning(self, *args, **kwargs):
+        _ = kwargs
         self.warnings.append(args)
 
     def exception(self, *args, **kwargs):
+        _ = kwargs
         self.exceptions.append(args)
 
 

--- a/src/api/tests/common/fixtures/fake_redis.py
+++ b/src/api/tests/common/fixtures/fake_redis.py
@@ -14,6 +14,7 @@ class FakeRedisLock:
         self._held = False
 
     def acquire(self, blocking: bool = True, blocking_timeout: int | None = None):
+        _ = (blocking, blocking_timeout)
         if self._locks.get(self._key, False):
             return False
         self._locks[self._key] = True
@@ -83,6 +84,7 @@ class FakeRedis:
         *args,
         **kwargs,
     ):
+        _ = kwargs
         if ex is None and args:
             ex = args[0]
         if nx and self.get(key) is not None:
@@ -137,6 +139,7 @@ class FakeRedis:
         timeout: int | None = None,
         blocking_timeout: int | None = None,
     ):
+        _ = (timeout, blocking_timeout)
         return FakeRedisLock(self._locks, key)
 
     def ping(self):

--- a/src/api/tests/common/test_celery_fork_pool_dispose.py
+++ b/src/api/tests/common/test_celery_fork_pool_dispose.py
@@ -52,6 +52,7 @@ def test_one_failing_bind_does_not_block_the_rest(app, monkeypatch):
 
     class _BrokenEngine:
         def dispose(self, close):
+            _ = close
             message = "bind gone"
             raise RuntimeError(message)
 

--- a/src/api/tests/common/test_gevent_hub_observer.py
+++ b/src/api/tests/common/test_gevent_hub_observer.py
@@ -68,6 +68,7 @@ def test_logger_failure_never_blocks_the_original_handler():
 
     class _BrokenLogger:
         def error(self, *args, **kwargs):
+            _ = (args, kwargs)
             message = "logging backend down"
             raise RuntimeError(message)
 

--- a/src/api/tests/common/test_pool_desync_detection.py
+++ b/src/api/tests/common/test_pool_desync_detection.py
@@ -176,6 +176,7 @@ class _FakePingablePyMySQLConnection(_FakePyMySQLConnection):
         self.pings = 0
 
     def ping(self, reconnect):
+        _ = reconnect
         self.pings += 1
 
 

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -56,13 +56,14 @@ class _TestPluginManager:
         self.extension_functions.setdefault(target_func_name, []).append(func)
 
     def execute_extensions(self, _func_name, result, *args, **kwargs):
+        _ = (args, kwargs)
         return result
 
     def register_extensible_generic(self, func_name, func):
         self.extensible_generic_functions.setdefault(func_name, []).append(func)
 
     def execute_extensible_generic(self, _func_name, *args, **kwargs):
-        return None
+        _ = (args, kwargs)
 
 
 set_plugin_manager(_TestPluginManager())

--- a/src/api/tests/contract/test_sms_contract.py
+++ b/src/api/tests/contract/test_sms_contract.py
@@ -125,6 +125,7 @@ def test_send_sms_code_ali_handles_client_error(monkeypatch):
             captured["config"] = config
 
         def send_sms_with_options(self, request, runtime):
+            _ = (request, runtime)
             raise DummyError
 
     def fake_assert(message):

--- a/src/api/tests/service/billing/billing_write_routes_test_helpers.py
+++ b/src/api/tests/service/billing/billing_write_routes_test_helpers.py
@@ -389,6 +389,7 @@ def billing_write_client(monkeypatch):
 
     class FakeStripeProvider:
         def create_payment(self, *, request, app):
+            _ = app
             stripe_requests.append(
                 {
                     "order_bid": request.order_bid,
@@ -412,6 +413,7 @@ def billing_write_client(monkeypatch):
             return self.create_payment(request=request, app=app)
 
         def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+            _ = app
             assert reference_type == "checkout_session"
             return PaymentNotificationResult(
                 order_bid="",
@@ -436,6 +438,7 @@ def billing_write_client(monkeypatch):
         def cancel_subscription(
             self, *, subscription_bid: str, provider_subscription_id: str, app
         ):
+            _ = app
             return SubscriptionUpdateResult(
                 provider_reference=provider_subscription_id,
                 raw_response={
@@ -451,6 +454,7 @@ def billing_write_client(monkeypatch):
         def resume_subscription(
             self, *, subscription_bid: str, provider_subscription_id: str, app
         ):
+            _ = app
             return SubscriptionUpdateResult(
                 provider_reference=provider_subscription_id,
                 raw_response={
@@ -464,6 +468,7 @@ def billing_write_client(monkeypatch):
             )
 
         def refund_payment(self, *, request, app):
+            _ = app
             refund_requests.append(
                 {
                     "order_bid": request.order_bid,
@@ -480,6 +485,7 @@ def billing_write_client(monkeypatch):
 
     class FakePingxxProvider:
         def create_payment(self, *, request, app):
+            _ = app
             pingxx_requests.append(
                 {
                     "order_bid": request.order_bid,
@@ -496,6 +502,7 @@ def billing_write_client(monkeypatch):
             )
 
         def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+            _ = app
             assert reference_type == "charge"
             return PaymentNotificationResult(
                 order_bid="",

--- a/src/api/tests/service/billing/test_billing_callbacks.py
+++ b/src/api/tests/service/billing/test_billing_callbacks.py
@@ -603,6 +603,7 @@ class TestBillingNativeCallbacks:
     ) -> None:
         class FakeAlipayProvider:
             def handle_notification(self, *, payload, app):
+                _ = (payload, app)
                 return _alipay_notification("bill-native-alipay-1", "TRADE_SUCCESS")
 
         monkeypatch.setattr(
@@ -792,6 +793,7 @@ class TestBillingNativeCallbacks:
     ) -> None:
         class FakeAlipayProvider:
             def handle_notification(self, *, payload, app):
+                _ = (payload, app)
                 return _alipay_notification("missing-native-order", "TRADE_SUCCESS")
 
         monkeypatch.setattr(
@@ -817,6 +819,7 @@ class TestBillingNativeCallbacks:
     ) -> None:
         class FakeWechatPayProvider:
             def verify_webhook(self, *, headers, raw_body, app):
+                _ = (headers, raw_body, app)
                 return _wechatpay_notification("legacy-wechatpay-attempt-1", "SUCCESS")
 
         monkeypatch.setattr(
@@ -882,6 +885,7 @@ class TestBillingNativeCallbacks:
     ) -> None:
         class FakeWechatPayProvider:
             def verify_webhook(self, *, headers, raw_body, app):
+                _ = (headers, raw_body, app)
                 message = "secret verification detail"
                 raise RuntimeError(message)
 

--- a/src/api/tests/service/billing/test_billing_renewal_compensation.py
+++ b/src/api/tests/service/billing/test_billing_renewal_compensation.py
@@ -53,6 +53,7 @@ def billing_renewal_compensation_env(monkeypatch: pytest.MonkeyPatch):
 
     class FakeStripeProvider:
         def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+            _ = app
             assert reference_type == "subscription"
             assert provider_reference == sync_state["subscription"]["id"]
             return PaymentNotificationResult(

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -261,6 +261,7 @@ def test_sync_billing_order_enqueues_subscription_purchase_sms_once(
 
     class FakeStripeProvider:
         def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+            _ = app
             assert reference_type == "subscription"
             return PaymentNotificationResult(
                 order_bid="",
@@ -413,6 +414,7 @@ def test_sync_billing_order_enqueues_subscription_paid_feishu_once(
 
     class FakeStripeProvider:
         def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+            _ = app
             assert reference_type == "subscription"
             return PaymentNotificationResult(
                 order_bid="",
@@ -573,6 +575,7 @@ def test_sync_billing_topup_enqueues_billing_paid_feishu_once(
 
     class FakePingxxProvider:
         def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+            _ = app
             assert provider_reference == "ch_billing_feishu_topup_sync_1"
             assert reference_type == "charge"
             return PaymentNotificationResult(
@@ -657,6 +660,7 @@ def test_sync_pingxx_order_syncs_manual_trial_subscription_provider(
 
     class FakePingxxProvider:
         def sync_reference(self, *, provider_reference: str, reference_type: str, app):
+            _ = app
             assert provider_reference == "ch_trial_upgrade_sync_pingxx_1"
             assert reference_type == "charge"
             return PaymentNotificationResult(

--- a/src/api/tests/service/billing/test_billing_tasks.py
+++ b/src/api/tests/service/billing/test_billing_tasks.py
@@ -1039,6 +1039,7 @@ def test_sync_billing_order_runs_under_per_creator_credit_ledger_lock(
             self._key = key
 
         def acquire(self, blocking: bool = True) -> bool:
+            _ = blocking
             events.append(("acquire", self._key))
             return True
 
@@ -1047,6 +1048,7 @@ def test_sync_billing_order_runs_under_per_creator_credit_ledger_lock(
 
     class _RecordingCache:
         def lock(self, key, timeout=None, blocking_timeout=None):
+            _ = (timeout, blocking_timeout)
             return _RecordingLock(key)
 
     monkeypatch.setattr(checkout_mod.cache_provider, "cache", _RecordingCache())

--- a/src/api/tests/service/billing/test_provider_catalog.py
+++ b/src/api/tests/service/billing/test_provider_catalog.py
@@ -87,6 +87,7 @@ class _FakeStripe:
 
 class _FailingStripeResource:
     def retrieve(self, *args, **kwargs):
+        _ = (args, kwargs)
         message = "secret sk_test_should_not_leak"
         raise RuntimeError(message)
 
@@ -102,6 +103,7 @@ class _FakeStripeAdapter(StripeCatalogReadAdapter):
         self.stripe = stripe
 
     def _client_options(self, app):
+        _ = app
         return self.stripe, build_stripe_request_options()
 
 

--- a/src/api/tests/service/billing/test_provider_price_mappings.py
+++ b/src/api/tests/service/billing/test_provider_price_mappings.py
@@ -51,6 +51,7 @@ class _FakeStripeCatalogAdapter(StripeCatalogReadAdapter):
         provider_product_id: str,
         provider_price_id: str,
     ) -> ProviderCatalogSnapshot:
+        _ = app
         self.calls.append(
             {
                 "provider_product_id": provider_product_id,

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -1120,6 +1120,7 @@ def test_settle_usage_acquires_creator_scoped_lock(
             self.release_calls = 0
 
         def acquire(self, blocking: bool = True, blocking_timeout=None):
+            _ = blocking_timeout
             self.acquire_calls.append(bool(blocking))
             return True
 
@@ -1206,6 +1207,7 @@ def test_settle_usage_releases_creator_lock_on_error(
             self.release_calls = 0
 
         def acquire(self, blocking: bool = True, blocking_timeout=None):
+            _ = (blocking, blocking_timeout)
             return True
 
         def release(self) -> None:

--- a/src/api/tests/service/common/test_umami_client.py
+++ b/src/api/tests/service/common/test_umami_client.py
@@ -197,6 +197,7 @@ def test_get_course_visit_count_30d_returns_fetched_value_when_cache_write_fails
             return self._cache.delete(*keys)
 
         def setex(self, key, ttl, value):
+            _ = (key, ttl, value)
             message = "cache unavailable"
             raise RuntimeError(message)
 
@@ -242,6 +243,7 @@ def test_get_course_visit_count_30d_returns_zero_when_failure_cache_write_fails(
             return self._cache.delete(*keys)
 
         def setex(self, key, ttl, value):
+            _ = (key, ttl, value)
             message = "cache unavailable"
             raise RuntimeError(message)
 
@@ -280,6 +282,7 @@ def test_get_course_visit_count_30d_waits_for_cache_on_lock_contention(
 
     class BusyLock:
         def acquire(self, blocking=True, blocking_timeout=None):
+            _ = (blocking, blocking_timeout)
             return False
 
         def release(self):
@@ -287,15 +290,17 @@ def test_get_course_visit_count_30d_waits_for_cache_on_lock_contention(
 
     class CacheWrapper:
         def get(self, key):
-            return None
+            _ = key
 
         def delete(self, *keys):
+            _ = keys
             return 0
 
         def setex(self, key, ttl, value):
-            return None
+            _ = (key, ttl, value)
 
         def lock(self, key, timeout=None, blocking_timeout=None):
+            _ = (key, timeout, blocking_timeout)
             return BusyLock()
 
     read_values = iter([None, None, 11])
@@ -326,6 +331,7 @@ def test_login_for_access_token_rechecks_cache_when_lock_is_busy(monkeypatch):
 
     class BusyLock:
         def acquire(self, blocking=True, blocking_timeout=None):
+            _ = (blocking, blocking_timeout)
             return False
 
         def release(self):
@@ -342,6 +348,7 @@ def test_login_for_access_token_rechecks_cache_when_lock_is_busy(monkeypatch):
             return cache_provider.setex(key, ttl, value)
 
         def lock(self, key, timeout=None, blocking_timeout=None):
+            _ = (key, timeout, blocking_timeout)
             return BusyLock()
 
     monkeypatch.setattr(umami_client, "cache", CacheWrapper())
@@ -370,6 +377,7 @@ def test_login_for_access_token_returns_token_when_cache_write_fails(monkeypatch
             return self._cache.get(key)
 
         def setex(self, key, ttl, value):
+            _ = (key, ttl, value)
             message = "cache unavailable"
             raise RuntimeError(message)
 

--- a/src/api/tests/service/config/test_funcs.py
+++ b/src/api/tests/service/config/test_funcs.py
@@ -793,6 +793,7 @@ class TestAddConfig:
         app,
     ):
         """Test that add_config ignores cached encrypted values when adding."""
+        _ = mock_db
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
             app.config["SECRET_KEY"] = "test-secret-key-12345"
@@ -834,6 +835,7 @@ class TestAddConfig:
         app,
     ):
         """Test that add_config uses cached plain value if exists."""
+        _ = mock_db
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
             mock_get_config_from_common.return_value = None
@@ -882,6 +884,7 @@ class TestAddConfig:
         app,
     ):
         """DB writes should proceed when the key is not explicitly in os.environ."""
+        _ = mock_redis
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
             mock_get_config_from_common.return_value = "parent-default"
@@ -976,6 +979,7 @@ class TestUpdateConfig:
         app,
     ):
         """Test updating encrypted config."""
+        _ = mock_db
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
             app.config["SECRET_KEY"] = "test-secret-key-12345"
@@ -1021,6 +1025,7 @@ class TestUpdateConfig:
         app,
     ):
         """update_config must persist the caller's new value, not a stale cached one, even when the cache is warm (regression: a warm cache used to overwrite the new value and re-persist the old one)."""
+        _ = mock_db
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
             app.config["SECRET_KEY"] = "test-secret-key-12345"
@@ -1066,6 +1071,7 @@ class TestUpdateConfig:
         app,
     ):
         """update_config must persist the caller's new plain value, not a stale cached one, even when the cache is warm."""
+        _ = mock_db
         with app.app_context():
             app.config["REDIS_KEY_PREFIX"] = "test:"
             mock_get_config_from_common.return_value = None

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -1108,6 +1108,7 @@ class StreamTtsTeardownTests(unittest.TestCase):
                 self.finalize_calls = 0
 
             def finalize(self, *, commit=True):
+                _ = commit
                 self.finalize_calls += 1
                 yield "audio-complete"
 
@@ -1154,6 +1155,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
     def test_init_calls_visual_mode_when_api_exists(self):
         class FakeMarkdownFlow:
             def __init__(self, *args, **kwargs) -> None:
+                _ = (args, kwargs)
                 self.visual_mode = None
 
             def set_visual_mode(self, visual_mode):
@@ -1170,6 +1172,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
     def test_init_uses_explicit_output_language_when_enabled(self):
         class FakeMarkdownFlow:
             def __init__(self, *args, **kwargs) -> None:
+                _ = (args, kwargs)
                 self.output_language = None
 
             def set_output_language(self, language):

--- a/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
+++ b/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
@@ -130,6 +130,7 @@ def test_tts_finalize_failure_runs_classified_cleanup(app, monkeypatch):
         next_element_index = 0
 
         def finalize(self, *, commit):
+            _ = commit
             message = "desynced during finalize"
             raise ResourceClosedError(message)
             yield  # pragma: no cover - generator marker

--- a/src/api/tests/service/learn/test_learn_funcs.py
+++ b/src/api/tests/service/learn/test_learn_funcs.py
@@ -249,6 +249,7 @@ class LearnRecordLoadTests(unittest.TestCase):
             last_context = None
 
             def __init__(self, *args, **kwargs) -> None:
+                _ = (args, kwargs)
                 self.blocks = [DummyBlock(BlockType.CONTENT, "md content", 0)]
 
             def set_visual_mode(self, *_args, **_kwargs):
@@ -266,6 +267,7 @@ class LearnRecordLoadTests(unittest.TestCase):
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
             ):
+                _ = (block_index, mode, variables, user_input)
                 FakeMarkdownFlow.last_context = context
 
                 def _gen():
@@ -366,6 +368,7 @@ class LearnRecordLoadTests(unittest.TestCase):
 
         class FakeMarkdownFlow:
             def __init__(self, *args, **kwargs) -> None:
+                _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(MarkdownFlowBlockType.CONTENT, "first content", 0),
                     DummyBlock(MarkdownFlowBlockType.CONTENT, "second content", 1),
@@ -391,6 +394,7 @@ class LearnRecordLoadTests(unittest.TestCase):
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
             ):
+                _ = (mode, variables, context, user_input)
                 block = self.blocks[block_index]
                 if block.block_type == MarkdownFlowBlockType.INTERACTION:
                     return types.SimpleNamespace(content=block.content)
@@ -511,6 +515,7 @@ class LearnRecordLoadTests(unittest.TestCase):
             process_called = False
 
             def __init__(self, *args, **kwargs) -> None:
+                _ = (args, kwargs)
                 self.blocks = [DummyBlock(BlockType.CONTENT, "===fixed output===", 0)]
 
             def set_visual_mode(self, *_args, **_kwargs):
@@ -528,6 +533,7 @@ class LearnRecordLoadTests(unittest.TestCase):
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
             ):
+                _ = (block_index, mode, variables, context, user_input)
                 FakeMarkdownFlow.process_called = True
                 return types.SimpleNamespace(content="should-not-be-emitted")
 
@@ -635,6 +641,7 @@ class LearnRecordLoadTests(unittest.TestCase):
             process_called = False
 
             def __init__(self, *args, **kwargs) -> None:
+                _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(BlockType.CONTENT, "===fixed output===", 0),
                     DummyBlock(BlockType.INTERACTION, "?[%{{v}} A|B]", 1),
@@ -655,6 +662,7 @@ class LearnRecordLoadTests(unittest.TestCase):
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
             ):
+                _ = (block_index, mode, variables, context, user_input)
                 FakeMarkdownFlow.process_called = True
                 return types.SimpleNamespace(content="should-not-be-called")
 
@@ -755,6 +763,7 @@ class LearnRecordLoadTests(unittest.TestCase):
             process_called = False
 
             def __init__(self, *args, **kwargs) -> None:
+                _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(BlockType.CONTENT, "===fixed output===", 0),
                     DummyBlock(BlockType.INTERACTION, "?[%{{v}} A|B]", 1),
@@ -775,6 +784,7 @@ class LearnRecordLoadTests(unittest.TestCase):
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
             ):
+                _ = (block_index, mode, variables, context, user_input)
                 FakeMarkdownFlow.process_called = True
                 return types.SimpleNamespace(content="should-not-be-called")
 

--- a/src/api/tests/service/learn/test_listen_elements.py
+++ b/src/api/tests/service/learn/test_listen_elements.py
@@ -1410,6 +1410,7 @@ def test_listen_run_persists_content_block_before_element_rows(app):
 
         class FakeMarkdownFlow:
             def __init__(self, *args, **kwargs) -> None:
+                _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(
                         MarkdownFlowBlockType.CONTENT,
@@ -1433,6 +1434,7 @@ def test_listen_run_persists_content_block_before_element_rows(app):
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
             ):
+                _ = (mode, variables, context, user_input)
                 block = self.blocks[block_index]
 
                 def _gen():
@@ -1600,6 +1602,7 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
 
         class FakeMarkdownFlow:
             def __init__(self, *args, **kwargs) -> None:
+                _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(
                         MarkdownFlowBlockType.CONTENT,
@@ -1623,6 +1626,8 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
             def process(
                 self, block_index, mode, variables=None, context=None, user_input=None
             ):
+                _ = (block_index, mode, variables, context, user_input)
+
                 def _gen():
                     yield DummyLLMResult(
                         [DummyFormattedElement("Intro narration.\n", "text", 0)]
@@ -1664,6 +1669,7 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
                     yield None
 
             def finalize(self, *, commit=True):
+                _ = commit
                 if self.stream_element_number == 0:
                     time.sleep(0.02)
                 resolved_audio_url = (

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -37,6 +37,7 @@ class FakeLock:
         self.release_calls = 0
 
     def acquire(self, blocking=True):
+        _ = blocking
         self.acquire_calls += 1
         if self._acquire_results:
             return self._acquire_results.pop(0)

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -488,6 +488,7 @@ def test_legacy_stripe_checkout_urls_are_derived_from_host_url(
 
     class FakeStripeProvider:
         def create_payment(self, *, request, app):
+            _ = app
             stripe_requests.append(
                 {
                     "order_bid": request.order_bid,

--- a/src/api/tests/service/order/test_native_payment_split_tables.py
+++ b/src/api/tests/service/order/test_native_payment_split_tables.py
@@ -228,6 +228,7 @@ def test_learner_sync_and_admin_payment_detail_read_alipay_table(
 ) -> None:
     class FakeAlipayProvider:
         def sync_reference(self, *, provider_reference, reference_type, app):
+            _ = app
             assert reference_type == "payment"
             return PaymentNotificationResult(
                 order_bid=provider_reference,
@@ -308,6 +309,7 @@ def test_learner_sync_does_not_mark_paid_when_native_amount_mismatches(
 ) -> None:
     class FakeAlipayProvider:
         def sync_reference(self, *, provider_reference, reference_type, app):
+            _ = app
             assert reference_type == "payment"
             return PaymentNotificationResult(
                 order_bid=provider_reference,

--- a/src/api/tests/service/order/test_order_init_lock.py
+++ b/src/api/tests/service/order/test_order_init_lock.py
@@ -12,6 +12,7 @@ class DummyLock:
         self.released = 0
 
     def acquire(self, blocking=True):
+        _ = blocking
         self.acquired += 1
         return True
 
@@ -62,6 +63,7 @@ def test_order_init_lock_uses_prefixed_key(monkeypatch):
 def test_order_init_lock_skips_when_cache_provider_errors(monkeypatch):
     class _BrokenCacheProvider:
         def lock(self, *args, **kwargs):
+            _ = (args, kwargs)
             message = "lock unavailable"
             raise RuntimeError(message)
 

--- a/src/api/tests/service/order/test_stripe_refund.py
+++ b/src/api/tests/service/order/test_stripe_refund.py
@@ -18,6 +18,7 @@ class DummyStripeRefundProvider:
         self._result = result
 
     def refund_payment(self, *, request, app):  # pylint: disable=unused-argument
+        _ = (request, app)
         return self._result
 
 

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -315,6 +315,7 @@ def test_run_minimax_voice_clone_success_captures_credit_once(
             return SimpleNamespace(file_id="file-source")
 
         def upload_prompt_audio(self, audio_bytes, filename, content_type):
+            _ = (audio_bytes, filename, content_type)
             message = "prompt upload should not be called"
             raise AssertionError(message)
 
@@ -430,10 +431,12 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
 
     class FakeClient:
         def upload_clone_audio(self, audio_bytes, filename, content_type):
+            _ = (filename, content_type)
             assert audio_bytes == b"WAV"
             return SimpleNamespace(file_id="file-source")
 
         def upload_prompt_audio(self, audio_bytes, filename, content_type):
+            _ = (audio_bytes, filename, content_type)
             message = "prompt upload should not be called"
             raise AssertionError(message)
 
@@ -598,9 +601,11 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(monkeypatch
 
     class FakeClient:
         def upload_clone_audio(self, audio_bytes, filename, content_type):
+            _ = (audio_bytes, filename, content_type)
             return SimpleNamespace(file_id="file-source")
 
         def upload_prompt_audio(self, audio_bytes, filename, content_type):
+            _ = (audio_bytes, filename, content_type)
             message = "prompt upload should not be called"
             raise AssertionError(message)
 

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -773,6 +773,7 @@ class TestFinalizeDelayManagement:
         self, mock_sleep, mock_is_configured, mock_executor, mock_app
     ):
         """Test that _yield_ready_segments adds delay between segment yields."""
+        _ = mock_executor
         mock_is_configured.return_value = True
 
         processor = create_test_processor(mock_app)

--- a/src/api/tests/service/tts/test_volcengine_ws_provider.py
+++ b/src/api/tests/service/tts/test_volcengine_ws_provider.py
@@ -61,9 +61,11 @@ def test_volcengine_ws_waits_for_session_started_before_task_request(monkeypatch
             return b"start_session"
 
         def encode_task_request(self, session_id, text):
+            _ = (session_id, text)
             return b"task_request"
 
         def encode_finish_session(self, session_id):
+            _ = session_id
             return b"finish_session"
 
         def encode_finish_connection(self):
@@ -137,6 +139,7 @@ def test_volcengine_ws_waits_for_session_started_before_task_request(monkeypatch
         def __init__(
             self, url, header, on_message, on_error, on_close, on_open
         ) -> None:
+            _ = (url, header, on_error)
             self.on_message = on_message
             self.on_close = on_close
             self.on_open = on_open
@@ -145,9 +148,11 @@ def test_volcengine_ws_waits_for_session_started_before_task_request(monkeypatch
             captured["ws"] = self
 
         def run_forever(self, **kwargs):
+            _ = kwargs
             self.on_open(self)
 
         def send(self, frame, opcode=None):
+            _ = opcode
             self.sent.append(frame)
             if frame == b"start_connection":
                 self.on_message(self, b"connection_started")

--- a/src/api/tests/test_gunicorn_worker_patch_guard.py
+++ b/src/api/tests/test_gunicorn_worker_patch_guard.py
@@ -65,6 +65,7 @@ def test_observer_skips_unpatched_processes(monkeypatch):
 
     class _Logger:
         def error(self, *args, **kwargs):
+            _ = (args, kwargs)
             message = "must not log during a skipped install"
             raise AssertionError(message)
 


### PR DESCRIPTION
## Summary

- remove repository-owned unused method parameters
- explicitly consume framework, protocol, fixture, and test-double compatibility values
- preserve public and keyword-call signatures
- enforce ARG002

## Verification

- 152 focused tests passed, 4 skipped
- Ruff 0.16.3 configured check passed
- Ruff 0.16.3 isolated ARG002 check passed
- repository pre-commit hooks passed