### PR TITLE
test: enforce unused lambda arguments safely

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -394,6 +394,11 @@ Apply the same ownership test to `ARG001`: remove a function parameter only
 when all callers are repository-owned; explicitly consume values required by
 framework callbacks, fixtures, migrations, and compatibility facades.
 
+For `ARG005`, prefer zero-argument lambdas when callers pass nothing. When a
+callback or test double must accept positional or keyword arguments, use a
+named helper or underscore-prefixed parameters that preserve the actual call
+contract; do not rename externally supplied keyword parameters.
+
 For `N815`, keep Python DTO field names in snake_case even when the public JSON
 contract uses camelCase. Pydantic DTOs should declare the public name with
 `Field(alias="...")`, accept internal construction through `populate_by_name`,

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -226,6 +226,11 @@ plan's progress update for that rule.
   values without changing accepted signatures.
 - [ ] Merge or retarget ARG001 PR #2634 after ARG002 without combining it with
   the next rule unit.
+- [x] 2026-08-22: Rebuilt the ARG005 stage on `sunner/ruff-arg005`, stacked on
+  ARG001. Removed unused lambda arguments while preserving provider, callback,
+  and test-double keyword contracts through named helpers where required.
+- [ ] Merge or retarget ARG005 PR #2635 after ARG001 without combining it with
+  the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/ruff.toml
+++ b/ruff.toml
@@ -29,7 +29,6 @@
 #   patterns here (moderation, logging, notification side channels).
 # - C901 / PLR09xx: complexity and argument-count budgets that the existing
 #   service and route modules exceed by design.
-# - ARG005: unused lambda arguments are pervasive in callbacks and test doubles.
 # - TD003 / FIX002: the remaining TODOs have no tracking issue to link, and
 #   inventing one (or downgrading the comment) would hide real pending work.
 
@@ -126,14 +125,12 @@ select = [
     # --- Paths, suppressions, shadowing, security -------------------------
     "PTH",     # os.path calls that should use pathlib
     "PGH",     # blanket noqa / type: ignore, invalid suppressions
-    # Remove unused function and method parameters when the repository owns the
-    # complete signature. When a framework, protocol, fixture or test double
-    # owns it, preserve keyword names and explicitly consume compatibility-only
-    # values in signature order.
-    "ARG001",  # unused function argument
-    "ARG002",  # unused method argument
-    "ARG003",  # unused classmethod argument
-    "ARG004",  # unused staticmethod argument
+    # Remove unused callable parameters when the repository owns the complete
+    # signature. Preserve framework, protocol, fixture, and test-double keyword
+    # names and consume them explicitly. Promote fixed keyword-compatible
+    # lambdas to named functions; use **_kwargs only for intentionally open,
+    # ignored keyword sets instead of renaming parameters callers still use.
+    "ARG",     # flake8-unused-arguments
     "A001",    # local variable shadowing a builtin
     "A002",    # function argument shadowing a builtin
     "A006",    # lambda argument shadowing a builtin

--- a/src/api/tests/api/doc/test_feishu_notify.py
+++ b/src/api/tests/api/doc/test_feishu_notify.py
@@ -46,12 +46,14 @@ class _Response:
 def test_send_notify_returns_metadata_for_successful_non_json_response(monkeypatch):
     app = _App()
     monkeypatch.setattr(
-        feishu, "get_config", lambda key, default=None: "https://example.test/webhook"
+        feishu,
+        "get_config",
+        lambda key, default=None: "https://example.test/webhook",  # noqa: ARG005 -- preserve get_config keyword contract
     )
     monkeypatch.setattr(
         feishu.requests,
         "post",
-        lambda *args, **kwargs: _Response(
+        lambda *_args, **_kwargs: _Response(
             status_code=200, text="ok", json_exc=ValueError("not json")
         ),
     )
@@ -65,12 +67,14 @@ def test_send_notify_returns_metadata_for_successful_non_json_response(monkeypat
 def test_send_notify_returns_none_for_non_2xx_response(monkeypatch):
     app = _App()
     monkeypatch.setattr(
-        feishu, "get_config", lambda key, default=None: "https://example.test/webhook"
+        feishu,
+        "get_config",
+        lambda key, default=None: "https://example.test/webhook",  # noqa: ARG005 -- preserve get_config keyword contract
     )
     monkeypatch.setattr(
         feishu.requests,
         "post",
-        lambda *args, **kwargs: _Response(status_code=400, text="bad request"),
+        lambda *_args, **_kwargs: _Response(status_code=400, text="bad request"),
     )
 
     result = feishu.send_notify(app, "标题", ["消息"])
@@ -82,7 +86,9 @@ def test_send_notify_returns_none_for_non_2xx_response(monkeypatch):
 def test_send_notify_returns_none_for_request_error(monkeypatch):
     app = _App()
     monkeypatch.setattr(
-        feishu, "get_config", lambda key, default=None: "https://example.test/webhook"
+        feishu,
+        "get_config",
+        lambda key, default=None: "https://example.test/webhook",  # noqa: ARG005 -- preserve get_config keyword contract
     )
 
     def _raise(*args, **kwargs):

--- a/src/api/tests/common/test_celery_app.py
+++ b/src/api/tests/common/test_celery_app.py
@@ -165,7 +165,7 @@ def test_create_celery_app_executes_billing_tasks_in_eager_mode(
 
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.settle_bill_usage",
-        lambda app, *, usage_bid="": {
+        lambda _app, *, usage_bid="": {
             "status": "settled",
             "usage_bid": usage_bid,
             "creator_bid": "creator-eager-1",
@@ -173,7 +173,7 @@ def test_create_celery_app_executes_billing_tasks_in_eager_mode(
     )
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.expire_credit_wallet_buckets",
-        lambda app, *, creator_bid="", expire_before=None: {
+        lambda _app, *, creator_bid="", expire_before=None: {
             "status": "expired",
             "creator_bid": creator_bid,
             "expire_before": expire_before.isoformat() if expire_before else None,
@@ -182,7 +182,7 @@ def test_create_celery_app_executes_billing_tasks_in_eager_mode(
     )
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.aggregate_daily_usage_metrics",
-        lambda app, *, stat_date="", creator_bid="", finalize=False: {
+        lambda _app, *, stat_date="", creator_bid="", finalize=False: {
             "status": "finalized" if finalize else "aggregated",
             "stat_date": stat_date,
             "creator_bid": creator_bid or None,
@@ -191,7 +191,7 @@ def test_create_celery_app_executes_billing_tasks_in_eager_mode(
     )
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.aggregate_daily_ledger_summary",
-        lambda app, *, stat_date="", creator_bid="", finalize=False: {
+        lambda _app, *, stat_date="", creator_bid="", finalize=False: {
             "status": "finalized" if finalize else "aggregated",
             "stat_date": stat_date,
             "creator_bid": creator_bid or None,
@@ -200,7 +200,7 @@ def test_create_celery_app_executes_billing_tasks_in_eager_mode(
     )
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.rebuild_daily_aggregates",
-        lambda app, *, creator_bid="", shifu_bid="", date_from="", date_to="": {
+        lambda _app, *, creator_bid="", shifu_bid="", date_from="", date_to="": {
             "status": "rebuilt",
             "creator_bid": creator_bid or None,
             "shifu_bid": shifu_bid or None,
@@ -210,7 +210,7 @@ def test_create_celery_app_executes_billing_tasks_in_eager_mode(
     )
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.verify_domain_binding",
-        lambda app, *, creator_bid="", domain_binding_bid="", host="", verification_token="": {
+        lambda _app, *, creator_bid="", domain_binding_bid="", host="", verification_token="": {
             "action": "verify",
             "creator_bid": creator_bid or None,
             "binding": {

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -151,7 +151,7 @@ def test_teardown_hook_invalidates_before_session_removal(app, monkeypatch):
     monkeypatch.setattr(
         dao,
         "invalidate_session",
-        lambda *, source, session=None: order.append(f"invalidate:{source}") or True,
+        lambda *, source, session=None: order.append(f"invalidate:{source}") or True,  # noqa: ARG005 -- preserve invalidation keyword contract
     )
     original_remove = db.session.remove
 
@@ -178,7 +178,7 @@ def test_teardown_hook_ignores_ordinary_exceptions(app, monkeypatch):
     monkeypatch.setattr(
         dao,
         "invalidate_session",
-        lambda *, source, session=None: invalidations.append(source) or True,
+        lambda *, source, session=None: invalidations.append(source) or True,  # noqa: ARG005 -- preserve invalidation keyword contract
     )
 
     message = "business"
@@ -194,10 +194,16 @@ def test_release_session_classified_invalidates_during_propagating_interrupt(
     from flaskr import dao
 
     order = []
+
+    def invalidate_session(*, source: object, session: object | None = None) -> bool:
+        del source, session
+        order.append("invalidate")
+        return True
+
     monkeypatch.setattr(
         dao,
         "invalidate_session",
-        lambda *, source, session=None: order.append("invalidate") or True,
+        invalidate_session,
     )
     original_remove = db.session.remove
     monkeypatch.setattr(
@@ -242,7 +248,7 @@ def test_release_session_classified_ignores_ordinary_exceptions(app, monkeypatch
     monkeypatch.setattr(
         dao,
         "invalidate_session",
-        lambda *, source, session=None: invalidations.append(source) or True,
+        lambda *, source, session=None: invalidations.append(source) or True,  # noqa: ARG005 -- preserve invalidation keyword contract
     )
 
     with app.app_context():

--- a/src/api/tests/common/test_log.py
+++ b/src/api/tests/common/test_log.py
@@ -73,7 +73,7 @@ def test_feishu_log_handler_reentrancy_guard_blocks_nested_emit(monkeypatch):
 
     def fake_post(*args, **kwargs):
         calls.append((args, kwargs))
-        return type("Response", (), {"raise_for_status": lambda self: None})()
+        return type("Response", (), {"raise_for_status": lambda _self: None})()
 
     monkeypatch.setattr(requests, "post", fake_post)
 
@@ -102,7 +102,7 @@ def test_feishu_log_handler_truncates_oversized_payload(monkeypatch):
     def fake_post(_url, *, json, timeout):
         captured["payload"] = json
         captured["timeout"] = timeout
-        return type("Response", (), {"raise_for_status": lambda self: None})()
+        return type("Response", (), {"raise_for_status": lambda _self: None})()
 
     monkeypatch.setattr(requests, "post", fake_post)
 

--- a/src/api/tests/service/billing/test_admin_billing_routes.py
+++ b/src/api/tests/service/billing/test_admin_billing_routes.py
@@ -86,6 +86,15 @@ billing_routes_module = load_billing_routes_module()
 register_billing_routes = load_register_billing_routes()
 
 
+def _resolve_existing_target(creator_bid: str = "", creator_mobile: str = "") -> str:
+    del creator_mobile
+    return creator_bid or "creator-1"
+
+
+def _no_saas(required: object = None) -> None:
+    del required
+
+
 def _set_login_methods(monkeypatch: pytest.MonkeyPatch, methods: str) -> None:
     """Pin the login methods this deployment accepts.
 
@@ -164,7 +173,7 @@ def admin_billing_client(monkeypatch):
     monkeypatch.setattr(
         billing_routes_module,
         "clear_admin_creator_customization_draft",
-        lambda *args, **kwargs: {"status": "noop"},
+        lambda *_args, **_kwargs: {"status": "noop"},
     )
 
     register_billing_routes(app=app)
@@ -1133,10 +1142,13 @@ class TestAdminBillingRoutes:
             lambda: True,
         )
 
-        monkeypatch.setattr(
-            billing_routes_module,
-            "build_admin_creator_customization_draft",
-            lambda _app, creator_bid="", creator_mobile="": {
+        def build_draft(
+            app: object,
+            creator_bid: str = "",
+            creator_mobile: str = "",
+        ) -> dict[str, object]:
+            del app, creator_bid
+            return {
                 "creator_mobile": creator_mobile,
                 "branding_enabled": False,
                 "custom_domain_enabled": False,
@@ -1156,7 +1168,12 @@ class TestAdminBillingRoutes:
                         "wechatpay",
                     )
                 },
-            },
+            }
+
+        monkeypatch.setattr(
+            billing_routes_module,
+            "build_admin_creator_customization_draft",
+            build_draft,
         )
         monkeypatch.setattr(
             billing_routes_module,
@@ -1229,7 +1246,7 @@ class TestAdminBillingRoutes:
         monkeypatch.setattr(
             billing_routes_module,
             "_resolve_existing_admin_billing_target_user_bid",
-            lambda creator_bid="", creator_mobile="": creator_bid or "creator-1",
+            _resolve_existing_target,
         )
         monkeypatch.setattr(
             billing_routes_module,
@@ -1265,7 +1282,7 @@ class TestAdminBillingRoutes:
         monkeypatch.setattr(
             billing_routes_module,
             "_resolve_existing_admin_billing_target_user_bid",
-            lambda creator_bid="", creator_mobile="": creator_bid or "creator-1",
+            _resolve_existing_target,
         )
 
         def _save_branding(_app, creator_bid, payload, **kwargs):
@@ -1304,7 +1321,7 @@ class TestAdminBillingRoutes:
         monkeypatch.setattr(
             billing_customization_module,
             "_saas_funcs",
-            lambda required=True: None,
+            _no_saas,
         )
         monkeypatch.setattr(
             billing_routes_module,
@@ -1314,7 +1331,7 @@ class TestAdminBillingRoutes:
         monkeypatch.setattr(
             billing_routes_module,
             "_resolve_existing_admin_billing_target_user_bid",
-            lambda creator_bid="", creator_mobile="": creator_bid or "creator-1",
+            _resolve_existing_target,
         )
 
         with app.app_context():

--- a/src/api/tests/service/billing/test_billing_callbacks.py
+++ b/src/api/tests/service/billing/test_billing_callbacks.py
@@ -500,19 +500,19 @@ class TestBillingPingxxCallbacks:
     ) -> None:
         monkeypatch.setattr(
             "flaskr.service.order.funs.get_shifu_creator_bid",
-            lambda *args, **kwargs: "creator-legacy-1",
+            lambda *_args, **_kwargs: "creator-legacy-1",
         )
         monkeypatch.setattr(
             "flaskr.service.order.funs.set_user_state",
-            lambda *args, **kwargs: None,
+            lambda *_args, **_kwargs: None,
         )
         monkeypatch.setattr(
             "flaskr.service.order.funs.send_order_feishu",
-            lambda *args, **kwargs: None,
+            lambda *_args, **_kwargs: None,
         )
         monkeypatch.setattr(
             "flaskr.service.order.funs.query_buy_record",
-            lambda *args, **kwargs: {},
+            lambda *_args, **_kwargs: {},
         )
 
         with billing_callback_app.app_context():
@@ -608,7 +608,7 @@ class TestBillingNativeCallbacks:
 
         monkeypatch.setattr(
             "flaskr.service.billing.webhooks.get_payment_provider",
-            lambda provider_name: FakeAlipayProvider(),
+            lambda _provider_name: FakeAlipayProvider(),
         )
 
         with billing_callback_app.app_context():
@@ -798,11 +798,11 @@ class TestBillingNativeCallbacks:
 
         monkeypatch.setattr(
             "flaskr.route.callback.get_payment_provider",
-            lambda provider_name: FakeAlipayProvider(),
+            lambda _provider_name: FakeAlipayProvider(),
         )
         monkeypatch.setattr(
             "flaskr.route.callback.success_buy_record_from_native",
-            lambda *args, **kwargs: False,
+            lambda *_args, **_kwargs: False,
         )
 
         with billing_callback_app.test_client() as client:
@@ -824,23 +824,23 @@ class TestBillingNativeCallbacks:
 
         monkeypatch.setattr(
             "flaskr.route.callback.get_payment_provider",
-            lambda provider_name: FakeWechatPayProvider(),
+            lambda _provider_name: FakeWechatPayProvider(),
         )
         monkeypatch.setattr(
             "flaskr.service.order.funs.get_shifu_creator_bid",
-            lambda *args, **kwargs: "creator-legacy-1",
+            lambda *_args, **_kwargs: "creator-legacy-1",
         )
         monkeypatch.setattr(
             "flaskr.service.order.funs.set_user_state",
-            lambda *args, **kwargs: None,
+            lambda *_args, **_kwargs: None,
         )
         monkeypatch.setattr(
             "flaskr.service.order.funs.send_order_feishu",
-            lambda *args, **kwargs: None,
+            lambda *_args, **_kwargs: None,
         )
         monkeypatch.setattr(
             "flaskr.service.order.funs.query_buy_record",
-            lambda *args, **kwargs: {},
+            lambda *_args, **_kwargs: {},
         )
 
         with billing_callback_app.app_context():
@@ -891,7 +891,7 @@ class TestBillingNativeCallbacks:
 
         monkeypatch.setattr(
             "flaskr.route.callback.get_payment_provider",
-            lambda provider_name: FakeWechatPayProvider(),
+            lambda _provider_name: FakeWechatPayProvider(),
         )
 
         with billing_callback_app.test_client() as client:

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -178,7 +178,7 @@ def test_billing_backfill_settlement_cli_prints_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.backfill_bill_usage_settlement",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "completed",
             "processed_count": 2,
             "backfill": True,
@@ -223,7 +223,7 @@ def test_billing_backfill_trial_plans_cli_prints_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.backfill_missing_creator_trial_credits",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "completed",
             "granted_count": 2,
             "kwargs": kwargs,
@@ -265,7 +265,7 @@ def test_billing_backfill_authoring_permission_creators_cli_prints_helper_payloa
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.backfill_authoring_permission_creators",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "completed",
             "role_granted_count": 1,
             "kwargs": kwargs,
@@ -298,7 +298,7 @@ def test_billing_rebuild_wallets_cli_prints_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.rebuild_credit_wallet_snapshots",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "rebuilt",
             "wallet_count": 1,
             "wallets": [{"wallet_bid": "wallet-1"}],
@@ -329,7 +329,7 @@ def test_billing_rebuild_wallets_cli_apply_persists_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.rebuild_credit_wallet_snapshots",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "rebuilt",
             "wallet_count": 1,
             "wallets": [{"wallet_bid": "wallet-1"}],
@@ -371,7 +371,7 @@ def test_billing_repair_topup_expiry_cli_prints_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.repair_topup_grant_expiries",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "repaired",
             "repaired_bucket_count": 1,
             "kwargs": kwargs,
@@ -414,7 +414,7 @@ def test_billing_restore_expired_topup_buckets_cli_prints_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.restore_wrongly_expired_credit_pack_buckets",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "dry_run",
             "repaired_bucket_count": 2,
             "kwargs": kwargs,
@@ -446,7 +446,7 @@ def test_billing_restore_expired_topup_buckets_cli_apply_persists_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.restore_wrongly_expired_credit_pack_buckets",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "repaired",
             "repaired_bucket_count": 1,
             "kwargs": kwargs,
@@ -491,7 +491,7 @@ def test_billing_repair_bucket_status_cli_prints_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.repair_credit_bucket_runtime_statuses",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "repaired",
             "repaired_bucket_count": 1,
             "kwargs": kwargs,
@@ -534,7 +534,7 @@ def test_billing_repair_expire_ledger_bucket_drift_cli_prints_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.repair_expire_ledger_bucket_drift",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "dry_run",
             "bucket_count": 1,
             "kwargs": kwargs,
@@ -565,7 +565,7 @@ def test_billing_repair_expire_ledger_bucket_drift_cli_apply_persists_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.repair_expire_ledger_bucket_drift",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "repaired",
             "bucket_count": 1,
             "kwargs": kwargs,
@@ -610,7 +610,7 @@ def test_billing_repair_renewal_state_drift_cli_prints_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.repair_renewal_state_drift",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "dry_run",
             "creator_count": 1,
             "kwargs": kwargs,
@@ -641,7 +641,7 @@ def test_billing_repair_renewal_state_drift_cli_apply_persists_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.repair_renewal_state_drift",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "repaired",
             "creator_count": 10,
             "kwargs": kwargs,
@@ -687,7 +687,7 @@ def test_billing_repair_subscription_cycle_cli_prints_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.repair_subscription_cycle_mismatches",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "repaired",
             "repaired_subscription_count": 1,
             "kwargs": kwargs,
@@ -716,7 +716,7 @@ def test_billing_reconcile_order_cli_prints_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.reconcile_billing_provider_reference",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "paid",
             "bill_order_bid": "bill-order-cli-1",
             "kwargs": kwargs,
@@ -747,7 +747,7 @@ def test_billing_retry_renewal_cli_prints_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.retry_billing_renewal_event",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "applied",
             "renewal_event_bid": kwargs.get("renewal_event_bid"),
         },
@@ -775,7 +775,7 @@ def test_billing_requeue_subscription_purchase_sms_cli_prints_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.requeue_subscription_purchase_sms",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "enqueued",
             "bill_order_bid": kwargs.get("bill_order_bid"),
             "enqueued": True,
@@ -816,7 +816,7 @@ def test_billing_rebuild_daily_aggregates_cli_prints_helper_payload(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.cli.rebuild_daily_aggregates",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "rebuilt",
             "day_count": 3,
             "kwargs": kwargs,
@@ -1383,7 +1383,7 @@ def test_billing_grant_plan_cli_accepts_explicit_effective_to(
 
     monkeypatch.setattr(
         "flaskr.service.billing.cli.enqueue_subscription_purchase_sms",
-        lambda app, *, bill_order_bid: {
+        lambda _app, *, bill_order_bid: {
             "status": "enqueued",
             "bill_order_bid": bill_order_bid,
             "enqueued": True,
@@ -1456,7 +1456,7 @@ def test_billing_grant_plan_cli_upgrades_active_manual_subscription(
 
     monkeypatch.setattr(
         "flaskr.service.billing.cli.enqueue_subscription_purchase_sms",
-        lambda app, *, bill_order_bid: {
+        lambda _app, *, bill_order_bid: {
             "status": "enqueued",
             "bill_order_bid": bill_order_bid,
             "enqueued": True,
@@ -1702,7 +1702,7 @@ def test_billing_grant_plan_cli_upgrades_active_pingxx_subscription(
 
     monkeypatch.setattr(
         "flaskr.service.billing.cli.enqueue_subscription_purchase_sms",
-        lambda app, *, bill_order_bid: {
+        lambda _app, *, bill_order_bid: {
             "status": "enqueued",
             "bill_order_bid": bill_order_bid,
             "enqueued": True,

--- a/src/api/tests/service/billing/test_billing_cycle_transitions.py
+++ b/src/api/tests/service/billing/test_billing_cycle_transitions.py
@@ -187,10 +187,10 @@ def test_resolve_order_effective_to_uses_topup_subscription_window() -> None:
         product=product,
         effective_from=effective_from,
         load_subscription_by_bid=lambda _: None,
-        resolve_topup_effective_to=lambda creator_bid, from_at: effective_to,
+        resolve_topup_effective_to=lambda _creator_bid, _from_at: effective_to,
         is_self_managed_order=lambda _: False,
-        calculate_provider_cycle_end=lambda _, cycle_start_at: None,
-        calculate_self_managed_cycle_end=lambda _, cycle_start_at: None,
+        calculate_provider_cycle_end=lambda _, _cycle_start_at: None,
+        calculate_self_managed_cycle_end=lambda _, _cycle_start_at: None,
     )
 
     assert resolved == effective_to
@@ -216,7 +216,7 @@ def test_resolve_order_effective_to_prefers_topup_window_over_order_metadata() -
         product=product,
         effective_from=effective_from,
         load_subscription_by_bid=_raise_unexpected_call,
-        resolve_topup_effective_to=lambda creator_bid, from_at: topup_effective_to,
+        resolve_topup_effective_to=lambda _creator_bid, _from_at: topup_effective_to,
         is_self_managed_order=_raise_unexpected_call,
         calculate_provider_cycle_end=_raise_unexpected_call,
         calculate_self_managed_cycle_end=_raise_unexpected_call,
@@ -310,10 +310,10 @@ def test_resolve_order_effective_to_prefers_existing_subscription_start_window()
         product=product,
         effective_from=effective_from,
         load_subscription_by_bid=lambda _: subscription,
-        resolve_topup_effective_to=lambda creator_bid, from_at: None,
+        resolve_topup_effective_to=lambda _creator_bid, _from_at: None,
         is_self_managed_order=lambda _: False,
-        calculate_provider_cycle_end=lambda _, cycle_start_at: None,
-        calculate_self_managed_cycle_end=lambda _, cycle_start_at: None,
+        calculate_provider_cycle_end=lambda _, _cycle_start_at: None,
+        calculate_self_managed_cycle_end=lambda _, _cycle_start_at: None,
     )
 
     assert resolved == effective_to
@@ -342,9 +342,9 @@ def test_resolve_order_effective_to_ignores_invalid_subscription_start_window() 
         product=product,
         effective_from=effective_from,
         load_subscription_by_bid=lambda _: subscription,
-        resolve_topup_effective_to=lambda creator_bid, from_at: None,
+        resolve_topup_effective_to=lambda _creator_bid, _from_at: None,
         is_self_managed_order=lambda _: False,
-        calculate_provider_cycle_end=lambda _, cycle_start_at: calculated_effective_to,
+        calculate_provider_cycle_end=lambda _, _cycle_start_at: calculated_effective_to,
         calculate_self_managed_cycle_end=_raise_unexpected_call,
     )
 
@@ -370,10 +370,10 @@ def test_resolve_order_effective_to_uses_provider_cycle_calculator() -> None:
         product=product,
         effective_from=effective_from,
         load_subscription_by_bid=lambda _: None,
-        resolve_topup_effective_to=lambda creator_bid, from_at: None,
+        resolve_topup_effective_to=lambda _creator_bid, _from_at: None,
         is_self_managed_order=lambda _: False,
-        calculate_provider_cycle_end=lambda _, cycle_start_at: effective_to,
-        calculate_self_managed_cycle_end=lambda _, cycle_start_at: None,
+        calculate_provider_cycle_end=lambda _, _cycle_start_at: effective_to,
+        calculate_self_managed_cycle_end=lambda _, _cycle_start_at: None,
     )
 
     assert resolved == effective_to
@@ -464,7 +464,7 @@ def test_resolve_order_effective_to_uses_self_managed_calculator(
         resolve_topup_effective_to=_raise_unexpected_call,
         is_self_managed_order=lambda _: True,
         calculate_provider_cycle_end=_raise_unexpected_call,
-        calculate_self_managed_cycle_end=lambda _, cycle_start_at: effective_to,
+        calculate_self_managed_cycle_end=lambda _, _cycle_start_at: effective_to,
     )
 
     assert resolved == effective_to

--- a/src/api/tests/service/billing/test_billing_daily_aggregate_rebuild.py
+++ b/src/api/tests/service/billing/test_billing_daily_aggregate_rebuild.py
@@ -61,7 +61,7 @@ def test_rebuild_daily_aggregates_rebuilds_creator_date_window(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.daily_aggregates.resolve_usage_creator_bid",
-        lambda app, usage: "creator-rebuild-1",
+        lambda _app, _usage: "creator-rebuild-1",
     )
 
     with billing_daily_rebuild_app.app_context():
@@ -163,7 +163,7 @@ def test_rebuild_daily_aggregates_scopes_usage_by_shifu_and_skips_ledger(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.daily_aggregates.resolve_usage_creator_bid",
-        lambda app, usage: "creator-rebuild-1",
+        lambda _app, _usage: "creator-rebuild-1",
     )
 
     with billing_daily_rebuild_app.app_context():

--- a/src/api/tests/service/billing/test_billing_daily_usage_aggregates.py
+++ b/src/api/tests/service/billing/test_billing_daily_usage_aggregates.py
@@ -59,7 +59,7 @@ def test_aggregate_daily_usage_metrics_respects_incremental_window_and_creator_s
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.daily_aggregates.resolve_usage_creator_bid",
-        lambda app, usage: {
+        lambda _app, usage: {
             "shifu-agg-1": "creator-agg-1",
             "shifu-agg-2": "creator-agg-2",
         }.get(usage.shifu_bid, ""),
@@ -204,7 +204,7 @@ def test_finalize_daily_usage_metrics_recomputes_full_day(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.daily_aggregates.resolve_usage_creator_bid",
-        lambda app, usage: "creator-agg-1",
+        lambda _app, _usage: "creator-agg-1",
     )
 
     with billing_daily_usage_app.app_context():
@@ -309,7 +309,7 @@ def test_aggregate_daily_usage_metrics_supports_single_usage_ledger_with_multi_m
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.daily_aggregates.resolve_usage_creator_bid",
-        lambda app, usage: "creator-agg-single-ledger",
+        lambda _app, _usage: "creator-agg-single-ledger",
     )
 
     with billing_daily_usage_app.app_context():
@@ -407,7 +407,7 @@ def test_aggregate_daily_usage_metrics_quantizes_consumed_credits_with_configure
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.daily_aggregates.resolve_usage_creator_bid",
-        lambda app, usage: "creator-agg-precision",
+        lambda _app, _usage: "creator-agg-precision",
     )
     monkeypatch.setattr(
         "flaskr.service.billing.primitives.get_config",
@@ -455,7 +455,7 @@ def test_aggregate_daily_usage_metrics_keeps_zero_amount_usage_ledgers(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.daily_aggregates.resolve_usage_creator_bid",
-        lambda app, usage: "creator-agg-zero-ledger",
+        lambda _app, _usage: "creator-agg-zero-ledger",
     )
 
     with billing_daily_usage_app.app_context():

--- a/src/api/tests/service/billing/test_billing_renewal_compensation.py
+++ b/src/api/tests/service/billing/test_billing_renewal_compensation.py
@@ -65,7 +65,7 @@ def billing_renewal_compensation_env(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr(
         "flaskr.service.billing.checkout.get_payment_provider",
-        lambda channel: FakeStripeProvider(),
+        lambda _channel: FakeStripeProvider(),
     )
 
     with app.app_context():

--- a/src/api/tests/service/billing/test_billing_renewal_retry_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_retry_execution.py
@@ -39,7 +39,7 @@ def test_run_billing_renewal_event_retries_latest_failed_renewal_order(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.renewal.sync_billing_order",
-        lambda app, creator_bid, bill_order_bid, payload: {
+        lambda _app, creator_bid, bill_order_bid, _payload: {
             "status": "paid",
             "creator_bid": creator_bid,
             "bill_order_bid": bill_order_bid,

--- a/src/api/tests/service/billing/test_billing_renewal_scheduled_execution.py
+++ b/src/api/tests/service/billing/test_billing_renewal_scheduled_execution.py
@@ -191,7 +191,7 @@ def test_run_billing_renewal_event_queues_subscription_renewal_order(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.renewal.sync_billing_order",
-        lambda app, creator_bid, bill_order_bid, payload: {
+        lambda _app, creator_bid, bill_order_bid, _payload: {
             "status": "pending",
             "creator_bid": creator_bid,
             "bill_order_bid": bill_order_bid,

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -172,7 +172,7 @@ def billing_test_client(monkeypatch):
     monkeypatch.setattr(
         billing_routes_module,
         "clear_admin_creator_customization_draft",
-        lambda *args, **kwargs: {"status": "noop"},
+        lambda *_args, **_kwargs: {"status": "noop"},
     )
 
     register_billing_routes(app=app)

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -946,18 +946,22 @@ def test_deliver_subscription_purchase_sms_marks_sent_and_stays_idempotent(
     cycle_end_at = datetime(2026, 5, 20, 0, 0, 0)
     captured: list[dict[str, object]] = []
 
+    def capture_sms(
+        app, mobile, *, template_code, template_params, sign_name=None
+    ) -> SimpleNamespace:
+        del app, sign_name
+        captured.append(
+            {
+                "mobile": mobile,
+                "template_code": template_code,
+                "template_params": dict(template_params),
+            }
+        )
+        return SimpleNamespace(ok=True)
+
     monkeypatch.setattr(
         "flaskr.service.billing.notifications.send_sms_ali",
-        lambda _app, mobile, *, template_code, template_params, _sign_name=None: (
-            captured.append(
-                {
-                    "mobile": mobile,
-                    "template_code": template_code,
-                    "template_params": dict(template_params),
-                }
-            )
-            or SimpleNamespace(ok=True)
-        ),
+        capture_sms,
     )
 
     with app.app_context():
@@ -1111,11 +1115,15 @@ def test_send_subscription_purchase_sms_task_raises_retryable_error_on_provider_
         "app",
         types.SimpleNamespace(create_app=lambda: app),
     )
+
+    def fail_sms(
+        app, mobile, *, template_code, template_params, sign_name=None
+    ) -> None:
+        del app, mobile, template_code, template_params, sign_name
+
     monkeypatch.setattr(
         "flaskr.service.billing.notifications.send_sms_ali",
-        lambda _app, _mobile, *, _template_code, _template_params, _sign_name=None: (
-            None
-        ),
+        fail_sms,
     )
 
     with pytest.raises(SubscriptionPurchaseSmsRetryableError):

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -282,11 +282,11 @@ def test_sync_billing_order_enqueues_subscription_purchase_sms_once(
 
     monkeypatch.setattr(
         "flaskr.service.billing.checkout.get_payment_provider",
-        lambda channel: FakeStripeProvider(),
+        lambda _channel: FakeStripeProvider(),
     )
     monkeypatch.setattr(
         "flaskr.service.billing.paid_side_effects._enqueue_subscription_purchase_sms",
-        lambda app, *, bill_order_bid: (
+        lambda _app, *, bill_order_bid: (
             enqueued.append(bill_order_bid) or {"status": "enqueued"}
         ),
     )
@@ -342,7 +342,7 @@ def test_stripe_subscription_webhook_enqueues_subscription_purchase_sms_once(
 
     monkeypatch.setattr(
         "flaskr.service.billing.paid_side_effects._enqueue_subscription_purchase_sms",
-        lambda app, *, bill_order_bid: (
+        lambda _app, *, bill_order_bid: (
             enqueued.append(bill_order_bid) or {"status": "enqueued"}
         ),
     )
@@ -435,15 +435,24 @@ def test_sync_billing_order_enqueues_subscription_paid_feishu_once(
 
     monkeypatch.setattr(
         "flaskr.service.billing.checkout.get_payment_provider",
-        lambda channel: FakeStripeProvider(),
+        lambda _channel: FakeStripeProvider(),
     )
+
+    def enqueue_subscription_purchase_sms(
+        app: object,
+        *,
+        bill_order_bid: str,
+    ) -> dict[str, str]:
+        del app, bill_order_bid
+        return {"status": "enqueued"}
+
     monkeypatch.setattr(
         "flaskr.service.billing.paid_side_effects._enqueue_subscription_purchase_sms",
-        lambda app, *, bill_order_bid: {"status": "enqueued"},
+        enqueue_subscription_purchase_sms,
     )
     monkeypatch.setattr(
         "flaskr.service.billing.paid_side_effects._enqueue_billing_paid_feishu",
-        lambda app, *, bill_order_bid: (
+        lambda _app, *, bill_order_bid: (
             enqueued.append(bill_order_bid) or {"status": "enqueued"}
         ),
     )
@@ -512,7 +521,7 @@ def test_pingxx_topup_webhook_enqueues_billing_paid_feishu_once(
 
     monkeypatch.setattr(
         "flaskr.service.billing.paid_side_effects._enqueue_billing_paid_feishu",
-        lambda app, *, bill_order_bid: (
+        lambda _app, *, bill_order_bid: (
             enqueued.append(bill_order_bid) or {"status": "enqueued"}
         ),
     )
@@ -596,11 +605,11 @@ def test_sync_billing_topup_enqueues_billing_paid_feishu_once(
 
     monkeypatch.setattr(
         "flaskr.service.billing.checkout.get_payment_provider",
-        lambda channel: FakePingxxProvider(),
+        lambda _channel: FakePingxxProvider(),
     )
     monkeypatch.setattr(
         "flaskr.service.billing.paid_side_effects._enqueue_billing_paid_feishu",
-        lambda app, *, bill_order_bid: (
+        lambda _app, *, bill_order_bid: (
             enqueued.append(bill_order_bid) or {"status": "enqueued"}
         ),
     )
@@ -681,7 +690,7 @@ def test_sync_pingxx_order_syncs_manual_trial_subscription_provider(
 
     monkeypatch.setattr(
         "flaskr.service.billing.checkout.get_payment_provider",
-        lambda channel: FakePingxxProvider(),
+        lambda _channel: FakePingxxProvider(),
     )
 
     with app.app_context():
@@ -771,7 +780,7 @@ def test_send_billing_paid_feishu_task_marks_sent(
     )
     monkeypatch.setattr(
         "flaskr.service.billing.notifications.send_notify",
-        lambda app, title, msgs: (
+        lambda _app, title, msgs: (
             captured.append({"title": title, "msgs": list(msgs)}) or {"ok": True}
         ),
     )
@@ -853,7 +862,7 @@ def test_send_billing_paid_feishu_task_raises_retryable_error_on_provider_failur
     )
     monkeypatch.setattr(
         "flaskr.service.billing.notifications.send_notify",
-        lambda app, title, msgs: None,
+        lambda _app, _title, _msgs: None,
     )
 
     with app.app_context():
@@ -895,7 +904,7 @@ def test_send_billing_paid_feishu_task_retries_failed_provider_notification(
     )
     monkeypatch.setattr(
         "flaskr.service.billing.notifications.send_notify",
-        lambda app, title, msgs: (
+        lambda _app, title, msgs: (
             captured.append({"title": title, "msgs": list(msgs)}) or {"ok": True}
         ),
     )
@@ -939,7 +948,7 @@ def test_deliver_subscription_purchase_sms_marks_sent_and_stays_idempotent(
 
     monkeypatch.setattr(
         "flaskr.service.billing.notifications.send_sms_ali",
-        lambda app, mobile, *, template_code, template_params, sign_name=None: (
+        lambda _app, mobile, *, template_code, template_params, _sign_name=None: (
             captured.append(
                 {
                     "mobile": mobile,
@@ -1104,7 +1113,9 @@ def test_send_subscription_purchase_sms_task_raises_retryable_error_on_provider_
     )
     monkeypatch.setattr(
         "flaskr.service.billing.notifications.send_sms_ali",
-        lambda app, mobile, *, template_code, template_params, sign_name=None: None,
+        lambda _app, _mobile, *, _template_code, _template_params, _sign_name=None: (
+            None
+        ),
     )
 
     with pytest.raises(SubscriptionPurchaseSmsRetryableError):
@@ -1135,9 +1146,14 @@ def test_requeue_subscription_purchase_sms_enqueues_failed_provider_order(
             captured_kwargs.append(dict(kwargs))
 
     fake_celery = SimpleNamespace(tasks={SUBSCRIPTION_SMS_TASK_NAME: FakeTask()})
+
+    def get_celery_app(flask_app: object | None = None) -> object:
+        del flask_app
+        return fake_celery
+
     monkeypatch.setattr(
         "flaskr.common.celery_app.get_celery_app",
-        lambda flask_app=None: fake_celery,
+        get_celery_app,
     )
 
     with app.app_context():

--- a/src/api/tests/service/billing/test_billing_tasks.py
+++ b/src/api/tests/service/billing/test_billing_tasks.py
@@ -142,7 +142,7 @@ def test_settle_usage_task_normalizes_empty_creator_bid(
     _install_fake_app_module(monkeypatch, fake_app)
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.settle_bill_usage",
-        lambda app, *, usage_bid="": {"status": "noop", "usage_bid": usage_bid},
+        lambda _app, *, usage_bid="": {"status": "noop", "usage_bid": usage_bid},
     )
 
     payload = settle_usage_task(creator_bid="  ", usage_bid="usage-task-2")
@@ -520,7 +520,7 @@ def test_settle_usage_task_serializes_same_creator_concurrent_usage(
     _install_fake_app_module(monkeypatch, billing_task_integration_app)
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-concurrent-1",
+        lambda _app, _usage: "creator-concurrent-1",
     )
     dummy_cache = _ThreadLockCacheProvider()
     monkeypatch.setattr("flaskr.service.billing.settlement.cache_provider", dummy_cache)
@@ -1178,7 +1178,7 @@ def test_dispatch_due_renewal_events_task_noops_when_disabled(
     _install_fake_app_module(monkeypatch, billing_task_integration_app)
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.get_config",
-        lambda key, default="": json.dumps(
+        lambda _key, _default="": json.dumps(
             {
                 "enabled": 0,
                 "batch_size": 5,
@@ -1215,7 +1215,7 @@ def test_dispatch_due_renewal_events_task_enqueues_due_pending_events_only(
     _install_fake_app_module(monkeypatch, billing_task_integration_app)
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.get_config",
-        lambda key, default="": json.dumps(
+        lambda _key, _default="": json.dumps(
             {
                 "enabled": 1,
                 "batch_size": 2,
@@ -1376,7 +1376,7 @@ def test_dispatch_due_renewal_events_recovers_stale_processing_events(
     _install_fake_app_module(monkeypatch, billing_task_integration_app)
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.get_config",
-        lambda key, default="": json.dumps(
+        lambda _key, _default="": json.dumps(
             {
                 "enabled": 1,
                 "batch_size": 5,
@@ -1470,7 +1470,7 @@ def test_dispatch_due_renewal_events_uses_dedicated_queue_when_enabled(
     _install_fake_app_module(monkeypatch, billing_task_integration_app)
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.get_config",
-        lambda key, default="": json.dumps(
+        lambda _key, _default="": json.dumps(
             {
                 "enabled": 1,
                 "batch_size": 5,
@@ -1534,7 +1534,7 @@ def test_billing_task_entrypoints_return_json_serializable_payloads(
     _install_fake_app_module(monkeypatch, fake_app)
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.settle_bill_usage",
-        lambda app, *, usage_bid="": {
+        lambda _app, *, usage_bid="": {
             "status": "settled",
             "usage_bid": usage_bid,
             "creator_bid": "creator-json-1",
@@ -1542,7 +1542,7 @@ def test_billing_task_entrypoints_return_json_serializable_payloads(
     )
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.expire_credit_wallet_buckets",
-        lambda app, *, creator_bid="", expire_before=None: {
+        lambda _app, *, creator_bid="", expire_before=None: {
             "status": "expired",
             "creator_bid": creator_bid,
             "expire_before": expire_before.isoformat() if expire_before else None,
@@ -1550,7 +1550,7 @@ def test_billing_task_entrypoints_return_json_serializable_payloads(
     )
     monkeypatch.setattr(
         "flaskr.service.billing.tasks._run_reconcile_provider_reference",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "paid",
             "bill_order_bid": kwargs.get("bill_order_bid"),
         },
@@ -1582,7 +1582,7 @@ def test_run_renewal_event_task_delegates_to_renewal_runner(
     _install_fake_app_module(monkeypatch, fake_app)
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.run_billing_renewal_event",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "applied",
             "renewal_event_bid": kwargs["renewal_event_bid"],
             "event_status": "succeeded",
@@ -1659,7 +1659,7 @@ def test_retry_failed_renewal_task_delegates_to_renewal_helper_without_reference
     _install_fake_app_module(monkeypatch, fake_app)
     monkeypatch.setattr(
         "flaskr.service.billing.tasks.retry_billing_renewal_event",
-        lambda app, **kwargs: {
+        lambda _app, **kwargs: {
             "status": "paid",
             "bill_order_bid": "bill-order-task-retry-auto",
             "renewal_event_bid": kwargs["renewal_event_bid"],

--- a/src/api/tests/service/billing/test_billing_v11_upgrade_validation.py
+++ b/src/api/tests/service/billing/test_billing_v11_upgrade_validation.py
@@ -82,7 +82,7 @@ def test_billing_v11_upgrade_can_backfill_new_views_from_v1_source_rows(
     now = datetime(2026, 4, 8, 12, 0, 0)
     monkeypatch.setattr(
         "flaskr.service.billing.daily_aggregates.resolve_usage_creator_bid",
-        lambda app, usage: "creator-upgrade-1",
+        lambda _app, _usage: "creator-upgrade-1",
     )
 
     with billing_v11_upgrade_app.app_context():

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_usage.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_usage.py
@@ -48,7 +48,7 @@ def test_usage_split_and_bucket_expiry_keep_wallet_bucket_and_ledger_consistent(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-consistency-1",
+        lambda _app, _usage: "creator-consistency-1",
     )
 
     with billing_wallet_lifecycle_app.app_context():

--- a/src/api/tests/service/billing/test_creator_customization.py
+++ b/src/api/tests/service/billing/test_creator_customization.py
@@ -995,7 +995,7 @@ def test_custom_wechat_identifiers_are_scoped_by_app_id(app, monkeypatch):
     monkeypatch.setattr(
         user_service,
         "resolve_creator_public_integrations",
-        lambda creator_bid: {"wechat_oauth": {"app_id": "wx-owner-1"}},
+        lambda _creator_bid: {"wechat_oauth": {"app_id": "wx-owner-1"}},
     )
     try:
         assert user_service._wechat_identifiers(app, "openid-1", "unionid-1") == (
@@ -1013,7 +1013,7 @@ def test_custom_wechat_identifiers_fail_when_integration_resolution_fails(
     monkeypatch.setattr(
         user_service,
         "resolve_creator_public_integrations",
-        lambda creator_bid: (_ for _ in ()).throw(RuntimeError("resolver failed")),
+        lambda _creator_bid: (_ for _ in ()).throw(RuntimeError("resolver failed")),
     )
     try:
         with pytest.raises(RuntimeError, match="resolver failed"):
@@ -1027,7 +1027,7 @@ def test_custom_wechat_identifiers_require_custom_app_id(app, monkeypatch):
     monkeypatch.setattr(
         user_service,
         "resolve_creator_public_integrations",
-        lambda creator_bid: {"wechat_oauth": {"app_id": ""}},
+        lambda _creator_bid: {"wechat_oauth": {"app_id": ""}},
     )
     try:
         with pytest.raises(RuntimeError, match="missing app_id"):

--- a/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
@@ -107,7 +107,7 @@ def _neutralize_savepoints_on_sqlite(monkeypatch):
 
     from sqlalchemy.orm import Session
 
-    monkeypatch.setattr(Session, "begin_nested", lambda self: nullcontext())
+    monkeypatch.setattr(Session, "begin_nested", lambda _self: nullcontext())
 
 
 def _seed_creator(

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -360,7 +360,7 @@ def test_credit_granted_notification_stages_once_and_delivers_sms(
 
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.send_sms_ali",
-        lambda app, mobile, *, template_code, template_params, sign_name=None: (
+        lambda _app, mobile, *, template_code, template_params, sign_name=None: (  # noqa: ARG005 -- preserve send_sms_ali keyword contract
             captured.append(
                 {
                     "mobile": mobile,
@@ -428,7 +428,7 @@ def test_credit_notification_policy_blocks_creator_by_email_identifier(
     )
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.send_sms_ali",
-        lambda *args, **kwargs: pytest.fail("blocked notification should not send"),
+        lambda *_args, **_kwargs: pytest.fail("blocked notification should not send"),
     )
     with app.app_context():
         _seed_credit_ledger()
@@ -480,19 +480,28 @@ def test_credit_notification_delivery_normalizes_legacy_iso_expires_at(
         }
         dao.db.session.commit()
 
+    def send_sms(
+        app: object,
+        mobile: str,
+        *,
+        template_code: str,
+        template_params: dict[str, object],
+        sign_name: str | None = None,
+    ) -> SimpleNamespace:
+        del app, mobile, template_code, sign_name
+        captured.append(dict(template_params))
+        return SimpleNamespace(
+            body=SimpleNamespace(
+                code="OK",
+                message="accepted",
+                request_id="req-legacy",
+                biz_id="biz-legacy",
+            )
+        )
+
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.send_sms_ali",
-        lambda app, mobile, *, template_code, template_params, sign_name=None: (
-            captured.append(dict(template_params))
-            or SimpleNamespace(
-                body=SimpleNamespace(
-                    code="OK",
-                    message="accepted",
-                    request_id="req-legacy",
-                    biz_id="biz-legacy",
-                )
-            )
-        ),
+        send_sms,
     )
 
     delivered = deliver_credit_notification(
@@ -718,7 +727,7 @@ def test_sync_credit_notification_template_persists_aliyun_template(
 
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.get_sms_template_ali",
-        lambda app, *, template_code: SimpleNamespace(
+        lambda _app, *, template_code: SimpleNamespace(
             body=SimpleNamespace(
                 code="OK",
                 message="OK",
@@ -801,9 +810,15 @@ def test_list_credit_notification_templates_syncs_provider_list(
         ALIBABA_CLOUD_SMS_ACCESS_KEY_ID=f"test-key-{secrets.token_hex(4)}",
         ALIBABA_CLOUD_SMS_ACCESS_KEY_SECRET=secrets.token_urlsafe(24),
     )
-    monkeypatch.setattr(
-        "flaskr.service.billing.credit_notifications.query_sms_template_list_ali",
-        lambda app, *, page_index, page_size: SimpleNamespace(
+
+    def query_templates(
+        app: object,
+        *,
+        page_index: int,
+        page_size: int,
+    ) -> SimpleNamespace:
+        del app, page_index, page_size
+        return SimpleNamespace(
             body=SimpleNamespace(
                 code="OK",
                 message="OK",
@@ -821,7 +836,11 @@ def test_list_credit_notification_templates_syncs_provider_list(
                     )
                 ],
             )
-        ),
+        )
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.credit_notifications.query_sms_template_list_ali",
+        query_templates,
     )
 
     payload = list_credit_notification_templates(app)
@@ -917,15 +936,20 @@ def test_credit_notification_policy_revalidates_cached_template_with_provider(
         template_code="TPL-DELETED",
         placeholders=["credits"],
     )
-    monkeypatch.setattr(
-        "flaskr.service.billing.credit_notifications.get_sms_template_ali",
-        lambda app, *, template_code: SimpleNamespace(
+
+    def get_template(app: object, *, template_code: str) -> SimpleNamespace:
+        del app, template_code
+        return SimpleNamespace(
             body=SimpleNamespace(
                 code="isv.SMS_TEMPLATE_ILLEGAL",
                 message="template not found",
                 request_id="req-deleted",
             )
-        ),
+        )
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.credit_notifications.get_sms_template_ali",
+        get_template,
     )
 
     with pytest.raises(AppError):
@@ -1078,7 +1102,7 @@ def test_credit_notification_skips_creator_without_mobile(
     enqueue_calls: list[str] = []
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
-        lambda app, *, notification_bid: enqueue_calls.append(notification_bid),
+        lambda _app, *, notification_bid: enqueue_calls.append(notification_bid),
     )
     with app.app_context():
         _seed_credit_ledger(
@@ -1139,7 +1163,7 @@ def test_credit_notification_skips_invalid_mobile(
     enqueue_calls: list[str] = []
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
-        lambda app, *, notification_bid: enqueue_calls.append(notification_bid),
+        lambda _app, *, notification_bid: enqueue_calls.append(notification_bid),
     )
     with app.app_context():
         _seed_credit_ledger(
@@ -1614,7 +1638,7 @@ def test_expiring_and_low_balance_scans_stage_deduped_notifications(
     _enable_policy(app)
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
-        lambda app, *, notification_bid: {
+        lambda _app, *, notification_bid: {
             "status": "enqueued",
             "notification_bid": notification_bid,
             "enqueued": True,
@@ -1664,7 +1688,7 @@ def test_expiring_scan_merges_same_creator_buckets(
     _enable_policy(app)
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
-        lambda app, *, notification_bid: {
+        lambda _app, *, notification_bid: {
             "status": "enqueued",
             "notification_bid": notification_bid,
             "enqueued": True,
@@ -1792,7 +1816,7 @@ def test_low_balance_estimated_days_scan_uses_daily_ledger_summary(
     )
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
-        lambda app, *, notification_bid: {
+        lambda _app, *, notification_bid: {
             "status": "enqueued",
             "notification_bid": notification_bid,
             "enqueued": True,
@@ -1885,7 +1909,7 @@ def test_low_balance_estimated_days_uses_fallback_fixed_threshold_when_history_i
     )
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
-        lambda app, *, notification_bid: {
+        lambda _app, *, notification_bid: {
             "status": "enqueued",
             "notification_bid": notification_bid,
             "enqueued": True,
@@ -1934,7 +1958,7 @@ def test_low_balance_estimated_days_skips_when_valid_daily_consumption_is_missin
     enqueue_calls: list[str] = []
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
-        lambda app, *, notification_bid: enqueue_calls.append(notification_bid),
+        lambda _app, *, notification_bid: enqueue_calls.append(notification_bid),
     )
 
     with app.app_context():
@@ -1974,7 +1998,7 @@ def test_low_balance_scan_skips_zero_balance_without_estimated_remaining_days(
     enqueue_calls: list[str] = []
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
-        lambda app, *, notification_bid: enqueue_calls.append(notification_bid),
+        lambda _app, *, notification_bid: enqueue_calls.append(notification_bid),
     )
 
     with app.app_context():
@@ -2016,7 +2040,7 @@ def test_low_balance_scan_skips_template_params_missing_for_mode(
     enqueue_calls: list[str] = []
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
-        lambda app, *, notification_bid: enqueue_calls.append(notification_bid),
+        lambda _app, *, notification_bid: enqueue_calls.append(notification_bid),
     )
 
     with app.app_context():
@@ -2050,7 +2074,7 @@ def test_low_balance_delivery_skips_zero_balance_without_estimated_remaining_day
     send_calls: list[dict[str, object]] = []
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.send_sms_ali",
-        lambda app, mobile, *, template_code, template_params, sign_name=None: (
+        lambda _app, mobile, *, template_code, template_params, sign_name=None: (  # noqa: ARG005 -- preserve send_sms_ali keyword contract
             send_calls.append(
                 {
                     "mobile": mobile,
@@ -2127,7 +2151,7 @@ def test_low_balance_delivery_skips_template_params_missing_for_mode(
     send_calls: list[dict[str, object]] = []
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.send_sms_ali",
-        lambda app, mobile, *, template_code, template_params, sign_name=None: (
+        lambda _app, mobile, *, template_code, template_params, sign_name=None: (  # noqa: ARG005 -- preserve send_sms_ali keyword contract
             send_calls.append(
                 {
                     "mobile": mobile,
@@ -2201,18 +2225,21 @@ def test_failed_provider_notification_can_be_requeued(
         def apply_async(self, kwargs):
             captured_kwargs.append(dict(kwargs))
 
+    def get_celery_app(flask_app: object | None = None) -> object:
+        del flask_app
+        return SimpleNamespace(tasks={"billing.send_credit_notification": FakeTask()})
+
+    def sms_no_response(app, mobile, *, template_code, template_params, sign_name=None):
+        del app, mobile, template_code, template_params, sign_name
+
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.send_sms_ali",
-        lambda app, mobile, *, template_code, template_params, sign_name=None: None,
+        sms_no_response,
     )
     monkeypatch.setitem(
         sys.modules,
         "flaskr.common.celery_app",
-        SimpleNamespace(
-            get_celery_app=lambda flask_app=None: SimpleNamespace(
-                tasks={"billing.send_credit_notification": FakeTask()}
-            )
-        ),
+        SimpleNamespace(get_celery_app=get_celery_app),
     )
 
     with app.app_context():
@@ -2249,13 +2276,17 @@ def test_requeue_keeps_failed_status_when_enqueue_fails(
     app = credit_notifications_app
     _seed_creator(app)
     _enable_policy(app)
+
+    def sms_no_response(app, mobile, *, template_code, template_params, sign_name=None):
+        del app, mobile, template_code, template_params, sign_name
+
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.send_sms_ali",
-        lambda app, mobile, *, template_code, template_params, sign_name=None: None,
+        sms_no_response,
     )
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
-        lambda app, *, notification_bid: {
+        lambda _app, *, notification_bid: {
             "status": "enqueue_failed",
             "notification_bid": notification_bid,
             "enqueued": False,
@@ -2292,13 +2323,17 @@ def test_requeue_records_operator_audit_metadata(
     app = credit_notifications_app
     _seed_creator(app)
     _enable_policy(app)
+
+    def sms_no_response(app, mobile, *, template_code, template_params, sign_name=None):
+        del app, mobile, template_code, template_params, sign_name
+
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.send_sms_ali",
-        lambda app, mobile, *, template_code, template_params, sign_name=None: None,
+        sms_no_response,
     )
     monkeypatch.setattr(
         "flaskr.service.billing.credit_notifications.enqueue_credit_notification",
-        lambda app, *, notification_bid: {
+        lambda _app, *, notification_bid: {
             "status": "enqueued",
             "notification_bid": notification_bid,
             "enqueued": True,
@@ -2379,7 +2414,7 @@ def test_send_credit_notification_task_raises_retryable_on_provider_failure(
     )
     monkeypatch.setattr(
         "flaskr.service.billing.tasks._deliver_credit_notification",
-        lambda app, *, notification_bid: {
+        lambda _app, *, notification_bid: {
             "status": CREDIT_NOTIFICATION_STATUS_FAILED_PROVIDER,
             "notification_bid": notification_bid,
             "error_code": "provider_failed",
@@ -2401,7 +2436,7 @@ def test_send_credit_notification_task_does_not_retry_config_failure(
     )
     monkeypatch.setattr(
         "flaskr.service.billing.tasks._deliver_credit_notification",
-        lambda app, *, notification_bid: {
+        lambda _app, *, notification_bid: {
             "status": CREDIT_NOTIFICATION_STATUS_FAILED_PROVIDER,
             "notification_bid": notification_bid,
             "error_code": "missing_template_code",

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -90,7 +90,7 @@ def runtime_config_client(monkeypatch):
     )
     monkeypatch.setattr(
         "flaskr.common.shifu_context._get_shifu_creator_bid_cached",
-        lambda app, shifu_bid: "creator-1" if shifu_bid == "shifu-1" else None,
+        lambda _app, shifu_bid: "creator-1" if shifu_bid == "shifu-1" else None,
     )
 
     config_route.register_config_handler(app, "/api")
@@ -230,7 +230,7 @@ def test_runtime_config_hides_creator_keys_without_matching_capability(
     monkeypatch.setattr(
         config_route,
         "resolve_creator_public_integrations",
-        lambda creator_bid: {
+        lambda _creator_bid: {
             "wechat_oauth": {"app_id": "wx-custom"},
             "stripe": {"publishable_key": "pk_creator"},
         },
@@ -456,13 +456,13 @@ def test_runtime_billing_builder_and_route_config_use_dto_outputs(
 def test_default_runtime_billing_context_is_database_free(monkeypatch) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.runtime_config.resolve_creator_entitlement_state",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
             AssertionError("entitlement resolver must not run in default builder")
         ),
     )
     monkeypatch.setattr(
         "flaskr.service.billing.runtime_config.resolve_runtime_domain_result",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
             AssertionError("domain resolver must not run in default builder")
         ),
     )
@@ -515,7 +515,7 @@ def test_runtime_config_reports_disabled_billing_flag(
     monkeypatch.setattr(
         config_route,
         "build_runtime_billing_context",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
             AssertionError("billing builder should not run when disabled")
         ),
     )
@@ -555,7 +555,7 @@ def test_runtime_config_falls_back_when_billing_context_build_fails(
     monkeypatch.setattr(
         config_route,
         "build_runtime_billing_context",
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
     )
 
     response = runtime_config_client.get(

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -305,7 +305,7 @@ def test_settle_llm_usage_consumes_multi_metric_in_bucket_priority_order(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-1",
+        lambda _app, _usage: "creator-1",
     )
 
     with billing_settlement_app.app_context():
@@ -425,7 +425,7 @@ def test_settle_usage_rounds_consumption_before_persisting(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-rounding",
+        lambda _app, _usage: "creator-rounding",
     )
     monkeypatch.setattr(
         "flaskr.service.billing.primitives.get_config",
@@ -490,7 +490,7 @@ def test_settle_usage_writes_zero_amount_bill_when_consumption_quantizes_to_zero
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-zero-bill",
+        lambda _app, _usage: "creator-zero-bill",
     )
     monkeypatch.setattr(
         "flaskr.service.billing.primitives.get_config",
@@ -561,7 +561,7 @@ def test_settle_tts_usage_is_idempotent(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-2",
+        lambda _app, _usage: "creator-2",
     )
 
     with billing_settlement_app.app_context():
@@ -623,7 +623,7 @@ def test_settle_tts_usage_supports_char_mode_when_request_rate_missing(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-tts-char",
+        lambda _app, _usage: "creator-tts-char",
     )
 
     with billing_settlement_app.app_context():
@@ -684,7 +684,7 @@ def test_settle_usage_consumes_manual_grant_without_subscription_and_skips_topup
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-manual-settlement",
+        lambda _app, _usage: "creator-manual-settlement",
     )
 
     with billing_settlement_app.app_context():
@@ -756,7 +756,7 @@ def test_settle_usage_prefers_exact_rate_over_wildcard(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-3",
+        lambda _app, _usage: "creator-3",
     )
 
     with billing_settlement_app.app_context():
@@ -827,7 +827,7 @@ def test_settle_usage_applies_scene_specific_rate_and_records_scene_metadata(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-scene-settlement",
+        lambda _app, _usage: "creator-scene-settlement",
     )
 
     with billing_settlement_app.app_context():
@@ -905,7 +905,7 @@ def test_settle_usage_rebuilds_wallet_snapshot_from_bucket_balances(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-5",
+        lambda _app, _usage: "creator-5",
     )
 
     with billing_settlement_app.app_context():
@@ -973,7 +973,7 @@ def test_settle_usage_prefers_earliest_expiry_then_oldest_created_in_same_priori
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-6",
+        lambda _app, _usage: "creator-6",
     )
 
     with billing_settlement_app.app_context():
@@ -1063,7 +1063,7 @@ def test_settle_usage_skips_segment_and_non_billable_records(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-4",
+        lambda _app, _usage: "creator-4",
     )
 
     with billing_settlement_app.app_context():
@@ -1144,7 +1144,7 @@ def test_settle_usage_acquires_creator_scoped_lock(
 
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-lock-1",
+        lambda _app, _usage: "creator-lock-1",
     )
     dummy_cache = _DummyCacheProvider()
     monkeypatch.setattr("flaskr.service.billing.settlement.cache_provider", dummy_cache)
@@ -1216,15 +1216,17 @@ def test_settle_usage_releases_creator_lock_on_error(
     lock = _DummyLock()
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.cache_provider",
-        SimpleNamespace(lock=lambda *args, **kwargs: lock),
+        SimpleNamespace(lock=lambda *_args, **_kwargs: lock),
     )
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-lock-err",
+        lambda _app, _usage: "creator-lock-err",
     )
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.build_usage_metric_charges",
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("lock-test-error")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("lock-test-error")
+        ),
     )
 
     with billing_settlement_app.app_context():
@@ -1283,7 +1285,7 @@ def test_replay_bill_usage_settlement_keeps_existing_consumption_idempotent(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-replay-1",
+        lambda _app, _usage: "creator-replay-1",
     )
 
     with billing_settlement_app.app_context():
@@ -1343,7 +1345,7 @@ def test_replay_bill_usage_settlement_rejects_creator_mismatch(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-replay-real",
+        lambda _app, _usage: "creator-replay-real",
     )
 
     with billing_settlement_app.app_context():
@@ -1378,7 +1380,7 @@ def test_backfill_bill_usage_settlement_replays_one_usage_range_safely(
 ) -> None:
     monkeypatch.setattr(
         "flaskr.service.billing.settlement.resolve_usage_creator_bid",
-        lambda app, usage: "creator-backfill-1",
+        lambda _app, _usage: "creator-backfill-1",
     )
 
     with billing_settlement_app.app_context():

--- a/src/api/tests/service/common/test_umami_client.py
+++ b/src/api/tests/service/common/test_umami_client.py
@@ -212,7 +212,7 @@ def test_get_course_visit_count_30d_returns_fetched_value_when_cache_write_fails
     monkeypatch.setattr(
         umami_client,
         "_fetch_distinct_ids_for_event",
-        lambda **kwargs: 7,
+        lambda **_kwargs: 7,
     )
 
     with app.app_context():
@@ -258,7 +258,7 @@ def test_get_course_visit_count_30d_returns_zero_when_failure_cache_write_fails(
     monkeypatch.setattr(
         umami_client,
         "_fetch_distinct_ids_for_event",
-        lambda **kwargs: (_ for _ in ()).throw(
+        lambda **_kwargs: (_ for _ in ()).throw(
             requests.RequestException("umami unavailable")
         ),
     )
@@ -311,7 +311,7 @@ def test_get_course_visit_count_30d_waits_for_cache_on_lock_contention(
     monkeypatch.setattr(
         umami_client,
         "_read_cached_int",
-        lambda cache_key: next(read_values),
+        lambda _cache_key: next(read_values),
     )
     monkeypatch.setattr(umami_client.time, "sleep", sleep_calls.append)
 
@@ -392,7 +392,7 @@ def test_login_for_access_token_returns_token_when_cache_write_fails(monkeypatch
     monkeypatch.setattr(
         umami_client.requests,
         "post",
-        lambda *args, **kwargs: SimpleNamespace(
+        lambda *_args, **_kwargs: SimpleNamespace(
             status_code=200,
             raise_for_status=lambda: None,
             json=lambda: {"token": "fresh-token"},

--- a/src/api/tests/service/config/test_funcs.py
+++ b/src/api/tests/service/config/test_funcs.py
@@ -60,7 +60,7 @@ def disable_explicit_env_override(monkeypatch):
     """Default test posture: config helpers should read/write DB-backed values."""
     monkeypatch.setattr(
         "flaskr.service.config.funcs.has_explicit_env_override",
-        lambda key: False,
+        lambda _key: False,
     )
 
 
@@ -189,7 +189,7 @@ def build_runtime_branding():
         "build_google_oauth_callback_url",
         lambda: "https://app.example.com/login/google-callback",
     )
-    monkeypatch.setattr(config_route, "get_config", lambda key, default="": default)
+    monkeypatch.setattr(config_route, "get_config", lambda _key, default="": default)
     monkeypatch.setattr(config_route, "is_billing_enabled", lambda: True)
 
     runtime_billing_context = RuntimeBillingContextDTO(
@@ -214,15 +214,28 @@ def build_runtime_branding():
             creator_bid="creator-plugin",
         ),
     )
+
+    def build_runtime_context(
+        flask_app: object,
+        creator_bid: str,
+        request_host: str,
+    ) -> object:
+        del flask_app, creator_bid, request_host
+        return runtime_billing_context
+
+    def build_default_runtime_context(creator_bid: str, request_host: str) -> object:
+        del creator_bid, request_host
+        return runtime_billing_context
+
     monkeypatch.setattr(
         config_route,
         "build_runtime_billing_context",
-        lambda flask_app, creator_bid, request_host: runtime_billing_context,
+        build_runtime_context,
     )
     monkeypatch.setattr(
         config_route,
         "build_default_runtime_billing_context",
-        lambda creator_bid, request_host: runtime_billing_context,
+        build_default_runtime_context,
     )
 
     config_route.register_config_handler(app, "/api")

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -26,7 +26,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.get_model_info = get_model_info
-    litellm_stub.completion = lambda *args, **kwargs: iter([])
+    litellm_stub.completion = lambda *_args, **_kwargs: iter([])
     sys.modules["litellm"] = litellm_stub
 
 
@@ -2597,7 +2597,7 @@ class StreamContentBlockPromptCaptureTests(unittest.TestCase):
         def fake_stream():
             yield from stream_items
 
-        mdflow_context = types.SimpleNamespace(process=lambda **kwargs: fake_stream())
+        mdflow_context = types.SimpleNamespace(process=lambda **_kwargs: fake_stream())
         attend = types.SimpleNamespace(shifu_bid="shifu-prompt-1")
         state = types.SimpleNamespace(
             run_script_info=types.SimpleNamespace(

--- a/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
+++ b/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
@@ -54,7 +54,7 @@ def test_early_consumer_exit_invalidates_producer_session(app, monkeypatch):
     monkeypatch.setattr(
         context_v2,
         "invalidate_session",
-        lambda *, source, session=None: invalidations.append(source) or True,
+        lambda *, source, _session=None: invalidations.append(source) or True,
     )
 
     stop_streaming = threading.Event()
@@ -88,7 +88,7 @@ def test_natural_exhaustion_does_not_invalidate_producer_session(app, monkeypatc
     monkeypatch.setattr(
         context_v2,
         "invalidate_session",
-        lambda *, source, session=None: invalidations.append(source) or True,
+        lambda *, source, _session=None: invalidations.append(source) or True,
     )
 
     def short_stream():
@@ -118,12 +118,16 @@ def test_tts_finalize_failure_runs_classified_cleanup(app, monkeypatch):
     from sqlalchemy.exc import ResourceClosedError
 
     outcomes = []
+
+    def cleanup_session_after(exc, *, source, session=None):
+        del session
+        outcomes.append((type(exc).__name__, source))
+        return "invalidated"
+
     monkeypatch.setattr(
         context_v2,
         "cleanup_session_after",
-        lambda exc, *, source, session=None: (
-            outcomes.append((type(exc).__name__, source)) or "invalidated"
-        ),
+        cleanup_session_after,
     )
 
     class _FailingProcessor:

--- a/src/api/tests/service/learn/test_handle_input_ask_provider.py
+++ b/src/api/tests/service/learn/test_handle_input_ask_provider.py
@@ -18,7 +18,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.get_model_info = get_model_info
-    litellm_stub.completion = lambda *args, **kwargs: iter([])
+    litellm_stub.completion = lambda *_args, **_kwargs: iter([])
     sys.modules["litellm"] = litellm_stub
 
 

--- a/src/api/tests/service/learn/test_learn_funcs.py
+++ b/src/api/tests/service/learn/test_learn_funcs.py
@@ -198,7 +198,7 @@ class LearnRecordLoadTests(unittest.TestCase):
         ctx = RunScriptContextV2.__new__(RunScriptContextV2)
         ctx.app = self.app
         ctx._trace_args = {}
-        ctx._trace = types.SimpleNamespace(update=lambda **kwargs: None)
+        ctx._trace = types.SimpleNamespace(update=lambda **_kwargs: None)
         ctx._outline_item_info = types.SimpleNamespace(
             bid=progress.outline_item_bid,
             shifu_bid=progress.shifu_bid,
@@ -218,22 +218,24 @@ class LearnRecordLoadTests(unittest.TestCase):
         ctx._element_index_cursor = 0
         ctx._current_attend = progress
         ctx._get_current_attend = types.MethodType(
-            lambda self, outline_bid: progress, ctx
+            lambda _self, _outline_bid: progress, ctx
         )
-        ctx._get_next_outline_item = types.MethodType(lambda self: [], ctx)
+        ctx._get_next_outline_item = types.MethodType(lambda _self: [], ctx)
         ctx.get_llm_settings = types.MethodType(
-            lambda self, outline_bid: LLMSettings(model="fake", temperature=0.0), ctx
+            lambda _self, _outline_bid: LLMSettings(model="fake", temperature=0.0), ctx
         )
-        ctx.get_system_prompt = types.MethodType(lambda self, outline_bid: None, ctx)
-        ctx._get_run_script_info = types.MethodType(
-            lambda self, attend, is_ask=False: RunScriptInfo(
+        ctx.get_system_prompt = types.MethodType(lambda _self, _outline_bid: None, ctx)
+
+        def get_run_script_info(self, attend, *, is_ask=False):
+            del self, is_ask
+            return RunScriptInfo(
                 attend=attend,
                 outline_bid=attend.outline_item_bid,
                 block_position=0,
                 mdflow="doc",
-            ),
-            ctx,
-        )
+            )
+
+        ctx._get_run_script_info = types.MethodType(get_run_script_info, ctx)
 
         class DummyBlock:
             def __init__(self, block_type, content, index) -> None:
@@ -318,7 +320,7 @@ class LearnRecordLoadTests(unittest.TestCase):
         ctx = RunScriptContextV2.__new__(RunScriptContextV2)
         ctx.app = self.app
         ctx._trace_args = {}
-        ctx._trace = types.SimpleNamespace(update=lambda **kwargs: None)
+        ctx._trace = types.SimpleNamespace(update=lambda **_kwargs: None)
         ctx._outline_item_info = types.SimpleNamespace(
             bid=progress.outline_item_bid,
             shifu_bid=progress.shifu_bid,
@@ -339,15 +341,16 @@ class LearnRecordLoadTests(unittest.TestCase):
         ctx._element_index_cursor = 0
         ctx._current_attend = progress
         ctx._get_current_attend = types.MethodType(
-            lambda self, outline_bid: progress, ctx
+            lambda _self, _outline_bid: progress, ctx
         )
-        ctx._get_next_outline_item = types.MethodType(lambda self: [], ctx)
+        ctx._get_next_outline_item = types.MethodType(lambda _self: [], ctx)
         ctx.get_llm_settings = types.MethodType(
-            lambda self, outline_bid: LLMSettings(model="fake", temperature=0.0), ctx
+            lambda _self, _outline_bid: LLMSettings(model="fake", temperature=0.0), ctx
         )
-        ctx.get_system_prompt = types.MethodType(lambda self, outline_bid: None, ctx)
+        ctx.get_system_prompt = types.MethodType(lambda _self, _outline_bid: None, ctx)
+
         ctx._get_run_script_info = types.MethodType(
-            lambda self, attend, is_ask=False: RunScriptInfo(
+            lambda _self, attend, **_kwargs: RunScriptInfo(
                 attend=attend,
                 outline_bid=attend.outline_item_bid,
                 block_position=attend.block_position,
@@ -468,7 +471,7 @@ class LearnRecordLoadTests(unittest.TestCase):
         ctx = RunScriptContextV2.__new__(RunScriptContextV2)
         ctx.app = self.app
         ctx._trace_args = {}
-        ctx._trace = types.SimpleNamespace(update=lambda **kwargs: None)
+        ctx._trace = types.SimpleNamespace(update=lambda **_kwargs: None)
         ctx._outline_item_info = types.SimpleNamespace(
             bid=progress.outline_item_bid,
             shifu_bid=progress.shifu_bid,
@@ -488,15 +491,16 @@ class LearnRecordLoadTests(unittest.TestCase):
         ctx._element_index_cursor = 0
         ctx._current_attend = progress
         ctx._get_current_attend = types.MethodType(
-            lambda self, outline_bid: progress, ctx
+            lambda _self, _outline_bid: progress, ctx
         )
-        ctx._get_next_outline_item = types.MethodType(lambda self: [], ctx)
+        ctx._get_next_outline_item = types.MethodType(lambda _self: [], ctx)
         ctx.get_llm_settings = types.MethodType(
-            lambda self, outline_bid: LLMSettings(model="fake", temperature=0.0), ctx
+            lambda _self, _outline_bid: LLMSettings(model="fake", temperature=0.0), ctx
         )
-        ctx.get_system_prompt = types.MethodType(lambda self, outline_bid: None, ctx)
+        ctx.get_system_prompt = types.MethodType(lambda _self, _outline_bid: None, ctx)
+
         ctx._get_run_script_info = types.MethodType(
-            lambda self, attend, is_ask=False: RunScriptInfo(
+            lambda _self, attend, **_kwargs: RunScriptInfo(
                 attend=attend,
                 outline_bid=attend.outline_item_bid,
                 block_position=0,
@@ -594,7 +598,7 @@ class LearnRecordLoadTests(unittest.TestCase):
         ctx = RunScriptContextV2.__new__(RunScriptContextV2)
         ctx.app = self.app
         ctx._trace_args = {}
-        ctx._trace = types.SimpleNamespace(update=lambda **kwargs: None)
+        ctx._trace = types.SimpleNamespace(update=lambda **_kwargs: None)
         ctx._outline_item_info = types.SimpleNamespace(
             bid=progress.outline_item_bid,
             shifu_bid=progress.shifu_bid,
@@ -614,15 +618,16 @@ class LearnRecordLoadTests(unittest.TestCase):
         ctx._element_index_cursor = 0
         ctx._current_attend = progress
         ctx._get_current_attend = types.MethodType(
-            lambda self, outline_bid: progress, ctx
+            lambda _self, _outline_bid: progress, ctx
         )
-        ctx._get_next_outline_item = types.MethodType(lambda self: [], ctx)
+        ctx._get_next_outline_item = types.MethodType(lambda _self: [], ctx)
         ctx.get_llm_settings = types.MethodType(
-            lambda self, outline_bid: LLMSettings(model="fake", temperature=0.0), ctx
+            lambda _self, _outline_bid: LLMSettings(model="fake", temperature=0.0), ctx
         )
-        ctx.get_system_prompt = types.MethodType(lambda self, outline_bid: None, ctx)
+        ctx.get_system_prompt = types.MethodType(lambda _self, _outline_bid: None, ctx)
+
         ctx._get_run_script_info = types.MethodType(
-            lambda self, attend, is_ask=False: RunScriptInfo(
+            lambda _self, attend, **_kwargs: RunScriptInfo(
                 attend=attend,
                 outline_bid=attend.outline_item_bid,
                 block_position=0,
@@ -716,7 +721,7 @@ class LearnRecordLoadTests(unittest.TestCase):
         ctx = RunScriptContextV2.__new__(RunScriptContextV2)
         ctx.app = self.app
         ctx._trace_args = {}
-        ctx._trace = types.SimpleNamespace(update=lambda **kwargs: None)
+        ctx._trace = types.SimpleNamespace(update=lambda **_kwargs: None)
         ctx._outline_item_info = types.SimpleNamespace(
             bid=progress.outline_item_bid,
             shifu_bid=progress.shifu_bid,
@@ -736,15 +741,16 @@ class LearnRecordLoadTests(unittest.TestCase):
         ctx._element_index_cursor = 0
         ctx._current_attend = progress
         ctx._get_current_attend = types.MethodType(
-            lambda self, outline_bid: progress, ctx
+            lambda _self, _outline_bid: progress, ctx
         )
-        ctx._get_next_outline_item = types.MethodType(lambda self: [], ctx)
+        ctx._get_next_outline_item = types.MethodType(lambda _self: [], ctx)
         ctx.get_llm_settings = types.MethodType(
-            lambda self, outline_bid: LLMSettings(model="fake", temperature=0.0), ctx
+            lambda _self, _outline_bid: LLMSettings(model="fake", temperature=0.0), ctx
         )
-        ctx.get_system_prompt = types.MethodType(lambda self, outline_bid: None, ctx)
+        ctx.get_system_prompt = types.MethodType(lambda _self, _outline_bid: None, ctx)
+
         ctx._get_run_script_info = types.MethodType(
-            lambda self, attend, is_ask=False: RunScriptInfo(
+            lambda _self, attend, **_kwargs: RunScriptInfo(
                 attend=attend,
                 outline_bid=attend.outline_item_bid,
                 block_position=0,

--- a/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
+++ b/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
@@ -15,14 +15,16 @@ from sqlalchemy.exc import ResourceClosedError
 @pytest.fixture
 def invalidations(monkeypatch):
     calls = []
+
+    def release_db_session(app: object, *, source: str) -> None:
+        del app, source
+
     monkeypatch.setattr(
         learn_routes,
         "invalidate_session",
-        lambda *, source, session=None: calls.append(source) or True,
+        lambda *, source, _session=None: calls.append(source) or True,
     )
-    monkeypatch.setattr(
-        learn_routes, "_release_db_session", lambda _app, *, source: None
-    )
+    monkeypatch.setattr(learn_routes, "_release_db_session", release_db_session)
     return calls
 
 

--- a/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
+++ b/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
@@ -20,7 +20,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.get_model_info = get_model_info
-    litellm_stub.completion = lambda *args, **kwargs: iter([])
+    litellm_stub.completion = lambda *_args, **_kwargs: iter([])
     sys.modules["litellm"] = litellm_stub
 
 

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -150,7 +150,7 @@ def test_find_active_element_row_ids_invalidates_desynced_connection(app, monkey
         monkeypatch.setattr(
             listen_element_run_persistence,
             "invalidate_session",
-            lambda *, source, session=None: invalidations.append(source) or True,
+            lambda *, source, _session=None: invalidations.append(source) or True,
         )
 
         with pytest.raises(ResourceClosedError):

--- a/src/api/tests/service/learn/test_listen_elements.py
+++ b/src/api/tests/service/learn/test_listen_elements.py
@@ -541,7 +541,7 @@ def test_get_listen_element_record_returns_all_persisted_elements_across_progres
 
         monkeypatch.setattr(
             "flaskr.service.learn.listen_elements.get_learn_record",
-            lambda *args, **kwargs: pytest.fail(
+            lambda *_args, **_kwargs: pytest.fail(
                 "persisted element query should not fall back to legacy records"
             ),
         )
@@ -676,7 +676,7 @@ def test_get_listen_element_record_keeps_block_order_when_run_sessions_reset_ind
 
         monkeypatch.setattr(
             "flaskr.service.learn.listen_elements.build_legacy_record_for_progress",
-            lambda *args, **kwargs: LegacyLearnRecord(
+            lambda *_args, **_kwargs: LegacyLearnRecord(
                 records=[
                     LegacyGeneratedBlockRecord(
                         "generated-block-first",
@@ -697,7 +697,7 @@ def test_get_listen_element_record_keeps_block_order_when_run_sessions_reset_ind
         )
         monkeypatch.setattr(
             "flaskr.service.learn.listen_elements.get_learn_record",
-            lambda *args, **kwargs: pytest.fail(
+            lambda *_args, **_kwargs: pytest.fail(
                 "persisted element query should not fall back to legacy records"
             ),
         )
@@ -1049,7 +1049,7 @@ def test_get_listen_element_record_dedupes_older_progress_records_with_same_bloc
 
         monkeypatch.setattr(
             "flaskr.service.learn.listen_elements.get_learn_record",
-            lambda *args, **kwargs: pytest.fail(
+            lambda *_args, **_kwargs: pytest.fail(
                 "persisted element query should not fall back to legacy records"
             ),
         )
@@ -1282,11 +1282,11 @@ def test_get_listen_element_record_includes_persisted_rows_missing_progress_bid(
 
         monkeypatch.setattr(
             "flaskr.service.learn.listen_elements.build_legacy_record_for_progress",
-            lambda *args, **kwargs: LegacyLearnRecord(records=[]),
+            lambda *_args, **_kwargs: LegacyLearnRecord(records=[]),
         )
         monkeypatch.setattr(
             "flaskr.service.learn.listen_elements.get_learn_record",
-            lambda *args, **kwargs: pytest.fail(
+            lambda *_args, **_kwargs: pytest.fail(
                 "persisted rows should satisfy the record query without legacy fallback"
             ),
         )
@@ -1353,7 +1353,7 @@ def test_listen_run_persists_content_block_before_element_rows(app):
         ctx = RunScriptContextV2.__new__(RunScriptContextV2)
         ctx.app = app
         ctx._trace_args = {}
-        ctx._trace = types.SimpleNamespace(update=lambda **kwargs: None)
+        ctx._trace = types.SimpleNamespace(update=lambda **_kwargs: None)
         ctx._outline_item_info = types.SimpleNamespace(
             bid=outline_bid,
             shifu_bid=shifu_bid,
@@ -1374,22 +1374,23 @@ def test_listen_run_persists_content_block_before_element_rows(app):
         ctx._element_index_cursor = 0
         ctx._current_attend = progress
         ctx._get_current_attend = types.MethodType(
-            lambda self, current_outline_bid: progress, ctx
+            lambda _self, _current_outline_bid: progress, ctx
         )
-        ctx._get_next_outline_item = types.MethodType(lambda self: [], ctx)
+        ctx._get_next_outline_item = types.MethodType(lambda _self: [], ctx)
         ctx.get_llm_settings = types.MethodType(
-            lambda self, current_outline_bid: LLMSettings(
+            lambda _self, _current_outline_bid: LLMSettings(
                 model="fake",
                 temperature=0.0,
             ),
             ctx,
         )
         ctx.get_system_prompt = types.MethodType(
-            lambda self, current_outline_bid: None,
+            lambda _self, _current_outline_bid: None,
             ctx,
         )
+
         ctx._get_run_script_info = types.MethodType(
-            lambda self, attend, is_ask=False: RunScriptInfo(
+            lambda _self, attend, **_kwargs: RunScriptInfo(
                 attend=attend,
                 outline_bid=attend.outline_item_bid,
                 block_position=attend.block_position,
@@ -1456,16 +1457,16 @@ def test_listen_run_persists_content_block_before_element_rows(app):
             )
             monkeypatch.setattr(
                 "flaskr.service.learn.context_v2.get_user_profiles",
-                lambda *args, **kwargs: {},
+                lambda *_args, **_kwargs: {},
             )
             monkeypatch.setattr(
                 "flaskr.service.learn.context_v2.get_profile_item_definition_list",
-                lambda *args, **kwargs: [],
+                lambda *_args, **_kwargs: [],
             )
             monkeypatch.setattr(
                 RunScriptContextV2,
                 "_should_stream_tts",
-                lambda self: False,
+                lambda _self: False,
             )
             streamed = list(adapter.process(ctx.run_inner(app)))
 
@@ -1538,7 +1539,7 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
         ctx = RunScriptContextV2.__new__(RunScriptContextV2)
         ctx.app = app
         ctx._trace_args = {}
-        ctx._trace = types.SimpleNamespace(update=lambda **kwargs: None)
+        ctx._trace = types.SimpleNamespace(update=lambda **_kwargs: None)
         ctx._outline_item_info = types.SimpleNamespace(
             bid=outline_bid,
             shifu_bid=shifu_bid,
@@ -1559,22 +1560,23 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
         ctx._element_index_cursor = 0
         ctx._current_attend = progress
         ctx._get_current_attend = types.MethodType(
-            lambda self, current_outline_bid: progress, ctx
+            lambda _self, _current_outline_bid: progress, ctx
         )
-        ctx._get_next_outline_item = types.MethodType(lambda self: [], ctx)
+        ctx._get_next_outline_item = types.MethodType(lambda _self: [], ctx)
         ctx.get_llm_settings = types.MethodType(
-            lambda self, current_outline_bid: LLMSettings(
+            lambda _self, _current_outline_bid: LLMSettings(
                 model="fake",
                 temperature=0.0,
             ),
             ctx,
         )
         ctx.get_system_prompt = types.MethodType(
-            lambda self, current_outline_bid: None,
+            lambda _self, _current_outline_bid: None,
             ctx,
         )
+
         ctx._get_run_script_info = types.MethodType(
-            lambda self, attend, is_ask=False: RunScriptInfo(
+            lambda _self, attend, **_kwargs: RunScriptInfo(
                 attend=attend,
                 outline_bid=attend.outline_item_bid,
                 block_position=attend.block_position,
@@ -1582,7 +1584,7 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
             ),
             ctx,
         )
-        ctx._should_stream_tts = types.MethodType(lambda self: True, ctx)
+        ctx._should_stream_tts = types.MethodType(lambda _self: True, ctx)
 
         class DummyBlock:
             def __init__(self, block_type, content, index) -> None:
@@ -1724,11 +1726,11 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
             )
             monkeypatch.setattr(
                 "flaskr.service.learn.context_v2.get_user_profiles",
-                lambda *args, **kwargs: {},
+                lambda *_args, **_kwargs: {},
             )
             monkeypatch.setattr(
                 "flaskr.service.learn.context_v2.get_profile_item_definition_list",
-                lambda *args, **kwargs: [],
+                lambda *_args, **_kwargs: [],
             )
             monkeypatch.setitem(app.config, "STREAM_TTS_IDLE_DRAIN_INTERVAL", 0.005)
             streamed = list(adapter.process(ctx.run_inner(app)))
@@ -1849,7 +1851,7 @@ def test_listen_run_persists_exception_gate_block_before_element_rows(app):
         )
         ctx._current_attend = progress
         ctx._emit_feedback_before_exception_gate = types.MethodType(
-            lambda self: iter(()),
+            lambda _self: iter(()),
             ctx,
         )
 

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -605,8 +605,8 @@ def test_log_run_script_stream_error_does_not_error_for_app_exception():
     app = Flask(__name__)
     info_calls = []
     error_calls = []
-    app.logger.info = lambda *args, **kwargs: info_calls.append(args)
-    app.logger.error = lambda *args, **kwargs: error_calls.append(args)
+    app.logger.info = lambda *args, **_kwargs: info_calls.append(args)
+    app.logger.error = lambda *args, **_kwargs: error_calls.append(args)
 
     runscript_v2._log_run_script_stream_error(
         app, AppError("outline unit does not exist", status_code=1001)
@@ -621,8 +621,8 @@ def test_log_run_script_stream_error_keeps_error_for_unexpected_exception():
     app = Flask(__name__)
     info_calls = []
     error_calls = []
-    app.logger.info = lambda *args, **kwargs: info_calls.append(args)
-    app.logger.error = lambda *args, **kwargs: error_calls.append(args)
+    app.logger.info = lambda *args, **_kwargs: info_calls.append(args)
+    app.logger.error = lambda *args, **_kwargs: error_calls.append(args)
 
     runscript_v2._log_run_script_stream_error(app, RuntimeError("boom"))
 

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -83,19 +83,19 @@ def _patch_run_dependencies(monkeypatch, script):
     monkeypatch.setattr(
         runscript_v2,
         "get_outline_item_dto",
-        lambda _app, _bid, preview_mode: types.SimpleNamespace(
+        lambda _app, _bid, _preview_mode: types.SimpleNamespace(
             bid="outline-1", shifu_bid="shifu-1", __json__=dict
         ),
     )
     monkeypatch.setattr(
         runscript_v2,
         "get_shifu_dto",
-        lambda _app, _bid, preview_mode: types.SimpleNamespace(bid="shifu-1", price=0),
+        lambda _app, _bid, _preview_mode: types.SimpleNamespace(bid="shifu-1", price=0),
     )
     monkeypatch.setattr(
         runscript_v2,
         "get_shifu_struct",
-        lambda _app, _bid, preview_mode: types.SimpleNamespace(bid="shifu-1"),
+        lambda _app, _bid, _preview_mode: types.SimpleNamespace(bid="shifu-1"),
     )
     _StubRunContext.script = list(script)
     monkeypatch.setattr(runscript_v2, "RunScriptContextV2", _StubRunContext)

--- a/src/api/tests/service/learn/test_runtime_tts_admission.py
+++ b/src/api/tests/service/learn/test_runtime_tts_admission.py
@@ -26,7 +26,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.get_model_info = get_model_info
-    litellm_stub.completion = lambda *args, **kwargs: iter([])
+    litellm_stub.completion = lambda *_args, **_kwargs: iter([])
     sys.modules["litellm"] = litellm_stub
 
 
@@ -372,7 +372,7 @@ def test_preview_route_skips_admission_and_runtime_slot_for_builtin_demo(
     )
     monkeypatch.setattr(
         "flaskr.service.learn.context_v2.RunScriptPreviewContextV2.stream_preview",
-        lambda self, **_kwargs: iter(
+        lambda _self, **_kwargs: iter(
             [
                 {
                     "type": "element",

--- a/src/api/tests/service/metering/test_recording.py
+++ b/src/api/tests/service/metering/test_recording.py
@@ -378,7 +378,7 @@ def test_persist_invalidates_on_base_exception_interrupt(app, monkeypatch):
     monkeypatch.setattr(
         recorder_module,
         "invalidate_session",
-        lambda *, source, session=None: invalidations.append(source) or True,
+        lambda *, source, _session=None: invalidations.append(source) or True,
     )
 
     class _Interrupt(BaseException):

--- a/src/api/tests/service/metering/test_tts_usage_recorder.py
+++ b/src/api/tests/service/metering/test_tts_usage_recorder.py
@@ -37,9 +37,14 @@ def test_record_tts_usage_persists_supplied_output_without_provider_mapping(
         "flaskr.service.metering.recorder.generate_id",
         lambda _app: "usage-tts-explicit-output",
     )
+
+    def resolve_billable(app: object, *, context: object, usage_scene: int) -> int:
+        del app, context, usage_scene
+        return 1
+
     monkeypatch.setattr(
         "flaskr.service.metering.recorder._resolve_billable",
-        lambda _app, *, context, usage_scene: 1,
+        resolve_billable,
     )
     monkeypatch.setattr(
         "flaskr.service.metering.recorder._persist_usage_record",

--- a/src/api/tests/service/order/test_import_activation_permissions.py
+++ b/src/api/tests/service/order/test_import_activation_permissions.py
@@ -93,9 +93,17 @@ def test_admin_import_activation_allows_owner(monkeypatch, test_client, app):
     _seed_shifu(app, shifu_bid, owner_bid)
     _mock_user(monkeypatch, owner_bid, is_creator=True)
 
+    def get_shifu_info(
+        app: object,
+        shifu_bid: str,
+        preview_mode: object,
+    ) -> SimpleNamespace:
+        del app, shifu_bid, preview_mode
+        return SimpleNamespace(price=Decimal(0))
+
     monkeypatch.setattr(
         "flaskr.route.order.get_shifu_info",
-        lambda _app, _shifu_bid, preview_mode: SimpleNamespace(price=Decimal(0)),
+        get_shifu_info,
         raising=False,
     )
     monkeypatch.setattr(

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -65,16 +65,20 @@ def test_legacy_order_purchase_flow_stays_on_order_tables(
 ) -> None:
     from flaskr.service.order import funs as order_funs
 
+    def get_shifu_info(app: object, bid: str, preview_mode: object) -> SimpleNamespace:
+        del app, bid, preview_mode
+        return SimpleNamespace(
+            price=Decimal("99.00"),
+            title="Legacy course",
+            description="Legacy checkout flow",
+        )
+
     monkeypatch.setattr(order_funs, "get_shifu_creator_bid", lambda _app, _bid: "u1")
     monkeypatch.setattr(order_funs, "set_shifu_context", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, preview_mode: SimpleNamespace(
-            price=Decimal("99.00"),
-            title="Legacy course",
-            description="Legacy checkout flow",
-        ),
+        get_shifu_info,
     )
     monkeypatch.setattr(
         order_funs, "apply_promo_campaigns", lambda *_args, **_kwargs: []
@@ -344,15 +348,20 @@ def test_creator_payment_config_smoke_supports_alipay_and_wechatpay_checkout(
         order_funs, "get_shifu_creator_bid", lambda _app, _bid: "teacher-pay-1"
     )
     monkeypatch.setattr(order_funs, "set_shifu_context", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        order_funs,
-        "get_shifu_info",
-        lambda _app, bid, preview_mode: SimpleNamespace(
+
+    def get_shifu_info(app: object, bid: str, preview_mode: object) -> SimpleNamespace:
+        del app, preview_mode
+        return SimpleNamespace(
             bid=bid,
             price=Decimal("99.00"),
             title="Paid course",
             description="Course checkout",
-        ),
+        )
+
+    monkeypatch.setattr(
+        order_funs,
+        "get_shifu_info",
+        get_shifu_info,
     )
     monkeypatch.setattr(
         order_funs, "apply_promo_campaigns", lambda *_args, **_kwargs: []
@@ -514,7 +523,7 @@ def test_legacy_stripe_checkout_urls_are_derived_from_host_url(
     monkeypatch.setattr(
         order_funs,
         "get_payment_provider",
-        lambda provider_name: FakeStripeProvider(),
+        lambda _provider_name: FakeStripeProvider(),
     )
 
     with legacy_order_app.app_context():

--- a/src/api/tests/service/order/test_native_payment_split_tables.py
+++ b/src/api/tests/service/order/test_native_payment_split_tables.py
@@ -244,7 +244,7 @@ def test_learner_sync_and_admin_payment_detail_read_alipay_table(
 
     monkeypatch.setattr(
         "flaskr.service.order.funs.get_payment_provider",
-        lambda provider_name: FakeAlipayProvider(),
+        lambda _provider_name: FakeAlipayProvider(),
     )
 
     with native_payment_split_app.app_context():
@@ -326,7 +326,7 @@ def test_learner_sync_does_not_mark_paid_when_native_amount_mismatches(
 
     monkeypatch.setattr(
         "flaskr.service.order.funs.get_payment_provider",
-        lambda provider_name: FakeAlipayProvider(),
+        lambda _provider_name: FakeAlipayProvider(),
     )
 
     with native_payment_split_app.app_context():

--- a/src/api/tests/service/order/test_provider_public_urls.py
+++ b/src/api/tests/service/order/test_provider_public_urls.py
@@ -153,7 +153,7 @@ def test_stripe_subscription_discount_coupon_uses_lowercase_currency_and_idempot
                 "SessionResponse",
                 (),
                 {
-                    "to_dict": lambda self: {
+                    "to_dict": lambda _self: {
                         "id": "cs_1",
                         "url": "https://stripe.test/checkout",
                         "payment_intent": "",

--- a/src/api/tests/service/order/test_stripe_refund.py
+++ b/src/api/tests/service/order/test_stripe_refund.py
@@ -114,7 +114,7 @@ def test_refund_order_payment_updates_status(app, monkeypatch):
         provider = DummyStripeRefundProvider(result)
         monkeypatch.setattr(
             "flaskr.service.order.funs.get_payment_provider",
-            lambda channel: provider,
+            lambda _channel: provider,
         )
 
         # refund_order_payment now joins the caller's session and commits its

--- a/src/api/tests/service/order/test_stripe_webhook.py
+++ b/src/api/tests/service/order/test_stripe_webhook.py
@@ -216,11 +216,11 @@ def test_handle_stripe_webhook_marks_order_paid(stripe_webhook_app, monkeypatch)
 
     monkeypatch.setattr(
         "flaskr.service.order.funs.get_payment_provider",
-        lambda channel: DummyStripeProvider(notification),
+        lambda _channel: DummyStripeProvider(notification),
     )
     monkeypatch.setattr(
         "flaskr.service.order.funs.send_order_feishu",
-        lambda *args, **kwargs: None,
+        lambda *_args, **_kwargs: None,
     )
 
     payload, status_code = handle_stripe_webhook(stripe_webhook_app, b"{}", "sig")
@@ -291,11 +291,11 @@ def test_stripe_webhook_route_marks_legacy_order_paid(stripe_webhook_app, monkey
     )
     monkeypatch.setattr(
         "flaskr.service.order.funs.get_payment_provider",
-        lambda channel: DummyStripeProvider(notification),
+        lambda _channel: DummyStripeProvider(notification),
     )
     monkeypatch.setattr(
         "flaskr.service.order.funs.send_order_feishu",
-        lambda *args, **kwargs: None,
+        lambda *_args, **_kwargs: None,
     )
 
     with stripe_webhook_app.test_client() as client:
@@ -358,7 +358,7 @@ def test_handle_stripe_webhook_routes_bill_orders_without_regression(
     )
     monkeypatch.setattr(
         "flaskr.service.order.funs.get_payment_provider",
-        lambda channel: DummyStripeProvider(success_notification),
+        lambda _channel: DummyStripeProvider(success_notification),
     )
     payload, status_code = handle_stripe_webhook(stripe_webhook_app, b"{}", "sig")
 
@@ -389,7 +389,7 @@ def test_handle_stripe_webhook_routes_bill_orders_without_regression(
     )
     monkeypatch.setattr(
         "flaskr.service.order.funs.get_payment_provider",
-        lambda channel: DummyStripeProvider(failed_notification),
+        lambda _channel: DummyStripeProvider(failed_notification),
     )
     payload, status_code = handle_stripe_webhook(stripe_webhook_app, b"{}", "sig")
 
@@ -464,7 +464,7 @@ def test_stripe_webhook_route_delegates_bill_orders(stripe_webhook_app, monkeypa
     )
     monkeypatch.setattr(
         "flaskr.service.order.funs.get_payment_provider",
-        lambda channel: DummyStripeProvider(notification),
+        lambda _channel: DummyStripeProvider(notification),
     )
 
     with stripe_webhook_app.test_client() as client:
@@ -541,7 +541,7 @@ def test_handle_stripe_webhook_duplicate_paid_event_is_idempotent(
     )
     monkeypatch.setattr(
         "flaskr.service.order.funs.get_payment_provider",
-        lambda channel: DummyStripeProvider(notification),
+        lambda _channel: DummyStripeProvider(notification),
     )
 
     first_payload, first_status = handle_stripe_webhook(
@@ -617,7 +617,7 @@ def test_handle_stripe_webhook_ignores_stale_subscription_updates(
     )
     monkeypatch.setattr(
         "flaskr.service.order.funs.get_payment_provider",
-        lambda channel: DummyStripeProvider(notification),
+        lambda _channel: DummyStripeProvider(notification),
     )
 
     payload, status_code = handle_stripe_webhook(stripe_webhook_app, b"{}", "sig")
@@ -658,7 +658,7 @@ def test_handle_stripe_webhook_ignores_orphan_billing_event(
     )
     monkeypatch.setattr(
         "flaskr.service.order.funs.get_payment_provider",
-        lambda channel: DummyStripeProvider(notification),
+        lambda _channel: DummyStripeProvider(notification),
     )
 
     payload, status_code = handle_stripe_webhook(stripe_webhook_app, b"{}", "sig")

--- a/src/api/tests/service/order/test_uow_failure_paths.py
+++ b/src/api/tests/service/order/test_uow_failure_paths.py
@@ -60,16 +60,20 @@ def order_app():
 
 @pytest.fixture
 def stub_shifu(monkeypatch: pytest.MonkeyPatch):
+    def get_shifu_info(app: object, bid: str, preview_mode: object) -> SimpleNamespace:
+        del app, bid, preview_mode
+        return SimpleNamespace(
+            price=Decimal("100.00"),
+            title="UOW course",
+            description="UOW failure-path course",
+        )
+
     monkeypatch.setattr(order_funs, "get_shifu_creator_bid", lambda _app, _bid: "c1")
     monkeypatch.setattr(order_funs, "set_shifu_context", lambda *_a, **_k: None)
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, preview_mode: SimpleNamespace(
-            price=Decimal("100.00"),
-            title="UOW course",
-            description="UOW failure-path course",
-        ),
+        get_shifu_info,
     )
 
 

--- a/src/api/tests/service/profile/test_profile_routes.py
+++ b/src/api/tests/service/profile/test_profile_routes.py
@@ -6,7 +6,8 @@ import flaskr.service.config.funcs as config_funcs
 import pytest
 
 _dummy_lock = SimpleNamespace(
-    acquire=lambda *args, **kwargs: False, release=lambda *args, **kwargs: None
+    acquire=lambda *_args, **_kwargs: False,
+    release=lambda *_args, **_kwargs: None,
 )
 
 
@@ -17,8 +18,8 @@ def _stub_profile_config_cache(monkeypatch):
         "redis",
         SimpleNamespace(
             get=lambda _key: None,
-            set=lambda *args, **kwargs: None,
-            lock=lambda *args, **kwargs: _dummy_lock,
+            set=lambda *_args, **_kwargs: None,
+            lock=lambda *_args, **_kwargs: _dummy_lock,
         ),
     )
 

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -119,11 +119,15 @@ def _pin_app_timezone_to_utc(app):
 
 @pytest.fixture(autouse=True)
 def _mock_bcrypt_module(monkeypatch):
+    def gensalt(rounds=12):
+        del rounds
+        return b"salt"
+
     monkeypatch.setitem(
         sys.modules,
         "bcrypt",
         SimpleNamespace(
-            gensalt=lambda rounds=12: b"salt",
+            gensalt=gensalt,
             hashpw=lambda plain, salt: plain + b":" + salt,
             checkpw=lambda plain, hashed: hashed == plain + b":salt",
         ),

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -664,7 +664,7 @@ def test_list_operator_courses_filters_by_course_status():
         ),
     ):
         creator_mock.return_value = None
-        latest_mock.side_effect = lambda model, **kwargs: (
+        latest_mock.side_effect = lambda model, **_kwargs: (
             [draft_only_course]
             if model.__name__ == "DraftShifu"
             else [published_course]
@@ -762,7 +762,7 @@ def test_list_operator_courses_applies_quick_filters(monkeypatch):
         ),
     ):
         creator_mock.return_value = None
-        latest_mock.side_effect = lambda model, **kwargs: (
+        latest_mock.side_effect = lambda model, **_kwargs: (
             [
                 recent_course,
                 paid_course,

--- a/src/api/tests/service/shifu/test_admin_credit_notifications.py
+++ b/src/api/tests/service/shifu/test_admin_credit_notifications.py
@@ -21,12 +21,12 @@ def test_operator_credit_notification_services_delegate_to_billing(monkeypatch):
     monkeypatch.setattr(
         module,
         "list_credit_notifications",
-        lambda received_app, **kwargs: calls.append(("list", kwargs)) or {"items": []},
+        lambda _received_app, **kwargs: calls.append(("list", kwargs)) or {"items": []},
     )
     monkeypatch.setattr(
         module,
         "get_credit_notification_detail",
-        lambda received_app, **kwargs: (
+        lambda _received_app, **kwargs: (
             calls.append(("detail", kwargs))
             or {"notification_bid": kwargs["notification_bid"]}
         ),
@@ -34,7 +34,7 @@ def test_operator_credit_notification_services_delegate_to_billing(monkeypatch):
     monkeypatch.setattr(
         module,
         "sync_credit_notification_template",
-        lambda received_app, **kwargs: (
+        lambda _received_app, **kwargs: (
             calls.append(("sync", kwargs)) or {"template_code": kwargs["template_code"]}
         ),
     )
@@ -46,14 +46,14 @@ def test_operator_credit_notification_services_delegate_to_billing(monkeypatch):
     monkeypatch.setattr(
         module,
         "dry_run_credit_notifications",
-        lambda received_app, **kwargs: (
+        lambda _received_app, **kwargs: (
             calls.append(("dry_run", kwargs)) or {"ok": True}
         ),
     )
     monkeypatch.setattr(
         module,
         "requeue_credit_notification",
-        lambda received_app, **kwargs: (
+        lambda _received_app, **kwargs: (
             calls.append(("requeue", kwargs)) or {"status": "enqueued"}
         ),
     )

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -112,7 +112,7 @@ def _mock_bcrypt_module(monkeypatch):
         sys.modules,
         "bcrypt",
         SimpleNamespace(
-            gensalt=lambda rounds=12: b"salt",
+            gensalt=lambda _rounds=12: b"salt",
             hashpw=lambda plain, salt: plain + b":" + salt,
             checkpw=lambda plain, hashed: hashed == plain + b":salt",
         ),

--- a/src/api/tests/service/shifu/test_course_copy.py
+++ b/src/api/tests/service/shifu/test_course_copy.py
@@ -36,7 +36,7 @@ def _unique_email(label: str) -> str:
 def _stub_copy_course_risk_control(monkeypatch):
     monkeypatch.setattr(
         "flaskr.service.shifu.admin.check_text_with_risk_control",
-        lambda *args, **kwargs: None,
+        lambda *_args, **_kwargs: None,
     )
 
 
@@ -372,7 +372,7 @@ def test_copy_course_creates_missing_target_user_and_grants_creator_role(
 
         monkeypatch.setattr(
             "flaskr.service.shifu.admin.run_creator_granted_post_auth",
-            lambda *args, **kwargs: post_auth_calls.append(kwargs),
+            lambda *_args, **kwargs: post_auth_calls.append(kwargs),
         )
 
         result = copy_operator_course(

--- a/src/api/tests/service/shifu/test_create_outlines_batch.py
+++ b/src/api/tests/service/shifu/test_create_outlines_batch.py
@@ -31,13 +31,13 @@ def _isolate_side_effects(monkeypatch):
     monkeypatch.setattr(
         shifu_outline_funcs,
         "check_text_with_risk_control",
-        lambda *args, **kwargs: None,
+        lambda *_args, **_kwargs: None,
         raising=True,
     )
     monkeypatch.setattr(
         shifu_outline_funcs,
         "save_new_outline_history",
-        lambda *args, **kwargs: None,
+        lambda *_args, **_kwargs: None,
         raising=True,
     )
 
@@ -153,7 +153,7 @@ def test_batch_risk_checks_every_node(app, monkeypatch):
     monkeypatch.setattr(
         shifu_outline_funcs,
         "check_text_with_risk_control",
-        lambda app, bid, user_id, text: checked.append(text),
+        lambda _app, _bid, _user_id, text: checked.append(text),
         raising=True,
     )
     with app.app_context():

--- a/src/api/tests/service/shifu/test_minimax_voice_clone_routes.py
+++ b/src/api/tests/service/shifu/test_minimax_voice_clone_routes.py
@@ -189,13 +189,18 @@ def test_minimax_voice_clone_submit_creates_queued_voice(
         "flaskr.service.billing.primitives.is_billing_enabled",
         lambda: True,
     )
+
+    def enqueue_clone(app: object, *, voice_bid: str) -> bool:
+        del app, voice_bid
+        return True
+
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone._enqueue_minimax_clone_task",
-        lambda _app, *, voice_bid: True,
+        enqueue_clone,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone._store_resource_bytes",
-        lambda app, **kwargs: SimpleNamespace(
+        lambda _app, **kwargs: SimpleNamespace(
             resource_bid=f"res-{kwargs['resource_kind']}",
             url=f"/resource/{kwargs['resource_kind']}",
             object_key=f"key/{kwargs['resource_kind']}",

--- a/src/api/tests/service/shifu/test_reorder_outline_tree.py
+++ b/src/api/tests/service/shifu/test_reorder_outline_tree.py
@@ -19,13 +19,13 @@ def _stub_reorder_side_effects(monkeypatch):
     monkeypatch.setattr(
         shifu_outline_funcs,
         "cleanup_outline_history_versions",
-        lambda *args, **kwargs: None,
+        lambda *_args, **_kwargs: None,
         raising=True,
     )
     monkeypatch.setattr(
         shifu_outline_funcs,
         "save_outline_tree_history",
-        lambda *args, **kwargs: None,
+        lambda *_args, **_kwargs: None,
         raising=True,
     )
 

--- a/src/api/tests/service/shifu/test_shifu_publish_funcs.py
+++ b/src/api/tests/service/shifu/test_shifu_publish_funcs.py
@@ -27,7 +27,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.get_model_info = get_model_info
-    litellm_stub.completion = lambda *args, **kwargs: iter([])
+    litellm_stub.completion = lambda *_args, **_kwargs: iter([])
     sys.modules["litellm"] = litellm_stub
 
 
@@ -162,10 +162,15 @@ def test_get_summary_updates_trace_and_span_output(monkeypatch):
     from flaskr.service.shifu import shifu_publish_funcs as module
 
     fake_langfuse = _FakeLangfuseClient()
+
+    def create_trace_id(seed=None):
+        del seed
+        return "a" * 32
+
     monkeypatch.setattr(
         langfuse_module.Langfuse,
         "create_trace_id",
-        lambda seed=None: "a" * 32,
+        create_trace_id,
         raising=False,
     )
     monkeypatch.setattr(
@@ -260,7 +265,7 @@ def test_run_summary_logs_error_for_other_failures(monkeypatch):
 def test_publish_shifu_draft_preserves_outline_updated_at(app, monkeypatch):
     from flaskr.service.shifu import shifu_publish_funcs as module
 
-    monkeypatch.setattr(module, "_run_summary_with_error_handling", lambda *args: None)
+    monkeypatch.setattr(module, "_run_summary_with_error_handling", lambda *_args: None)
     original_load_existing_outline_items = module.load_existing_outline_items
     outline_load_calls = []
 

--- a/src/api/tests/service/shifu/test_transfer_creator.py
+++ b/src/api/tests/service/shifu/test_transfer_creator.py
@@ -325,7 +325,7 @@ def test_transfer_creator_skips_post_auth_when_target_already_creator(app, monke
 
         monkeypatch.setattr(
             "flaskr.service.shifu.admin.run_creator_granted_post_auth",
-            lambda *args, **kwargs: post_auth_calls.append(kwargs),
+            lambda *_args, **kwargs: post_auth_calls.append(kwargs),
         )
 
         transfer_operator_course_creator(

--- a/src/api/tests/service/shifu/test_tts_preview_helper.py
+++ b/src/api/tests/service/shifu/test_tts_preview_helper.py
@@ -18,6 +18,16 @@ class _FakeAudioSettings:
     sample_rate: int = 24000
 
 
+def _split_hello_world(text: str, provider_name: str = "") -> list[str]:
+    del text, provider_name
+    return ["hello", "world"]
+
+
+def _split_hello(text: str, provider_name: str = "") -> list[str]:
+    del text, provider_name
+    return ["hello"]
+
+
 def test_build_tts_preview_response_records_debug_usage_and_summary(
     monkeypatch,
 ) -> None:
@@ -59,7 +69,7 @@ def test_build_tts_preview_response_records_debug_usage_and_summary(
     )
     monkeypatch.setattr(
         "flaskr.service.shifu.tts_preview.split_text_for_tts",
-        lambda _text, provider_name="": ["hello", "world"],
+        _split_hello_world,
         raising=False,
     )
     monkeypatch.setattr(
@@ -182,7 +192,7 @@ def test_build_tts_preview_response_normalizes_removed_fields(monkeypatch) -> No
     )
     monkeypatch.setattr(
         "flaskr.service.shifu.tts_preview.split_text_for_tts",
-        lambda _text, provider_name="": ["hello"],
+        _split_hello,
         raising=False,
     )
     monkeypatch.setattr(
@@ -313,7 +323,7 @@ def _stub_preview_pipeline(monkeypatch):
     )
     monkeypatch.setattr(
         "flaskr.service.shifu.tts_preview.split_text_for_tts",
-        lambda _text, provider_name="": ["hello", "world"],
+        _split_hello_world,
         raising=False,
     )
     monkeypatch.setattr(
@@ -351,7 +361,7 @@ def test_preview_stream_close_invalidates_session(monkeypatch) -> None:
     invalidations: list[str] = []
     monkeypatch.setattr(
         "flaskr.service.shifu.tts_preview.invalidate_session",
-        lambda *, source, session=None: invalidations.append(source) or True,
+        lambda *, source, _session=None: invalidations.append(source) or True,
         raising=False,
     )
 

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -29,6 +29,10 @@ def _sse_line(payload):
     return f"data: {json.dumps(payload)}"
 
 
+def _ignore_saved_audio_record(record: object, commit: object = None) -> None:
+    del record, commit
+
+
 def test_minimax_http_streaming_parses_audio_and_final_subtitles(monkeypatch):
     from flaskr.api.tts.base import AudioSettings, VoiceSettings
     from flaskr.api.tts.minimax_provider import MinimaxTTSProvider
@@ -191,7 +195,7 @@ def test_minimax_http_streaming_raises_on_business_error(monkeypatch):
     )
     monkeypatch.setattr(
         "flaskr.api.tts.minimax_provider.requests.post",
-        lambda *args, **kwargs: _FakeResponse(
+        lambda *_args, **_kwargs: _FakeResponse(
             [
                 _sse_line(
                     {
@@ -265,7 +269,7 @@ def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        lambda parts, output_format="mp3": b"".join(parts),  # noqa: ARG005 -- preserve concatenation keyword contract
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -277,7 +281,7 @@ def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",
-        lambda _record, commit=True: None,
+        _ignore_saved_audio_record,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.tts_handler.upload_audio_to_oss",
@@ -397,7 +401,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_for_partial_subtitles(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        lambda parts, output_format="mp3": b"".join(parts),  # noqa: ARG005 -- preserve concatenation keyword contract
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -409,7 +413,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_for_partial_subtitles(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",
-        lambda _record, commit=True: None,
+        _ignore_saved_audio_record,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.tts_handler.upload_audio_to_oss",
@@ -527,7 +531,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        lambda parts, output_format="mp3": b"".join(parts),  # noqa: ARG005 -- preserve concatenation keyword contract
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -539,7 +543,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",
-        lambda _record, commit=True: None,
+        _ignore_saved_audio_record,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.tts_handler.upload_audio_to_oss",
@@ -650,7 +654,7 @@ def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitle
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        lambda parts, output_format="mp3": b"".join(parts),  # noqa: ARG005 -- preserve concatenation keyword contract
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -662,7 +666,7 @@ def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitle
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",
-        lambda _record, commit=True: None,
+        _ignore_saved_audio_record,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.tts_handler.upload_audio_to_oss",
@@ -796,7 +800,7 @@ def test_streaming_tts_minimax_http_stream_does_not_emit_audio_past_subtitles(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        lambda parts, output_format="mp3": b"".join(parts),  # noqa: ARG005 -- preserve concatenation keyword contract
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -808,7 +812,7 @@ def test_streaming_tts_minimax_http_stream_does_not_emit_audio_past_subtitles(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",
-        lambda _record, commit=True: None,
+        _ignore_saved_audio_record,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.tts_handler.upload_audio_to_oss",
@@ -929,7 +933,7 @@ def test_streaming_tts_minimax_http_stream_offsets_live_cues_by_emitted_audio(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        lambda parts, output_format="mp3": b"".join(parts),  # noqa: ARG005 -- preserve concatenation keyword contract
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -941,7 +945,7 @@ def test_streaming_tts_minimax_http_stream_offsets_live_cues_by_emitted_audio(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",
-        lambda _record, commit=True: None,
+        _ignore_saved_audio_record,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.tts_handler.upload_audio_to_oss",
@@ -1071,7 +1075,7 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        lambda parts, output_format="mp3": b"".join(parts),  # noqa: ARG005 -- preserve concatenation keyword contract
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -1089,7 +1093,7 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",
-        lambda _record, commit=True: None,
+        _ignore_saved_audio_record,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.tts_handler.upload_audio_to_oss",
@@ -1224,7 +1228,7 @@ def test_streaming_tts_minimax_http_stream_keeps_provider_middle_cue_timing(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        lambda parts, output_format="mp3": b"".join(parts),  # noqa: ARG005 -- preserve concatenation keyword contract
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -1236,7 +1240,7 @@ def test_streaming_tts_minimax_http_stream_keeps_provider_middle_cue_timing(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",
-        lambda _record, commit=True: None,
+        _ignore_saved_audio_record,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.tts_handler.upload_audio_to_oss",
@@ -1378,7 +1382,7 @@ def test_streaming_tts_minimax_http_stream_freezes_emitted_prefix_for_same_count
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.concat_audio_best_effort",
-        lambda parts, output_format="mp3": b"".join(parts),
+        lambda parts, output_format="mp3": b"".join(parts),  # noqa: ARG005 -- preserve concatenation keyword contract
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.get_audio_duration_ms",
@@ -1390,7 +1394,7 @@ def test_streaming_tts_minimax_http_stream_freezes_emitted_prefix_for_same_count
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.save_audio_record",
-        lambda _record, commit=True: None,
+        _ignore_saved_audio_record,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.tts_handler.upload_audio_to_oss",

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -28,6 +28,21 @@ from flaskr.service.metering.models import BillUsageRecord
 from flaskr.service.shifu.models import DraftShifu
 
 
+def _enqueue_clone(app: object, *, voice_bid: str) -> bool:
+    del app, voice_bid
+    return True
+
+
+def _normalize_audio(data: bytes, filename: str, purpose: str) -> SimpleNamespace:
+    del data, filename, purpose
+    return SimpleNamespace(
+        audio_bytes=b"WAV",
+        duration_ms=12_000,
+        extension="wav",
+        content_type="audio/wav",
+    )
+
+
 @pytest.fixture
 def minimax_clone_app(monkeypatch):
     app = Flask(__name__)
@@ -283,11 +298,11 @@ def test_run_minimax_voice_clone_success_captures_credit_once(
     _seed_course_wallet_and_rate(minimax_clone_app)
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone._enqueue_minimax_clone_task",
-        lambda _app, *, voice_bid: True,
+        _enqueue_clone,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone._store_resource_bytes",
-        lambda app, **kwargs: SimpleNamespace(
+        lambda _app, **kwargs: SimpleNamespace(
             resource_bid=f"res-{kwargs['resource_kind']}",
             url=f"/resource/{kwargs['resource_kind']}",
             object_key=f"key/{kwargs['resource_kind']}",
@@ -295,16 +310,11 @@ def test_run_minimax_voice_clone_success_captures_credit_once(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone._delete_resource_object",
-        lambda app, resource_bid: None,
+        lambda _app, _resource_bid: None,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone.normalize_audio_blob",
-        lambda data, filename, purpose: SimpleNamespace(
-            audio_bytes=b"WAV",
-            duration_ms=12_000,
-            extension="wav",
-            content_type="audio/wav",
-        ),
+        _normalize_audio,
     )
 
     class FakeClient:
@@ -407,7 +417,7 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
 
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone._enqueue_minimax_clone_task",
-        lambda _app, *, voice_bid: True,
+        _enqueue_clone,
     )
     monkeypatch.setattr(
         minimax_voice_clone,
@@ -422,12 +432,7 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
     monkeypatch.setattr(
         minimax_voice_clone,
         "normalize_audio_blob",
-        lambda data, filename, purpose: SimpleNamespace(
-            audio_bytes=b"WAV",
-            duration_ms=12_000,
-            extension="wav",
-            content_type="audio/wav",
-        ),
+        _normalize_audio,
     )
 
     class FakeClient:
@@ -548,21 +553,17 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(monkeypatch
     monkeypatch.setattr(
         minimax_voice_clone,
         "_load_voice_row",
-        lambda voice_bid: row,
+        lambda _voice_bid: row,
     )
     monkeypatch.setattr(
         minimax_voice_clone,
         "_read_resource_bytes",
-        lambda resource_bid: b"RAW",
+        lambda _resource_bid: b"RAW",
     )
     monkeypatch.setattr(
         minimax_voice_clone,
         "normalize_audio_blob",
-        lambda data, filename, purpose: SimpleNamespace(
-            audio_bytes=b"WAV",
-            duration_ms=12_000,
-            content_type="audio/wav",
-        ),
+        _normalize_audio,
     )
 
     def fake_store_resource_bytes(_app, **kwargs):
@@ -652,11 +653,11 @@ def test_soft_deleted_minimax_voice_id_can_be_reused(
     _seed_course_wallet_and_rate(minimax_clone_app)
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone._enqueue_minimax_clone_task",
-        lambda _app, *, voice_bid: True,
+        _enqueue_clone,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone._store_resource_bytes",
-        lambda app, **kwargs: SimpleNamespace(
+        lambda _app, **kwargs: SimpleNamespace(
             resource_bid=f"res-{kwargs['resource_kind']}-{kwargs['filename']}",
             url=f"/resource/{kwargs['resource_kind']}",
             object_key=f"key/{kwargs['resource_kind']}",
@@ -709,11 +710,11 @@ def test_run_minimax_voice_clone_releases_credit_on_normalization_failure(
     _seed_course_wallet_and_rate(minimax_clone_app)
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone._enqueue_minimax_clone_task",
-        lambda _app, *, voice_bid: True,
+        _enqueue_clone,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone._store_resource_bytes",
-        lambda app, **kwargs: SimpleNamespace(
+        lambda _app, **kwargs: SimpleNamespace(
             resource_bid=f"res-{kwargs['resource_kind']}",
             url=f"/resource/{kwargs['resource_kind']}",
             object_key=f"key/{kwargs['resource_kind']}",
@@ -721,7 +722,7 @@ def test_run_minimax_voice_clone_releases_credit_on_normalization_failure(
     )
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone._delete_resource_object",
-        lambda app, resource_bid: None,
+        lambda _app, _resource_bid: None,
     )
     monkeypatch.setattr(
         "flaskr.service.tts.minimax_voice_clone.normalize_audio_blob",
@@ -769,12 +770,12 @@ def test_retry_minimax_voice_clone_re_reserves_after_released_failure(
     monkeypatch.setattr(
         minimax_voice_clone,
         "_enqueue_minimax_clone_task",
-        lambda _app, *, voice_bid: True,
+        _enqueue_clone,
     )
     monkeypatch.setattr(
         minimax_voice_clone,
         "_store_resource_bytes",
-        lambda app, **kwargs: SimpleNamespace(
+        lambda _app, **kwargs: SimpleNamespace(
             resource_bid=f"res-{kwargs['resource_kind']}",
             url=f"/resource/{kwargs['resource_kind']}",
             object_key=f"key/{kwargs['resource_kind']}",
@@ -783,7 +784,7 @@ def test_retry_minimax_voice_clone_re_reserves_after_released_failure(
     monkeypatch.setattr(
         minimax_voice_clone,
         "_delete_resource_object",
-        lambda app, resource_bid: None,
+        lambda _app, _resource_bid: None,
     )
     monkeypatch.setattr(
         minimax_voice_clone,

--- a/src/api/tests/service/tts/test_tencent_provider.py
+++ b/src/api/tests/service/tts/test_tencent_provider.py
@@ -140,7 +140,7 @@ def test_tencent_provider_config_validation_and_explicit_only(monkeypatch):
     )
 
     _patch_tencent_config(monkeypatch, tencent_provider)
-    monkeypatch.setattr(tts_api, "get_config", lambda key, default=None: "")
+    monkeypatch.setattr(tts_api, "get_config", lambda _key, _default=None: "")
     tts_api._provider_instances.clear()
 
     provider = tencent_provider.TencentTTSProvider()
@@ -320,15 +320,25 @@ def test_tencent_provider_synthesize_collects_audio_and_sentence_subtitles(
         )
 
     monkeypatch.setattr(tencent_provider.requests, "post", fake_post)
+
+    def concat_audio(segments: list[bytes], output_format: str = "mp3") -> bytes:
+        del output_format
+        return b"".join(segments)
+
     monkeypatch.setattr(
         tencent_provider,
         "concat_audio_best_effort",
-        lambda segments, output_format="mp3": b"".join(segments),
+        concat_audio,
     )
+
+    def export_pcm(audio_data: bytes, sample_rate: int) -> bytes:
+        del sample_rate
+        return audio_data
+
     monkeypatch.setattr(
         tencent_provider,
         "_export_tencent_pcm_to_mp3",
-        lambda audio_data, sample_rate: audio_data,
+        export_pcm,
     )
     monkeypatch.setattr(
         tencent_provider,

--- a/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
+++ b/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
@@ -188,15 +188,20 @@ def test_synthesize_builds_payload_and_concatenates_segments(monkeypatch):
         )
 
     monkeypatch.setattr(module.requests, "post", _fake_post)
+
+    def concat_audio(segments: list[bytes], output_format: str = "mp3") -> bytes:
+        del output_format
+        return b"".join(segments)
+
     monkeypatch.setattr(
         module,
         "concat_audio_best_effort",
-        lambda segments, output_format="mp3": b"".join(segments),
+        concat_audio,
     )
     monkeypatch.setattr(
         module,
         "try_get_audio_duration_ms",
-        lambda audio, **_kwargs: 1234,
+        lambda _audio, **_kwargs: 1234,
     )
 
     provider = module.TencentTextToVoiceProvider()
@@ -228,7 +233,7 @@ def test_synthesize_raises_on_api_error_with_code(monkeypatch):
     monkeypatch.setattr(
         module.requests,
         "post",
-        lambda *args, **kwargs: _FakeResponse(
+        lambda *_args, **_kwargs: _FakeResponse(
             {
                 "Response": {
                     "Error": {
@@ -258,7 +263,7 @@ def test_synthesize_raises_on_empty_audio(monkeypatch):
     monkeypatch.setattr(
         module.requests,
         "post",
-        lambda *args, **kwargs: _FakeResponse(
+        lambda *_args, **_kwargs: _FakeResponse(
             {"Response": {"Audio": "", "RequestId": "req-empty"}}
         ),
     )

--- a/src/api/tests/service/tts/test_tts_config_options.py
+++ b/src/api/tests/service/tts/test_tts_config_options.py
@@ -53,7 +53,7 @@ def test_tts_config_model_options_follow_allowlist_and_localized_names(
     monkeypatch.setattr(
         tts_api,
         "_resolve_credit_multiplier_label",
-        lambda provider, model: "2x" if provider == "minimax" else None,
+        lambda provider, _model: "2x" if provider == "minimax" else None,
     )
     monkeypatch.setenv(
         "TTS_ALLOWED_MODELS",
@@ -390,7 +390,7 @@ def test_tts_config_three_tier_allowlist_orders_and_localizes(monkeypatch):
         tts_api, "_PROVIDER_PRIORITY", ("volcengine", "tencent_texttovoice")
     )
     monkeypatch.setattr(
-        tts_api, "_resolve_credit_multiplier_label", lambda provider, model: None
+        tts_api, "_resolve_credit_multiplier_label", lambda _provider, _model: None
     )
     monkeypatch.setenv(
         "TTS_ALLOWED_MODELS",
@@ -435,7 +435,7 @@ def _patch_two_provider_registry(monkeypatch, tts_api):
     )
     monkeypatch.setattr(tts_api, "_PROVIDER_PRIORITY", ("minimax", "baidu"))
     monkeypatch.setattr(
-        tts_api, "_resolve_credit_multiplier_label", lambda provider, model: None
+        tts_api, "_resolve_credit_multiplier_label", lambda _provider, _model: None
     )
 
 

--- a/src/api/tests/service/tts/test_volcengine_voice_clone.py
+++ b/src/api/tests/service/tts/test_volcengine_voice_clone.py
@@ -80,7 +80,7 @@ def test_query_status_raises_on_base_resp_error(monkeypatch) -> None:
     monkeypatch.setattr(
         volcengine_voice_clone.requests,
         "post",
-        lambda *args, **kwargs: _FakeResponse(
+        lambda *_args, **_kwargs: _FakeResponse(
             {"BaseResp": {"StatusCode": 1001, "StatusMessage": "bad request"}}
         ),
     )
@@ -124,7 +124,7 @@ def test_query_status_converts_invalid_json_to_param_error(monkeypatch) -> None:
     monkeypatch.setattr(
         volcengine_voice_clone.requests,
         "post",
-        lambda *args, **kwargs: _BadJsonResponse(),
+        lambda *_args, **_kwargs: _BadJsonResponse(),
     )
     with pytest.raises(AppError):
         query_volcengine_voice_status("S_xxxxxxxxxx")
@@ -136,7 +136,7 @@ def test_query_status_converts_http_error_to_param_error(monkeypatch) -> None:
     monkeypatch.setattr(
         volcengine_voice_clone.requests,
         "post",
-        lambda *args, **kwargs: _FakeResponse(
+        lambda *_args, **_kwargs: _FakeResponse(
             {"message": "parameter license not found for appid"}, status_code=403
         ),
     )
@@ -150,7 +150,7 @@ def test_verify_accepts_success_and_active(monkeypatch, status) -> None:
     monkeypatch.setattr(
         volcengine_voice_clone.requests,
         "post",
-        lambda *args, **kwargs: _FakeResponse(
+        lambda *_args, **_kwargs: _FakeResponse(
             {"BaseResp": {"StatusCode": 0}, "status": status}
         ),
     )
@@ -163,7 +163,7 @@ def test_verify_rejects_not_ready_statuses(monkeypatch, status) -> None:
     monkeypatch.setattr(
         volcengine_voice_clone.requests,
         "post",
-        lambda *args, **kwargs: _FakeResponse(
+        lambda *_args, **_kwargs: _FakeResponse(
             {"BaseResp": {"StatusCode": 0}, "status": status}
         ),
     )

--- a/src/api/tests/service/user/test_oauth_origins.py
+++ b/src/api/tests/service/user/test_oauth_origins.py
@@ -49,7 +49,7 @@ def _verified_custom_domain(monkeypatch):
     monkeypatch.setattr(
         oauth_origins,
         "_resolve_creator_bid_by_host",
-        lambda app, host: "creator-1" if host == CUSTOM_DOMAIN else None,
+        lambda _app, host: "creator-1" if host == CUSTOM_DOMAIN else None,
     )
 
 
@@ -73,7 +73,7 @@ class TestIsAllowedOAuthOrigin:
     def test_unverified_custom_domain_is_refused(self, app, monkeypatch) -> None:
         # Not yet verified, or entitlement revoked -> no hand-back.
         monkeypatch.setattr(
-            oauth_origins, "_resolve_creator_bid_by_host", lambda app, host: None
+            oauth_origins, "_resolve_creator_bid_by_host", lambda _app, _host: None
         )
         assert oauth_origins.is_allowed_oauth_origin(app, CUSTOM_ORIGIN) is False
 
@@ -175,7 +175,7 @@ class TestResolveStateReturnOrigin:
         # State was minted while the domain was valid; it no longer is.
         state = _encode_state(app, {"origin": CUSTOM_ORIGIN})
         monkeypatch.setattr(
-            oauth_origins, "_resolve_creator_bid_by_host", lambda app, host: None
+            oauth_origins, "_resolve_creator_bid_by_host", lambda _app, _host: None
         )
         assert resolve_state_return_origin(app, state) == ""
 

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -90,7 +90,7 @@ def test_onboarding_status_returns_eligible_creator_scene_state(
     )
     monkeypatch.setattr(
         "flaskr.service.shifu.demo_courses._load_shifu_demo_metadata",
-        lambda app, shifu_bid: (
+        lambda _app, shifu_bid: (
             [("AI Shifu Guide Course", "system")]
             if shifu_bid == "demo-zh-course"
             else [("AI-Shifu Creation Guide", "system")]
@@ -381,7 +381,7 @@ def test_complete_onboarding_scene_is_idempotent(app, test_client, monkeypatch):
     )
     monkeypatch.setattr(
         "flaskr.service.shifu.demo_courses.get_dynamic_config",
-        lambda key, default="": default,
+        lambda _key, default="": default,
     )
 
     payload = {
@@ -605,7 +605,7 @@ def test_complete_onboarding_scene_handles_integrity_error(
     )
     monkeypatch.setattr(
         "flaskr.service.shifu.demo_courses.get_dynamic_config",
-        lambda key, default="": default,
+        lambda _key, default="": default,
     )
 
     original_commit = db.session.commit
@@ -652,7 +652,7 @@ def test_complete_onboarding_scene_rejects_ineligible_user(
 
     monkeypatch.setattr(
         "flaskr.service.user.onboarding.get_dynamic_config",
-        lambda key, default="": default,
+        lambda _key, default="": default,
     )
 
     response = test_client.post(
@@ -681,7 +681,7 @@ def test_complete_onboarding_scene_handles_non_object_payload(
 
     monkeypatch.setattr(
         "flaskr.service.user.onboarding.get_dynamic_config",
-        lambda key, default="": default,
+        lambda _key, default="": default,
     )
 
     response = test_client.post(

--- a/src/api/tests/service/user/test_user_repository.py
+++ b/src/api/tests/service/user/test_user_repository.py
@@ -8,17 +8,26 @@ def test_transactional_session_classifies_before_savepoint_rollback(app, monkeyp
     from sqlalchemy.exc import ResourceClosedError
 
     events = []
+
+    def invalidate(*, source, session=None):
+        del session
+        events.append(("invalidate", source))
+        return True
+
+    def cleanup(exc, *, source, session=None):
+        del exc, session
+        events.append(("cleanup", source))
+        return "rolled_back"
+
     monkeypatch.setattr(
         repo_module,
         "invalidate_session",
-        lambda *, source, _session=None: events.append(("invalidate", source)) or True,
+        invalidate,
     )
     monkeypatch.setattr(
         repo_module,
         "cleanup_session_after",
-        lambda _exc, *, source, _session=None: (
-            events.append(("cleanup", source)) or "rolled_back"
-        ),
+        cleanup,
     )
 
     class _Nested:

--- a/src/api/tests/service/user/test_user_repository.py
+++ b/src/api/tests/service/user/test_user_repository.py
@@ -11,12 +11,12 @@ def test_transactional_session_classifies_before_savepoint_rollback(app, monkeyp
     monkeypatch.setattr(
         repo_module,
         "invalidate_session",
-        lambda *, source, session=None: events.append(("invalidate", source)) or True,
+        lambda *, source, _session=None: events.append(("invalidate", source)) or True,
     )
     monkeypatch.setattr(
         repo_module,
         "cleanup_session_after",
-        lambda exc, *, source, session=None: (
+        lambda _exc, *, source, _session=None: (
             events.append(("cleanup", source)) or "rolled_back"
         ),
     )

--- a/src/api/tests/test_feishu.py
+++ b/src/api/tests/test_feishu.py
@@ -22,11 +22,17 @@ def test_send_order_feishu_formats_notification(app, monkeypatch):
     aggregate = SimpleNamespace(mobile="13800000000", name="Tester")
     shifu_info = SimpleNamespace(title="Test Course")
 
+    def get_shifu_info(
+        app: object,
+        course_id: str,
+        preview_mode: object,
+    ) -> SimpleNamespace:
+        del app, course_id, preview_mode
+        return shifu_info
+
     monkeypatch.setattr(order_funs, "query_buy_record", lambda _app, _id: order_info)
     monkeypatch.setattr(order_funs, "load_user_aggregate", lambda _id: aggregate)
-    monkeypatch.setattr(
-        order_funs, "get_shifu_info", lambda _app, _cid, preview_mode: shifu_info
-    )
+    monkeypatch.setattr(order_funs, "get_shifu_info", get_shifu_info)
 
     class FakeQuery:
         def __init__(self, first_value=None, count_value=0) -> None:

--- a/src/api/tests/test_gunicorn_worker_patch_guard.py
+++ b/src/api/tests/test_gunicorn_worker_patch_guard.py
@@ -61,7 +61,7 @@ def test_observer_skips_unpatched_processes(monkeypatch):
     from flaskr.common.gevent_hub_observer import install_hub_error_observer
     from gevent import monkey
 
-    monkeypatch.setattr(monkey, "is_module_patched", lambda name: False)
+    monkeypatch.setattr(monkey, "is_module_patched", lambda _name: False)
 
     class _Logger:
         def error(self, *args, **kwargs):

--- a/src/api/tests/test_langfuse_v4_semantics.py
+++ b/src/api/tests/test_langfuse_v4_semantics.py
@@ -31,7 +31,7 @@ def captured_spans(monkeypatch):
     monkeypatch.setattr(
         LangfuseTransformingSpanExporter,
         "export",
-        lambda self, spans: SpanExportResult.SUCCESS,
+        lambda _self, _spans: SpanExportResult.SUCCESS,
         raising=False,
     )
     exporter = InMemorySpanExporter()

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -33,7 +33,7 @@ def _install_litellm_stub() -> None:
     litellm_stub.register_model = register_model
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.get_model_info = get_model_info
-    litellm_stub.completion = lambda *args, **kwargs: iter([])
+    litellm_stub.completion = lambda *_args, **_kwargs: iter([])
     sys.modules["litellm"] = litellm_stub
 
 
@@ -600,11 +600,11 @@ def test_load_model_max_output_tokens_ignores_invalid_config(monkeypatch):
 def test_stream_litellm_completion_falls_back_to_litellm_limit(monkeypatch, app):
     captured = {}
     monkeypatch.setattr(llm, "MODEL_MAX_OUTPUT_TOKENS", {})
-    monkeypatch.setattr(llm.litellm, "get_max_tokens", lambda model: 8192)
+    monkeypatch.setattr(llm.litellm, "get_max_tokens", lambda _model: 8192)
     monkeypatch.setattr(
         llm.litellm,
         "completion",
-        lambda *args, **kwargs: captured.update(kwargs) or iter([]),
+        lambda *_args, **kwargs: captured.update(kwargs) or iter([]),
     )
 
     list(
@@ -640,7 +640,7 @@ def test_stream_litellm_completion_applies_configured_limit_as_ceiling(
     monkeypatch.setattr(
         llm.litellm,
         "completion",
-        lambda *args, **kwargs: captured.update(kwargs) or iter([]),
+        lambda *_args, **kwargs: captured.update(kwargs) or iter([]),
     )
     kwargs = {}
     if requested_max_tokens is not None:
@@ -672,7 +672,7 @@ def test_stream_litellm_completion_omits_unknown_limit(monkeypatch, app):
     monkeypatch.setattr(
         llm.litellm,
         "completion",
-        lambda *args, **kwargs: captured.update(kwargs) or iter([]),
+        lambda *_args, **kwargs: captured.update(kwargs) or iter([]),
     )
 
     list(
@@ -797,7 +797,7 @@ def test_openai_params_fall_back_when_capability_metadata_is_partial(monkeypatch
     monkeypatch.setattr(
         llm.litellm,
         "get_model_info",
-        lambda *args, **kwargs: {"supports_none_reasoning_effort": False},
+        lambda *_args, **_kwargs: {"supports_none_reasoning_effort": False},
     )
 
     assert llm._reload_openai_params("gpt-5.2-custom", 0.4) == {
@@ -1330,7 +1330,7 @@ def test_invoke_llm_uses_actual_model_for_provider_params(monkeypatch, app):
         return iter([FakeResponse("chunk-1", content="ok", finish_reason="stop")])
 
     monkeypatch.setattr(llm.litellm, "completion", fake_completion)
-    monkeypatch.setattr(llm, "record_llm_usage", lambda *args, **kwargs: None)
+    monkeypatch.setattr(llm, "record_llm_usage", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         llm,
         "PROVIDER_STATES",
@@ -1379,7 +1379,7 @@ def test_chat_llm_ends_partial_response_on_repeated_stream_chunk(monkeypatch, ap
         raise RepeatedChunkError(message)
 
     monkeypatch.setattr(llm.litellm, "completion", fake_completion)
-    monkeypatch.setattr(llm, "record_llm_usage", lambda *args, **kwargs: None)
+    monkeypatch.setattr(llm, "record_llm_usage", lambda *_args, **_kwargs: None)
     provider_state = llm.ProviderState(
         enabled=True,
         params={"api_key": "test-key", "api_base": "https://example.com"},
@@ -1431,7 +1431,7 @@ def test_chat_llm_streams(monkeypatch, app):
     monkeypatch.setattr(
         llm,
         "record_llm_usage",
-        lambda *args, **kwargs: captured_usage.update(kwargs),
+        lambda *_args, **kwargs: captured_usage.update(kwargs),
     )
     provider_state = llm.ProviderState(
         enabled=True,
@@ -1494,7 +1494,7 @@ def test_llm_sends_reasoning_output_to_langfuse_without_streaming_it(
         )
 
     monkeypatch.setattr(llm.litellm, "completion", fake_completion)
-    monkeypatch.setattr(llm, "record_llm_usage", lambda *args, **kwargs: None)
+    monkeypatch.setattr(llm, "record_llm_usage", lambda *_args, **_kwargs: None)
     provider_state = llm.ProviderState(
         enabled=True,
         params={"api_key": "test-key", "api_base": "https://example.com"},

--- a/src/api/tests/test_openai.py
+++ b/src/api/tests/test_openai.py
@@ -21,7 +21,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub.get_max_tokens = lambda _model: 4096
     litellm_stub.get_model_info = get_model_info
-    litellm_stub.completion = lambda *args, **kwargs: iter([])
+    litellm_stub.completion = lambda *_args, **_kwargs: iter([])
     sys.modules["litellm"] = litellm_stub
 
 

--- a/src/api/tests/test_order.py
+++ b/src/api/tests/test_order.py
@@ -25,6 +25,22 @@ from flaskr.service.promo.models import (
 from flaskr.util.datetime import now_utc
 
 
+def _fake_shifu_info(price: str) -> object:
+    def get_shifu_info(app: object, bid: str, preview_mode: object) -> SimpleNamespace:
+        del app, bid, preview_mode
+        return SimpleNamespace(price=Decimal(price))
+
+    return get_shifu_info
+
+
+def _query_promo_applications(items: list[object]) -> object:
+    def query(app: object, order_id: str, recalc_discount: object) -> list[object]:
+        del app, order_id, recalc_discount
+        return items
+
+    return query
+
+
 def test_init_buy_record_creates_order(app, monkeypatch):
     from flaskr.service.order import funs as order_funs
 
@@ -33,7 +49,7 @@ def test_init_buy_record_creates_order(app, monkeypatch):
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, preview_mode: SimpleNamespace(price=Decimal("100.00")),
+        _fake_shifu_info("100.00"),
     )
     monkeypatch.setattr(
         order_funs, "apply_promo_campaigns", lambda *_args, **_kwargs: []
@@ -62,7 +78,7 @@ def test_init_buy_record_refreshes_existing_unpaid_order_promotions(app, monkeyp
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, preview_mode: SimpleNamespace(price=Decimal("100.00")),
+        _fake_shifu_info("100.00"),
     )
 
     promo_application = SimpleNamespace(
@@ -121,7 +137,7 @@ def test_init_buy_record_reactivates_voided_promo_redemption(app, monkeypatch):
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, preview_mode: SimpleNamespace(price=Decimal("500.00")),
+        _fake_shifu_info("500.00"),
     )
 
     now = now_utc()
@@ -189,7 +205,7 @@ def test_init_buy_record_applies_legacy_campaign(app, monkeypatch):
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, preview_mode: SimpleNamespace(price=Decimal("500.00")),
+        _fake_shifu_info("500.00"),
     )
 
     now = now_utc()
@@ -282,7 +298,7 @@ def test_init_buy_record_refresh_keeps_existing_coupon_discount(app, monkeypatch
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, preview_mode: SimpleNamespace(price=Decimal("500.00")),
+        _fake_shifu_info("500.00"),
     )
 
     promo_application = SimpleNamespace(
@@ -298,7 +314,7 @@ def test_init_buy_record_refresh_keeps_existing_coupon_discount(app, monkeypatch
     monkeypatch.setattr(
         order_funs,
         "query_promo_campaign_applications",
-        lambda _app, _order_id, recalc_discount: [promo_application],
+        _query_promo_applications([promo_application]),
     )
 
     with app.app_context():

--- a/src/api/tests/test_query_order.py
+++ b/src/api/tests/test_query_order.py
@@ -14,6 +14,14 @@ from flaskr.service.promo.consts import (
 from flaskr.service.promo.models import Coupon, CouponUsage
 
 
+def _query_promo_applications(items: list[object]) -> object:
+    def query(app: object, order_id: str, recalc_discount: object) -> list[object]:
+        del app, order_id, recalc_discount
+        return items
+
+    return query
+
+
 def test_query_buy_record_returns_dto(app):
     with app.app_context():
         order = Order(
@@ -52,12 +60,14 @@ def test_query_buy_record_keeps_stored_discount_for_unpaid_order(app, monkeypatc
     monkeypatch.setattr(
         order_funs,
         "query_promo_campaign_applications",
-        lambda _app, _order_id, recalc_discount: [
-            SimpleNamespace(
-                discount_amount=Decimal("123.45"),
-                promo_name="spring-promo",
-            )
-        ],
+        _query_promo_applications(
+            [
+                SimpleNamespace(
+                    discount_amount=Decimal("123.45"),
+                    promo_name="spring-promo",
+                )
+            ]
+        ),
     )
 
     result = query_buy_record(app, "order-query-discount-1")
@@ -110,7 +120,7 @@ def test_query_buy_record_uses_coupon_name_and_code_in_price_item(app, monkeypat
     monkeypatch.setattr(
         order_funs,
         "query_promo_campaign_applications",
-        lambda _app, _order_id, recalc_discount: [],
+        _query_promo_applications([]),
     )
 
     result = query_buy_record(app, "order-query-coupon-1")
@@ -174,7 +184,7 @@ def test_query_buy_record_does_not_supplement_voided_campaign_redemption(
     monkeypatch.setattr(
         order_funs,
         "query_promo_campaign_applications",
-        lambda _app, _order_id, recalc_discount: [],
+        _query_promo_applications([]),
     )
 
     result = query_buy_record(app, "order-query-voided-promo-1")

--- a/src/api/tests/test_retry_on_deadlock.py
+++ b/src/api/tests/test_retry_on_deadlock.py
@@ -107,7 +107,7 @@ def test_protocol_interrupt_invalidates_and_does_not_retry(monkeypatch):
     monkeypatch.setattr(
         dao,
         "invalidate_session",
-        lambda *, source, session=None: invalidations.append(source) or True,
+        lambda *, source, _session=None: invalidations.append(source) or True,
     )
     calls = {"n": 0}
 
@@ -130,7 +130,7 @@ def test_rollback_db_failure_escalates_and_stops_retrying(monkeypatch):
     monkeypatch.setattr(
         dao,
         "invalidate_session",
-        lambda *, source, session=None: invalidations.append(source) or True,
+        lambda *, source, _session=None: invalidations.append(source) or True,
     )
 
     class _BrokenSession:

--- a/src/api/tests/test_shifu_upload_file.py
+++ b/src/api/tests/test_shifu_upload_file.py
@@ -18,7 +18,7 @@ def test_upload_file_creates_resource_when_resource_id_is_missing(app, monkeypat
     )
 
     monkeypatch.setattr(funcs, "get_image_content_type", lambda _filename: "image/png")
-    monkeypatch.setattr(funcs, "upload_to_storage", lambda *args, **kwargs: uploaded)
+    monkeypatch.setattr(funcs, "upload_to_storage", lambda *_args, **_kwargs: uploaded)
 
     with app.app_context():
         db.session.query(Resource).filter_by(resource_id="missing-resource-id").delete()

--- a/src/api/tests/test_uow.py
+++ b/src/api/tests/test_uow.py
@@ -11,7 +11,7 @@ def test_unit_of_work_invalidates_on_base_exception(app, monkeypatch):
     monkeypatch.setattr(
         dao,
         "invalidate_session",
-        lambda *, source, session=None: invalidations.append(source) or True,
+        lambda *, source, _session=None: invalidations.append(source) or True,
     )
 
     class _Interrupt(BaseException):
@@ -31,7 +31,7 @@ def test_unit_of_work_classifies_desync_exceptions(app, monkeypatch):
     monkeypatch.setattr(
         dao,
         "cleanup_session_after",
-        lambda exc, *, source, session=None: (
+        lambda exc, *, source, _session=None: (
             outcomes.append((type(exc).__name__, source)) or "invalidated"
         ),
     )

--- a/src/api/tests/test_wx_pub_order.py
+++ b/src/api/tests/test_wx_pub_order.py
@@ -16,6 +16,10 @@ def test_generate_charge_uses_pingxx_channel(app, monkeypatch):
     course_bid = "course-wx-pub-1"
     user_bid = "user-wx-pub-1"
 
+    def get_shifu_info(app: object, bid: str, preview_mode: object) -> SimpleNamespace:
+        del app, bid, preview_mode
+        return SimpleNamespace(title="Course", description="Desc")
+
     with app.app_context():
         order = Order(
             order_bid=order_bid,
@@ -33,9 +37,7 @@ def test_generate_charge_uses_pingxx_channel(app, monkeypatch):
     monkeypatch.setattr(
         order_funs,
         "get_shifu_info",
-        lambda _app, _bid, preview_mode: SimpleNamespace(
-            title="Course", description="Desc"
-        ),
+        get_shifu_info,
     )
 
     captured = {}


### PR DESCRIPTION
## Summary

- remove unused lambda arguments
- preserve provider, callback, and test-double keyword contracts with named helpers or narrow explained suppressions
- document the preferred callback pattern
- enable the complete ARG rule family
- preserve the reviewed SMS and transactional-session mock keyword contracts with named helpers

## Verification

- original focused suite: 135 tests passed
- review regression suite: 193 tests passed, 4 skipped
- review follow-up: 15 tests passed across both affected test files
- Ruff 0.16.3 configured and isolated ARG005 checks passed
- repository pre-commit hooks passed for both review-fix commits