### PR TITLE
chore: remove redundant class docstring ignore

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -41,7 +41,7 @@ jobs:
           fi
 
           git diff --name-only "$BASE_SHA...$HEAD_SHA" > /tmp/backend-changed-files.txt
-          if grep -Eq '^(\.github/workflows/backend-tests\.yml$|src/api/)' /tmp/backend-changed-files.txt; then
+          if grep -Eq '^(\.github/workflows/backend-tests\.yml$|ruff\.toml$|src/api/)' /tmp/backend-changed-files.txt; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -215,6 +215,12 @@ jobs:
                   full_run = True
                   break
               if not path.startswith("src/api/"):
+                  if path == "ruff.toml":
+                      # Ruff policy tests use stdin fixtures, so they catch a
+                      # configuration-only regression without running the full
+                      # backend suite.
+                      targets.add("tests/scripts")
+                      continue
                   if path == ".github/workflows/backend-tests.yml":
                       continue
                   continue

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -425,6 +425,14 @@ consumers before bulk work, prove executable AST equality after removing only
 the new function docstrings, and run focused Swagger or CLI regressions for the
 affected surfaces.
 
+For `D203`, retain `D211` and the Ruff formatter's class-docstring layout:
+place a class docstring immediately after the class definition, without a blank
+line. `D203` requires the inverse layout, and Ruff automatically ignores it
+when both incompatible rules are selected; do not add it to `ignore`. Do not
+insert a blank line before a class docstring, disable `D211`, or add a local
+`noqa` to work around the pair; use the formatter-compatible `D211` form for
+every new class.
+
 For `N815`, keep Python DTO field names in snake_case even when the public JSON
 contract uses camelCase. Pydantic DTOs should declare the public name with
 `Field(alias="...")`, accept internal construction through `populate_by_name`,

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -309,12 +309,13 @@ plan's progress update for that rule.
   learner-route specifications contain invalid YAML; the new parser test
   freezes their exact identities without changing them in this rule PR, while
   rejecting any additional unparseable specification.
-- D203 and D213 conflict with the formatter-compatible D211 and D212 layouts.
-  When the `D` prefix selects each pair, Ruff emits its incompatibility warning
-  and resolves D203/D213 in favor of D211/D212. The project deliberately
-  accepts that built-in resolution instead of retaining redundant global
-  ignores; focused policy tests run the normal configuration against violating
-  fixtures so D211 and D212 cannot silently stop being enforced.
+- D203 conflicts with the formatter-compatible D211 layout. When the `D`
+  prefix selects that pair, Ruff emits its incompatibility warning and resolves
+  D203 in favor of D211. The project deliberately accepts that built-in
+  resolution instead of retaining a redundant global ignore; the focused D203
+  policy test runs the normal configuration against a violating fixture so
+  D211 cannot silently stop being enforced. The following D213 stage owns the
+  corresponding D212/D213 confirmation.
 - Adding the final D107 docstring to the no-op Langfuse client made its old
   `pass` statement redundant under the already-selected PIE790 rule. Removing
   that no-op preserves the configured baseline and runtime behavior; it does

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -309,11 +309,12 @@ plan's progress update for that rule.
   learner-route specifications contain invalid YAML; the new parser test
   freezes their exact identities without changing them in this rule PR, while
   rejecting any additional unparseable specification.
-- D203 and D213 are necessary explicit conflict exceptions rather than clean
-  rules. Selected alone, they report 293 and 656 findings respectively;
-  selected with D211 or D212, Ruff emits an incompatibility warning and ignores
-  D203 or D213. Removing the explicit ignores would shrink the file only by
-  making every normal run noisy and relying on implicit conflict resolution.
+- D203 and D213 conflict with the formatter-compatible D211 and D212 layouts.
+  When the `D` prefix selects each pair, Ruff emits its incompatibility warning
+  and resolves D203/D213 in favor of D211/D212. The project deliberately
+  accepts that built-in resolution instead of retaining redundant global
+  ignores; focused policy tests run the normal configuration against violating
+  fixtures so D211 and D212 cannot silently stop being enforced.
 - Adding the final D107 docstring to the no-op Langfuse client made its old
   `pass` statement redundant under the already-selected PIE790 rule. Removing
   that no-op preserves the configured baseline and runtime behavior; it does

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -256,6 +256,13 @@ plan's progress update for that rule.
   normalized AST audit found no executable differences; the D103 policy and
   Swagger regressions pass, followed by the full backend suite at 3,042 passed
   with 17 skipped and every applicable repository pre-commit gate.
+- [x] 2026-08-22: Prepared the D203 policy stage on
+  `sunner/ruff-d203-rebuild`, stacked on D103. The direct D203 census reports
+  730 formatter-fixable findings while selected D211 is clean, proving their
+  mutually exclusive class-docstring layouts. Ruff automatically ignores D203
+  when the D prefix selects both rules, so this stage removes the redundant
+  global ignore, documents the formatter-compatible D211 convention, and
+  protects the built-in resolution with a focused Ruff policy test.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/ruff.toml
+++ b/ruff.toml
@@ -228,7 +228,6 @@ select = [
 ]
 ignore = [
     "E501",    # line length is owned by the formatter
-    "D203",    # blank line before a class docstring -- conflicts with D211
     "D213",    # summary on the second line -- conflicts with D212
     "DTZ001",  # naive datetime() -- naive UTC is the house convention
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)

--- a/src/api/requirements-ci.txt
+++ b/src/api/requirements-ci.txt
@@ -3,3 +3,4 @@
 coverage==7.15.4
 pip==26.2.1
 pytest-testmon==2.2.0
+ruff==0.16.3

--- a/src/api/tests/scripts/test_ruff_d203_policy.py
+++ b/src/api/tests/scripts/test_ruff_d203_policy.py
@@ -33,8 +33,8 @@ class RuffD203PolicyTest(unittest.TestCase):
         """Resolve the same Ruff executable used by local and CI checks."""
         cls.ruff = os.environ.get("RUFF_BIN") or shutil.which("ruff")
         if cls.ruff is None:
-            message = "ruff is not installed"
-            raise unittest.SkipTest(message)
+            message = "ruff is required to verify the D203 policy"
+            raise AssertionError(message)
 
     def run_ruff(
         self, source: str, *extra_args: str

--- a/src/api/tests/scripts/test_ruff_d203_policy.py
+++ b/src/api/tests/scripts/test_ruff_d203_policy.py
@@ -16,6 +16,13 @@ CLASS_DOCSTRING_SOURCE = '''"""Fixture module used to verify the D203 policy."""
 class Example:
     """Represent the formatter-compatible class-docstring layout."""
 '''
+CLASS_DOCSTRING_D211_VIOLATION_SOURCE = '''"""Fixture module used to verify the D203 policy."""
+
+
+class Example:
+
+    """Represent a class-docstring layout that D211 must reject."""
+'''
 
 
 class RuffD203PolicyTest(unittest.TestCase):
@@ -29,7 +36,9 @@ class RuffD203PolicyTest(unittest.TestCase):
             message = "ruff is not installed"
             raise unittest.SkipTest(message)
 
-    def run_ruff(self, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    def run_ruff(
+        self, source: str, *extra_args: str
+    ) -> subprocess.CompletedProcess[str]:
         """Run the configured Ruff policy against a class-docstring fixture."""
         return subprocess.run(
             [
@@ -43,7 +52,7 @@ class RuffD203PolicyTest(unittest.TestCase):
                 "-",
             ],
             cwd=REPO_ROOT,
-            input=CLASS_DOCSTRING_SOURCE,
+            input=source,
             capture_output=True,
             text=True,
             check=False,
@@ -58,7 +67,7 @@ class RuffD203PolicyTest(unittest.TestCase):
         assert "D203" not in ignored_codes
         assert "D211" not in ignored_codes
 
-        configured_result = self.run_ruff()
+        configured_result = self.run_ruff(CLASS_DOCSTRING_SOURCE)
         assert configured_result.returncode == 0, (
             configured_result.stdout + configured_result.stderr
         )
@@ -66,11 +75,19 @@ class RuffD203PolicyTest(unittest.TestCase):
         assert "D203" in configured_output
         assert "D211" in configured_output
 
-        d203_result = self.run_ruff("--select", "D203")
+        configured_violation_result = self.run_ruff(
+            CLASS_DOCSTRING_D211_VIOLATION_SOURCE
+        )
+        assert configured_violation_result.returncode == 1, (
+            configured_violation_result.stdout + configured_violation_result.stderr
+        )
+        assert "D211" in configured_violation_result.stdout
+
+        d203_result = self.run_ruff(CLASS_DOCSTRING_SOURCE, "--select", "D203")
         assert d203_result.returncode == 1, d203_result.stdout + d203_result.stderr
         assert "D203" in d203_result.stdout
 
-        d211_result = self.run_ruff("--select", "D211")
+        d211_result = self.run_ruff(CLASS_DOCSTRING_SOURCE, "--select", "D211")
         assert d211_result.returncode == 0, d211_result.stdout + d211_result.stderr
 
 

--- a/src/api/tests/scripts/test_ruff_d203_policy.py
+++ b/src/api/tests/scripts/test_ruff_d203_policy.py
@@ -1,0 +1,78 @@
+"""Verify that Ruff resolves the D203 class-docstring rule conflict."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CLASS_DOCSTRING_SOURCE = '''"""Fixture module used to verify the D203 policy."""
+
+
+class Example:
+    """Represent the formatter-compatible class-docstring layout."""
+'''
+
+
+class RuffD203PolicyTest(unittest.TestCase):
+    """Protect the D211 class-docstring convention selected by this project."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Resolve the same Ruff executable used by local and CI checks."""
+        cls.ruff = os.environ.get("RUFF_BIN") or shutil.which("ruff")
+        if cls.ruff is None:
+            message = "ruff is not installed"
+            raise unittest.SkipTest(message)
+
+    def run_ruff(self, *extra_args: str) -> subprocess.CompletedProcess[str]:
+        """Run the configured Ruff policy against a class-docstring fixture."""
+        return subprocess.run(
+            [
+                self.ruff,
+                "check",
+                "--config",
+                str(REPO_ROOT / "ruff.toml"),
+                *extra_args,
+                "--stdin-filename",
+                "src/api/flaskr/class_docstring_fixture.py",
+                "-",
+            ],
+            cwd=REPO_ROOT,
+            input=CLASS_DOCSTRING_SOURCE,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_ruff_resolves_the_d203_and_d211_layout_conflict(self) -> None:
+        """Keep both layout rules selected without a redundant global ignore."""
+        with (REPO_ROOT / "ruff.toml").open("rb") as ruff_file:
+            config = tomllib.load(ruff_file)
+
+        ignored_codes = config["lint"]["ignore"]
+        assert "D203" not in ignored_codes
+        assert "D211" not in ignored_codes
+
+        configured_result = self.run_ruff()
+        assert configured_result.returncode == 0, (
+            configured_result.stdout + configured_result.stderr
+        )
+        configured_output = configured_result.stdout + configured_result.stderr
+        assert "D203" in configured_output
+        assert "D211" in configured_output
+
+        d203_result = self.run_ruff("--select", "D203")
+        assert d203_result.returncode == 1, d203_result.stdout + d203_result.stderr
+        assert "D203" in d203_result.stdout
+
+        d211_result = self.run_ruff("--select", "D211")
+        assert d211_result.returncode == 0, d211_result.stdout + d211_result.stderr
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Remove the redundant D203 global ignore from ruff.toml.
- Keep D211's formatter-compatible class-docstring convention; Ruff 0.16.3 automatically resolves the incompatible D203/D211 pair when both are selected.
- Test the normal configured policy with both compliant and D211-violating fixtures, so a future selection regression fails without relying on `--select`.
- Reconcile the active ExecPlan decision record with the adopted built-in conflict resolution.

## Validation

- Direct census: D203 reports 730 formatter-fixable findings; D211 reports none.
- Configured D-family scan: Ruff reports the D203/D211 conflict and passes without a manual ignore.
- D203 policy test passed, including the configured D211-negative fixture.
- Ruff check and Ruff format checks passed.
- Repository harness, architecture boundary check, fixed-toolchain dev check, and staged pre-commit gate passed.
