### PR TITLE
chore: type variadic keyword parameters

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -403,6 +403,10 @@ For `ANN002`, annotate the element type accepted by `*args`, not a tuple type.
 Use the narrow shared type when the forwarding contract is homogeneous and
 `object` only for genuinely heterogeneous compatibility forwarding.
 
+For `ANN003`, annotate the value type accepted by `**kwargs`, not a dictionary
+type. Prefer a shared narrow value type for homogeneous options and `object`
+only when an adapter genuinely forwards heterogeneous keyword values.
+
 For `N815`, keep Python DTO field names in snake_case even when the public JSON
 contract uses camelCase. Pydantic DTOs should declare the public name with
 `Field(alias="...")`, accept internal construction through `populate_by_name`,

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -237,6 +237,11 @@ plan's progress update for that rule.
   heterogeneous compatibility boundaries.
 - [ ] Merge or retarget ANN002 PR #2636 after ARG005 without combining it with
   the next rule unit.
+- [x] 2026-08-22: Rebuilt the ANN003 stage on `sunner/ruff-ann003`, stacked on
+  ANN002. Annotated every variadic keyword parameter with its value type while
+  preserving all accepted keyword options and forwarding behavior.
+- [ ] Merge or retarget ANN003 PR #2637 after ANN002 without combining it with
+  the next rule unit.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,8 +15,8 @@
 #   below, so the rationale survives the next Ruff upgrade.
 #
 # Deliberately not selected:
-# - ANN (except ANN002/ANN204/ANN205/ANN206, see `select`) / SLF001 / PLC0415 /
-#   PLR2004
+# - ANN (except ANN002/ANN003/ANN204/ANN205/ANN206, see `select`) / SLF001 /
+#   PLC0415 / PLR2004
 #   (and D1xx, see the ignore block): thousands of violations each; enforcing
 #   them is a codebase-wide project, not a lint config change.
 # - ISC004: every hit is the deliberate long-string wrapping idiom inside
@@ -170,8 +170,8 @@ select = [
 
     # --- Type annotations -------------------------------------------------
     # flake8-annotations is otherwise off (see the header): annotating every
-    # argument and return in the repo is a separate project. Variadic positional
-    # parameters name the element type after the star; use a concrete homogeneous
+    # argument and return in the repo is a separate project. Variadic parameters
+    # name the element/value type after the stars; use a concrete homogeneous
     # type when known and `object` for intentionally heterogeneous forwarding.
     # ANN205 is small enough to keep enforced, and a staticmethod is where a
     # missing return type hides the most, since there is no `self` to infer from.
@@ -182,6 +182,7 @@ select = [
     # serialization dunders (`__json__` returning a dict vs an enum value's str)
     # readable at a glance.
     "ANN002",  # missing type for *args
+    "ANN003",  # missing type for **kwargs
     "ANN204",  # missing return type on a special method
     "ANN205",  # missing return type on a staticmethod
     "ANN206",  # missing return type on a classmethod

--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -64,13 +64,13 @@ _LINK_KEYS = {"trace_id", "parent_observation_id", "id"}
 class MockClient:
     """Provide a no-op Langfuse client when tracing is disabled."""
 
-    def __init__(self, *args: object, **kwargs) -> None:
+    def __init__(self, *args: object, **kwargs: object) -> None:
         """Initialize the no-op Langfuse client."""
 
     def __getattr__(self, name) -> Any:
         """Return a no-op callable for any Langfuse operation."""
 
-        def method(*args: object, **kwargs):
+        def method(*args: object, **kwargs: object):
             _ = (args, kwargs)
             return self
 
@@ -412,34 +412,34 @@ class LangfuseObservationHandle:
     def _child(self, delegate: Any) -> "LangfuseObservationHandle":
         return LangfuseObservationHandle(delegate, self.trace_id, self._propagation)
 
-    def span(self, **kwargs) -> "LangfuseObservationHandle":
+    def span(self, **kwargs: object) -> "LangfuseObservationHandle":
         payload = _map_observation_kwargs(kwargs, _OBSERVATION_KEYS)
         payload.setdefault("name", "span")
         with self._propagation.scope(self._delegate):
             child = self._delegate.start_observation(as_type="span", **payload)
         return self._child(child)
 
-    def generation(self, **kwargs) -> "LangfuseObservationHandle":
+    def generation(self, **kwargs: object) -> "LangfuseObservationHandle":
         payload = _map_observation_kwargs(kwargs, _GENERATION_KEYS)
         payload.setdefault("name", "generation")
         with self._propagation.scope(self._delegate):
             child = self._delegate.start_observation(as_type="generation", **payload)
         return self._child(child)
 
-    def event(self, **kwargs) -> "LangfuseObservationHandle":
+    def event(self, **kwargs: object) -> "LangfuseObservationHandle":
         payload = _map_observation_kwargs(kwargs, _OBSERVATION_KEYS)
         payload.setdefault("name", "event")
         with self._propagation.scope(self._delegate):
             child = self._delegate.create_event(**payload)
         return self._child(child)
 
-    def update(self, **kwargs) -> "LangfuseObservationHandle":
+    def update(self, **kwargs: object) -> "LangfuseObservationHandle":
         payload = _map_observation_kwargs(kwargs, _GENERATION_KEYS)
         if payload:
             self._delegate.update(**payload)
         return self
 
-    def end(self, **kwargs) -> "LangfuseObservationHandle":
+    def end(self, **kwargs: object) -> "LangfuseObservationHandle":
         # SDK end() only accepts end_time; flush attribute updates first.
         end_time = kwargs.pop("end_time", None)
         payload = _map_observation_kwargs(kwargs, _GENERATION_KEYS)
@@ -451,7 +451,7 @@ class LangfuseObservationHandle:
             self._delegate.end()
         return self
 
-    def update_trace(self, **kwargs) -> "LangfuseObservationHandle":
+    def update_trace(self, **kwargs: object) -> "LangfuseObservationHandle":
         payload = _map_trace_kwargs(kwargs)
         if not payload:
             return self
@@ -470,7 +470,7 @@ class LangfuseObservationHandle:
 class LangfuseTraceHandle(LangfuseObservationHandle):
     """v2-style trace facade; trace attributes live on the observations in v4."""
 
-    def update(self, **kwargs) -> "LangfuseTraceHandle":
+    def update(self, **kwargs: object) -> "LangfuseTraceHandle":
         self.update_trace(**kwargs)
         return self
 
@@ -509,7 +509,9 @@ def create_trace_with_root_span(
     return trace, LangfuseObservationHandle(root_span, trace_id, propagation)
 
 
-def update_langfuse_trace(trace: Any, payload: dict[str, Any] | None = None, **kwargs):
+def update_langfuse_trace(
+    trace: Any, payload: dict[str, Any] | None = None, **kwargs: object
+):
     update_payload = compact_langfuse_payload(payload or kwargs)
     if update_payload:
         trace.update(**update_payload)
@@ -519,7 +521,7 @@ def update_langfuse_trace(trace: Any, payload: dict[str, Any] | None = None, **k
 def update_langfuse_observation(
     observation: Any,
     payload: dict[str, Any] | None = None,
-    **kwargs,
+    **kwargs: object,
 ):
     update_payload = compact_langfuse_payload(payload or kwargs)
     if update_payload:

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -62,7 +62,7 @@ _original_asyncio_run = asyncio.run
 _background_asyncio_tasks: set[asyncio.Task] = set()
 
 
-def _safe_asyncio_run(coro, *args: object, **kwargs):
+def _safe_asyncio_run(coro, *args: object, **kwargs: object):
     try:
         return _original_asyncio_run(coro, *args, **kwargs)
     except RuntimeError as exc:
@@ -1018,7 +1018,7 @@ def invoke_llm(
     request_id: str | None = None,
     trace_id: str | None = None,
     usage_metadata: dict[str, Any] | None = None,
-    **kwargs,
+    **kwargs: object,
 ) -> Generator[LLMStreamResponse, None, None]:
     stream_flag = bool(kwargs.get("stream", True))
     kwargs.pop("stream", None)
@@ -1201,7 +1201,7 @@ def chat_llm(
     request_id: str | None = None,
     trace_id: str | None = None,
     usage_metadata: dict[str, Any] | None = None,
-    **kwargs,
+    **kwargs: object,
 ) -> Generator[LLMStreamResponse, None, None]:
     app.logger.info(
         "chat_llm [%s] %s ,json:%s ,kwargs:%s", model, messages, json, kwargs

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -38,7 +38,7 @@ class CacheProvider(Protocol):
         nx: bool = False,
         xx: bool = False,
         *args: object,
-        **kwargs,
+        **kwargs: object,
     ):
         raise NotImplementedError
 
@@ -96,7 +96,7 @@ class _DynamicRedisCacheProvider:
         nx: bool = False,
         xx: bool = False,
         *args: object,
-        **kwargs,
+        **kwargs: object,
     ):
         if ex is None and args:
             ex = args[0]
@@ -212,7 +212,7 @@ class InMemoryCacheProvider:
         nx: bool = False,
         xx: bool = False,
         *args: object,
-        **kwargs,
+        **kwargs: object,
     ):
         _ = kwargs
         with self._mu:
@@ -292,7 +292,7 @@ class FallbackCacheProvider:
         self._primary = primary
         self._fallback = fallback
 
-    def _call(self, method: str, *args: object, **kwargs):
+    def _call(self, method: str, *args: object, **kwargs: object):
         primary_fn = getattr(self._primary, method)
         fallback_fn = getattr(self._fallback, method)
         try:
@@ -318,7 +318,7 @@ class FallbackCacheProvider:
         nx: bool = False,
         xx: bool = False,
         *args: object,
-        **kwargs,
+        **kwargs: object,
     ):
         return self._call(
             "set",

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -149,7 +149,7 @@ class FeishuLogHandler(logging.Handler):
 class ColoredRequestFormatter(RequestFormatter, colorlog.ColoredFormatter):
     """Format request logs with terminal color metadata."""
 
-    def __init__(self, fmt, **kwargs) -> None:
+    def __init__(self, fmt, **kwargs: object) -> None:
         """Initialize the parent request and color log formatters."""
         super().__init__(fmt, **kwargs)
 

--- a/src/api/flaskr/common/shifu_context.py
+++ b/src/api/flaskr/common/shifu_context.py
@@ -173,7 +173,7 @@ def with_shifu_context(
 
     def decorator(func: Callable) -> Callable:
         @wraps(func)
-        def wrapper(*args: object, **kwargs):
+        def wrapper(*args: object, **kwargs: object):
             try:
                 from flask import current_app, request
             except Exception:

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -516,7 +516,7 @@ def retry_on_deadlock(max_attempts: int = 3, backoff_seconds: float = 0.1):
 
     def decorator(func):
         @functools.wraps(func)
-        def wrapper(*args: object, **kwargs):
+        def wrapper(*args: object, **kwargs: object):
             attempt = 0
             while True:
                 try:

--- a/src/api/flaskr/framework/plugin/inject.py
+++ b/src/api/flaskr/framework/plugin/inject.py
@@ -6,7 +6,7 @@ from functools import wraps
 # inject app to function and set inject flag
 def inject(func):
     @wraps(func)
-    def wrapper(*args: object, **kwargs):
+    def wrapper(*args: object, **kwargs: object):
         app = kwargs.get("app")
         if app:
             with app.app_context():

--- a/src/api/flaskr/framework/plugin/plugin_manager.py
+++ b/src/api/flaskr/framework/plugin/plugin_manager.py
@@ -50,7 +50,7 @@ class PluginManager:
             self.extension_functions[target_func_name] = []
         self.extension_functions[target_func_name].append(func)
 
-    def execute_extensions(self, func_name, result, *args: object, **kwargs):
+    def execute_extensions(self, func_name, result, *args: object, **kwargs: object):
         self.app.logger.info("execute_extensions: %s", func_name)
         if not self.is_enabled:
             return result
@@ -70,7 +70,13 @@ class PluginManager:
             self.extensible_generic_functions[func_name] = []
         self.extensible_generic_functions[func_name].append(func)
 
-    def execute_extensible_generic(self, func_name, result, *args: object, **kwargs):
+    def execute_extensible_generic(
+        self,
+        func_name,
+        result,
+        *args: object,
+        **kwargs: object,
+    ):
         self.app.logger.info("execute_extensible_generic: %s", func_name)
         if not self.is_enabled:
             return result
@@ -149,7 +155,7 @@ def extensible_generic_register(func_name):
 # extensible decorator
 def extensible(func):
     @wraps(func)
-    def wrapper(*args: object, **kwargs):
+    def wrapper(*args: object, **kwargs: object):
         result = func(*args, **kwargs)
         manager = get_plugin_manager()
         if manager is None:
@@ -170,7 +176,7 @@ def extensible_generic(func):
         pass
 
     @wraps(func)
-    def wrapper(*args: object, **kwargs):
+    def wrapper(*args: object, **kwargs: object):
         result = func(*args, **kwargs)
         if result:
             yield from result

--- a/src/api/flaskr/route/common.py
+++ b/src/api/flaskr/route/common.py
@@ -64,7 +64,7 @@ def bypass_token_validation(func):
     by_pass_login_func.append(func.__name__)
 
     @wraps(func)
-    def wrapper(*args: object, **kwargs):
+    def wrapper(*args: object, **kwargs: object):
         return func(*args, **kwargs)
 
     return wrapper

--- a/src/api/flaskr/route/open_api.py
+++ b/src/api/flaskr/route/open_api.py
@@ -19,7 +19,7 @@ def require_api_key(f):
     """Authenticate Open API requests via X-User-Uid + X-Api-Key headers."""
 
     @wraps(f)
-    def wrapper(*args: object, **kwargs):
+    def wrapper(*args: object, **kwargs: object):
         user_uid = request.headers.get("X-User-Uid", "").strip()
         api_key = request.headers.get("X-Api-Key", "").strip()
 

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -187,7 +187,7 @@ def _extract_referral_post_auth_fields(payload: dict) -> dict[str, str]:
 
 def optional_token_validation(f):
     @wraps(f)
-    def decorated_function(*args: object, **kwargs):
+    def decorated_function(*args: object, **kwargs: object):
         token = request.cookies.get("token", None)
         if not token:
             token = request.args.get("token", None)

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -70,7 +70,7 @@ try:  # pragma: no cover - exercised indirectly when Celery is installed
     from celery import shared_task
 except ImportError:  # pragma: no cover - local fallback for non-Celery test envs
 
-    def shared_task(*args: object, **kwargs):
+    def shared_task(*args: object, **kwargs: object):
         _ = (args, kwargs)
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/src/api/flaskr/service/common/models.py
+++ b/src/api/flaskr/service/common/models.py
@@ -75,7 +75,7 @@ def raise_error(error_name):
     )
 
 
-def raise_error_with_args(error_name, **kwargs):
+def raise_error_with_args(error_name, **kwargs: object):
     raise AppError(
         _(error_name).format(**kwargs),
         ERROR_CODE.get(error_name, ERROR_CODE["server.common.unknownError"]),

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -42,7 +42,7 @@ _pingpp_client_state = _PingppClientState()
 
 def _serialized_pingpp_config(func):
     @wraps(func)
-    def wrapped(*args: object, **kwargs):
+    def wrapped(*args: object, **kwargs: object):
         with _PINGPP_CONFIG_LOCK:
             return func(*args, **kwargs)
 

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -177,7 +177,7 @@ class ShifuTokenValidation:
 
     def __call__(self, f) -> Callable:
         @wraps(f)
-        def decorated_function(*args: object, **kwargs):
+        def decorated_function(*args: object, **kwargs: object):
             token = request.cookies.get("token", None)
             if not token:
                 token = request.args.get("token", None)

--- a/src/api/flaskr/service/tts/api.py
+++ b/src/api/flaskr/service/tts/api.py
@@ -32,7 +32,7 @@ from flaskr.service.tts.volcengine_voice_clone import (
 from flaskr.util.deprecation import deprecated_alias_getattr
 
 
-def create_streaming_tts_processor(**kwargs):
+def create_streaming_tts_processor(**kwargs: object):
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     return StreamingTTSProcessor(**kwargs)

--- a/src/api/flaskr/service/tts/minimax_voice_clone.py
+++ b/src/api/flaskr/service/tts/minimax_voice_clone.py
@@ -21,7 +21,7 @@ except Exception:  # pragma: no cover - exercised only when pydub is missing.
         """Reference one time range in a source audio file."""
 
         @staticmethod
-        def from_file(*_args: object, **_kwargs) -> None:
+        def from_file(*_args: object, **_kwargs: object) -> None:
             message = "audio decoder is not available"
             raise RuntimeError(message)
 

--- a/src/api/flaskr/service/tts/tasks.py
+++ b/src/api/flaskr/service/tts/tasks.py
@@ -12,7 +12,7 @@ try:  # pragma: no cover - exercised indirectly when Celery is installed.
     from celery import shared_task
 except ImportError:  # pragma: no cover - local fallback for non-Celery test envs.
 
-    def shared_task(*args: object, **kwargs):
+    def shared_task(*args: object, **kwargs: object):
         _ = (args, kwargs)
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/src/api/scripts/check_mdflow_listen_adapter.py
+++ b/src/api/scripts/check_mdflow_listen_adapter.py
@@ -44,12 +44,12 @@ if TYPE_CHECKING:
 
 
 @compiles(LONGTEXT, "sqlite")
-def _compile_longtext_sqlite(_type, _compiler, **_kw):
+def _compile_longtext_sqlite(_type, _compiler, **_kw: object):
     return "TEXT"
 
 
 @compiles(BIGINT, "sqlite")
-def _compile_bigint_sqlite(_type, _compiler, **_kw):
+def _compile_bigint_sqlite(_type, _compiler, **_kw: object):
     return "INTEGER"
 
 

--- a/src/api/scripts/check_sse_segmentation.py
+++ b/src/api/scripts/check_sse_segmentation.py
@@ -141,7 +141,7 @@ def _simulate_observed_segments(
     captured_by_position: dict[int, list[str]] = {}
 
     class CaptureStreamingTTSProcessor:
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, **kwargs: object) -> None:
             self.position = int(kwargs.get("position", 0) or 0)
             self._parts: list[str] = []
 

--- a/src/api/tests/api/doc/test_feishu_notify.py
+++ b/src/api/tests/api/doc/test_feishu_notify.py
@@ -10,15 +10,15 @@ class _Logger:
         self.warnings = []
         self.exceptions = []
 
-    def info(self, *args: object, **kwargs):
+    def info(self, *args: object, **kwargs: object):
         _ = kwargs
         self.infos.append(args)
 
-    def warning(self, *args: object, **kwargs):
+    def warning(self, *args: object, **kwargs: object):
         _ = kwargs
         self.warnings.append(args)
 
-    def exception(self, *args: object, **kwargs):
+    def exception(self, *args: object, **kwargs: object):
         _ = kwargs
         self.exceptions.append(args)
 
@@ -91,7 +91,7 @@ def test_send_notify_returns_none_for_request_error(monkeypatch):
         lambda key, default=None: "https://example.test/webhook",  # noqa: ARG005 -- preserve get_config keyword contract
     )
 
-    def _raise(*args: object, **kwargs):
+    def _raise(*args: object, **kwargs: object):
         _ = (args, kwargs)
         message = "network down"
         raise requests.RequestException(message)

--- a/src/api/tests/common/fixtures/fake_llm.py
+++ b/src/api/tests/common/fixtures/fake_llm.py
@@ -33,7 +33,10 @@ def _stream_chunks(stream: bool) -> list[str]:
     return ["mock-llm"]
 
 
-def fake_invoke_llm(*_args: object, **kwargs) -> Generator[FakeLLMResponse, None, None]:
+def fake_invoke_llm(
+    *_args: object,
+    **kwargs: object,
+) -> Generator[FakeLLMResponse, None, None]:
     stream = bool(kwargs.get("stream", False))
     chunks = _stream_chunks(stream)
     for idx, chunk in enumerate(chunks, start=1):
@@ -45,7 +48,10 @@ def fake_invoke_llm(*_args: object, **kwargs) -> Generator[FakeLLMResponse, None
         )
 
 
-def fake_chat_llm(*_args: object, **kwargs) -> Generator[FakeLLMResponse, None, None]:
+def fake_chat_llm(
+    *_args: object,
+    **kwargs: object,
+) -> Generator[FakeLLMResponse, None, None]:
     stream = bool(kwargs.get("stream", False))
     chunks = _stream_chunks(stream)
     for idx, chunk in enumerate(chunks, start=1):

--- a/src/api/tests/common/fixtures/fake_redis.py
+++ b/src/api/tests/common/fixtures/fake_redis.py
@@ -82,7 +82,7 @@ class FakeRedis:
         nx: bool = False,
         xx: bool = False,
         *args: object,
-        **kwargs,
+        **kwargs: object,
     ):
         _ = kwargs
         if ex is None and args:

--- a/src/api/tests/common/test_gevent_hub_observer.py
+++ b/src/api/tests/common/test_gevent_hub_observer.py
@@ -67,7 +67,7 @@ def test_logger_failure_never_blocks_the_original_handler():
     hub = _StubHub()
 
     class _BrokenLogger:
-        def error(self, *args: object, **kwargs):
+        def error(self, *args: object, **kwargs: object):
             _ = (args, kwargs)
             message = "logging backend down"
             raise RuntimeError(message)

--- a/src/api/tests/common/test_i18n_utils.py
+++ b/src/api/tests/common/test_i18n_utils.py
@@ -19,13 +19,13 @@ def test_french_native_name_reaches_content_and_interaction_prompts():
         def __init__(self) -> None:
             self.calls = []
 
-        def complete(self, messages, **_kwargs):
+        def complete(self, messages, **_kwargs: object):
             self.calls.append(messages)
             if "JSON Interaction Translation Task" in messages[0]["content"]:
                 return '{"buttons":["Continuer"]}'
             return "Réponse"
 
-        def stream(self, _messages, **_kwargs):
+        def stream(self, _messages, **_kwargs: object):
             return iter(())
 
     provider = CapturingProvider()

--- a/src/api/tests/common/test_log.py
+++ b/src/api/tests/common/test_log.py
@@ -15,7 +15,7 @@ class _FailingResponse:
 def test_feishu_log_handler_does_not_reemit_webhook_failures(monkeypatch):
     calls = []
 
-    def fake_post(*args: object, **kwargs):
+    def fake_post(*args: object, **kwargs: object):
         calls.append((args, kwargs))
         return _FailingResponse()
 
@@ -43,7 +43,7 @@ def test_feishu_log_handler_surfaces_delivery_failure_without_recursion(
 ):
     calls = []
 
-    def fake_post(*args: object, **kwargs):
+    def fake_post(*args: object, **kwargs: object):
         calls.append((args, kwargs))
         return _FailingResponse()
 
@@ -71,7 +71,7 @@ def test_feishu_log_handler_surfaces_delivery_failure_without_recursion(
 def test_feishu_log_handler_reentrancy_guard_blocks_nested_emit(monkeypatch):
     calls = []
 
-    def fake_post(*args: object, **kwargs):
+    def fake_post(*args: object, **kwargs: object):
         calls.append((args, kwargs))
         return type("Response", (), {"raise_for_status": lambda _self: None})()
 

--- a/src/api/tests/common/test_module_state_owners.py
+++ b/src/api/tests/common/test_module_state_owners.py
@@ -31,7 +31,7 @@ def test_redis_initialization_updates_the_owned_client(monkeypatch):
     sentinel = object()
     captured: dict[str, object] = {}
 
-    def fake_redis(**kwargs):
+    def fake_redis(**kwargs: object):
         captured.update(kwargs)
         return sentinel
 

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -55,14 +55,14 @@ class _TestPluginManager:
     def register_extension(self, target_func_name, func):
         self.extension_functions.setdefault(target_func_name, []).append(func)
 
-    def execute_extensions(self, _func_name, result, *args: object, **kwargs):
+    def execute_extensions(self, _func_name, result, *args: object, **kwargs: object):
         _ = (args, kwargs)
         return result
 
     def register_extensible_generic(self, func_name, func):
         self.extensible_generic_functions.setdefault(func_name, []).append(func)
 
-    def execute_extensible_generic(self, _func_name, *args: object, **kwargs):
+    def execute_extensible_generic(self, _func_name, *args: object, **kwargs: object):
         _ = (args, kwargs)
 
 
@@ -70,12 +70,12 @@ set_plugin_manager(_TestPluginManager())
 
 
 @compiles(LONGTEXT, "sqlite")
-def _compile_longtext_sqlite(_type, _compiler, **_kw):
+def _compile_longtext_sqlite(_type, _compiler, **_kw: object):
     return "TEXT"
 
 
 @compiles(BIGINT, "sqlite")
-def _compile_bigint_sqlite(_type, _compiler, **_kw):
+def _compile_bigint_sqlite(_type, _compiler, **_kw: object):
     return "INTEGER"
 
 

--- a/src/api/tests/golden/conftest.py
+++ b/src/api/tests/golden/conftest.py
@@ -104,7 +104,7 @@ def _iter_golden_completion(messages) -> list[str]:
     return list(GOLDEN_LLM_CHUNKS)
 
 
-def golden_chat_llm(*args: object, **kwargs):
+def golden_chat_llm(*args: object, **kwargs: object):
     messages = kwargs.get("messages")
     if messages is None:
         for arg in args:
@@ -121,7 +121,7 @@ def golden_chat_llm(*args: object, **kwargs):
         )
 
 
-def golden_invoke_llm(*args: object, **kwargs):
+def golden_invoke_llm(*args: object, **kwargs: object):
     yield from golden_chat_llm(*args, **kwargs)
 
 

--- a/src/api/tests/migrations/test_learner_profile_migration.py
+++ b/src/api/tests/migrations/test_learner_profile_migration.py
@@ -48,12 +48,12 @@ def test_learner_profile_column_remains_nullable_for_rolling_writers():
         def add_column(self, column):
             added_columns.append(column)
 
-        def alter_column(self, column_name, **kwargs):
+        def alter_column(self, column_name, **kwargs: object):
             altered_columns.append((column_name, kwargs))
 
     class _Operations:
         @contextmanager
-        def batch_alter_table(self, *_args: object, **_kwargs):
+        def batch_alter_table(self, *_args: object, **_kwargs: object):
             yield _BatchOperations()
 
         def execute(self, statement):

--- a/src/api/tests/service/billing/test_admin_billing_routes.py
+++ b/src/api/tests/service/billing/test_admin_billing_routes.py
@@ -1285,7 +1285,7 @@ class TestAdminBillingRoutes:
             _resolve_existing_target,
         )
 
-        def _save_branding(_app, creator_bid, payload, **kwargs):
+        def _save_branding(_app, creator_bid, payload, **kwargs: object):
             captured["creator_bid"] = creator_bid
             captured["payload"] = payload
             captured["kwargs"] = kwargs

--- a/src/api/tests/service/billing/test_admin_ops_state.py
+++ b/src/api/tests/service/billing/test_admin_ops_state.py
@@ -9,7 +9,7 @@ class _TrackingLock:
         self._events = events
         self._key = key
 
-    def acquire(self, **_kwargs):
+    def acquire(self, **_kwargs: object):
         self._events.append(("acquire", self._key))
         return True
 
@@ -21,7 +21,7 @@ class _TrackingRedis:
     def __init__(self) -> None:
         self.events = []
 
-    def lock(self, key, **_kwargs):
+    def lock(self, key, **_kwargs: object):
         self.events.append(("lock", key))
         return _TrackingLock(self.events, key)
 
@@ -32,7 +32,7 @@ def _patch_config_store(monkeypatch):
     def fake_get_config(key, default=None):
         return store.get(key, default)
 
-    def fake_update_config(_app, key, value, **kwargs):
+    def fake_update_config(_app, key, value, **kwargs: object):
         store[key] = value
         store[(key, "meta")] = kwargs
         return True

--- a/src/api/tests/service/billing/test_billing_cycle_transitions.py
+++ b/src/api/tests/service/billing/test_billing_cycle_transitions.py
@@ -20,7 +20,7 @@ from flaskr.service.billing.cycle_transitions import (
 )
 
 
-def _raise_unexpected_call(*_args: object, **_kwargs):
+def _raise_unexpected_call(*_args: object, **_kwargs: object):
     message = "unexpected callback call"
     raise AssertionError(message)
 

--- a/src/api/tests/service/billing/test_billing_error_specificity.py
+++ b/src/api/tests/service/billing/test_billing_error_specificity.py
@@ -31,7 +31,7 @@ class _UnavailableLock:
 
 
 class _LockFactory:
-    def lock(self, *_args: object, **_kwargs):
+    def lock(self, *_args: object, **_kwargs: object):
         return _UnavailableLock()
 
 

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -141,7 +141,7 @@ def _billing_paid_feishu_payload(
     }
 
 
-def _raise_if_send_notify_called(*args: object, **kwargs):
+def _raise_if_send_notify_called(*args: object, **kwargs: object):
     _ = (args, kwargs)
     message = "billing paid Feishu delivery should run in a Celery task"
     raise AssertionError(message)

--- a/src/api/tests/service/billing/test_billing_tasks.py
+++ b/src/api/tests/service/billing/test_billing_tasks.py
@@ -532,7 +532,7 @@ def test_settle_usage_task_serializes_same_creator_concurrent_usage(
 
     original_build_usage_metric_charges = settlement_module.build_usage_metric_charges
 
-    def _blocking_build_usage_metric_charges(*args: object, **kwargs):
+    def _blocking_build_usage_metric_charges(*args: object, **kwargs: object):
         usage = args[0]
         if usage.usage_bid == "usage-concurrent-1":
             entered_first_charge.set()
@@ -1190,7 +1190,7 @@ def test_dispatch_due_renewal_events_task_noops_when_disabled(
 
     called = {"apply_async": 0}
 
-    def _fake_apply_async(*, kwargs=None, **options):
+    def _fake_apply_async(*, kwargs=None, **options: object):
         del kwargs, options
         called["apply_async"] += 1
 
@@ -1332,7 +1332,7 @@ def test_dispatch_due_renewal_events_task_enqueues_due_pending_events_only(
 
     captured_calls: list[dict[str, object]] = []
 
-    def _fake_apply_async(*, kwargs=None, **options):
+    def _fake_apply_async(*, kwargs=None, **options: object):
         captured_calls.append(
             {
                 "kwargs": dict(kwargs or {}),
@@ -1423,7 +1423,7 @@ def test_dispatch_due_renewal_events_recovers_stale_processing_events(
 
     captured_calls: list[dict[str, object]] = []
 
-    def _fake_apply_async(*, kwargs=None, **options):
+    def _fake_apply_async(*, kwargs=None, **options: object):
         captured_calls.append(
             {
                 "kwargs": dict(kwargs or {}),
@@ -1501,7 +1501,7 @@ def test_dispatch_due_renewal_events_uses_dedicated_queue_when_enabled(
 
     captured_calls: list[dict[str, object]] = []
 
-    def _fake_apply_async(*, kwargs=None, **options):
+    def _fake_apply_async(*, kwargs=None, **options: object):
         captured_calls.append(
             {
                 "kwargs": dict(kwargs or {}),

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
@@ -565,7 +565,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_consumed_before_write(
         real_expire = wallets_mod._expire_bucket_available_credits_if_unchanged
         changed = {"done": False}
 
-        def _consume_before_expire(target_bucket, **kwargs):
+        def _consume_before_expire(target_bucket, **kwargs: object):
             if (
                 not changed["done"]
                 and target_bucket.wallet_bucket_bid
@@ -687,7 +687,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_extended_before_write(
         real_expire = wallets_mod._expire_bucket_available_credits_if_unchanged
         changed = {"done": False}
 
-        def _extend_before_expire(target_bucket, **kwargs):
+        def _extend_before_expire(target_bucket, **kwargs: object):
             if (
                 not changed["done"]
                 and target_bucket.wallet_bucket_bid
@@ -777,7 +777,7 @@ def test_expire_credit_wallet_buckets_skips_empty_bucket_released_before_status_
         real_sync = wallets_mod._sync_empty_available_bucket_status_if_unchanged
         changed = {"done": False}
 
-        def _release_before_status_sync(target_bucket, **kwargs):
+        def _release_before_status_sync(target_bucket, **kwargs: object):
             if not changed["done"]:
                 changed["done"] = True
                 CreditWalletBucket.query.filter(
@@ -1063,7 +1063,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_on_wallet_version_conflict(
         real_persist = wallets_mod.persist_credit_wallet_snapshot
         state = {"calls": 0}
 
-        def _persist_conflict_once(target_wallet, **kwargs):
+        def _persist_conflict_once(target_wallet, **kwargs: object):
             state["calls"] += 1
             if state["calls"] == 1:
                 message = "credit_wallet_version_conflict"

--- a/src/api/tests/service/billing/test_creator_customization.py
+++ b/src/api/tests/service/billing/test_creator_customization.py
@@ -618,7 +618,7 @@ def test_creator_brand_logo_upload_uses_courses_oss_and_can_be_saved(app, monkey
 
     uploaded = {}
 
-    def fake_upload_to_storage(_app, **kwargs):
+    def fake_upload_to_storage(_app, **kwargs: object):
         uploaded.update(kwargs)
         return SimpleNamespace(
             url=f"https://courses-oss.example.com/{kwargs['object_key']}",
@@ -726,7 +726,7 @@ def test_creator_brand_favicon_upload_converts_png_to_ico(app, monkeypatch):
 
     uploaded = {}
 
-    def fake_upload_to_storage(_app, **kwargs):
+    def fake_upload_to_storage(_app, **kwargs: object):
         uploaded.update(kwargs)
         return SimpleNamespace(
             url=f"https://courses-oss.example.com/{kwargs['object_key']}",
@@ -919,7 +919,7 @@ def test_creator_brand_logo_upload_rejects_invalid_or_oversized_image(app, monke
 def test_creator_brand_logo_upload_normalizes_square_variant(app, monkeypatch):
     uploaded = {}
 
-    def fake_upload_to_storage(_app, **kwargs):
+    def fake_upload_to_storage(_app, **kwargs: object):
         content = kwargs["file_content"].read()
         uploaded["content"] = content
         return type("UploadResult", (), {"url": "https://cdn.example.com/logo.png"})()
@@ -956,7 +956,7 @@ def test_creator_brand_logo_upload_normalizes_square_variant(app, monkeypatch):
 def test_creator_brand_logo_upload_preserves_wide_retina_variant(app, monkeypatch):
     uploaded = {}
 
-    def fake_upload_to_storage(_app, **kwargs):
+    def fake_upload_to_storage(_app, **kwargs: object):
         content = kwargs["file_content"].read()
         uploaded["content"] = content
         return type("UploadResult", (), {"url": "https://cdn.example.com/logo.png"})()

--- a/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
@@ -293,7 +293,7 @@ def test_scan_item_failure_is_isolated_from_neighbor_items(
 
     original_stage = credit_notifications._stage_notification_record
 
-    def staging_then_boom(app_arg, **kwargs):
+    def staging_then_boom(app_arg, **kwargs: object):
         result = original_stage(app_arg, **kwargs)
         if kwargs.get("creator_bid") == "creator-uow-2":
             message = "boom in creator-uow-2"
@@ -401,7 +401,7 @@ def test_failed_provider_marker_persists_and_stays_retryable(
     )
     notification_bid = str(staged["notification_bid"])
 
-    def crashing_send(*_args: object, **_kwargs):
+    def crashing_send(*_args: object, **_kwargs: object):
         message = "provider connection dropped"
         raise RuntimeError(message)
 

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -2372,7 +2372,7 @@ def test_provider_exception_marks_notification_failed(
     _seed_creator(app)
     _enable_policy(app)
 
-    def raise_provider_error(*args: object, **kwargs) -> None:
+    def raise_provider_error(*args: object, **kwargs: object) -> None:
         _ = (args, kwargs)
         message = "provider raised"
         raise RuntimeError(message)

--- a/src/api/tests/service/billing/test_provider_catalog.py
+++ b/src/api/tests/service/billing/test_provider_catalog.py
@@ -38,7 +38,7 @@ class _FakeStripeResource:
         self.payload = payload
         self.calls = []
 
-    def retrieve(self, *args: object, **kwargs):
+    def retrieve(self, *args: object, **kwargs: object):
         self.calls.append({"args": args, "kwargs": kwargs})
         return _StripeObject(self.payload)
 
@@ -86,7 +86,7 @@ class _FakeStripe:
 
 
 class _FailingStripeResource:
-    def retrieve(self, *args: object, **kwargs):
+    def retrieve(self, *args: object, **kwargs: object):
         _ = (args, kwargs)
         message = "secret sk_test_should_not_leak"
         raise RuntimeError(message)
@@ -107,7 +107,7 @@ class _FakeStripeAdapter(StripeCatalogReadAdapter):
         return self.stripe, build_stripe_request_options()
 
 
-def _plan_product(**overrides) -> BillingProduct:
+def _plan_product(**overrides: object) -> BillingProduct:
     values = {
         "product_bid": "bill-product-growth-month",
         "product_code": "creator-global-growth-monthly",
@@ -124,7 +124,7 @@ def _plan_product(**overrides) -> BillingProduct:
     return BillingProduct(**values)
 
 
-def _topup_product(**overrides) -> BillingProduct:
+def _topup_product(**overrides: object) -> BillingProduct:
     values = {
         "product_bid": "bill-product-topup-1000",
         "product_code": "creator-global-topup-1000",

--- a/src/api/tests/service/billing/test_referral_plan_rewards.py
+++ b/src/api/tests/service/billing/test_referral_plan_rewards.py
@@ -964,7 +964,7 @@ def test_pingxx_renewal_event_preserves_paid_referral_reward_order(
     boundary_at = normalize_mysql_datetime(now_utc() - timedelta(minutes=1))
     current_cycle_start = boundary_at - timedelta(days=30)
 
-    def _fail_provider_sync(*_args: object, **_kwargs):
+    def _fail_provider_sync(*_args: object, **_kwargs: object):
         message = "paid referral reward orders must not sync providers"
         raise AssertionError(message)
 

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -316,7 +316,7 @@ def test_renewal_order_persists_before_provider_sync_crash(
     )
     dao.db.session.commit()
 
-    def crashing_sync(*_args: object, **_kwargs):
+    def crashing_sync(*_args: object, **_kwargs: object):
         message = "provider sync crash"
         raise RuntimeError(message)
 
@@ -952,7 +952,7 @@ def test_provider_guard_renews_lease_before_cross_transaction_sync(
 
     recovery_counts: list[int] = []
 
-    def fake_sync(*_args: object, **_kwargs):
+    def fake_sync(*_args: object, **_kwargs: object):
         recovery_counts.append(
             billing_tasks._recover_stale_processing_renewal_events(
                 stale_before=now_utc() - timedelta(minutes=30),

--- a/src/api/tests/service/creator_analytics/test_dsl.py
+++ b/src/api/tests/service/creator_analytics/test_dsl.py
@@ -20,7 +20,7 @@ from flaskr.service.creator_analytics.dsl import (
 DEFAULT_LIMIT_MAX = 1000
 
 
-def _payload(**overrides):
+def _payload(**overrides: object):
     base = {
         "shifu_bid": "shifu-abc",
         "table": "learn_progress_records",
@@ -372,7 +372,7 @@ def test_select_user_bid_with_group_by_other_dimension_is_rejected() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _content_payload(**overrides):
+def _content_payload(**overrides: object):
     base = {
         "shifu_bid": "shifu-abc",
         "table": "learn_generated_blocks",
@@ -436,7 +436,7 @@ def test_generated_content_limit_at_100_is_allowed() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _user_users_payload(**overrides):
+def _user_users_payload(**overrides: object):
     base = {
         "shifu_bid": "shifu-abc",
         "table": "user_users",
@@ -504,7 +504,7 @@ def test_user_users_select_disallowed_column_rejected() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _user_users_identify_payload(**overrides):
+def _user_users_identify_payload(**overrides: object):
     base = {
         "shifu_bid": "shifu-abc",
         "table": "user_users",
@@ -579,7 +579,7 @@ def test_user_users_user_identify_not_groupable() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _daily_metric_payload(**overrides):
+def _daily_metric_payload(**overrides: object):
     base = {
         "shifu_bid": "shifu-abc",
         "table": "bill_daily_usage_metrics",
@@ -651,7 +651,7 @@ def test_bill_usage_table_rejected() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _generated_blocks_payload(**overrides):
+def _generated_blocks_payload(**overrides: object):
     """Build a baseline DSL payload for learn_generated_blocks tests."""
     base = {
         "shifu_bid": "shifu-abc",
@@ -763,7 +763,7 @@ def test_bill_daily_creator_bid_filter_rejected() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _shifu_meta_payload(table_key="shifu_published_shifus", **overrides):
+def _shifu_meta_payload(table_key="shifu_published_shifus", **overrides: object):
     """Build a baseline DSL payload for shifu metadata-table tests."""
     base = {
         "shifu_bid": "shifu-abc",

--- a/src/api/tests/service/creator_analytics/test_query.py
+++ b/src/api/tests/service/creator_analytics/test_query.py
@@ -691,7 +691,7 @@ def test_dedicated_engine_replacement_disposes_previous_owner(app, monkeypatch):
 
     created: list[_FakeEngine] = []
 
-    def fake_create_engine(uri, **_kwargs):
+    def fake_create_engine(uri, **_kwargs: object):
         engine = _FakeEngine(uri)
         created.append(engine)
         return engine

--- a/src/api/tests/service/creator_analytics/test_sql_builder.py
+++ b/src/api/tests/service/creator_analytics/test_sql_builder.py
@@ -290,7 +290,7 @@ def test_generated_blocks_status_explicit_filter_does_not_override_auto() -> Non
 # ---------------------------------------------------------------------------
 
 
-def _meta_payload(table_key="shifu_published_shifus", **overrides):
+def _meta_payload(table_key="shifu_published_shifus", **overrides: object):
     """Build a baseline DSL payload for shifu metadata-table compile tests."""
     base = {
         "shifu_bid": "shifu-abc",

--- a/src/api/tests/service/learn/run/test_run_recorder.py
+++ b/src/api/tests/service/learn/run/test_run_recorder.py
@@ -82,7 +82,7 @@ def _fail_next_flush(monkeypatch, exc: Exception) -> None:
     real_flush = dao.db.session.flush
     state = {"fired": False}
 
-    def _boom(*args: object, **kwargs):
+    def _boom(*args: object, **kwargs: object):
         if not state["fired"]:
             state["fired"] = True
             raise exc

--- a/src/api/tests/service/learn/test_ask_provider_adapters.py
+++ b/src/api/tests/service/learn/test_ask_provider_adapters.py
@@ -58,7 +58,7 @@ def test_dify_adapter_streams_success_content(app, monkeypatch):
         }.get,
     )
 
-    def _fake_post(*_args: object, **kwargs):
+    def _fake_post(*_args: object, **kwargs: object):
         request_state["json"] = kwargs.get("json")
         return _FakeResponse(
             lines=[
@@ -114,7 +114,7 @@ def test_coze_adapter_timeout_raises_timeout_error(app, monkeypatch):
         }.get,
     )
 
-    def _raise_timeout(*_args: object, **_kwargs):
+    def _raise_timeout(*_args: object, **_kwargs: object):
         message = "timeout"
         raise requests.Timeout(message)
 
@@ -204,7 +204,7 @@ def test_coze_workflow_adapter_streams_success_content(app, monkeypatch):
         }.get,
     )
 
-    def _fake_post(url, **kwargs):
+    def _fake_post(url, **kwargs: object):
         request_state["url"] = url
         request_state["json"] = kwargs.get("json")
         request_state["headers"] = kwargs.get("headers") or {}
@@ -358,7 +358,7 @@ def test_coze_adapter_uses_default_base_url_when_missing(app, monkeypatch):
         }.get,
     )
 
-    def _fake_post(url, **kwargs):
+    def _fake_post(url, **kwargs: object):
         request_state["url"] = url
         request_state["json"] = kwargs["json"]
         return _FakeResponse(
@@ -403,7 +403,7 @@ def test_volc_knowledge_adapter_streams_success_content(app, monkeypatch):
 
     request_state = {}
 
-    def _fake_request(*_args: object, **kwargs):
+    def _fake_request(*_args: object, **kwargs: object):
         request_state["method"] = kwargs.get("method")
         request_state["headers"] = kwargs.get("headers") or {}
         request_state["url"] = kwargs.get("url")
@@ -485,7 +485,7 @@ def test_get_biji_knowledge_adapter_synthesizes_with_llm_context(app, monkeypatc
 
     request_state = {}
 
-    def _fake_post(url, **kwargs):
+    def _fake_post(url, **kwargs: object):
         request_state["url"] = url
         request_state["headers"] = kwargs.get("headers") or {}
         request_state["json"] = kwargs.get("json")
@@ -750,7 +750,7 @@ def test_get_biji_knowledge_adapter_missing_config_raises_error(app):
 def test_get_biji_knowledge_adapter_timeout_raises_timeout_error(app, monkeypatch):
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
 
-    def _raise_timeout(*_args: object, **_kwargs):
+    def _raise_timeout(*_args: object, **_kwargs: object):
         message = "timeout"
         raise requests.Timeout(message)
 

--- a/src/api/tests/service/learn/test_ask_provider_langfuse.py
+++ b/src/api/tests/service/learn/test_ask_provider_langfuse.py
@@ -8,11 +8,11 @@ from flaskr.service.learn.ask_provider_langfuse import stream_provider_with_lang
 
 
 class _DummyGeneration:
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: object) -> None:
         self.kwargs = kwargs
         self.end_kwargs = {}
 
-    def end(self, **kwargs):
+    def end(self, **kwargs: object):
         self.end_kwargs = kwargs
 
 
@@ -22,7 +22,7 @@ class _DummySpan:
         self.id = span_id
         self.generations = []
 
-    def generation(self, **kwargs):
+    def generation(self, **kwargs: object):
         generation = _DummyGeneration(**kwargs)
         self.generations.append(generation)
         return generation

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -19,7 +19,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs):
+    def get_model_info(*args: object, **kwargs: object):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -149,10 +149,10 @@ class _FakeLangfuseSpan:
         self.updated = {}
         self.end_kwargs = {}
 
-    def update(self, **kwargs):
+    def update(self, **kwargs: object):
         self.updated = kwargs
 
-    def end(self, **kwargs):
+    def end(self, **kwargs: object):
         self.end_kwargs = kwargs
 
 
@@ -160,7 +160,7 @@ class _FakeLangfuseTrace:
     def __init__(self) -> None:
         self.updated = {}
 
-    def update(self, **kwargs):
+    def update(self, **kwargs: object):
         self.updated = kwargs
 
 
@@ -471,14 +471,14 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
             deleted = _Column()
 
         class _FakeQuery:
-            def filter(self, *_args: object, **_kwargs):
+            def filter(self, *_args: object, **_kwargs: object):
                 return self
 
             def all(self):
                 return [("outline-1", False, "Outline 1")]
 
         class _FakeMarkdownFlow:
-            def __init__(self, *args: object, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 pass
 
             def get_all_blocks(self):
@@ -540,7 +540,7 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
         attend = types.SimpleNamespace(outline_item_bid="outline-1", block_position=0)
 
         class _FakeMarkdownFlow:
-            def __init__(self, *args: object, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 pass
 
             def get_all_blocks(self):
@@ -1140,11 +1140,11 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
 
     def test_init_ignores_visual_mode_when_api_missing(self):
         class FakeMarkdownFlow:
-            def __init__(self, *args: object, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 self.args = args
                 self.kwargs = kwargs
 
-            def set_output_language(self, *_args: object, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs: object):
                 return self
 
         with patch("flaskr.service.learn.context_v2.MarkdownFlow", FakeMarkdownFlow):
@@ -1154,14 +1154,14 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
 
     def test_init_calls_visual_mode_when_api_exists(self):
         class FakeMarkdownFlow:
-            def __init__(self, *args: object, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 _ = (args, kwargs)
                 self.visual_mode = None
 
             def set_visual_mode(self, visual_mode):
                 self.visual_mode = visual_mode
 
-            def set_output_language(self, *_args: object, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs: object):
                 return self
 
         with patch("flaskr.service.learn.context_v2.MarkdownFlow", FakeMarkdownFlow):
@@ -1171,7 +1171,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
 
     def test_init_uses_explicit_output_language_when_enabled(self):
         class FakeMarkdownFlow:
-            def __init__(self, *args: object, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 _ = (args, kwargs)
                 self.output_language = None
 
@@ -1835,17 +1835,17 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
         captured = {}
 
         class _FakePreviewContextStore:
-            def __init__(self, *_args: object, **_kwargs) -> None:
+            def __init__(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def get_context(self, *_args: object, **_kwargs):
+            def get_context(self, *_args: object, **_kwargs: object):
                 return []
 
-            def replace_context(self, *_args: object, **_kwargs):
+            def replace_context(self, *_args: object, **_kwargs: object):
                 return None
 
         class _FakePreviewMdflowContext:
-            def __init__(self, *args: object, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 _ = args, kwargs
 
             @staticmethod
@@ -1861,7 +1861,7 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
                     block_type=PreviewBlockType.CONTENT, content="Prompt block"
                 )
 
-            def process(self, **_kwargs):
+            def process(self, **_kwargs: object):
                 return (
                     item
                     for item in [
@@ -1874,7 +1874,7 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
                 )
 
         class _FakePreviewAdapter:
-            def __init__(self, *_args: object, **_kwargs) -> None:
+            def __init__(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
             def process(self, events):

--- a/src/api/tests/service/learn/test_context_v2_tts_runtime_voice.py
+++ b/src/api/tests/service/learn/test_context_v2_tts_runtime_voice.py
@@ -28,7 +28,7 @@ def test_context_v2_tts_processor_uses_runtime_minimax_voice_fallback(monkeypatc
     captured_kwargs = {}
 
     class FakeStreamingTTSProcessor:
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, **kwargs: object) -> None:
             captured_kwargs.update(kwargs)
 
     monkeypatch.setattr(

--- a/src/api/tests/service/learn/test_element_protocol.py
+++ b/src/api/tests/service/learn/test_element_protocol.py
@@ -38,11 +38,11 @@ def adapter_app():
 
 
 class _FollowUpDummyGeneration:
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: object) -> None:
         self.kwargs = kwargs
         self.end_kwargs = {}
 
-    def end(self, **kwargs):
+    def end(self, **kwargs: object):
         self.end_kwargs = kwargs
 
 
@@ -52,21 +52,21 @@ class _FollowUpDummySpan:
         self.updated = {}
         self.output = ""
 
-    def generation(self, **kwargs):
+    def generation(self, **kwargs: object):
         generation = _FollowUpDummyGeneration(**kwargs)
         self.generations.append(generation)
         return generation
 
-    def span(self, **_kwargs):
+    def span(self, **_kwargs: object):
         return _FollowUpDummySpan()
 
-    def update(self, **kwargs):
+    def update(self, **kwargs: object):
         self.updated = kwargs
 
-    def event(self, **_kwargs):
+    def event(self, **_kwargs: object):
         return None
 
-    def end(self, output=None, **kwargs):
+    def end(self, output=None, **kwargs: object):
         self.output = output or ""
         self.end_kwargs = {"output": output, **kwargs}
 
@@ -75,10 +75,10 @@ class _FollowUpDummyTrace:
     def __init__(self) -> None:
         self.updated = {}
 
-    def span(self, **_kwargs):
+    def span(self, **_kwargs: object):
         return _FollowUpDummySpan()
 
-    def update(self, **kwargs):
+    def update(self, **kwargs: object):
         self.updated = kwargs
 
 
@@ -176,7 +176,7 @@ def _setup_handle_input_ask_test_doubles(
 
         call_counter = {"index": 0}
 
-        def _fake_init_generated_block(*_args: object, **_kwargs):
+        def _fake_init_generated_block(*_args: object, **_kwargs: object):
             call_counter["index"] += 1
             return types.SimpleNamespace(
                 generated_block_bid=f"gb-{call_counter['index']}",
@@ -259,7 +259,7 @@ class TestElementType:
 class TestElementDTONewFields:
     """Verify element DTO new fields behavior."""
 
-    def _make_dto(self, **overrides):
+    def _make_dto(self, **overrides: object):
         from flaskr.service.learn.learn_dtos import ElementDTO, ElementType
 
         defaults = {
@@ -2479,7 +2479,7 @@ class TestHandleAskAdapter:
                 patch_generated_blocks=False,
             )
 
-            def _raise_provider_error(**_kwargs):
+            def _raise_provider_error(**_kwargs: object):
                 if False:
                     yield None
                 message = "provider failed"

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -54,7 +54,7 @@ def _patch_run_tts_processor(
         lambda _provider: False,
     )
 
-    def _fake_synthesize_text(**kwargs):
+    def _fake_synthesize_text(**kwargs: object):
         synthesized_texts.append(kwargs["text"])
         return SimpleNamespace(
             audio_data=f"fake-audio:{kwargs['text']}".encode(),
@@ -935,7 +935,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
         synthesized_texts = _patch_run_tts_processor(monkeypatch)
 
-        def _fail_sem_acquire(*_args: object, **_kwargs):
+        def _fail_sem_acquire(*_args: object, **_kwargs: object):
             message = "cache fast-path should not acquire the synthesis semaphore"
             raise AssertionError(message)
 
@@ -1159,7 +1159,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
         synthesized_texts = _patch_run_tts_processor(monkeypatch)
 
-        def _fail_sem_acquire(*_args: object, **_kwargs):
+        def _fail_sem_acquire(*_args: object, **_kwargs: object):
             message = "markup-only blocks should not acquire the synthesis semaphore"
             raise AssertionError(message)
 

--- a/src/api/tests/service/learn/test_handle_input_ask_provider.py
+++ b/src/api/tests/service/learn/test_handle_input_ask_provider.py
@@ -11,7 +11,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs):
+    def get_model_info(*args: object, **kwargs: object):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -95,13 +95,13 @@ class _DummyOrderColumn(_DummyColumn):
 
 
 class _DummyQuery:
-    def filter(self, *_args: object, **_kwargs):
+    def filter(self, *_args: object, **_kwargs: object):
         return self
 
-    def order_by(self, *_args: object, **_kwargs):
+    def order_by(self, *_args: object, **_kwargs: object):
         return self
 
-    def limit(self, *_args: object, **_kwargs):
+    def limit(self, *_args: object, **_kwargs: object):
         return self
 
     def all(self):
@@ -118,7 +118,7 @@ class _DummyLearnGeneratedBlockModel:
 class _DummyNoneQuery:
     """Query that always returns None for .first()."""
 
-    def filter(self, *_args: object, **_kwargs):
+    def filter(self, *_args: object, **_kwargs: object):
         return self
 
     def first(self):
@@ -146,11 +146,11 @@ class _DummyFollowUpInfo:
 
 
 class _DummyGeneration:
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: object) -> None:
         self.kwargs = kwargs
         self.end_kwargs = {}
 
-    def end(self, **kwargs):
+    def end(self, **kwargs: object):
         self.end_kwargs = kwargs
 
 
@@ -164,23 +164,23 @@ class _DummySpan:
         self.end_kwargs = {}
         self.events = []
 
-    def generation(self, **kwargs):
+    def generation(self, **kwargs: object):
         generation = _DummyGeneration(**kwargs)
         self.generations.append(generation)
         return generation
 
-    def span(self, **kwargs):
+    def span(self, **kwargs: object):
         self.span_calls.append(kwargs)
         self.last_span = _DummySpan()
         return self.last_span
 
-    def update(self, **kwargs):
+    def update(self, **kwargs: object):
         self.updated = kwargs
 
-    def event(self, **kwargs):
+    def event(self, **kwargs: object):
         self.events.append(kwargs)
 
-    def end(self, output=None, **kwargs):
+    def end(self, output=None, **kwargs: object):
         self.output = output or ""
         self.end_kwargs = {"output": output, **kwargs}
 
@@ -191,11 +191,11 @@ class _DummyTrace:
         self.updated = {}
         self.last_span = None
 
-    def span(self, **_kwargs):
+    def span(self, **_kwargs: object):
         self.last_span = _DummySpan()
         return self.last_span
 
-    def update(self, **kwargs):
+    def update(self, **kwargs: object):
         self.updated = kwargs
 
 
@@ -277,7 +277,7 @@ def _setup_handle_input_ask_patches(monkeypatch, module, ask_provider_config):
 
     call_counter = {"index": 0}
 
-    def _fake_init_generated_block(*_args: object, **_kwargs):
+    def _fake_init_generated_block(*_args: object, **_kwargs: object):
         call_counter["index"] += 1
         return types.SimpleNamespace(
             generated_block_bid=f"gb-{call_counter['index']}",
@@ -311,13 +311,13 @@ def test_handle_input_ask_provider_only_returns_provider_error_without_llm(
 
     llm_call_counter = {"count": 0}
 
-    def _fake_chat_llm(*_args: object, **_kwargs):
+    def _fake_chat_llm(*_args: object, **_kwargs: object):
         llm_call_counter["count"] += 1
         yield _LLMChunk("should-not-run")
 
     monkeypatch.setattr(module, "chat_llm", _fake_chat_llm)
 
-    def _raise_provider_error(**_kwargs):
+    def _raise_provider_error(**_kwargs: object):
         if False:
             yield None
         message = "provider failed"
@@ -377,13 +377,13 @@ def test_handle_input_ask_provider_then_llm_falls_back_to_llm(app, monkeypatch):
 
     llm_call_counter = {"count": 0}
 
-    def _fake_chat_llm(*_args: object, **_kwargs):
+    def _fake_chat_llm(*_args: object, **_kwargs: object):
         llm_call_counter["count"] += 1
         yield _LLMChunk("llm-fallback-answer")
 
     monkeypatch.setattr(module, "chat_llm", _fake_chat_llm)
 
-    def _provider_then_llm_stream(**kwargs):
+    def _provider_then_llm_stream(**kwargs: object):
         if kwargs.get("provider") == "llm":
             runtime = kwargs.get("runtime")
             if runtime is None or runtime.llm_stream_factory is None:
@@ -449,13 +449,13 @@ def test_handle_input_ask_get_biji_synthesizes_via_context_factory(app, monkeypa
 
     llm_calls = []
 
-    def _fake_chat_llm(*_args: object, **kwargs):
+    def _fake_chat_llm(*_args: object, **kwargs: object):
         llm_calls.append(kwargs)
         yield _LLMChunk("synthesized-answer")
 
     monkeypatch.setattr(module, "chat_llm", _fake_chat_llm)
 
-    def _retrieval_provider_stream(**kwargs):
+    def _retrieval_provider_stream(**kwargs: object):
         # Mimic a retrieval adapter: synthesize through the runtime factory.
         runtime = kwargs.get("runtime")
         assert runtime is not None
@@ -520,7 +520,7 @@ def test_handle_input_ask_provider_response_skips_llm(app, monkeypatch):
 
     llm_call_counter = {"count": 0}
 
-    def _fake_chat_llm(*_args: object, **_kwargs):
+    def _fake_chat_llm(*_args: object, **_kwargs: object):
         llm_call_counter["count"] += 1
         yield _LLMChunk("should-not-run")
 
@@ -588,7 +588,7 @@ def test_handle_input_ask_dify_uses_context_without_follow_up_prompt(app, monkey
 
     captured = {"messages": None}
 
-    def _fake_stream_ask_provider_response(**kwargs):
+    def _fake_stream_ask_provider_response(**kwargs: object):
         if kwargs.get("provider") == "dify":
             captured["messages"] = kwargs.get("messages")
             return iter([types.SimpleNamespace(content="provider-answer")])
@@ -699,7 +699,7 @@ def test_handle_input_ask_formats_provider_prompt_with_request_language(
         }
         return template.format(**profiles)
 
-    def _fake_stream_ask_provider_response(**kwargs):
+    def _fake_stream_ask_provider_response(**kwargs: object):
         captured["messages"] = kwargs.get("messages")
         return iter([types.SimpleNamespace(content="provider-answer")])
 
@@ -753,7 +753,7 @@ def _setup_llm_only_patches(monkeypatch, module, llm_chunks):
     ask_provider_config = {"provider": "llm", "mode": "provider_then_llm", "config": {}}
     _setup_handle_input_ask_patches(monkeypatch, module, ask_provider_config)
 
-    def _fake_stream(**_kwargs):
+    def _fake_stream(**_kwargs: object):
         for chunk in llm_chunks:
             yield types.SimpleNamespace(content=chunk)
 

--- a/src/api/tests/service/learn/test_learn_funcs.py
+++ b/src/api/tests/service/learn/test_learn_funcs.py
@@ -250,14 +250,14 @@ class LearnRecordLoadTests(unittest.TestCase):
         class FakeMarkdownFlow:
             last_context = None
 
-            def __init__(self, *args: object, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 _ = (args, kwargs)
                 self.blocks = [DummyBlock(BlockType.CONTENT, "md content", 0)]
 
-            def set_visual_mode(self, *_args: object, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs: object):
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs: object):
                 return self
 
             def get_all_blocks(self):
@@ -370,7 +370,7 @@ class LearnRecordLoadTests(unittest.TestCase):
                 self.content = content
 
         class FakeMarkdownFlow:
-            def __init__(self, *args: object, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(MarkdownFlowBlockType.CONTENT, "first content", 0),
@@ -382,10 +382,10 @@ class LearnRecordLoadTests(unittest.TestCase):
                     ),
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs: object):
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs: object):
                 return self
 
             def get_all_blocks(self):
@@ -518,14 +518,14 @@ class LearnRecordLoadTests(unittest.TestCase):
         class FakeMarkdownFlow:
             process_called = False
 
-            def __init__(self, *args: object, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 _ = (args, kwargs)
                 self.blocks = [DummyBlock(BlockType.CONTENT, "===fixed output===", 0)]
 
-            def set_visual_mode(self, *_args: object, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs: object):
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs: object):
                 return self
 
             def get_all_blocks(self):
@@ -645,17 +645,17 @@ class LearnRecordLoadTests(unittest.TestCase):
         class FakeMarkdownFlow:
             process_called = False
 
-            def __init__(self, *args: object, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(BlockType.CONTENT, "===fixed output===", 0),
                     DummyBlock(BlockType.INTERACTION, "?[%{{v}} A|B]", 1),
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs: object):
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs: object):
                 return self
 
             def get_all_blocks(self):
@@ -768,17 +768,17 @@ class LearnRecordLoadTests(unittest.TestCase):
         class FakeMarkdownFlow:
             process_called = False
 
-            def __init__(self, *args: object, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(BlockType.CONTENT, "===fixed output===", 0),
                     DummyBlock(BlockType.INTERACTION, "?[%{{v}} A|B]", 1),
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs: object):
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs: object):
                 return self
 
             def get_all_blocks(self):

--- a/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
+++ b/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
@@ -13,7 +13,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs):
+    def get_model_info(*args: object, **kwargs: object):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -117,7 +117,7 @@ def test_find_active_element_row_ids_invalidates_desynced_connection(app, monkey
         def __init__(self) -> None:
             self.invalidated = 0
 
-        def execute(self, *_args: object, **_kwargs):
+        def execute(self, *_args: object, **_kwargs: object):
             return _DesyncedResult()
 
         def invalidate(self):

--- a/src/api/tests/service/learn/test_listen_elements.py
+++ b/src/api/tests/service/learn/test_listen_elements.py
@@ -1410,7 +1410,7 @@ def test_listen_run_persists_content_block_before_element_rows(app):
                 self.content = content
 
         class FakeMarkdownFlow:
-            def __init__(self, *args: object, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(
@@ -1420,10 +1420,10 @@ def test_listen_run_persists_content_block_before_element_rows(app):
                     )
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs: object):
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs: object):
                 return self
 
             def get_all_blocks(self):
@@ -1603,7 +1603,7 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
                 self.formatted_elements = formatted_elements
 
         class FakeMarkdownFlow:
-            def __init__(self, *args: object, **kwargs) -> None:
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 _ = (args, kwargs)
                 self.blocks = [
                     DummyBlock(
@@ -1613,10 +1613,10 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
                     )
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs):
+            def set_visual_mode(self, *_args: object, **_kwargs: object):
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs):
+            def set_output_language(self, *_args: object, **_kwargs: object):
                 return self
 
             def get_all_blocks(self):
@@ -1698,7 +1698,7 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app):
             position,
             stream_element_number,
             stream_element_type,
-            **_kwargs,
+            **_kwargs: object,
         ):
             _ = self
             return FakeTTSProcessor(

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -55,7 +55,7 @@ class FakeCacheProvider:
         self._lock = lock
         self.values: dict[str, bytes] = {}
 
-    def lock(self, *_args: object, **_kwargs):
+    def lock(self, *_args: object, **_kwargs: object):
         return self._lock
 
     def setex(self, key: str, _time_in_seconds: int, value):
@@ -78,7 +78,7 @@ class FakeCacheProvider:
 class FakeListenElementAdapter:
     """Simulate listen element adapter behavior for tests."""
 
-    def __init__(self, *_args: object, **_kwargs) -> None:
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
         """Initialize event sequencing for a fixed run session."""
         self._seq = 0
         self._run_session_bid = "run-session-1"
@@ -167,7 +167,7 @@ def test_run_script_retries_lock_then_streams(monkeypatch):
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         monkeypatch.setattr(runscript_v2.time, "sleep", lambda *_args, **_kwargs: None)
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             with app.app_context():
                 yield from [
                     RunMarkdownFlowDTO(
@@ -215,7 +215,7 @@ def test_run_script_producer_owns_app_context(monkeypatch):
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         observed = {"has_app_context": None, "manage_app_context": None}
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             observed["has_app_context"] = has_app_context()
             observed["manage_app_context"] = _kwargs.get("manage_app_context")
             yield RunMarkdownFlowDTO(
@@ -262,7 +262,7 @@ def test_run_script_removes_producer_db_session(monkeypatch):
             ),
         )
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
                 generated_block_bid="generated-1",
@@ -307,7 +307,7 @@ def test_run_script_producer_done_survives_db_session_remove_failure(monkeypatch
             SimpleNamespace(session=SimpleNamespace(remove=_remove)),
         )
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
                 generated_block_bid="generated-1",
@@ -341,7 +341,7 @@ def test_run_script_read_mode_keeps_interaction_after_block_break(monkeypatch):
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             with app.app_context():
                 yield from [
                     RunMarkdownFlowDTO(
@@ -395,7 +395,7 @@ def test_run_script_ask_mode_uses_element_protocol(monkeypatch):
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             with app.app_context():
                 element_adapter = _kwargs["element_adapter"]
                 yield from element_adapter.process(
@@ -450,7 +450,7 @@ def test_run_script_ask_mode_ignores_listen_flag(monkeypatch):
         observed: dict[str, object] = {}
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             observed["listen"] = _kwargs["listen"]
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
@@ -528,13 +528,13 @@ def test_run_script_inner_ask_mode_routes_events_through_element_adapter(monkeyp
     )
 
     class FakeRunScriptContext:
-        def __init__(self, **_kwargs) -> None:
+        def __init__(self, **_kwargs: object) -> None:
             self._has_next = True
 
-        def set_input(self, *_args: object, **_kwargs):
+        def set_input(self, *_args: object, **_kwargs: object):
             return None
 
-        def reload(self, *_args: object, **_kwargs):
+        def reload(self, *_args: object, **_kwargs: object):
             return []
 
         def has_next(self):
@@ -730,13 +730,13 @@ def test_run_script_inner_rolls_back_on_unexpected_exception(monkeypatch):
     )
 
     class FakeRunScriptContext:
-        def __init__(self, **_kwargs) -> None:
+        def __init__(self, **_kwargs: object) -> None:
             self._has_next = True
 
-        def set_input(self, *_args: object, **_kwargs):
+        def set_input(self, *_args: object, **_kwargs: object):
             return None
 
-        def reload(self, *_args: object, **_kwargs):
+        def reload(self, *_args: object, **_kwargs: object):
             return []
 
         def has_next(self):
@@ -816,15 +816,15 @@ def test_run_script_inner_finalizes_langfuse_after_loop(monkeypatch):
     class FakeRunScriptContext:
         last_instance = None
 
-        def __init__(self, **_kwargs) -> None:
+        def __init__(self, **_kwargs: object) -> None:
             self._has_next = True
             self.finalize_calls = 0
             FakeRunScriptContext.last_instance = self
 
-        def set_input(self, *_args: object, **_kwargs):
+        def set_input(self, *_args: object, **_kwargs: object):
             return None
 
-        def reload(self, *_args: object, **_kwargs):
+        def reload(self, *_args: object, **_kwargs: object):
             return []
 
         def has_next(self):
@@ -918,13 +918,13 @@ def test_run_script_inner_emits_audio_backfill_ready_after_final_commit(monkeypa
     )
 
     class FakeRunScriptContext:
-        def __init__(self, **_kwargs) -> None:
+        def __init__(self, **_kwargs: object) -> None:
             self._has_next = True
 
-        def set_input(self, *_args: object, **_kwargs):
+        def set_input(self, *_args: object, **_kwargs: object):
             return None
 
-        def reload(self, *_args: object, **_kwargs):
+        def reload(self, *_args: object, **_kwargs: object):
             return []
 
         def has_next(self):
@@ -1047,13 +1047,13 @@ def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(monkeypa
     )
 
     class FakeRunScriptContext:
-        def __init__(self, **_kwargs) -> None:
+        def __init__(self, **_kwargs: object) -> None:
             self._has_next = True
 
-        def set_input(self, *_args: object, **_kwargs):
+        def set_input(self, *_args: object, **_kwargs: object):
             return None
 
-        def reload(self, *_args: object, **_kwargs):
+        def reload(self, *_args: object, **_kwargs: object):
             return []
 
         def has_next(self):
@@ -1126,7 +1126,7 @@ def test_run_script_listen_keeps_interaction_after_block_done(monkeypatch):
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             with app.app_context():
                 element_adapter = _kwargs["element_adapter"]
                 yield from element_adapter.process(
@@ -1246,7 +1246,7 @@ def test_run_script_maps_llm_stream_connection_error_to_retryable_message(
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         monkeypatch.setattr(runscript_v2, "_", lambda key: f"translated:{key}")
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             message = "litellm.APIConnectionError: APIConnectionError: OpenAIException - [SSL] record layer failure (_ssl.c:2590)"
             raise RuntimeError(message)
             yield  # pragma: no cover
@@ -1280,7 +1280,7 @@ def test_run_script_maps_standard_timeout_error_to_retryable_message(monkeypatch
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         monkeypatch.setattr(runscript_v2, "_", lambda key: f"translated:{key}")
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             message = "stream failed"
             raise RuntimeError(message) from TimeoutError(
                 "The read operation timed out"
@@ -1315,7 +1315,7 @@ def test_run_script_listen_done_uses_element_protocol(monkeypatch):
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             if False:
                 yield None
 
@@ -1373,7 +1373,7 @@ def test_get_run_status_reports_true_while_stream_is_open(monkeypatch):
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         monkeypatch.setattr(runscript_v2.time, "time", lambda: 120.0)
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             with app.app_context():
                 yield RunMarkdownFlowDTO(
                     outline_bid="outline-1",
@@ -1424,7 +1424,7 @@ def test_run_script_close_during_data_yield_does_not_raise_runtime_error(monkeyp
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
                 generated_block_bid="generated-1",
@@ -1470,7 +1470,7 @@ def test_run_script_propagates_explicit_language_to_producer(monkeypatch):
 
         seen_languages: list[str] = []
 
-        def fake_run_script_inner(**_kwargs):
+        def fake_run_script_inner(**_kwargs: object):
             with app.app_context():
                 seen_languages.append(get_current_language())
                 yield RunMarkdownFlowDTO(

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -48,10 +48,10 @@ class _StubRunContext:
 
     script: ClassVar[list] = []
 
-    def __init__(self, **_kwargs) -> None:
+    def __init__(self, **_kwargs: object) -> None:
         self._steps = iter([True, False])
 
-    def set_input(self, *_args: object, **_kwargs):
+    def set_input(self, *_args: object, **_kwargs: object):
         pass
 
     def has_next(self):
@@ -192,7 +192,7 @@ def test_stop_event_cancellation_invalidates_instead_of_rollback(app, monkeypatc
     class _TwoRoundContext(_StubRunContext):
         # Two has_next rounds so the stop_event check at the loop boundary
         # fires between them.
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, **kwargs: object) -> None:
             super().__init__(**kwargs)
             # Each loop round consumes TWO steps: the while condition and the
             # has_next() call inside the log line.

--- a/src/api/tests/service/learn/test_runtime_tts_admission.py
+++ b/src/api/tests/service/learn/test_runtime_tts_admission.py
@@ -19,7 +19,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs):
+    def get_model_info(*args: object, **kwargs: object):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -412,7 +412,7 @@ def test_run_route_skips_runtime_admission_payload_for_builtin_demo(
         ),
     )
 
-    def _fake_run_script(*_args: object, **kwargs):
+    def _fake_run_script(*_args: object, **kwargs: object):
         assert "runtime_admission_payload" not in kwargs
         yield 'data: {"type":"done","event_type":"done","content":""}\n\n'
 
@@ -444,7 +444,7 @@ def test_run_route_uses_payload_language_as_generation_snapshot(
         lambda _app, shifu_bid: shifu_bid == "builtin-demo-1",
     )
 
-    def _fake_run_script(*_args: object, **kwargs):
+    def _fake_run_script(*_args: object, **kwargs: object):
         captured.update(kwargs)
         yield 'data: {"type":"done","event_type":"done","content":""}\n\n'
 

--- a/src/api/tests/service/learn/test_tts_synth_concurrency.py
+++ b/src/api/tests/service/learn/test_tts_synth_concurrency.py
@@ -42,7 +42,7 @@ class ExplodingRedis:
         """Reset the count of intentionally failing Redis calls."""
         self.calls = 0
 
-    def eval(self, *_args: object, **_kwargs):
+    def eval(self, *_args: object, **_kwargs: object):
         self.calls += 1
         message = "redis down"
         raise RuntimeError(message)

--- a/src/api/tests/service/order/test_import_activation_parse.py
+++ b/src/api/tests/service/order/test_import_activation_parse.py
@@ -258,7 +258,7 @@ def test_import_activation_does_not_consult_profile_state_for_nickname_defaults(
 
         original_ensure_user = order_admin.ensure_user_for_identifier
 
-        def track_ensure_user(*args: object, **kwargs):
+        def track_ensure_user(*args: object, **kwargs: object):
             reads_before_ensure.extend(read_order)
             return original_ensure_user(*args, **kwargs)
 

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -92,7 +92,7 @@ def test_legacy_order_purchase_flow_stays_on_order_tables(
         lambda *_args, **_kwargs: None,
     )
 
-    def _fake_pingxx_charge(**kwargs):
+    def _fake_pingxx_charge(**kwargs: object):
         buy_record = kwargs["buy_record"]
         buy_record.status = ORDER_STATUS_TO_BE_PAID
         dao.db.session.add(buy_record)

--- a/src/api/tests/service/order/test_order_import_error_specificity.py
+++ b/src/api/tests/service/order/test_order_import_error_specificity.py
@@ -9,7 +9,7 @@ from flaskr.i18n import _
 def test_import_activation_orders_unexpected_failure_returns_specific_message(
     app, monkeypatch
 ):
-    def raise_unexpected(*_args: object, **_kwargs):
+    def raise_unexpected(*_args: object, **_kwargs: object):
         message = "boom"
         raise RuntimeError(message)
 
@@ -35,7 +35,7 @@ def test_import_activation_orders_unexpected_failure_returns_specific_message(
 def test_import_activation_orders_from_entries_unexpected_failure_returns_specific_message(
     app, monkeypatch
 ):
-    def raise_unexpected(*_args: object, **_kwargs):
+    def raise_unexpected(*_args: object, **_kwargs: object):
         message = "boom"
         raise RuntimeError(message)
 

--- a/src/api/tests/service/order/test_order_init_lock.py
+++ b/src/api/tests/service/order/test_order_init_lock.py
@@ -62,7 +62,7 @@ def test_order_init_lock_uses_prefixed_key(monkeypatch):
 
 def test_order_init_lock_skips_when_cache_provider_errors(monkeypatch):
     class _BrokenCacheProvider:
-        def lock(self, *args: object, **kwargs):
+        def lock(self, *args: object, **kwargs: object):
             _ = (args, kwargs)
             message = "lock unavailable"
             raise RuntimeError(message)

--- a/src/api/tests/service/order/test_provider_public_urls.py
+++ b/src/api/tests/service/order/test_provider_public_urls.py
@@ -141,13 +141,13 @@ def test_stripe_subscription_discount_coupon_uses_lowercase_currency_and_idempot
 
     class FakeCoupon:
         @staticmethod
-        def create(**kwargs) -> dict[str, str]:
+        def create(**kwargs: object) -> dict[str, str]:
             captured_coupon.update(kwargs)
             return {"id": "coupon-1"}
 
     class FakeSession:
         @staticmethod
-        def create(**kwargs) -> object:
+        def create(**kwargs: object) -> object:
             captured_session.update(kwargs)
             return type(
                 "SessionResponse",
@@ -220,16 +220,16 @@ def test_stripe_subscription_discount_coupon_is_cleaned_up_on_session_failure(
 
     class FakeCoupon:
         @staticmethod
-        def create(**_kwargs) -> dict[str, str]:
+        def create(**_kwargs: object) -> dict[str, str]:
             return {"id": "coupon-cleanup-1"}
 
         @staticmethod
-        def delete(coupon_id, **_kwargs) -> None:
+        def delete(coupon_id, **_kwargs: object) -> None:
             deleted.append(coupon_id)
 
     class FakeSession:
         @staticmethod
-        def create(**_kwargs) -> None:
+        def create(**_kwargs: object) -> None:
             message = "session failed"
             raise RuntimeError(message)
 

--- a/src/api/tests/service/order/test_uow_failure_paths.py
+++ b/src/api/tests/service/order/test_uow_failure_paths.py
@@ -104,7 +104,7 @@ def _fail_after_pricing_sync(monkeypatch: pytest.MonkeyPatch) -> None:
     """Run the real pricing sync, then fail — simulating any late step error."""
     real_sync = order_funs._sync_order_campaign_pricing
 
-    def failing_sync(*args: object, **kwargs):
+    def failing_sync(*args: object, **kwargs: object):
         real_sync(*args, **kwargs)
         message = "boom after pricing sync"
         raise RuntimeError(message)
@@ -112,7 +112,7 @@ def _fail_after_pricing_sync(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(order_funs, "_sync_order_campaign_pricing", failing_sync)
 
 
-def _seed_order(**overrides) -> str:
+def _seed_order(**overrides: object) -> str:
     order = Order(
         order_bid=overrides.pop("order_bid", "uow-origin-order"),
         user_bid=USER_ID,
@@ -139,7 +139,7 @@ def test_init_buy_record_late_failure_persists_nothing(
     """
     _ = stub_shifu
 
-    def fake_apply_promo(_app, **kwargs):
+    def fake_apply_promo(_app, **kwargs: object):
         application = PromoRedemption(
             redemption_bid="uow-redemption-1",
             promo_bid="uow-promo-1",

--- a/src/api/tests/service/referral/test_referral_campaign_admin.py
+++ b/src/api/tests/service/referral/test_referral_campaign_admin.py
@@ -61,7 +61,7 @@ def _seed_plan_product(product_code: str = "creator-plan-monthly-pro") -> None:
     db.session.commit()
 
 
-def _payload(**overrides):
+def _payload(**overrides: object):
     payload = {
         "campaign_code": "domestic_creator_invite_202606",
         "campaign_name": "Domestic creator invite",

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -1245,7 +1245,7 @@ def test_list_operator_users_returns_learning_and_created_courses(app):
 def test_user_course_count_maps_use_lightweight_course_rows(app, monkeypatch):
     load_calls = []
 
-    def fake_load_latest_shifus(model, **kwargs):
+    def fake_load_latest_shifus(model, **kwargs: object):
         load_calls.append(("latest", model.__name__, kwargs.get("lightweight")))
         return []
 
@@ -4812,7 +4812,7 @@ def test_registration_source_map_skips_user_query_when_users_argument_is_empty(
     app, monkeypatch
 ):
     class ForbiddenUserQuery:
-        def filter(self, *_args: object, **_kwargs):
+        def filter(self, *_args: object, **_kwargs: object):
             message = "expected no user query when users=[] is provided"
             raise AssertionError(message)
 
@@ -4866,7 +4866,7 @@ def test_registration_source_map_skips_unknown_provider_when_supported_one_exist
 
 def test_contact_map_skips_user_query_when_users_argument_is_empty(app, monkeypatch):
     class ForbiddenUserQuery:
-        def filter(self, *_args: object, **_kwargs):
+        def filter(self, *_args: object, **_kwargs: object):
             message = "expected no user query when users=[] is provided"
             raise AssertionError(message)
 

--- a/src/api/tests/service/shifu/test_archive.py
+++ b/src/api/tests/service/shifu/test_archive.py
@@ -317,7 +317,7 @@ def test_create_shifu_draft_skips_risk_check_for_default_outline_content(
 
     monkeypatch.setattr(draft_module, "generate_id", lambda _app: "shifu-risk-skip")
 
-    def fake_draft_risk(*args: object, **kwargs):
+    def fake_draft_risk(*args: object, **kwargs: object):
         draft_risk_calls.append((args, kwargs))
 
     monkeypatch.setattr(
@@ -328,7 +328,7 @@ def test_create_shifu_draft_skips_risk_check_for_default_outline_content(
 
     from flaskr.service.shifu import shifu_outline_funcs
 
-    def fail_outline_risk(*_args: object, **_kwargs):
+    def fail_outline_risk(*_args: object, **_kwargs: object):
         message = "default outline content should not trigger risk check"
         raise AssertionError(message)
 
@@ -365,7 +365,7 @@ def test_create_shifu_draft_raises_when_default_outline_init_fails(app, monkeypa
         lambda *_args, **_kwargs: None,
     )
 
-    def fail_default_outlines(*_args: object, **_kwargs):
+    def fail_default_outlines(*_args: object, **_kwargs: object):
         message = "outline init failed"
         raise AppError(message)
 

--- a/src/api/tests/service/shifu/test_ask_preview_route.py
+++ b/src/api/tests/service/shifu/test_ask_preview_route.py
@@ -12,7 +12,7 @@ _PREVIEW_TOKEN = "preview-token"  # stub session token, `validate_user` is mocke
 class _FakeObservation:
     """Mimics a Langfuse SDK v4 observation object."""
 
-    def __init__(self, kind: str = "span", **kwargs) -> None:
+    def __init__(self, kind: str = "span", **kwargs: object) -> None:
         self.kind = kind
         self.kwargs = kwargs
         self.updates = []
@@ -24,7 +24,7 @@ class _FakeObservation:
         self.span_calls = []
         self.last_span = None
 
-    def start_observation(self, as_type="span", **kwargs):
+    def start_observation(self, as_type="span", **kwargs: object):
         child = _FakeObservation(as_type, **kwargs)
         if as_type == "generation":
             self.generations.append(child)
@@ -33,7 +33,7 @@ class _FakeObservation:
             self.last_span = child
         return child
 
-    def update(self, **kwargs):
+    def update(self, **kwargs: object):
         self.updates.append(kwargs)
 
     def set_trace_as_public(self):
@@ -54,7 +54,7 @@ class _FakeLangfuseClient:
     def __init__(self) -> None:
         self.traces = []
 
-    def start_observation(self, as_type="span", trace_context=None, **kwargs):
+    def start_observation(self, as_type="span", trace_context=None, **kwargs: object):
         root = _FakeObservation(as_type, **kwargs)
         root.trace_context = trace_context or {}
         self.traces.append(root)
@@ -89,7 +89,7 @@ def test_ask_preview_route_success_with_provider(monkeypatch, test_client):
     _mock_authenticated_user(monkeypatch)
     fake_langfuse = _FakeLangfuseClient()
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "dify"
@@ -148,7 +148,7 @@ def test_ask_preview_route_success_with_provider(monkeypatch, test_client):
 def test_ask_preview_route_fallbacks_to_llm(monkeypatch, test_client):
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
         _ = args
         provider = kwargs.get("provider", "")
         if provider == "dify":
@@ -221,7 +221,7 @@ def test_ask_preview_route_provider_only_does_not_require_ask_model(
 ):
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "coze"
@@ -264,7 +264,7 @@ def test_ask_preview_route_provider_only_accepts_coze_workflow(
 ):
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "coze_workflow"
@@ -308,7 +308,7 @@ def test_ask_preview_route_provider_only_accepts_get_biji_knowledge(
     _mock_authenticated_user(monkeypatch)
     captured: dict[str, object] = {}
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "get_biji_knowledge"
@@ -356,7 +356,7 @@ def test_ask_preview_route_provider_only_accepts_get_biji_knowledge(
 def test_ask_preview_route_surfaces_friendly_provider_error(monkeypatch, test_client):
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
         _ = (args, kwargs)
         message = (
             "get_biji_knowledge request failed: 401 Client Error for url: "
@@ -404,7 +404,7 @@ def test_ask_preview_route_falls_back_to_generic_provider_error(
 ):
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
         _ = (args, kwargs)
         message = "dify request failed: 500 | {raw body}"
         raise AskProviderError(message)
@@ -464,12 +464,12 @@ def test_ask_preview_route_uses_authenticated_creator_for_debug_billing(
         raising=False,
     )
 
-    def fake_chat_llm(*args: object, **kwargs):
+    def fake_chat_llm(*args: object, **kwargs: object):
         _ = args
         captured["chat_llm"] = kwargs
         yield SimpleNamespace(content="debug answer")
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
         _ = args
         runtime = kwargs.get("runtime")
         assert runtime is not None
@@ -521,12 +521,12 @@ def test_ask_preview_route_passes_debug_usage_context_for_creator(
     fake_langfuse = _FakeLangfuseClient()
     captured: dict[str, object] = {}
 
-    def fake_chat_llm(*args: object, **kwargs):
+    def fake_chat_llm(*args: object, **kwargs: object):
         _ = args
         captured.update(kwargs)
         yield SimpleNamespace(content="debug answer")
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
         _ = args
         runtime = kwargs.get("runtime")
         assert runtime is not None

--- a/src/api/tests/service/shifu/test_course_copy.py
+++ b/src/api/tests/service/shifu/test_course_copy.py
@@ -739,7 +739,7 @@ def test_copy_course_risk_rejection_does_not_create_target_user(app, monkeypatch
         )
         db.session.commit()
 
-    def _reject_risk(*args: object, **kwargs):
+    def _reject_risk(*args: object, **kwargs: object):
         _ = (args, kwargs)
         raise_error("server.check.checkRiskControlReject")
 

--- a/src/api/tests/service/shifu/test_operator_voice_clone_register.py
+++ b/src/api/tests/service/shifu/test_operator_voice_clone_register.py
@@ -183,7 +183,7 @@ def _mock_volcengine_status(monkeypatch, status: int) -> None:
 
 
 def _forbid_minimax_synthesis(monkeypatch) -> None:
-    def _fail(*_args: object, **_kwargs):
+    def _fail(*_args: object, **_kwargs: object):
         message = "synthesize_text must not be called for volcengine"
         raise AssertionError(message)
 

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -212,7 +212,7 @@ def test_save_shifu_draft_info_normalizes_removed_tts_fields(app, monkeypatch):
 
     captured: dict[str, object] = {}
 
-    def _fake_validate_tts_settings_strict(**kwargs):
+    def _fake_validate_tts_settings_strict(**kwargs: object):
         captured.update(kwargs)
         return SimpleNamespace(
             provider="minimax",
@@ -293,7 +293,7 @@ def test_save_shifu_draft_info_normalizes_legacy_tts_fields_when_omitted(
         legacy.tts_emotion = "happy"
         dao.db.session.commit()
 
-    def _fake_validate_tts_settings_strict(**kwargs):
+    def _fake_validate_tts_settings_strict(**kwargs: object):
         return SimpleNamespace(
             provider=kwargs["provider"],
             model=kwargs["model"],

--- a/src/api/tests/service/shifu/test_shifu_publish_funcs.py
+++ b/src/api/tests/service/shifu/test_shifu_publish_funcs.py
@@ -20,7 +20,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs):
+    def get_model_info(*args: object, **kwargs: object):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -89,7 +89,7 @@ _install_openai_responses_stub()
 class _FakeObservation:
     """Mimics a Langfuse SDK v4 observation object."""
 
-    def __init__(self, kind: str = "span", **kwargs) -> None:
+    def __init__(self, kind: str = "span", **kwargs: object) -> None:
         self.kind = kind
         self.kwargs = kwargs
         self.updates = []
@@ -99,13 +99,13 @@ class _FakeObservation:
         self.id = f"fake-{kind}-id"
         self.generations = []
 
-    def start_observation(self, as_type="span", **kwargs):
+    def start_observation(self, as_type="span", **kwargs: object):
         child = _FakeObservation(as_type, **kwargs)
         if as_type == "generation":
             self.generations.append(child)
         return child
 
-    def update(self, **kwargs):
+    def update(self, **kwargs: object):
         self.updates.append(kwargs)
 
     def set_trace_as_public(self):
@@ -126,7 +126,7 @@ class _FakeLangfuseClient:
     def __init__(self) -> None:
         self.traces = []
 
-    def start_observation(self, as_type="span", trace_context=None, **kwargs):
+    def start_observation(self, as_type="span", trace_context=None, **kwargs: object):
         root = _FakeObservation(as_type, **kwargs)
         root.trace_context = trace_context or {}
         self.traces.append(root)
@@ -216,7 +216,7 @@ def test_run_summary_downgrades_shutdown_race_to_warning(monkeypatch):
 
     monkeypatch.setattr(module, "apply_shifu_context_snapshot", lambda *_a, **_k: None)
 
-    def _raise_shutdown(*_a: object, **_k):
+    def _raise_shutdown(*_a: object, **_k: object):
         message = (
             "litellm.MidStreamFallbackError: APIConnectionError: OpenAIException - "
             "cannot schedule new futures after shutdown"
@@ -244,7 +244,7 @@ def test_run_summary_logs_error_for_other_failures(monkeypatch):
 
     monkeypatch.setattr(module, "apply_shifu_context_snapshot", lambda *_a, **_k: None)
 
-    def _raise_other(*_a: object, **_k):
+    def _raise_other(*_a: object, **_k: object):
         message = "boom"
         raise ValueError(message)
 
@@ -269,7 +269,7 @@ def test_publish_shifu_draft_preserves_outline_updated_at(app, monkeypatch):
     original_load_existing_outline_items = module.load_existing_outline_items
     outline_load_calls = []
 
-    def _record_outline_load(*args: object, **kwargs):
+    def _record_outline_load(*args: object, **kwargs: object):
         outline_load_calls.append((args, kwargs))
         return original_load_existing_outline_items(*args, **kwargs)
 

--- a/src/api/tests/service/shifu/test_tts_preview_helper.py
+++ b/src/api/tests/service/shifu/test_tts_preview_helper.py
@@ -93,7 +93,7 @@ def test_build_tts_preview_response_records_debug_usage_and_summary(
         raising=False,
     )
 
-    def _fake_record_tts_usage(app, context, **kwargs):
+    def _fake_record_tts_usage(app, context, **kwargs: object):
         captured.append(
             {
                 "app": app,
@@ -153,7 +153,7 @@ def test_build_tts_preview_response_normalizes_removed_fields(monkeypatch) -> No
     app = Flask(__name__)
     captured: dict[str, object] = {}
 
-    def _fake_validate_tts_settings_strict(**kwargs):
+    def _fake_validate_tts_settings_strict(**kwargs: object):
         captured.update(kwargs)
         return SimpleNamespace(
             provider="fake",

--- a/src/api/tests/service/tts/test_aliyun_nls_token.py
+++ b/src/api/tests/service/tts/test_aliyun_nls_token.py
@@ -13,7 +13,7 @@ from flaskr.api.tts.aliyun_provider import AliyunTTSProvider
 def test_get_aliyun_nls_token_uses_override_when_configured(monkeypatch):
     monkeypatch.setenv("ALIYUN_TTS_TOKEN", "override-token")
 
-    def fake_get(*args: object, **kwargs):
+    def fake_get(*args: object, **kwargs: object):
         _ = (args, kwargs)
         message = "requests.get should not be called when override token exists"
         raise AssertionError(message)
@@ -96,7 +96,7 @@ def test_get_aliyun_nls_token_refresh_falls_back_to_cached_token(monkeypatch):
 
     captured = {"calls": 0}
 
-    def fake_get(*args: object, **kwargs):
+    def fake_get(*args: object, **kwargs: object):
         _ = (args, kwargs)
         captured["calls"] += 1
         message = "network down"

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -55,7 +55,7 @@ def test_minimax_http_streaming_parses_audio_and_final_subtitles(monkeypatch):
         lambda **kwargs: gate_calls.append(kwargs),
     )
 
-    def _fake_post(url, **kwargs):
+    def _fake_post(url, **kwargs: object):
         post_calls.append((url, kwargs))
         return _FakeResponse(
             [
@@ -149,7 +149,7 @@ def test_minimax_synthesize_splits_word_count_and_usage_characters(monkeypatch):
         lambda key: config.get(key, ""),
     )
 
-    def _fake_post(url, **kwargs):
+    def _fake_post(url, **kwargs: object):
         post_calls.append((url, kwargs))
         return _FakeResponse(
             json_payload={
@@ -226,7 +226,7 @@ def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
     aggregate_usage_calls = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **kwargs):
+        def stream_synthesize(self, **kwargs: object):
             calls.append(kwargs["text"])
             yield SimpleNamespace(
                 audio_data=b"fake-mp3",
@@ -361,7 +361,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_for_partial_subtitles(
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs):
+        def stream_synthesize(self, **_kwargs: object):
             yield SimpleNamespace(
                 audio_data=b"fake-mp3",
                 is_final=False,
@@ -482,7 +482,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
     synthesize_calls = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **kwargs):
+        def stream_synthesize(self, **kwargs: object):
             stream_calls.append(kwargs["text"])
             yield SimpleNamespace(
                 audio_data=b"broken-stream-mp3",
@@ -494,7 +494,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
                 trace_id="trace-invalid-audio",
             )
 
-        def synthesize(self, **kwargs):
+        def synthesize(self, **kwargs: object):
             synthesize_calls.append(kwargs["text"])
             return SimpleNamespace(
                 audio_data=b"complete-mp3",
@@ -603,7 +603,7 @@ def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitle
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs):
+        def stream_synthesize(self, **_kwargs: object):
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -630,7 +630,7 @@ def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitle
 
     export_calls = []
 
-    def _fake_export(_audio_data, **kwargs):
+    def _fake_export(_audio_data, **kwargs: object):
         export_calls.append(kwargs)
         end_ms = kwargs.get("end_ms")
         start_ms = int(kwargs.get("start_ms") or 0)
@@ -729,7 +729,7 @@ def test_streaming_tts_minimax_http_stream_does_not_emit_audio_past_subtitles(
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs):
+        def stream_synthesize(self, **_kwargs: object):
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -778,7 +778,7 @@ def test_streaming_tts_minimax_http_stream_does_not_emit_audio_past_subtitles(
 
     export_calls = []
 
-    def _fake_export(_audio_data, **kwargs):
+    def _fake_export(_audio_data, **kwargs: object):
         export_calls.append(kwargs)
         end_ms = int(kwargs.get("end_ms") or 0)
         start_ms = int(kwargs.get("start_ms") or 0)
@@ -870,7 +870,7 @@ def test_streaming_tts_minimax_http_stream_offsets_live_cues_by_emitted_audio(
     saved_records = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **kwargs):
+        def stream_synthesize(self, **kwargs: object):
             calls.append(kwargs["text"])
             if kwargs["text"] == "First sentence.":
                 yield SimpleNamespace(
@@ -903,12 +903,12 @@ def test_streaming_tts_minimax_http_stream_offsets_live_cues_by_emitted_audio(
                 ],
             )
 
-    def _fake_export(audio_data, **_kwargs):
+    def _fake_export(audio_data, **_kwargs: object):
         if audio_data == b"first-mp3":
             return audio_data, 1000
         return audio_data, 1200
 
-    def _fake_build_completed_audio_record(**kwargs):
+    def _fake_build_completed_audio_record(**kwargs: object):
         saved_records.append(kwargs)
         return SimpleNamespace(**kwargs)
 
@@ -1025,7 +1025,7 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs):
+        def stream_synthesize(self, **_kwargs: object):
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -1052,7 +1052,7 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
                 ],
             )
 
-    def _fake_export(_audio_data, **kwargs):
+    def _fake_export(_audio_data, **kwargs: object):
         end_ms = kwargs.get("end_ms")
         start_ms = int(kwargs.get("start_ms") or 0)
         if end_ms is None:
@@ -1083,7 +1083,7 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
     )
     saved_records = []
 
-    def _fake_build_completed_audio_record(**kwargs):
+    def _fake_build_completed_audio_record(**kwargs: object):
         saved_records.append(kwargs)
         return SimpleNamespace(**kwargs)
 
@@ -1164,7 +1164,7 @@ def test_streaming_tts_minimax_http_stream_keeps_provider_middle_cue_timing(
     saved_records = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs):
+        def stream_synthesize(self, **_kwargs: object):
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -1201,14 +1201,14 @@ def test_streaming_tts_minimax_http_stream_keeps_provider_middle_cue_timing(
                 ],
             )
 
-    def _fake_export(_audio_data, **kwargs):
+    def _fake_export(_audio_data, **kwargs: object):
         end_ms = kwargs.get("end_ms")
         start_ms = int(kwargs.get("start_ms") or 0)
         if end_ms is None:
             return b"early-piece", 1900
         return b"final-piece", int(end_ms or 0) - start_ms
 
-    def _fake_build_completed_audio_record(**kwargs):
+    def _fake_build_completed_audio_record(**kwargs: object):
         saved_records.append(kwargs)
         return SimpleNamespace(**kwargs)
 
@@ -1325,7 +1325,7 @@ def test_streaming_tts_minimax_http_stream_freezes_emitted_prefix_for_same_count
     saved_records = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs):
+        def stream_synthesize(self, **_kwargs: object):
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -1355,14 +1355,14 @@ def test_streaming_tts_minimax_http_stream_freezes_emitted_prefix_for_same_count
                 ],
             )
 
-    def _fake_export(_audio_data, **kwargs):
+    def _fake_export(_audio_data, **kwargs: object):
         end_ms = kwargs.get("end_ms")
         start_ms = int(kwargs.get("start_ms") or 0)
         if end_ms is None:
             return b"early-piece", 1946
         return b"final-piece", int(end_ms or 0) - start_ms
 
-    def _fake_build_completed_audio_record(**kwargs):
+    def _fake_build_completed_audio_record(**kwargs: object):
         saved_records.append(kwargs)
         return SimpleNamespace(**kwargs)
 

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -329,7 +329,7 @@ def test_run_minimax_voice_clone_success_captures_credit_once(
             message = "prompt upload should not be called"
             raise AssertionError(message)
 
-        def clone_voice(self, **kwargs):
+        def clone_voice(self, **kwargs: object):
             assert kwargs["file_id"] == "file-source"
             return SimpleNamespace(
                 voice_id=kwargs["voice_id"],
@@ -400,7 +400,7 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
     stored_objects: dict[str, bytes] = {}
     read_calls: list[tuple[str, str]] = []
 
-    def fake_upload_to_storage(_app, *, file_content, object_key, **_kwargs):
+    def fake_upload_to_storage(_app, *, file_content, object_key, **_kwargs: object):
         if hasattr(file_content, "seek"):
             file_content.seek(0)
         stored_objects[object_key] = file_content.read()
@@ -446,7 +446,7 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
             message = "prompt upload should not be called"
             raise AssertionError(message)
 
-        def clone_voice(self, **kwargs):
+        def clone_voice(self, **kwargs: object):
             return SimpleNamespace(
                 voice_id=kwargs["voice_id"],
                 demo_audio="https://example.test/demo.mp3",
@@ -566,7 +566,7 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(monkeypatch
         _normalize_audio,
     )
 
-    def fake_store_resource_bytes(_app, **kwargs):
+    def fake_store_resource_bytes(_app, **kwargs: object):
         stored_calls.append(
             {
                 "owner_user_bid": kwargs["owner_user_bid"],
@@ -611,7 +611,7 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(monkeypatch
             message = "prompt upload should not be called"
             raise AssertionError(message)
 
-        def clone_voice(self, **kwargs):
+        def clone_voice(self, **kwargs: object):
             return SimpleNamespace(
                 voice_id=kwargs["voice_id"],
                 demo_audio="https://example.test/demo.mp3",

--- a/src/api/tests/service/tts/test_streaming_tts_av_contract.py
+++ b/src/api/tests/service/tts/test_streaming_tts_av_contract.py
@@ -20,7 +20,7 @@ def test_av_streaming_tts_processor_emits_av_contract_in_events(app, monkeypatch
     from flaskr.service.tts.streaming_tts import AVStreamingTTSProcessor
 
     class _FakeStreamingTTSProcessor:
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, **kwargs: object) -> None:
             self.generated_block_bid = kwargs.get("generated_block_bid", "")
             self.outline_bid = kwargs.get("outline_bid", "")
             self.position = int(kwargs.get("position", 0) or 0)
@@ -98,7 +98,7 @@ def test_av_streaming_tts_processor_skips_chunked_markdown_image(app, monkeypatc
     captured_chunks: list[str] = []
 
     class _CaptureStreamingTTSProcessor:
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, **kwargs: object) -> None:
             _ = kwargs
 
         def process_chunk(self, chunk):
@@ -154,7 +154,7 @@ def test_av_streaming_tts_processor_skips_chunked_html_img_tag(app, monkeypatch)
     captured_chunks: list[str] = []
 
     class _CaptureStreamingTTSProcessor:
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, **kwargs: object) -> None:
             _ = kwargs
 
         def process_chunk(self, chunk):
@@ -211,7 +211,7 @@ def test_av_streaming_tts_processor_does_not_split_markdown_h2_after_svg(
     captured_by_position: dict[int, list[str]] = {}
 
     class _CaptureStreamingTTSProcessor:
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, **kwargs: object) -> None:
             self.position = int(kwargs.get("position", 0) or 0)
             self._parts: list[str] = []
 
@@ -280,7 +280,7 @@ def test_av_streaming_tts_processor_advances_position_when_segment_has_no_audio(
     from flaskr.service.tts.streaming_tts import AVStreamingTTSProcessor
 
     class _LenGateStreamingTTSProcessor:
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, **kwargs: object) -> None:
             self.generated_block_bid = kwargs.get("generated_block_bid", "")
             self.outline_bid = kwargs.get("outline_bid", "")
             self.position = int(kwargs.get("position", 0) or 0)
@@ -347,7 +347,7 @@ def test_av_streaming_tts_processor_never_emits_new_slide_event(app, monkeypatch
     from flaskr.service.tts.streaming_tts import AVStreamingTTSProcessor
 
     class _FakeStreamingTTSProcessor:
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, **kwargs: object) -> None:
             self.generated_block_bid = kwargs.get("generated_block_bid", "")
             self.outline_bid = kwargs.get("outline_bid", "")
             self.position = int(kwargs.get("position", 0) or 0)
@@ -408,7 +408,7 @@ def test_av_streaming_tts_processor_updates_next_element_index_from_contract(
     from flaskr.service.tts.streaming_tts import AVStreamingTTSProcessor
 
     class _NoopStreamingTTSProcessor:
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, **kwargs: object) -> None:
             _ = kwargs
 
         def process_chunk(self, chunk):
@@ -421,7 +421,7 @@ def test_av_streaming_tts_processor_updates_next_element_index_from_contract(
             return
             yield
 
-    def _fake_build_visual_segments(**kwargs):
+    def _fake_build_visual_segments(**kwargs: object):
         _ = kwargs
         seg = VisualSegment(
             segment_id="seg-1",
@@ -466,7 +466,7 @@ def test_av_streaming_tts_processor_releases_sentence_before_long_list_tail(
     captured_chunks: list[str] = []
 
     class _CaptureStreamingTTSProcessor:
-        def __init__(self, **kwargs) -> None:
+        def __init__(self, **kwargs: object) -> None:
             _ = kwargs
 
         def process_chunk(self, chunk):

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -21,7 +21,7 @@ def mock_app():
     return app
 
 
-def create_test_processor(mock_app, **kwargs):
+def create_test_processor(mock_app, **kwargs: object):
     """Create a StreamingTTSProcessor with test defaults."""
     defaults = {
         "app": mock_app,
@@ -50,7 +50,7 @@ class TestFinalizeSegmentation:
         processor = create_test_processor(mock_app)
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs):
+        def mock_submit(*args: object, **kwargs: object):
             _ = kwargs
             if len(args) > 1:
                 segment = args[1]
@@ -91,7 +91,7 @@ class TestFinalizeSegmentation:
         # Track submitted tasks
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs):
+        def mock_submit(*args: object, **kwargs: object):
             # Positional args are the thread target followed by segment,
             # voice settings, audio settings, provider and model.
             # Capture the segment text from args[1]
@@ -133,7 +133,7 @@ class TestFinalizeSegmentation:
 
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs):
+        def mock_submit(*args: object, **kwargs: object):
             # Positional args are the thread target followed by segment,
             # voice settings, audio settings, provider and model.
             _ = kwargs
@@ -166,7 +166,7 @@ class TestFinalizeSegmentation:
 
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs):
+        def mock_submit(*args: object, **kwargs: object):
             # Positional args are the thread target followed by segment,
             # voice settings, audio settings, provider and model.
             _ = kwargs
@@ -230,7 +230,7 @@ class TestFinalizeSegmentation:
 
         remaining_text = "First sentence. Second sentence."
 
-        def mock_submit(*args: object, **kwargs):
+        def mock_submit(*args: object, **kwargs: object):
             _ = (args, kwargs)
             future = MagicMock()
             future.result.return_value = None
@@ -653,7 +653,7 @@ class TestOffsetDriftRegression:
         processor = create_test_processor(mock_app)
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs):
+        def mock_submit(*args: object, **kwargs: object):
             _ = kwargs
             if len(args) > 1:
                 segment = args[1]
@@ -695,7 +695,7 @@ class TestOffsetDriftRegression:
         processor = create_test_processor(mock_app)
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs):
+        def mock_submit(*args: object, **kwargs: object):
             _ = kwargs
             if len(args) > 1:
                 segment = args[1]

--- a/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
+++ b/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
@@ -38,7 +38,7 @@ def _run_retry(monkeypatch, outcomes, segment_index=0):
     calls = []
     sleeps = []
 
-    def _fake_synthesize_text(**kwargs):
+    def _fake_synthesize_text(**kwargs: object):
         calls.append(kwargs)
         outcome = outcomes[min(len(calls) - 1, len(outcomes) - 1)]
         if isinstance(outcome, Exception):

--- a/src/api/tests/service/tts/test_volcengine_voice_clone.py
+++ b/src/api/tests/service/tts/test_volcengine_voice_clone.py
@@ -100,7 +100,7 @@ def test_query_status_converts_transport_error_to_param_error(monkeypatch) -> No
 
     _patch_config(monkeypatch)
 
-    def _raise_transport_error(*args: object, **kwargs):
+    def _raise_transport_error(*args: object, **kwargs: object):
         _ = (args, kwargs)
         message = "connect timeout"
         raise requests_lib.exceptions.ConnectTimeout(message)

--- a/src/api/tests/service/tts/test_volcengine_ws_provider.py
+++ b/src/api/tests/service/tts/test_volcengine_ws_provider.py
@@ -56,7 +56,7 @@ def test_volcengine_ws_waits_for_session_started_before_task_request(monkeypatch
         def encode_start_connection(self):
             return b"start_connection"
 
-        def encode_start_session(self, **kwargs):
+        def encode_start_session(self, **kwargs: object):
             captured["start_session_kwargs"] = kwargs
             return b"start_session"
 
@@ -147,7 +147,7 @@ def test_volcengine_ws_waits_for_session_started_before_task_request(monkeypatch
             self.session_started_sent = False
             captured["ws"] = self
 
-        def run_forever(self, **kwargs):
+        def run_forever(self, **kwargs: object):
             _ = kwargs
             self.on_open(self)
 

--- a/src/api/tests/service/user/test_google_auth.py
+++ b/src/api/tests/service/user/test_google_auth.py
@@ -51,12 +51,12 @@ class _FakeGoogleSession:
         self._profile = profile
         self._fetch_token_error = fetch_token_error
 
-    def fetch_token(self, *_args: object, **_kwargs):
+    def fetch_token(self, *_args: object, **_kwargs: object):
         if self._fetch_token_error is not None:
             raise self._fetch_token_error
         return {"access_token": "fake-access-token"}
 
-    def get(self, *_args: object, **_kwargs):
+    def get(self, *_args: object, **_kwargs: object):
         return _FakeGoogleResponse(self._profile)
 
 

--- a/src/api/tests/service/user/test_import_user_command.py
+++ b/src/api/tests/service/user/test_import_user_command.py
@@ -166,7 +166,7 @@ def test_import_user_does_not_consult_profile_state_before_nickname_defaults(
 
         original_ensure_user = import_user_module.ensure_user_for_identifier
 
-        def track_ensure_user(*args: object, **kwargs):
+        def track_ensure_user(*args: object, **kwargs: object):
             reads_before_ensure.extend(read_order)
             return original_ensure_user(*args, **kwargs)
 

--- a/src/api/tests/service/user/test_learner_profile_optimizer.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer.py
@@ -60,7 +60,7 @@ def _snapshot_profile_state(user_bid: str) -> tuple:
 
 
 def _successful_llm(raw_output: str, captured: dict):
-    def invoke(*args: object, **kwargs):
+    def invoke(*args: object, **kwargs: object):
         captured["call_count"] = captured.get("call_count", 0) + 1
         captured["args"] = args
         captured["kwargs"] = kwargs
@@ -73,11 +73,11 @@ def _install_trace_spies(monkeypatch, captured: dict) -> None:
     trace = object()
     root_span = object()
 
-    def create_trace(**kwargs):
+    def create_trace(**kwargs: object):
         captured["trace_create"] = kwargs
         return trace, root_span
 
-    def finalize_trace(**kwargs):
+    def finalize_trace(**kwargs: object):
         captured["trace_finalize"] = kwargs
 
     monkeypatch.setattr(optimizer, "create_trace_with_root_span", create_trace)
@@ -311,7 +311,7 @@ def test_optimize_rejects_moderation_without_calling_llm_or_changing_state(
     invoked = False
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: False)
 
-    def unexpected_invoke(*_args: object, **_kwargs):
+    def unexpected_invoke(*_args: object, **_kwargs: object):
         nonlocal invoked
         invoked = True
         yield SimpleNamespace(result="unexpected")
@@ -385,7 +385,7 @@ def test_optimize_missing_default_model_does_not_call_llm_or_change_state(
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
     monkeypatch.setitem(app.config, "DEFAULT_LLM_MODEL", "")
 
-    def unexpected_invoke(*_args: object, **_kwargs):
+    def unexpected_invoke(*_args: object, **_kwargs: object):
         nonlocal invoked
         invoked = True
         yield SimpleNamespace(result="unexpected")
@@ -450,7 +450,7 @@ def test_optimize_timeout_finalizes_trace_without_changing_state(app, monkeypatc
     captured: dict = {}
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
-    def timeout_invoke(*_args: object, **_kwargs):
+    def timeout_invoke(*_args: object, **_kwargs: object):
         message = "provider timeout"
         raise TimeoutError(message)
         yield  # pragma: no cover
@@ -480,7 +480,7 @@ def test_optimize_reports_a_wrapped_timeout_as_timeout(app, monkeypatch):
     user_bid = "profile-optimize-wrapped-timeout"
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
-    def timeout_invoke(*_args: object, **_kwargs):
+    def timeout_invoke(*_args: object, **_kwargs: object):
         try:
             # The wrapped-timeout shape is exactly what this test asserts.
             message = "provider timeout"
@@ -521,7 +521,7 @@ def test_optimize_reports_runtime_failure_reason_without_changing_state(
     captured: dict = {}
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
-    def failed_invoke(*_args: object, **_kwargs):
+    def failed_invoke(*_args: object, **_kwargs: object):
         raise provider_error
         yield  # pragma: no cover
 
@@ -554,7 +554,7 @@ def test_optimize_reports_moderation_failure_reason_without_calling_llm(
         message = "moderation unavailable"
         raise RuntimeError(message)
 
-    def unexpected_invoke(*_args: object, **_kwargs):
+    def unexpected_invoke(*_args: object, **_kwargs: object):
         nonlocal invoked
         invoked = True
         yield SimpleNamespace(result="unexpected")

--- a/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer_admission.py
@@ -40,7 +40,7 @@ class FakeRedis:
 class ExplodingRedis:
     """Simulate a Redis failure for tests."""
 
-    def eval(self, *_args: object, **_kwargs):
+    def eval(self, *_args: object, **_kwargs: object):
         message = "redis unavailable"
         raise RuntimeError(message)
 

--- a/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
+++ b/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
@@ -66,10 +66,10 @@ class _FakeGoogleSession:
     def __init__(self, profile) -> None:
         self._profile = profile
 
-    def fetch_token(self, *_args: object, **_kwargs):
+    def fetch_token(self, *_args: object, **_kwargs: object):
         return {"access_token": "fake-access-token"}
 
-    def get(self, *_args: object, **_kwargs):
+    def get(self, *_args: object, **_kwargs: object):
         return _FakeGoogleResponse(self._profile)
 
 

--- a/src/api/tests/service/user/test_profile_onboarding.py
+++ b/src/api/tests/service/user/test_profile_onboarding.py
@@ -11,7 +11,7 @@ from flaskr.service.user.repository import create_user_entity
 
 
 @contextmanager
-def nullcontext_admission(*_args: object, **_kwargs):
+def nullcontext_admission(*_args: object, **_kwargs: object):
     yield
 
 

--- a/src/api/tests/service/user/test_user_identify.py
+++ b/src/api/tests/service/user/test_user_identify.py
@@ -191,7 +191,7 @@ def test_send_email_code_stores_lowercase_identifier(app, monkeypatch):
         sent_message = ""
         sent_to = ""
 
-        def __init__(self, *_args: object, **_kwargs) -> None:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
             pass
 
         def starttls(self):
@@ -280,7 +280,7 @@ def test_send_email_code_uses_requested_language_and_singular_expiry(app, monkey
     class _FakeSMTP:
         sent_message = ""
 
-        def __init__(self, *_args: object, **_kwargs) -> None:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
             pass
 
         def starttls(self):

--- a/src/api/tests/service/user/test_validate_user.py
+++ b/src/api/tests/service/user/test_validate_user.py
@@ -12,7 +12,7 @@ def test_validate_user_maps_invalid_algorithm_token_to_user_not_found(monkeypatc
     app.config["SECRET_KEY"] = "test-secret"
     app.config["ENVERIMENT"] = "prod"
 
-    def _raise_invalid_algorithm(*_args: object, **_kwargs):
+    def _raise_invalid_algorithm(*_args: object, **_kwargs: object):
         message = "The specified alg value is not allowed"
         raise jwt.exceptions.InvalidAlgorithmError(message)
 

--- a/src/api/tests/test_edun.py
+++ b/src/api/tests/test_edun.py
@@ -53,7 +53,7 @@ def test_ilivedata_send_wraps_oserror_as_urlerror(monkeypatch):
 
     from flaskr.api.check import ilivedata as ilivedata_module
 
-    def fake_urlopen(*_args: object, **_kwargs):
+    def fake_urlopen(*_args: object, **_kwargs: object):
         message = "timed out"
         raise TimeoutError(message)
 

--- a/src/api/tests/test_feishu.py
+++ b/src/api/tests/test_feishu.py
@@ -39,7 +39,7 @@ def test_send_order_feishu_formats_notification(app, monkeypatch):
             self._first_value = first_value
             self._count_value = count_value
 
-        def filter(self, *_args: object, **_kwargs):
+        def filter(self, *_args: object, **_kwargs: object):
             return self
 
         def first(self):

--- a/src/api/tests/test_gunicorn_worker_patch_guard.py
+++ b/src/api/tests/test_gunicorn_worker_patch_guard.py
@@ -64,7 +64,7 @@ def test_observer_skips_unpatched_processes(monkeypatch):
     monkeypatch.setattr(monkey, "is_module_patched", lambda _name: False)
 
     class _Logger:
-        def error(self, *args: object, **kwargs):
+        def error(self, *args: object, **kwargs: object):
             _ = (args, kwargs)
             message = "must not log during a skipped install"
             raise AssertionError(message)

--- a/src/api/tests/test_langfuse_preload_deferral.py
+++ b/src/api/tests/test_langfuse_preload_deferral.py
@@ -16,7 +16,7 @@ from flaskr.api.langfuse import MockClient, init_langfuse
 class _RecordingLangfuse:
     instances: ClassVar[list[dict[str, object]]] = []
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: object) -> None:
         _RecordingLangfuse.instances.append(kwargs)
 
 

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -25,7 +25,7 @@ def _install_litellm_stub() -> None:
     def register_model(model_map):
         litellm_stub.model_cost.update(model_map)
 
-    def get_model_info(*args: object, **kwargs):
+    def get_model_info(*args: object, **kwargs: object):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -122,14 +122,14 @@ class DummySpan:
         self.trace_id = trace_id
         self.id = span_id
 
-    def generation(self, **kwargs):
+    def generation(self, **kwargs: object):
         self.generation_args = kwargs
         return self
 
-    def end(self, **kwargs):
+    def end(self, **kwargs: object):
         self.end_args = kwargs
 
-    def update(self, **kwargs):
+    def update(self, **kwargs: object):
         self.update_args = kwargs
 
 
@@ -471,7 +471,7 @@ def test_deepseek_model_loader_lists_models(monkeypatch):
 
 
 def test_deepseek_model_loader_falls_back_when_list_models_fails(monkeypatch):
-    def fake_get(*args: object, **kwargs):
+    def fake_get(*args: object, **kwargs: object):
         _ = args, kwargs
         message = "network unavailable"
         raise RuntimeError(message)
@@ -496,7 +496,7 @@ def test_deepseek_model_loader_falls_back_when_list_models_fails(monkeypatch):
 def test_qwen_prefixed_model_routes_without_fetched_alias(monkeypatch, app):
     captured = {}
 
-    def fake_completion(model, *args: object, **kwargs):
+    def fake_completion(model, *args: object, **kwargs: object):
         _ = args
         captured["model"] = model
         captured["kwargs"] = kwargs
@@ -780,7 +780,7 @@ def test_openai_params_use_litellm_reasoning_capabilities(
 
 
 def test_openai_params_fall_back_to_existing_policy_for_unknown_model(monkeypatch):
-    def raise_unknown(*args: object, **kwargs):
+    def raise_unknown(*args: object, **kwargs: object):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -1249,7 +1249,7 @@ def test_litellm_195_native_adapter_contracts():
 def test_chat_llm_disables_deepseek_thinking(monkeypatch, app):
     captured_kwargs = {}
 
-    def fake_completion(*args: object, **kwargs):
+    def fake_completion(*args: object, **kwargs: object):
         _ = args
         captured_kwargs["kwargs"] = kwargs
         return iter([FakeResponse("chunk-1", content="Hi", finish_reason="stop")])
@@ -1323,7 +1323,7 @@ def test_invoke_llm_uses_actual_model_for_provider_params(monkeypatch, app):
         captured["reload_model"] = model_id
         return {"temperature": temperature}
 
-    def fake_completion(model, *args: object, **kwargs):
+    def fake_completion(model, *args: object, **kwargs: object):
         _ = args
         captured["completion_model"] = model
         captured["completion_kwargs"] = kwargs
@@ -1372,7 +1372,7 @@ def test_chat_llm_ends_partial_response_on_repeated_stream_chunk(monkeypatch, ap
     class RepeatedChunkError(Exception):
         __module__ = "litellm.exceptions"
 
-    def fake_completion(*args: object, **kwargs):
+    def fake_completion(*args: object, **kwargs: object):
         _ = (args, kwargs)
         yield FakeResponse("chunk-1", content="你好")
         message = "The model is repeating the same chunk = ！ ！ ."
@@ -1409,7 +1409,7 @@ def test_chat_llm_streams(monkeypatch, app):
     captured_kwargs = {}
     captured_usage = {}
 
-    def fake_completion(*args: object, **kwargs):
+    def fake_completion(*args: object, **kwargs: object):
         _ = args
         captured_kwargs["kwargs"] = kwargs
         chunks = [
@@ -1479,7 +1479,7 @@ def test_chat_llm_streams(monkeypatch, app):
 def test_llm_sends_reasoning_output_to_langfuse_without_streaming_it(
     monkeypatch, app, llm_method
 ):
-    def fake_completion(*args: object, **kwargs):
+    def fake_completion(*args: object, **kwargs: object):
         _ = args, kwargs
         return iter(
             [
@@ -1579,7 +1579,7 @@ def test_extract_reasoning_delta_supports_litellm_fallback_fields(delta, expecte
 
 
 def test_chat_llm_falls_back_to_request_trace_id(monkeypatch, app):
-    def fake_completion(*args: object, **kwargs):
+    def fake_completion(*args: object, **kwargs: object):
         _ = args, kwargs
         return iter([FakeResponse("chunk-1", content="Hi", finish_reason="stop")])
 

--- a/src/api/tests/test_openai.py
+++ b/src/api/tests/test_openai.py
@@ -14,7 +14,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs):
+    def get_model_info(*args: object, **kwargs: object):
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -95,14 +95,14 @@ class DummySpan:
         self.trace_id = trace_id
         self.id = span_id
 
-    def generation(self, **kwargs):
+    def generation(self, **kwargs: object):
         self.generation_args = kwargs
         return self
 
-    def end(self, **kwargs):
+    def end(self, **kwargs: object):
         self.end_args = kwargs
 
-    def update(self, **kwargs):
+    def update(self, **kwargs: object):
         self.updated = kwargs
 
 
@@ -130,7 +130,7 @@ class FakeUsage:
 def test_invoke_llm_streams_via_litellm(monkeypatch, app):
     captured_kwargs = {}
 
-    def fake_completion(*args: object, **kwargs):
+    def fake_completion(*args: object, **kwargs: object):
         captured_kwargs["args"] = args
         captured_kwargs["kwargs"] = kwargs
         usage = FakeUsage(prompt_tokens=5, completion_tokens=4, total_tokens=9)

--- a/src/api/tests/test_order.py
+++ b/src/api/tests/test_order.py
@@ -87,7 +87,7 @@ def test_init_buy_record_refreshes_existing_unpaid_order_promotions(app, monkeyp
     )
     apply_calls = {"count": 0}
 
-    def fake_apply_promo_campaigns(*_args: object, **_kwargs):
+    def fake_apply_promo_campaigns(*_args: object, **_kwargs: object):
         apply_calls["count"] += 1
         if apply_calls["count"] == 1:
             return []

--- a/src/api/tests/test_wx_pub_order.py
+++ b/src/api/tests/test_wx_pub_order.py
@@ -42,7 +42,7 @@ def test_generate_charge_uses_pingxx_channel(app, monkeypatch):
 
     captured = {}
 
-    def fake_generate_pingxx_charge(**kwargs):
+    def fake_generate_pingxx_charge(**kwargs: object):
         captured.update(kwargs)
         return BuyRecordDTO(
             kwargs["buy_record"].order_bid,


### PR DESCRIPTION
## Summary

- annotate every variadic keyword parameter with its value type
- use narrow types for homogeneous options
- reserve object for heterogeneous adapter and test-double forwarding
- enforce ANN003

## Verification

- 56 focused tests passed
- Ruff 0.16.3 configured check passed
- Ruff 0.16.3 isolated ANN003 check passed
- repository pre-commit hooks passed