### PR TITLE
chore: type variadic positional parameters

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -399,6 +399,10 @@ callback or test double must accept positional or keyword arguments, use a
 named helper or underscore-prefixed parameters that preserve the actual call
 contract; do not rename externally supplied keyword parameters.
 
+For `ANN002`, annotate the element type accepted by `*args`, not a tuple type.
+Use the narrow shared type when the forwarding contract is homogeneous and
+`object` only for genuinely heterogeneous compatibility forwarding.
+
 For `N815`, keep Python DTO field names in snake_case even when the public JSON
 contract uses camelCase. Pydantic DTOs should declare the public name with
 `Field(alias="...")`, accept internal construction through `populate_by_name`,

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -231,6 +231,12 @@ plan's progress update for that rule.
   and test-double keyword contracts through named helpers where required.
 - [ ] Merge or retarget ARG005 PR #2635 after ARG001 without combining it with
   the next rule unit.
+- [x] 2026-08-22: Rebuilt the ANN002 stage on `sunner/ruff-ann002`, stacked on
+  ARG005. Annotated every variadic positional parameter with its element type,
+  using narrow types for homogeneous forwarding and `object` for genuinely
+  heterogeneous compatibility boundaries.
+- [ ] Merge or retarget ANN002 PR #2636 after ARG005 without combining it with
+  the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,7 +15,8 @@
 #   below, so the rationale survives the next Ruff upgrade.
 #
 # Deliberately not selected:
-# - ANN (except ANN204/ANN205/ANN206, see `select`) / SLF001 / PLC0415 / PLR2004
+# - ANN (except ANN002/ANN204/ANN205/ANN206, see `select`) / SLF001 / PLC0415 /
+#   PLR2004
 #   (and D1xx, see the ignore block): thousands of violations each; enforcing
 #   them is a codebase-wide project, not a lint config change.
 # - ISC004: every hit is the deliberate long-string wrapping idiom inside
@@ -169,15 +170,18 @@ select = [
 
     # --- Type annotations -------------------------------------------------
     # flake8-annotations is otherwise off (see the header): annotating every
-    # argument and return in the repo is a separate project. ANN205 is small
-    # enough to keep enforced, and a staticmethod is where a missing return
-    # type hides the most, since there is no `self` to infer from. ANN206
-    # covers the classmethod counterpart, mostly alternative constructors and
-    # frozen-clock `now()` doubles. ANN204 is the same bet for special methods:
-    # `__init__`/`__exit__`/`__json__` and friends have a fixed contract, so the
-    # return type is never a judgement call and writing it down keeps the
+    # argument and return in the repo is a separate project. Variadic positional
+    # parameters name the element type after the star; use a concrete homogeneous
+    # type when known and `object` for intentionally heterogeneous forwarding.
+    # ANN205 is small enough to keep enforced, and a staticmethod is where a
+    # missing return type hides the most, since there is no `self` to infer from.
+    # ANN206 covers the classmethod counterpart, mostly alternative constructors
+    # and frozen-clock `now()` doubles. ANN204 is the same bet for special
+    # methods: `__init__`/`__exit__`/`__json__` and friends have a fixed contract,
+    # so the return type is never a judgement call and writing it down keeps the
     # serialization dunders (`__json__` returning a dict vs an enum value's str)
     # readable at a glance.
+    "ANN002",  # missing type for *args
     "ANN204",  # missing return type on a special method
     "ANN205",  # missing return type on a staticmethod
     "ANN206",  # missing return type on a classmethod

--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -64,13 +64,13 @@ _LINK_KEYS = {"trace_id", "parent_observation_id", "id"}
 class MockClient:
     """Provide a no-op Langfuse client when tracing is disabled."""
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: object, **kwargs) -> None:
         """Initialize the no-op Langfuse client."""
 
     def __getattr__(self, name) -> Any:
         """Return a no-op callable for any Langfuse operation."""
 
-        def method(*args, **kwargs):
+        def method(*args: object, **kwargs):
             _ = (args, kwargs)
             return self
 

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -62,7 +62,7 @@ _original_asyncio_run = asyncio.run
 _background_asyncio_tasks: set[asyncio.Task] = set()
 
 
-def _safe_asyncio_run(coro, *args, **kwargs):
+def _safe_asyncio_run(coro, *args: object, **kwargs):
     try:
         return _original_asyncio_run(coro, *args, **kwargs)
     except RuntimeError as exc:

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -37,7 +37,7 @@ class CacheProvider(Protocol):
         px: int | None = None,
         nx: bool = False,
         xx: bool = False,
-        *args,
+        *args: object,
         **kwargs,
     ):
         raise NotImplementedError
@@ -95,7 +95,7 @@ class _DynamicRedisCacheProvider:
         px: int | None = None,
         nx: bool = False,
         xx: bool = False,
-        *args,
+        *args: object,
         **kwargs,
     ):
         if ex is None and args:
@@ -211,7 +211,7 @@ class InMemoryCacheProvider:
         px: int | None = None,
         nx: bool = False,
         xx: bool = False,
-        *args,
+        *args: object,
         **kwargs,
     ):
         _ = kwargs
@@ -292,7 +292,7 @@ class FallbackCacheProvider:
         self._primary = primary
         self._fallback = fallback
 
-    def _call(self, method: str, *args, **kwargs):
+    def _call(self, method: str, *args: object, **kwargs):
         primary_fn = getattr(self._primary, method)
         fallback_fn = getattr(self._fallback, method)
         try:
@@ -317,7 +317,7 @@ class FallbackCacheProvider:
         px: int | None = None,
         nx: bool = False,
         xx: bool = False,
-        *args,
+        *args: object,
         **kwargs,
     ):
         return self._call(

--- a/src/api/flaskr/common/shifu_context.py
+++ b/src/api/flaskr/common/shifu_context.py
@@ -173,7 +173,7 @@ def with_shifu_context(
 
     def decorator(func: Callable) -> Callable:
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: object, **kwargs):
             try:
                 from flask import current_app, request
             except Exception:

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -516,7 +516,7 @@ def retry_on_deadlock(max_attempts: int = 3, backoff_seconds: float = 0.1):
 
     def decorator(func):
         @functools.wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: object, **kwargs):
             attempt = 0
             while True:
                 try:

--- a/src/api/flaskr/framework/plugin/inject.py
+++ b/src/api/flaskr/framework/plugin/inject.py
@@ -6,7 +6,7 @@ from functools import wraps
 # inject app to function and set inject flag
 def inject(func):
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: object, **kwargs):
         app = kwargs.get("app")
         if app:
             with app.app_context():

--- a/src/api/flaskr/framework/plugin/plugin_manager.py
+++ b/src/api/flaskr/framework/plugin/plugin_manager.py
@@ -50,7 +50,7 @@ class PluginManager:
             self.extension_functions[target_func_name] = []
         self.extension_functions[target_func_name].append(func)
 
-    def execute_extensions(self, func_name, result, *args, **kwargs):
+    def execute_extensions(self, func_name, result, *args: object, **kwargs):
         self.app.logger.info("execute_extensions: %s", func_name)
         if not self.is_enabled:
             return result
@@ -70,7 +70,7 @@ class PluginManager:
             self.extensible_generic_functions[func_name] = []
         self.extensible_generic_functions[func_name].append(func)
 
-    def execute_extensible_generic(self, func_name, result, *args, **kwargs):
+    def execute_extensible_generic(self, func_name, result, *args: object, **kwargs):
         self.app.logger.info("execute_extensible_generic: %s", func_name)
         if not self.is_enabled:
             return result
@@ -149,7 +149,7 @@ def extensible_generic_register(func_name):
 # extensible decorator
 def extensible(func):
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: object, **kwargs):
         result = func(*args, **kwargs)
         manager = get_plugin_manager()
         if manager is None:
@@ -170,7 +170,7 @@ def extensible_generic(func):
         pass
 
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: object, **kwargs):
         result = func(*args, **kwargs)
         if result:
             yield from result

--- a/src/api/flaskr/route/common.py
+++ b/src/api/flaskr/route/common.py
@@ -64,7 +64,7 @@ def bypass_token_validation(func):
     by_pass_login_func.append(func.__name__)
 
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: object, **kwargs):
         return func(*args, **kwargs)
 
     return wrapper

--- a/src/api/flaskr/route/open_api.py
+++ b/src/api/flaskr/route/open_api.py
@@ -19,7 +19,7 @@ def require_api_key(f):
     """Authenticate Open API requests via X-User-Uid + X-Api-Key headers."""
 
     @wraps(f)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: object, **kwargs):
         user_uid = request.headers.get("X-User-Uid", "").strip()
         api_key = request.headers.get("X-Api-Key", "").strip()
 

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -187,7 +187,7 @@ def _extract_referral_post_auth_fields(payload: dict) -> dict[str, str]:
 
 def optional_token_validation(f):
     @wraps(f)
-    def decorated_function(*args, **kwargs):
+    def decorated_function(*args: object, **kwargs):
         token = request.cookies.get("token", None)
         if not token:
             token = request.args.get("token", None)

--- a/src/api/flaskr/service/billing/referral_plan_rewards.py
+++ b/src/api/flaskr/service/billing/referral_plan_rewards.py
@@ -65,7 +65,7 @@ class _NullContext:
     def __enter__(self) -> None:
         return None
 
-    def __exit__(self, *_exc) -> bool | None:
+    def __exit__(self, *_exc: object) -> bool | None:
         return False
 
 

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -70,7 +70,7 @@ try:  # pragma: no cover - exercised indirectly when Celery is installed
     from celery import shared_task
 except ImportError:  # pragma: no cover - local fallback for non-Celery test envs
 
-    def shared_task(*args, **kwargs):
+    def shared_task(*args: object, **kwargs):
         _ = (args, kwargs)
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -42,7 +42,7 @@ _pingpp_client_state = _PingppClientState()
 
 def _serialized_pingpp_config(func):
     @wraps(func)
-    def wrapped(*args, **kwargs):
+    def wrapped(*args: object, **kwargs):
         with _PINGPP_CONFIG_LOCK:
             return func(*args, **kwargs)
 

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -272,7 +272,7 @@ def _build_user_keyword_query(keyword: str):
     )
 
 
-def _apply_keyword_filter(query, keyword: str, user_bid_field, *text_fields):
+def _apply_keyword_filter(query, keyword: str, user_bid_field, *text_fields: object):
     normalized = str(keyword or "").strip().lower()
     if not normalized:
         return query

--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -125,7 +125,7 @@ class _NullContext:
     def __enter__(self) -> None:
         return None
 
-    def __exit__(self, *_exc) -> bool | None:
+    def __exit__(self, *_exc: object) -> bool | None:
         return False
 
 

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -177,7 +177,7 @@ class ShifuTokenValidation:
 
     def __call__(self, f) -> Callable:
         @wraps(f)
-        def decorated_function(*args, **kwargs):
+        def decorated_function(*args: object, **kwargs):
             token = request.cookies.get("token", None)
             if not token:
                 token = request.args.get("token", None)

--- a/src/api/flaskr/service/tts/minimax_voice_clone.py
+++ b/src/api/flaskr/service/tts/minimax_voice_clone.py
@@ -21,7 +21,7 @@ except Exception:  # pragma: no cover - exercised only when pydub is missing.
         """Reference one time range in a source audio file."""
 
         @staticmethod
-        def from_file(*_args, **_kwargs) -> None:
+        def from_file(*_args: object, **_kwargs) -> None:
             message = "audio decoder is not available"
             raise RuntimeError(message)
 

--- a/src/api/flaskr/service/tts/tasks.py
+++ b/src/api/flaskr/service/tts/tasks.py
@@ -12,7 +12,7 @@ try:  # pragma: no cover - exercised indirectly when Celery is installed.
     from celery import shared_task
 except ImportError:  # pragma: no cover - local fallback for non-Celery test envs.
 
-    def shared_task(*args, **kwargs):
+    def shared_task(*args: object, **kwargs):
         _ = (args, kwargs)
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/src/api/tests/api/doc/test_feishu_notify.py
+++ b/src/api/tests/api/doc/test_feishu_notify.py
@@ -10,15 +10,15 @@ class _Logger:
         self.warnings = []
         self.exceptions = []
 
-    def info(self, *args, **kwargs):
+    def info(self, *args: object, **kwargs):
         _ = kwargs
         self.infos.append(args)
 
-    def warning(self, *args, **kwargs):
+    def warning(self, *args: object, **kwargs):
         _ = kwargs
         self.warnings.append(args)
 
-    def exception(self, *args, **kwargs):
+    def exception(self, *args: object, **kwargs):
         _ = kwargs
         self.exceptions.append(args)
 
@@ -91,7 +91,7 @@ def test_send_notify_returns_none_for_request_error(monkeypatch):
         lambda key, default=None: "https://example.test/webhook",  # noqa: ARG005 -- preserve get_config keyword contract
     )
 
-    def _raise(*args, **kwargs):
+    def _raise(*args: object, **kwargs):
         _ = (args, kwargs)
         message = "network down"
         raise requests.RequestException(message)

--- a/src/api/tests/command/test_unified_migration_task.py
+++ b/src/api/tests/command/test_unified_migration_task.py
@@ -124,7 +124,7 @@ def test_migrate_table_logs_formatted_batch_progress(caplog):
     async def table_count(_table_name):
         return 20
 
-    async def process_batch(*_args):
+    async def process_batch(*_args: object):
         return {"synced": 5, "errors": 0, "error_messages": []}
 
     task._table_exists_async = table_exists

--- a/src/api/tests/common/fixtures/fake_llm.py
+++ b/src/api/tests/common/fixtures/fake_llm.py
@@ -33,7 +33,7 @@ def _stream_chunks(stream: bool) -> list[str]:
     return ["mock-llm"]
 
 
-def fake_invoke_llm(*_args, **kwargs) -> Generator[FakeLLMResponse, None, None]:
+def fake_invoke_llm(*_args: object, **kwargs) -> Generator[FakeLLMResponse, None, None]:
     stream = bool(kwargs.get("stream", False))
     chunks = _stream_chunks(stream)
     for idx, chunk in enumerate(chunks, start=1):
@@ -45,7 +45,7 @@ def fake_invoke_llm(*_args, **kwargs) -> Generator[FakeLLMResponse, None, None]:
         )
 
 
-def fake_chat_llm(*_args, **kwargs) -> Generator[FakeLLMResponse, None, None]:
+def fake_chat_llm(*_args: object, **kwargs) -> Generator[FakeLLMResponse, None, None]:
     stream = bool(kwargs.get("stream", False))
     chunks = _stream_chunks(stream)
     for idx, chunk in enumerate(chunks, start=1):

--- a/src/api/tests/common/fixtures/fake_redis.py
+++ b/src/api/tests/common/fixtures/fake_redis.py
@@ -81,7 +81,7 @@ class FakeRedis:
         px: int | None = None,
         nx: bool = False,
         xx: bool = False,
-        *args,
+        *args: object,
         **kwargs,
     ):
         _ = kwargs

--- a/src/api/tests/common/test_gevent_hub_observer.py
+++ b/src/api/tests/common/test_gevent_hub_observer.py
@@ -67,7 +67,7 @@ def test_logger_failure_never_blocks_the_original_handler():
     hub = _StubHub()
 
     class _BrokenLogger:
-        def error(self, *args, **kwargs):
+        def error(self, *args: object, **kwargs):
             _ = (args, kwargs)
             message = "logging backend down"
             raise RuntimeError(message)

--- a/src/api/tests/common/test_log.py
+++ b/src/api/tests/common/test_log.py
@@ -15,7 +15,7 @@ class _FailingResponse:
 def test_feishu_log_handler_does_not_reemit_webhook_failures(monkeypatch):
     calls = []
 
-    def fake_post(*args, **kwargs):
+    def fake_post(*args: object, **kwargs):
         calls.append((args, kwargs))
         return _FailingResponse()
 
@@ -43,7 +43,7 @@ def test_feishu_log_handler_surfaces_delivery_failure_without_recursion(
 ):
     calls = []
 
-    def fake_post(*args, **kwargs):
+    def fake_post(*args: object, **kwargs):
         calls.append((args, kwargs))
         return _FailingResponse()
 
@@ -71,7 +71,7 @@ def test_feishu_log_handler_surfaces_delivery_failure_without_recursion(
 def test_feishu_log_handler_reentrancy_guard_blocks_nested_emit(monkeypatch):
     calls = []
 
-    def fake_post(*args, **kwargs):
+    def fake_post(*args: object, **kwargs):
         calls.append((args, kwargs))
         return type("Response", (), {"raise_for_status": lambda _self: None})()
 

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -55,14 +55,14 @@ class _TestPluginManager:
     def register_extension(self, target_func_name, func):
         self.extension_functions.setdefault(target_func_name, []).append(func)
 
-    def execute_extensions(self, _func_name, result, *args, **kwargs):
+    def execute_extensions(self, _func_name, result, *args: object, **kwargs):
         _ = (args, kwargs)
         return result
 
     def register_extensible_generic(self, func_name, func):
         self.extensible_generic_functions.setdefault(func_name, []).append(func)
 
-    def execute_extensible_generic(self, _func_name, *args, **kwargs):
+    def execute_extensible_generic(self, _func_name, *args: object, **kwargs):
         _ = (args, kwargs)
 
 

--- a/src/api/tests/golden/conftest.py
+++ b/src/api/tests/golden/conftest.py
@@ -104,7 +104,7 @@ def _iter_golden_completion(messages) -> list[str]:
     return list(GOLDEN_LLM_CHUNKS)
 
 
-def golden_chat_llm(*args, **kwargs):
+def golden_chat_llm(*args: object, **kwargs):
     messages = kwargs.get("messages")
     if messages is None:
         for arg in args:
@@ -121,7 +121,7 @@ def golden_chat_llm(*args, **kwargs):
         )
 
 
-def golden_invoke_llm(*args, **kwargs):
+def golden_invoke_llm(*args: object, **kwargs):
     yield from golden_chat_llm(*args, **kwargs)
 
 

--- a/src/api/tests/migrations/test_learner_profile_migration.py
+++ b/src/api/tests/migrations/test_learner_profile_migration.py
@@ -53,7 +53,7 @@ def test_learner_profile_column_remains_nullable_for_rolling_writers():
 
     class _Operations:
         @contextmanager
-        def batch_alter_table(self, *_args, **_kwargs):
+        def batch_alter_table(self, *_args: object, **_kwargs):
             yield _BatchOperations()
 
         def execute(self, statement):

--- a/src/api/tests/service/billing/test_billing_cycle_transitions.py
+++ b/src/api/tests/service/billing/test_billing_cycle_transitions.py
@@ -20,7 +20,7 @@ from flaskr.service.billing.cycle_transitions import (
 )
 
 
-def _raise_unexpected_call(*_args, **_kwargs):
+def _raise_unexpected_call(*_args: object, **_kwargs):
     message = "unexpected callback call"
     raise AssertionError(message)
 

--- a/src/api/tests/service/billing/test_billing_error_specificity.py
+++ b/src/api/tests/service/billing/test_billing_error_specificity.py
@@ -31,7 +31,7 @@ class _UnavailableLock:
 
 
 class _LockFactory:
-    def lock(self, *_args, **_kwargs):
+    def lock(self, *_args: object, **_kwargs):
         return _UnavailableLock()
 
 

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -1220,7 +1220,7 @@ class TestBillingRoutes:
         with app.app_context():
             order_select_count = 0
 
-            def _count_order_selects(_conn, _cursor, statement, *_args):
+            def _count_order_selects(_conn, _cursor, statement, *_args: object):
                 nonlocal order_select_count
                 if "bill_orders" in statement.lower():
                     order_select_count += 1
@@ -1689,7 +1689,7 @@ class TestBillingRoutes:
 
         order_select_count = 0
 
-        def _count_order_selects(_conn, _cursor, statement, *_args):
+        def _count_order_selects(_conn, _cursor, statement, *_args: object):
             nonlocal order_select_count
             if "bill_orders" in statement.lower():
                 order_select_count += 1

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -141,7 +141,7 @@ def _billing_paid_feishu_payload(
     }
 
 
-def _raise_if_send_notify_called(*args, **kwargs):
+def _raise_if_send_notify_called(*args: object, **kwargs):
     _ = (args, kwargs)
     message = "billing paid Feishu delivery should run in a Celery task"
     raise AssertionError(message)

--- a/src/api/tests/service/billing/test_billing_tasks.py
+++ b/src/api/tests/service/billing/test_billing_tasks.py
@@ -532,7 +532,7 @@ def test_settle_usage_task_serializes_same_creator_concurrent_usage(
 
     original_build_usage_metric_charges = settlement_module.build_usage_metric_charges
 
-    def _blocking_build_usage_metric_charges(*args, **kwargs):
+    def _blocking_build_usage_metric_charges(*args: object, **kwargs):
         usage = args[0]
         if usage.usage_bid == "usage-concurrent-1":
             entered_first_charge.set()

--- a/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
@@ -401,7 +401,7 @@ def test_failed_provider_marker_persists_and_stays_retryable(
     )
     notification_bid = str(staged["notification_bid"])
 
-    def crashing_send(*_args, **_kwargs):
+    def crashing_send(*_args: object, **_kwargs):
         message = "provider connection dropped"
         raise RuntimeError(message)
 

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -2372,7 +2372,7 @@ def test_provider_exception_marks_notification_failed(
     _seed_creator(app)
     _enable_policy(app)
 
-    def raise_provider_error(*args, **kwargs) -> None:
+    def raise_provider_error(*args: object, **kwargs) -> None:
         _ = (args, kwargs)
         message = "provider raised"
         raise RuntimeError(message)

--- a/src/api/tests/service/billing/test_provider_catalog.py
+++ b/src/api/tests/service/billing/test_provider_catalog.py
@@ -38,7 +38,7 @@ class _FakeStripeResource:
         self.payload = payload
         self.calls = []
 
-    def retrieve(self, *args, **kwargs):
+    def retrieve(self, *args: object, **kwargs):
         self.calls.append({"args": args, "kwargs": kwargs})
         return _StripeObject(self.payload)
 
@@ -86,7 +86,7 @@ class _FakeStripe:
 
 
 class _FailingStripeResource:
-    def retrieve(self, *args, **kwargs):
+    def retrieve(self, *args: object, **kwargs):
         _ = (args, kwargs)
         message = "secret sk_test_should_not_leak"
         raise RuntimeError(message)

--- a/src/api/tests/service/billing/test_referral_plan_rewards.py
+++ b/src/api/tests/service/billing/test_referral_plan_rewards.py
@@ -964,7 +964,7 @@ def test_pingxx_renewal_event_preserves_paid_referral_reward_order(
     boundary_at = normalize_mysql_datetime(now_utc() - timedelta(minutes=1))
     current_cycle_start = boundary_at - timedelta(days=30)
 
-    def _fail_provider_sync(*_args, **_kwargs):
+    def _fail_provider_sync(*_args: object, **_kwargs):
         message = "paid referral reward orders must not sync providers"
         raise AssertionError(message)
 

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -316,7 +316,7 @@ def test_renewal_order_persists_before_provider_sync_crash(
     )
     dao.db.session.commit()
 
-    def crashing_sync(*_args, **_kwargs):
+    def crashing_sync(*_args: object, **_kwargs):
         message = "provider sync crash"
         raise RuntimeError(message)
 
@@ -952,7 +952,7 @@ def test_provider_guard_renews_lease_before_cross_transaction_sync(
 
     recovery_counts: list[int] = []
 
-    def fake_sync(*_args, **_kwargs):
+    def fake_sync(*_args: object, **_kwargs):
         recovery_counts.append(
             billing_tasks._recover_stale_processing_renewal_events(
                 stale_before=now_utc() - timedelta(minutes=30),

--- a/src/api/tests/service/common/test_umami_client.py
+++ b/src/api/tests/service/common/test_umami_client.py
@@ -195,7 +195,7 @@ def test_get_course_visit_count_30d_returns_fetched_value_when_cache_write_fails
         def get(self, key):
             return self._cache.get(key)
 
-        def delete(self, *keys):
+        def delete(self, *keys: str):
             return self._cache.delete(*keys)
 
         def setex(self, key, ttl, value):
@@ -241,7 +241,7 @@ def test_get_course_visit_count_30d_returns_zero_when_failure_cache_write_fails(
         def get(self, key):
             return self._cache.get(key)
 
-        def delete(self, *keys):
+        def delete(self, *keys: str):
             return self._cache.delete(*keys)
 
         def setex(self, key, ttl, value):
@@ -294,7 +294,7 @@ def test_get_course_visit_count_30d_waits_for_cache_on_lock_contention(
         def get(self, key):
             _ = key
 
-        def delete(self, *keys):
+        def delete(self, *keys: str):
             _ = keys
             return 0
 

--- a/src/api/tests/service/learn/run/test_run_recorder.py
+++ b/src/api/tests/service/learn/run/test_run_recorder.py
@@ -82,7 +82,7 @@ def _fail_next_flush(monkeypatch, exc: Exception) -> None:
     real_flush = dao.db.session.flush
     state = {"fired": False}
 
-    def _boom(*args, **kwargs):
+    def _boom(*args: object, **kwargs):
         if not state["fired"]:
             state["fired"] = True
             raise exc

--- a/src/api/tests/service/learn/test_ask_provider_adapters.py
+++ b/src/api/tests/service/learn/test_ask_provider_adapters.py
@@ -58,7 +58,7 @@ def test_dify_adapter_streams_success_content(app, monkeypatch):
         }.get,
     )
 
-    def _fake_post(*_args, **kwargs):
+    def _fake_post(*_args: object, **kwargs):
         request_state["json"] = kwargs.get("json")
         return _FakeResponse(
             lines=[
@@ -114,7 +114,7 @@ def test_coze_adapter_timeout_raises_timeout_error(app, monkeypatch):
         }.get,
     )
 
-    def _raise_timeout(*_args, **_kwargs):
+    def _raise_timeout(*_args: object, **_kwargs):
         message = "timeout"
         raise requests.Timeout(message)
 
@@ -403,7 +403,7 @@ def test_volc_knowledge_adapter_streams_success_content(app, monkeypatch):
 
     request_state = {}
 
-    def _fake_request(*_args, **kwargs):
+    def _fake_request(*_args: object, **kwargs):
         request_state["method"] = kwargs.get("method")
         request_state["headers"] = kwargs.get("headers") or {}
         request_state["url"] = kwargs.get("url")
@@ -750,7 +750,7 @@ def test_get_biji_knowledge_adapter_missing_config_raises_error(app):
 def test_get_biji_knowledge_adapter_timeout_raises_timeout_error(app, monkeypatch):
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
 
-    def _raise_timeout(*_args, **_kwargs):
+    def _raise_timeout(*_args: object, **_kwargs):
         message = "timeout"
         raise requests.Timeout(message)
 

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -19,7 +19,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args, **kwargs):
+    def get_model_info(*args: object, **kwargs):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -471,14 +471,14 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
             deleted = _Column()
 
         class _FakeQuery:
-            def filter(self, *_args, **_kwargs):
+            def filter(self, *_args: object, **_kwargs):
                 return self
 
             def all(self):
                 return [("outline-1", False, "Outline 1")]
 
         class _FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs) -> None:
                 pass
 
             def get_all_blocks(self):
@@ -540,7 +540,7 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
         attend = types.SimpleNamespace(outline_item_bid="outline-1", block_position=0)
 
         class _FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs) -> None:
                 pass
 
             def get_all_blocks(self):
@@ -1140,11 +1140,11 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
 
     def test_init_ignores_visual_mode_when_api_missing(self):
         class FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs) -> None:
                 self.args = args
                 self.kwargs = kwargs
 
-            def set_output_language(self, *_args, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs):
                 return self
 
         with patch("flaskr.service.learn.context_v2.MarkdownFlow", FakeMarkdownFlow):
@@ -1154,14 +1154,14 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
 
     def test_init_calls_visual_mode_when_api_exists(self):
         class FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs) -> None:
                 _ = (args, kwargs)
                 self.visual_mode = None
 
             def set_visual_mode(self, visual_mode):
                 self.visual_mode = visual_mode
 
-            def set_output_language(self, *_args, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs):
                 return self
 
         with patch("flaskr.service.learn.context_v2.MarkdownFlow", FakeMarkdownFlow):
@@ -1171,7 +1171,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
 
     def test_init_uses_explicit_output_language_when_enabled(self):
         class FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs) -> None:
                 _ = (args, kwargs)
                 self.output_language = None
 
@@ -1835,17 +1835,17 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
         captured = {}
 
         class _FakePreviewContextStore:
-            def __init__(self, *_args, **_kwargs) -> None:
+            def __init__(self, *_args: object, **_kwargs) -> None:
                 pass
 
-            def get_context(self, *_args, **_kwargs):
+            def get_context(self, *_args: object, **_kwargs):
                 return []
 
-            def replace_context(self, *_args, **_kwargs):
+            def replace_context(self, *_args: object, **_kwargs):
                 return None
 
         class _FakePreviewMdflowContext:
-            def __init__(self, *args, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs) -> None:
                 _ = args, kwargs
 
             @staticmethod
@@ -1874,7 +1874,7 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
                 )
 
         class _FakePreviewAdapter:
-            def __init__(self, *_args, **_kwargs) -> None:
+            def __init__(self, *_args: object, **_kwargs) -> None:
                 pass
 
             def process(self, events):

--- a/src/api/tests/service/learn/test_element_protocol.py
+++ b/src/api/tests/service/learn/test_element_protocol.py
@@ -176,7 +176,7 @@ def _setup_handle_input_ask_test_doubles(
 
         call_counter = {"index": 0}
 
-        def _fake_init_generated_block(*_args, **_kwargs):
+        def _fake_init_generated_block(*_args: object, **_kwargs):
             call_counter["index"] += 1
             return types.SimpleNamespace(
                 generated_block_bid=f"gb-{call_counter['index']}",

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -935,7 +935,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
         synthesized_texts = _patch_run_tts_processor(monkeypatch)
 
-        def _fail_sem_acquire(*_args, **_kwargs):
+        def _fail_sem_acquire(*_args: object, **_kwargs):
             message = "cache fast-path should not acquire the synthesis semaphore"
             raise AssertionError(message)
 
@@ -1159,7 +1159,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
         synthesized_texts = _patch_run_tts_processor(monkeypatch)
 
-        def _fail_sem_acquire(*_args, **_kwargs):
+        def _fail_sem_acquire(*_args: object, **_kwargs):
             message = "markup-only blocks should not acquire the synthesis semaphore"
             raise AssertionError(message)
 

--- a/src/api/tests/service/learn/test_handle_input_ask_provider.py
+++ b/src/api/tests/service/learn/test_handle_input_ask_provider.py
@@ -11,7 +11,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args, **kwargs):
+    def get_model_info(*args: object, **kwargs):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -95,13 +95,13 @@ class _DummyOrderColumn(_DummyColumn):
 
 
 class _DummyQuery:
-    def filter(self, *_args, **_kwargs):
+    def filter(self, *_args: object, **_kwargs):
         return self
 
-    def order_by(self, *_args, **_kwargs):
+    def order_by(self, *_args: object, **_kwargs):
         return self
 
-    def limit(self, *_args, **_kwargs):
+    def limit(self, *_args: object, **_kwargs):
         return self
 
     def all(self):
@@ -118,7 +118,7 @@ class _DummyLearnGeneratedBlockModel:
 class _DummyNoneQuery:
     """Query that always returns None for .first()."""
 
-    def filter(self, *_args, **_kwargs):
+    def filter(self, *_args: object, **_kwargs):
         return self
 
     def first(self):
@@ -277,7 +277,7 @@ def _setup_handle_input_ask_patches(monkeypatch, module, ask_provider_config):
 
     call_counter = {"index": 0}
 
-    def _fake_init_generated_block(*_args, **_kwargs):
+    def _fake_init_generated_block(*_args: object, **_kwargs):
         call_counter["index"] += 1
         return types.SimpleNamespace(
             generated_block_bid=f"gb-{call_counter['index']}",
@@ -311,7 +311,7 @@ def test_handle_input_ask_provider_only_returns_provider_error_without_llm(
 
     llm_call_counter = {"count": 0}
 
-    def _fake_chat_llm(*_args, **_kwargs):
+    def _fake_chat_llm(*_args: object, **_kwargs):
         llm_call_counter["count"] += 1
         yield _LLMChunk("should-not-run")
 
@@ -377,7 +377,7 @@ def test_handle_input_ask_provider_then_llm_falls_back_to_llm(app, monkeypatch):
 
     llm_call_counter = {"count": 0}
 
-    def _fake_chat_llm(*_args, **_kwargs):
+    def _fake_chat_llm(*_args: object, **_kwargs):
         llm_call_counter["count"] += 1
         yield _LLMChunk("llm-fallback-answer")
 
@@ -449,7 +449,7 @@ def test_handle_input_ask_get_biji_synthesizes_via_context_factory(app, monkeypa
 
     llm_calls = []
 
-    def _fake_chat_llm(*_args, **kwargs):
+    def _fake_chat_llm(*_args: object, **kwargs):
         llm_calls.append(kwargs)
         yield _LLMChunk("synthesized-answer")
 
@@ -520,7 +520,7 @@ def test_handle_input_ask_provider_response_skips_llm(app, monkeypatch):
 
     llm_call_counter = {"count": 0}
 
-    def _fake_chat_llm(*_args, **_kwargs):
+    def _fake_chat_llm(*_args: object, **_kwargs):
         llm_call_counter["count"] += 1
         yield _LLMChunk("should-not-run")
 

--- a/src/api/tests/service/learn/test_learn_funcs.py
+++ b/src/api/tests/service/learn/test_learn_funcs.py
@@ -250,14 +250,14 @@ class LearnRecordLoadTests(unittest.TestCase):
         class FakeMarkdownFlow:
             last_context = None
 
-            def __init__(self, *args, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs) -> None:
                 _ = (args, kwargs)
                 self.blocks = [DummyBlock(BlockType.CONTENT, "md content", 0)]
 
-            def set_visual_mode(self, *_args, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs):
                 pass
 
-            def set_output_language(self, *_args, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs):
                 return self
 
             def get_all_blocks(self):
@@ -370,7 +370,7 @@ class LearnRecordLoadTests(unittest.TestCase):
                 self.content = content
 
         class FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs) -> None:
                 _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(MarkdownFlowBlockType.CONTENT, "first content", 0),
@@ -382,10 +382,10 @@ class LearnRecordLoadTests(unittest.TestCase):
                     ),
                 ]
 
-            def set_visual_mode(self, *_args, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs):
                 pass
 
-            def set_output_language(self, *_args, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs):
                 return self
 
             def get_all_blocks(self):
@@ -518,14 +518,14 @@ class LearnRecordLoadTests(unittest.TestCase):
         class FakeMarkdownFlow:
             process_called = False
 
-            def __init__(self, *args, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs) -> None:
                 _ = (args, kwargs)
                 self.blocks = [DummyBlock(BlockType.CONTENT, "===fixed output===", 0)]
 
-            def set_visual_mode(self, *_args, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs):
                 pass
 
-            def set_output_language(self, *_args, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs):
                 return self
 
             def get_all_blocks(self):
@@ -645,17 +645,17 @@ class LearnRecordLoadTests(unittest.TestCase):
         class FakeMarkdownFlow:
             process_called = False
 
-            def __init__(self, *args, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs) -> None:
                 _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(BlockType.CONTENT, "===fixed output===", 0),
                     DummyBlock(BlockType.INTERACTION, "?[%{{v}} A|B]", 1),
                 ]
 
-            def set_visual_mode(self, *_args, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs):
                 pass
 
-            def set_output_language(self, *_args, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs):
                 return self
 
             def get_all_blocks(self):
@@ -768,17 +768,17 @@ class LearnRecordLoadTests(unittest.TestCase):
         class FakeMarkdownFlow:
             process_called = False
 
-            def __init__(self, *args, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs) -> None:
                 _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(BlockType.CONTENT, "===fixed output===", 0),
                     DummyBlock(BlockType.INTERACTION, "?[%{{v}} A|B]", 1),
                 ]
 
-            def set_visual_mode(self, *_args, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs):
                 pass
 
-            def set_output_language(self, *_args, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs):
                 return self
 
             def get_all_blocks(self):

--- a/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
+++ b/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
@@ -13,7 +13,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args, **kwargs):
+    def get_model_info(*args: object, **kwargs):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -117,7 +117,7 @@ def test_find_active_element_row_ids_invalidates_desynced_connection(app, monkey
         def __init__(self) -> None:
             self.invalidated = 0
 
-        def execute(self, *_args, **_kwargs):
+        def execute(self, *_args: object, **_kwargs):
             return _DesyncedResult()
 
         def invalidate(self):

--- a/src/api/tests/service/learn/test_listen_elements.py
+++ b/src/api/tests/service/learn/test_listen_elements.py
@@ -1410,7 +1410,7 @@ def test_listen_run_persists_content_block_before_element_rows(app):
                 self.content = content
 
         class FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs) -> None:
                 _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(
@@ -1420,10 +1420,10 @@ def test_listen_run_persists_content_block_before_element_rows(app):
                     )
                 ]
 
-            def set_visual_mode(self, *_args, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs):
                 pass
 
-            def set_output_language(self, *_args, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs):
                 return self
 
             def get_all_blocks(self):
@@ -1603,7 +1603,7 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
                 self.formatted_elements = formatted_elements
 
         class FakeMarkdownFlow:
-            def __init__(self, *args, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs) -> None:
                 _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(
@@ -1613,10 +1613,10 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
                     )
                 ]
 
-            def set_visual_mode(self, *_args, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs):
                 pass
 
-            def set_output_language(self, *_args, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs):
                 return self
 
             def get_all_blocks(self):

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -55,7 +55,7 @@ class FakeCacheProvider:
         self._lock = lock
         self.values: dict[str, bytes] = {}
 
-    def lock(self, *_args, **_kwargs):
+    def lock(self, *_args: object, **_kwargs):
         return self._lock
 
     def setex(self, key: str, _time_in_seconds: int, value):
@@ -78,7 +78,7 @@ class FakeCacheProvider:
 class FakeListenElementAdapter:
     """Simulate listen element adapter behavior for tests."""
 
-    def __init__(self, *_args, **_kwargs) -> None:
+    def __init__(self, *_args: object, **_kwargs) -> None:
         """Initialize event sequencing for a fixed run session."""
         self._seq = 0
         self._run_session_bid = "run-session-1"
@@ -531,10 +531,10 @@ def test_run_script_inner_ask_mode_routes_events_through_element_adapter(monkeyp
         def __init__(self, **_kwargs) -> None:
             self._has_next = True
 
-        def set_input(self, *_args, **_kwargs):
+        def set_input(self, *_args: object, **_kwargs):
             return None
 
-        def reload(self, *_args, **_kwargs):
+        def reload(self, *_args: object, **_kwargs):
             return []
 
         def has_next(self):
@@ -733,10 +733,10 @@ def test_run_script_inner_rolls_back_on_unexpected_exception(monkeypatch):
         def __init__(self, **_kwargs) -> None:
             self._has_next = True
 
-        def set_input(self, *_args, **_kwargs):
+        def set_input(self, *_args: object, **_kwargs):
             return None
 
-        def reload(self, *_args, **_kwargs):
+        def reload(self, *_args: object, **_kwargs):
             return []
 
         def has_next(self):
@@ -821,10 +821,10 @@ def test_run_script_inner_finalizes_langfuse_after_loop(monkeypatch):
             self.finalize_calls = 0
             FakeRunScriptContext.last_instance = self
 
-        def set_input(self, *_args, **_kwargs):
+        def set_input(self, *_args: object, **_kwargs):
             return None
 
-        def reload(self, *_args, **_kwargs):
+        def reload(self, *_args: object, **_kwargs):
             return []
 
         def has_next(self):
@@ -921,10 +921,10 @@ def test_run_script_inner_emits_audio_backfill_ready_after_final_commit(monkeypa
         def __init__(self, **_kwargs) -> None:
             self._has_next = True
 
-        def set_input(self, *_args, **_kwargs):
+        def set_input(self, *_args: object, **_kwargs):
             return None
 
-        def reload(self, *_args, **_kwargs):
+        def reload(self, *_args: object, **_kwargs):
             return []
 
         def has_next(self):
@@ -1050,10 +1050,10 @@ def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(monkeypa
         def __init__(self, **_kwargs) -> None:
             self._has_next = True
 
-        def set_input(self, *_args, **_kwargs):
+        def set_input(self, *_args: object, **_kwargs):
             return None
 
-        def reload(self, *_args, **_kwargs):
+        def reload(self, *_args: object, **_kwargs):
             return []
 
         def has_next(self):

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -51,7 +51,7 @@ class _StubRunContext:
     def __init__(self, **_kwargs) -> None:
         self._steps = iter([True, False])
 
-    def set_input(self, *_args, **_kwargs):
+    def set_input(self, *_args: object, **_kwargs):
         pass
 
     def has_next(self):

--- a/src/api/tests/service/learn/test_runtime_tts_admission.py
+++ b/src/api/tests/service/learn/test_runtime_tts_admission.py
@@ -19,7 +19,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = ModuleType("litellm")
 
-    def get_model_info(*args, **kwargs):
+    def get_model_info(*args: object, **kwargs):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -412,7 +412,7 @@ def test_run_route_skips_runtime_admission_payload_for_builtin_demo(
         ),
     )
 
-    def _fake_run_script(*_args, **kwargs):
+    def _fake_run_script(*_args: object, **kwargs):
         assert "runtime_admission_payload" not in kwargs
         yield 'data: {"type":"done","event_type":"done","content":""}\n\n'
 
@@ -444,7 +444,7 @@ def test_run_route_uses_payload_language_as_generation_snapshot(
         lambda _app, shifu_bid: shifu_bid == "builtin-demo-1",
     )
 
-    def _fake_run_script(*_args, **kwargs):
+    def _fake_run_script(*_args: object, **kwargs):
         captured.update(kwargs)
         yield 'data: {"type":"done","event_type":"done","content":""}\n\n'
 

--- a/src/api/tests/service/learn/test_tts_synth_concurrency.py
+++ b/src/api/tests/service/learn/test_tts_synth_concurrency.py
@@ -19,7 +19,7 @@ class FakeRedis:
         """Initialize semaphore counters keyed by synthesis slot."""
         self.counters: dict[str, int] = {}
 
-    def eval(self, _script, _numkeys, *args):
+    def eval(self, _script, _numkeys, *args: object):
         key = args[0]
         if len(args) >= 3:  # acquire: key, max_count, ttl
             max_count = int(args[1])
@@ -42,7 +42,7 @@ class ExplodingRedis:
         """Reset the count of intentionally failing Redis calls."""
         self.calls = 0
 
-    def eval(self, *_args, **_kwargs):
+    def eval(self, *_args: object, **_kwargs):
         self.calls += 1
         message = "redis down"
         raise RuntimeError(message)

--- a/src/api/tests/service/order/test_import_activation_parse.py
+++ b/src/api/tests/service/order/test_import_activation_parse.py
@@ -258,7 +258,7 @@ def test_import_activation_does_not_consult_profile_state_for_nickname_defaults(
 
         original_ensure_user = order_admin.ensure_user_for_identifier
 
-        def track_ensure_user(*args, **kwargs):
+        def track_ensure_user(*args: object, **kwargs):
             reads_before_ensure.extend(read_order)
             return original_ensure_user(*args, **kwargs)
 

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -243,7 +243,7 @@ class _FakeSaasQuery:
     def filter(self, *conditions: tuple[str, object]) -> _FakeSaasQuery:
         return _FakeSaasQuery(self._fake_saas, [*self._conditions, *conditions])
 
-    def order_by(self, *_args) -> _FakeSaasQuery:
+    def order_by(self, *_args: object) -> _FakeSaasQuery:
         return self
 
     def first(self):

--- a/src/api/tests/service/order/test_order_import_error_specificity.py
+++ b/src/api/tests/service/order/test_order_import_error_specificity.py
@@ -9,7 +9,7 @@ from flaskr.i18n import _
 def test_import_activation_orders_unexpected_failure_returns_specific_message(
     app, monkeypatch
 ):
-    def raise_unexpected(*_args, **_kwargs):
+    def raise_unexpected(*_args: object, **_kwargs):
         message = "boom"
         raise RuntimeError(message)
 
@@ -35,7 +35,7 @@ def test_import_activation_orders_unexpected_failure_returns_specific_message(
 def test_import_activation_orders_from_entries_unexpected_failure_returns_specific_message(
     app, monkeypatch
 ):
-    def raise_unexpected(*_args, **_kwargs):
+    def raise_unexpected(*_args: object, **_kwargs):
         message = "boom"
         raise RuntimeError(message)
 

--- a/src/api/tests/service/order/test_order_init_lock.py
+++ b/src/api/tests/service/order/test_order_init_lock.py
@@ -62,7 +62,7 @@ def test_order_init_lock_uses_prefixed_key(monkeypatch):
 
 def test_order_init_lock_skips_when_cache_provider_errors(monkeypatch):
     class _BrokenCacheProvider:
-        def lock(self, *args, **kwargs):
+        def lock(self, *args: object, **kwargs):
             _ = (args, kwargs)
             message = "lock unavailable"
             raise RuntimeError(message)

--- a/src/api/tests/service/order/test_uow_failure_paths.py
+++ b/src/api/tests/service/order/test_uow_failure_paths.py
@@ -104,7 +104,7 @@ def _fail_after_pricing_sync(monkeypatch: pytest.MonkeyPatch) -> None:
     """Run the real pricing sync, then fail — simulating any late step error."""
     real_sync = order_funs._sync_order_campaign_pricing
 
-    def failing_sync(*args, **kwargs):
+    def failing_sync(*args: object, **kwargs):
         real_sync(*args, **kwargs)
         message = "boom after pricing sync"
         raise RuntimeError(message)

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -1608,11 +1608,11 @@ class FakeLatestQuery:
         self.grouped_by = []
         self.subquery_value = FakeLatestSubquery()
 
-    def filter(self, *conditions):
+    def filter(self, *conditions: object):
         self.filters.extend(conditions)
         return self
 
-    def group_by(self, *columns):
+    def group_by(self, *columns: object):
         self.grouped_by.extend(columns)
         return self
 
@@ -1639,19 +1639,19 @@ class FakeOuterQuery:
         self.options_calls = []
         self.with_entities_calls = []
 
-    def filter(self, *conditions):
+    def filter(self, *conditions: object):
         self.filters.extend(conditions)
         return self
 
-    def options(self, *options):
+    def options(self, *options: object):
         self.options_calls.extend(options)
         return self
 
-    def order_by(self, *ordering):
+    def order_by(self, *ordering: object):
         self.ordering.extend(ordering)
         return self
 
-    def with_entities(self, *columns):
+    def with_entities(self, *columns: object):
         self.with_entities_calls.append(columns)
         return self
 

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -4812,7 +4812,7 @@ def test_registration_source_map_skips_user_query_when_users_argument_is_empty(
     app, monkeypatch
 ):
     class ForbiddenUserQuery:
-        def filter(self, *_args, **_kwargs):
+        def filter(self, *_args: object, **_kwargs):
             message = "expected no user query when users=[] is provided"
             raise AssertionError(message)
 
@@ -4866,7 +4866,7 @@ def test_registration_source_map_skips_unknown_provider_when_supported_one_exist
 
 def test_contact_map_skips_user_query_when_users_argument_is_empty(app, monkeypatch):
     class ForbiddenUserQuery:
-        def filter(self, *_args, **_kwargs):
+        def filter(self, *_args: object, **_kwargs):
             message = "expected no user query when users=[] is provided"
             raise AssertionError(message)
 

--- a/src/api/tests/service/shifu/test_archive.py
+++ b/src/api/tests/service/shifu/test_archive.py
@@ -317,7 +317,7 @@ def test_create_shifu_draft_skips_risk_check_for_default_outline_content(
 
     monkeypatch.setattr(draft_module, "generate_id", lambda _app: "shifu-risk-skip")
 
-    def fake_draft_risk(*args, **kwargs):
+    def fake_draft_risk(*args: object, **kwargs):
         draft_risk_calls.append((args, kwargs))
 
     monkeypatch.setattr(
@@ -328,7 +328,7 @@ def test_create_shifu_draft_skips_risk_check_for_default_outline_content(
 
     from flaskr.service.shifu import shifu_outline_funcs
 
-    def fail_outline_risk(*_args, **_kwargs):
+    def fail_outline_risk(*_args: object, **_kwargs):
         message = "default outline content should not trigger risk check"
         raise AssertionError(message)
 
@@ -365,7 +365,7 @@ def test_create_shifu_draft_raises_when_default_outline_init_fails(app, monkeypa
         lambda *_args, **_kwargs: None,
     )
 
-    def fail_default_outlines(*_args, **_kwargs):
+    def fail_default_outlines(*_args: object, **_kwargs):
         message = "outline init failed"
         raise AppError(message)
 

--- a/src/api/tests/service/shifu/test_ask_preview_route.py
+++ b/src/api/tests/service/shifu/test_ask_preview_route.py
@@ -89,7 +89,7 @@ def test_ask_preview_route_success_with_provider(monkeypatch, test_client):
     _mock_authenticated_user(monkeypatch)
     fake_langfuse = _FakeLangfuseClient()
 
-    def fake_stream_ask_provider_response(*args, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs):
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "dify"
@@ -148,7 +148,7 @@ def test_ask_preview_route_success_with_provider(monkeypatch, test_client):
 def test_ask_preview_route_fallbacks_to_llm(monkeypatch, test_client):
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs):
         _ = args
         provider = kwargs.get("provider", "")
         if provider == "dify":
@@ -221,7 +221,7 @@ def test_ask_preview_route_provider_only_does_not_require_ask_model(
 ):
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs):
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "coze"
@@ -264,7 +264,7 @@ def test_ask_preview_route_provider_only_accepts_coze_workflow(
 ):
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs):
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "coze_workflow"
@@ -308,7 +308,7 @@ def test_ask_preview_route_provider_only_accepts_get_biji_knowledge(
     _mock_authenticated_user(monkeypatch)
     captured: dict[str, object] = {}
 
-    def fake_stream_ask_provider_response(*args, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs):
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "get_biji_knowledge"
@@ -356,7 +356,7 @@ def test_ask_preview_route_provider_only_accepts_get_biji_knowledge(
 def test_ask_preview_route_surfaces_friendly_provider_error(monkeypatch, test_client):
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs):
         _ = (args, kwargs)
         message = (
             "get_biji_knowledge request failed: 401 Client Error for url: "
@@ -404,7 +404,7 @@ def test_ask_preview_route_falls_back_to_generic_provider_error(
 ):
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs):
         _ = (args, kwargs)
         message = "dify request failed: 500 | {raw body}"
         raise AskProviderError(message)
@@ -464,12 +464,12 @@ def test_ask_preview_route_uses_authenticated_creator_for_debug_billing(
         raising=False,
     )
 
-    def fake_chat_llm(*args, **kwargs):
+    def fake_chat_llm(*args: object, **kwargs):
         _ = args
         captured["chat_llm"] = kwargs
         yield SimpleNamespace(content="debug answer")
 
-    def fake_stream_ask_provider_response(*args, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs):
         _ = args
         runtime = kwargs.get("runtime")
         assert runtime is not None
@@ -521,12 +521,12 @@ def test_ask_preview_route_passes_debug_usage_context_for_creator(
     fake_langfuse = _FakeLangfuseClient()
     captured: dict[str, object] = {}
 
-    def fake_chat_llm(*args, **kwargs):
+    def fake_chat_llm(*args: object, **kwargs):
         _ = args
         captured.update(kwargs)
         yield SimpleNamespace(content="debug answer")
 
-    def fake_stream_ask_provider_response(*args, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs):
         _ = args
         runtime = kwargs.get("runtime")
         assert runtime is not None

--- a/src/api/tests/service/shifu/test_course_copy.py
+++ b/src/api/tests/service/shifu/test_course_copy.py
@@ -739,7 +739,7 @@ def test_copy_course_risk_rejection_does_not_create_target_user(app, monkeypatch
         )
         db.session.commit()
 
-    def _reject_risk(*args, **kwargs):
+    def _reject_risk(*args: object, **kwargs):
         _ = (args, kwargs)
         raise_error("server.check.checkRiskControlReject")
 

--- a/src/api/tests/service/shifu/test_operator_voice_clone_register.py
+++ b/src/api/tests/service/shifu/test_operator_voice_clone_register.py
@@ -183,7 +183,7 @@ def _mock_volcengine_status(monkeypatch, status: int) -> None:
 
 
 def _forbid_minimax_synthesis(monkeypatch) -> None:
-    def _fail(*_args, **_kwargs):
+    def _fail(*_args: object, **_kwargs):
         message = "synthesize_text must not be called for volcengine"
         raise AssertionError(message)
 

--- a/src/api/tests/service/shifu/test_shifu_publish_funcs.py
+++ b/src/api/tests/service/shifu/test_shifu_publish_funcs.py
@@ -20,7 +20,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args, **kwargs):
+    def get_model_info(*args: object, **kwargs):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -216,7 +216,7 @@ def test_run_summary_downgrades_shutdown_race_to_warning(monkeypatch):
 
     monkeypatch.setattr(module, "apply_shifu_context_snapshot", lambda *_a, **_k: None)
 
-    def _raise_shutdown(*_a, **_k):
+    def _raise_shutdown(*_a: object, **_k):
         message = (
             "litellm.MidStreamFallbackError: APIConnectionError: OpenAIException - "
             "cannot schedule new futures after shutdown"
@@ -244,7 +244,7 @@ def test_run_summary_logs_error_for_other_failures(monkeypatch):
 
     monkeypatch.setattr(module, "apply_shifu_context_snapshot", lambda *_a, **_k: None)
 
-    def _raise_other(*_a, **_k):
+    def _raise_other(*_a: object, **_k):
         message = "boom"
         raise ValueError(message)
 
@@ -269,7 +269,7 @@ def test_publish_shifu_draft_preserves_outline_updated_at(app, monkeypatch):
     original_load_existing_outline_items = module.load_existing_outline_items
     outline_load_calls = []
 
-    def _record_outline_load(*args, **kwargs):
+    def _record_outline_load(*args: object, **kwargs):
         outline_load_calls.append((args, kwargs))
         return original_load_existing_outline_items(*args, **kwargs)
 

--- a/src/api/tests/service/tts/test_aliyun_nls_token.py
+++ b/src/api/tests/service/tts/test_aliyun_nls_token.py
@@ -13,7 +13,7 @@ from flaskr.api.tts.aliyun_provider import AliyunTTSProvider
 def test_get_aliyun_nls_token_uses_override_when_configured(monkeypatch):
     monkeypatch.setenv("ALIYUN_TTS_TOKEN", "override-token")
 
-    def fake_get(*args, **kwargs):
+    def fake_get(*args: object, **kwargs):
         _ = (args, kwargs)
         message = "requests.get should not be called when override token exists"
         raise AssertionError(message)
@@ -96,7 +96,7 @@ def test_get_aliyun_nls_token_refresh_falls_back_to_cached_token(monkeypatch):
 
     captured = {"calls": 0}
 
-    def fake_get(*args, **kwargs):
+    def fake_get(*args: object, **kwargs):
         _ = (args, kwargs)
         captured["calls"] += 1
         message = "network down"

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -513,7 +513,7 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(monkeypatch
                     in_context = True
                     return self
 
-                def __exit__(self, *_args) -> bool | None:
+                def __exit__(self, *_args: object) -> bool | None:
                     nonlocal in_context
                     in_context = False
                     return False

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -50,7 +50,7 @@ class TestFinalizeSegmentation:
         processor = create_test_processor(mock_app)
         submitted_texts = []
 
-        def mock_submit(*args, **kwargs):
+        def mock_submit(*args: object, **kwargs):
             _ = kwargs
             if len(args) > 1:
                 segment = args[1]
@@ -91,7 +91,7 @@ class TestFinalizeSegmentation:
         # Track submitted tasks
         submitted_texts = []
 
-        def mock_submit(*args, **kwargs):
+        def mock_submit(*args: object, **kwargs):
             # Positional args are the thread target followed by segment,
             # voice settings, audio settings, provider and model.
             # Capture the segment text from args[1]
@@ -133,7 +133,7 @@ class TestFinalizeSegmentation:
 
         submitted_texts = []
 
-        def mock_submit(*args, **kwargs):
+        def mock_submit(*args: object, **kwargs):
             # Positional args are the thread target followed by segment,
             # voice settings, audio settings, provider and model.
             _ = kwargs
@@ -166,7 +166,7 @@ class TestFinalizeSegmentation:
 
         submitted_texts = []
 
-        def mock_submit(*args, **kwargs):
+        def mock_submit(*args: object, **kwargs):
             # Positional args are the thread target followed by segment,
             # voice settings, audio settings, provider and model.
             _ = kwargs
@@ -230,7 +230,7 @@ class TestFinalizeSegmentation:
 
         remaining_text = "First sentence. Second sentence."
 
-        def mock_submit(*args, **kwargs):
+        def mock_submit(*args: object, **kwargs):
             _ = (args, kwargs)
             future = MagicMock()
             future.result.return_value = None
@@ -653,7 +653,7 @@ class TestOffsetDriftRegression:
         processor = create_test_processor(mock_app)
         submitted_texts = []
 
-        def mock_submit(*args, **kwargs):
+        def mock_submit(*args: object, **kwargs):
             _ = kwargs
             if len(args) > 1:
                 segment = args[1]
@@ -695,7 +695,7 @@ class TestOffsetDriftRegression:
         processor = create_test_processor(mock_app)
         submitted_texts = []
 
-        def mock_submit(*args, **kwargs):
+        def mock_submit(*args: object, **kwargs):
             _ = kwargs
             if len(args) > 1:
                 segment = args[1]

--- a/src/api/tests/service/tts/test_volcengine_voice_clone.py
+++ b/src/api/tests/service/tts/test_volcengine_voice_clone.py
@@ -100,7 +100,7 @@ def test_query_status_converts_transport_error_to_param_error(monkeypatch) -> No
 
     _patch_config(monkeypatch)
 
-    def _raise_transport_error(*args, **kwargs):
+    def _raise_transport_error(*args: object, **kwargs):
         _ = (args, kwargs)
         message = "connect timeout"
         raise requests_lib.exceptions.ConnectTimeout(message)

--- a/src/api/tests/service/user/test_google_auth.py
+++ b/src/api/tests/service/user/test_google_auth.py
@@ -51,12 +51,12 @@ class _FakeGoogleSession:
         self._profile = profile
         self._fetch_token_error = fetch_token_error
 
-    def fetch_token(self, *_args, **_kwargs):
+    def fetch_token(self, *_args: object, **_kwargs):
         if self._fetch_token_error is not None:
             raise self._fetch_token_error
         return {"access_token": "fake-access-token"}
 
-    def get(self, *_args, **_kwargs):
+    def get(self, *_args: object, **_kwargs):
         return _FakeGoogleResponse(self._profile)
 
 

--- a/src/api/tests/service/user/test_import_user_command.py
+++ b/src/api/tests/service/user/test_import_user_command.py
@@ -166,7 +166,7 @@ def test_import_user_does_not_consult_profile_state_before_nickname_defaults(
 
         original_ensure_user = import_user_module.ensure_user_for_identifier
 
-        def track_ensure_user(*args, **kwargs):
+        def track_ensure_user(*args: object, **kwargs):
             reads_before_ensure.extend(read_order)
             return original_ensure_user(*args, **kwargs)
 

--- a/src/api/tests/service/user/test_learner_profile_optimizer.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer.py
@@ -60,7 +60,7 @@ def _snapshot_profile_state(user_bid: str) -> tuple:
 
 
 def _successful_llm(raw_output: str, captured: dict):
-    def invoke(*args, **kwargs):
+    def invoke(*args: object, **kwargs):
         captured["call_count"] = captured.get("call_count", 0) + 1
         captured["args"] = args
         captured["kwargs"] = kwargs
@@ -311,7 +311,7 @@ def test_optimize_rejects_moderation_without_calling_llm_or_changing_state(
     invoked = False
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: False)
 
-    def unexpected_invoke(*_args, **_kwargs):
+    def unexpected_invoke(*_args: object, **_kwargs):
         nonlocal invoked
         invoked = True
         yield SimpleNamespace(result="unexpected")
@@ -385,7 +385,7 @@ def test_optimize_missing_default_model_does_not_call_llm_or_change_state(
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
     monkeypatch.setitem(app.config, "DEFAULT_LLM_MODEL", "")
 
-    def unexpected_invoke(*_args, **_kwargs):
+    def unexpected_invoke(*_args: object, **_kwargs):
         nonlocal invoked
         invoked = True
         yield SimpleNamespace(result="unexpected")
@@ -450,7 +450,7 @@ def test_optimize_timeout_finalizes_trace_without_changing_state(app, monkeypatc
     captured: dict = {}
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
-    def timeout_invoke(*_args, **_kwargs):
+    def timeout_invoke(*_args: object, **_kwargs):
         message = "provider timeout"
         raise TimeoutError(message)
         yield  # pragma: no cover
@@ -480,7 +480,7 @@ def test_optimize_reports_a_wrapped_timeout_as_timeout(app, monkeypatch):
     user_bid = "profile-optimize-wrapped-timeout"
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
-    def timeout_invoke(*_args, **_kwargs):
+    def timeout_invoke(*_args: object, **_kwargs):
         try:
             # The wrapped-timeout shape is exactly what this test asserts.
             message = "provider timeout"
@@ -521,7 +521,7 @@ def test_optimize_reports_runtime_failure_reason_without_changing_state(
     captured: dict = {}
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
-    def failed_invoke(*_args, **_kwargs):
+    def failed_invoke(*_args: object, **_kwargs):
         raise provider_error
         yield  # pragma: no cover
 
@@ -550,11 +550,11 @@ def test_optimize_reports_moderation_failure_reason_without_calling_llm(
 ):
     invoked = False
 
-    def failed_moderation(*_args):
+    def failed_moderation(*_args: object):
         message = "moderation unavailable"
         raise RuntimeError(message)
 
-    def unexpected_invoke(*_args, **_kwargs):
+    def unexpected_invoke(*_args: object, **_kwargs):
         nonlocal invoked
         invoked = True
         yield SimpleNamespace(result="unexpected")
@@ -580,7 +580,7 @@ def test_optimize_rejects_invalid_input_before_moderation(
 ):
     moderated = False
 
-    def unexpected_moderation(*_args):
+    def unexpected_moderation(*_args: object):
         nonlocal moderated
         moderated = True
         return True

--- a/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
@@ -16,7 +16,7 @@ class FakeRedis:
         self.in_flight_tokens: dict[str, str] = {}
         self.acquire_ttls: list[int] = []
 
-    def eval(self, script, numkeys, *args):
+    def eval(self, script, numkeys, *args: object):
         assert numkeys == 1
         key = str(args[0])
         token = str(args[1])
@@ -40,7 +40,7 @@ class FakeRedis:
 class ExplodingRedis:
     """Simulate a Redis failure for tests."""
 
-    def eval(self, *_args, **_kwargs):
+    def eval(self, *_args: object, **_kwargs):
         message = "redis unavailable"
         raise RuntimeError(message)
 

--- a/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
+++ b/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
@@ -47,7 +47,7 @@ class _FakeRedis:
     def get(self, _key):
         return None
 
-    def delete(self, *_keys):
+    def delete(self, *_keys: str):
         return None
 
 
@@ -66,10 +66,10 @@ class _FakeGoogleSession:
     def __init__(self, profile) -> None:
         self._profile = profile
 
-    def fetch_token(self, *_args, **_kwargs):
+    def fetch_token(self, *_args: object, **_kwargs):
         return {"access_token": "fake-access-token"}
 
-    def get(self, *_args, **_kwargs):
+    def get(self, *_args: object, **_kwargs):
         return _FakeGoogleResponse(self._profile)
 
 

--- a/src/api/tests/service/user/test_profile_onboarding.py
+++ b/src/api/tests/service/user/test_profile_onboarding.py
@@ -11,7 +11,7 @@ from flaskr.service.user.repository import create_user_entity
 
 
 @contextmanager
-def nullcontext_admission(*_args, **_kwargs):
+def nullcontext_admission(*_args: object, **_kwargs):
     yield
 
 

--- a/src/api/tests/service/user/test_user_identify.py
+++ b/src/api/tests/service/user/test_user_identify.py
@@ -11,7 +11,7 @@ class _FakeRedis:
     def get(self, key):
         return self.values.get(key)
 
-    def delete(self, *keys):
+    def delete(self, *keys: str):
         self.deleted.extend(keys)
         return len(keys)
 
@@ -191,13 +191,13 @@ def test_send_email_code_stores_lowercase_identifier(app, monkeypatch):
         sent_message = ""
         sent_to = ""
 
-        def __init__(self, *_args, **_kwargs) -> None:
+        def __init__(self, *_args: object, **_kwargs) -> None:
             pass
 
         def starttls(self):
             return None
 
-        def login(self, *_args):
+        def login(self, *_args: object):
             return None
 
         def sendmail(self, _sender, recipient, message):
@@ -280,13 +280,13 @@ def test_send_email_code_uses_requested_language_and_singular_expiry(app, monkey
     class _FakeSMTP:
         sent_message = ""
 
-        def __init__(self, *_args, **_kwargs) -> None:
+        def __init__(self, *_args: object, **_kwargs) -> None:
             pass
 
         def starttls(self):
             return None
 
-        def login(self, *_args):
+        def login(self, *_args: object):
             return None
 
         def sendmail(self, _sender, _recipient, message):

--- a/src/api/tests/service/user/test_validate_user.py
+++ b/src/api/tests/service/user/test_validate_user.py
@@ -12,7 +12,7 @@ def test_validate_user_maps_invalid_algorithm_token_to_user_not_found(monkeypatc
     app.config["SECRET_KEY"] = "test-secret"
     app.config["ENVERIMENT"] = "prod"
 
-    def _raise_invalid_algorithm(*_args, **_kwargs):
+    def _raise_invalid_algorithm(*_args: object, **_kwargs):
         message = "The specified alg value is not allowed"
         raise jwt.exceptions.InvalidAlgorithmError(message)
 

--- a/src/api/tests/test_edun.py
+++ b/src/api/tests/test_edun.py
@@ -53,7 +53,7 @@ def test_ilivedata_send_wraps_oserror_as_urlerror(monkeypatch):
 
     from flaskr.api.check import ilivedata as ilivedata_module
 
-    def fake_urlopen(*_args, **_kwargs):
+    def fake_urlopen(*_args: object, **_kwargs):
         message = "timed out"
         raise TimeoutError(message)
 

--- a/src/api/tests/test_feishu.py
+++ b/src/api/tests/test_feishu.py
@@ -39,7 +39,7 @@ def test_send_order_feishu_formats_notification(app, monkeypatch):
             self._first_value = first_value
             self._count_value = count_value
 
-        def filter(self, *_args, **_kwargs):
+        def filter(self, *_args: object, **_kwargs):
             return self
 
         def first(self):

--- a/src/api/tests/test_gunicorn_worker_patch_guard.py
+++ b/src/api/tests/test_gunicorn_worker_patch_guard.py
@@ -64,7 +64,7 @@ def test_observer_skips_unpatched_processes(monkeypatch):
     monkeypatch.setattr(monkey, "is_module_patched", lambda _name: False)
 
     class _Logger:
-        def error(self, *args, **kwargs):
+        def error(self, *args: object, **kwargs):
             _ = (args, kwargs)
             message = "must not log during a skipped install"
             raise AssertionError(message)

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -25,7 +25,7 @@ def _install_litellm_stub() -> None:
     def register_model(model_map):
         litellm_stub.model_cost.update(model_map)
 
-    def get_model_info(*args, **kwargs):
+    def get_model_info(*args: object, **kwargs):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -471,7 +471,7 @@ def test_deepseek_model_loader_lists_models(monkeypatch):
 
 
 def test_deepseek_model_loader_falls_back_when_list_models_fails(monkeypatch):
-    def fake_get(*args, **kwargs):
+    def fake_get(*args: object, **kwargs):
         _ = args, kwargs
         message = "network unavailable"
         raise RuntimeError(message)
@@ -496,7 +496,7 @@ def test_deepseek_model_loader_falls_back_when_list_models_fails(monkeypatch):
 def test_qwen_prefixed_model_routes_without_fetched_alias(monkeypatch, app):
     captured = {}
 
-    def fake_completion(model, *args, **kwargs):
+    def fake_completion(model, *args: object, **kwargs):
         _ = args
         captured["model"] = model
         captured["kwargs"] = kwargs
@@ -780,7 +780,7 @@ def test_openai_params_use_litellm_reasoning_capabilities(
 
 
 def test_openai_params_fall_back_to_existing_policy_for_unknown_model(monkeypatch):
-    def raise_unknown(*args, **kwargs):
+    def raise_unknown(*args: object, **kwargs):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -1249,7 +1249,7 @@ def test_litellm_195_native_adapter_contracts():
 def test_chat_llm_disables_deepseek_thinking(monkeypatch, app):
     captured_kwargs = {}
 
-    def fake_completion(*args, **kwargs):
+    def fake_completion(*args: object, **kwargs):
         _ = args
         captured_kwargs["kwargs"] = kwargs
         return iter([FakeResponse("chunk-1", content="Hi", finish_reason="stop")])
@@ -1323,7 +1323,7 @@ def test_invoke_llm_uses_actual_model_for_provider_params(monkeypatch, app):
         captured["reload_model"] = model_id
         return {"temperature": temperature}
 
-    def fake_completion(model, *args, **kwargs):
+    def fake_completion(model, *args: object, **kwargs):
         _ = args
         captured["completion_model"] = model
         captured["completion_kwargs"] = kwargs
@@ -1372,7 +1372,7 @@ def test_chat_llm_ends_partial_response_on_repeated_stream_chunk(monkeypatch, ap
     class RepeatedChunkError(Exception):
         __module__ = "litellm.exceptions"
 
-    def fake_completion(*args, **kwargs):
+    def fake_completion(*args: object, **kwargs):
         _ = (args, kwargs)
         yield FakeResponse("chunk-1", content="你好")
         message = "The model is repeating the same chunk = ！ ！ ."
@@ -1409,7 +1409,7 @@ def test_chat_llm_streams(monkeypatch, app):
     captured_kwargs = {}
     captured_usage = {}
 
-    def fake_completion(*args, **kwargs):
+    def fake_completion(*args: object, **kwargs):
         _ = args
         captured_kwargs["kwargs"] = kwargs
         chunks = [
@@ -1479,7 +1479,7 @@ def test_chat_llm_streams(monkeypatch, app):
 def test_llm_sends_reasoning_output_to_langfuse_without_streaming_it(
     monkeypatch, app, llm_method
 ):
-    def fake_completion(*args, **kwargs):
+    def fake_completion(*args: object, **kwargs):
         _ = args, kwargs
         return iter(
             [
@@ -1579,7 +1579,7 @@ def test_extract_reasoning_delta_supports_litellm_fallback_fields(delta, expecte
 
 
 def test_chat_llm_falls_back_to_request_trace_id(monkeypatch, app):
-    def fake_completion(*args, **kwargs):
+    def fake_completion(*args: object, **kwargs):
         _ = args, kwargs
         return iter([FakeResponse("chunk-1", content="Hi", finish_reason="stop")])
 

--- a/src/api/tests/test_openai.py
+++ b/src/api/tests/test_openai.py
@@ -14,7 +14,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args, **kwargs):
+    def get_model_info(*args: object, **kwargs):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -130,7 +130,7 @@ class FakeUsage:
 def test_invoke_llm_streams_via_litellm(monkeypatch, app):
     captured_kwargs = {}
 
-    def fake_completion(*args, **kwargs):
+    def fake_completion(*args: object, **kwargs):
         captured_kwargs["args"] = args
         captured_kwargs["kwargs"] = kwargs
         usage = FakeUsage(prompt_tokens=5, completion_tokens=4, total_tokens=9)

--- a/src/api/tests/test_order.py
+++ b/src/api/tests/test_order.py
@@ -87,7 +87,7 @@ def test_init_buy_record_refreshes_existing_unpaid_order_promotions(app, monkeyp
     )
     apply_calls = {"count": 0}
 
-    def fake_apply_promo_campaigns(*_args, **_kwargs):
+    def fake_apply_promo_campaigns(*_args: object, **_kwargs):
         apply_calls["count"] += 1
         if apply_calls["count"] == 1:
             return []


### PR DESCRIPTION
## Summary

- annotate every variadic positional parameter with its element type
- use narrow types for homogeneous forwarding
- reserve object for genuinely heterogeneous compatibility boundaries
- enforce ANN002

## Verification

- 120 focused tests passed, 4 skipped
- Ruff 0.16.3 configured check passed
- Ruff 0.16.3 isolated ANN002 check passed
- repository pre-commit hooks passed