### PR TITLE
chore: remove redundant summary docstring ignore

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -433,6 +433,14 @@ insert a blank line before a class docstring, disable `D211`, or add a local
 `noqa` to work around the pair; use the formatter-compatible `D211` form for
 every new class.
 
+For `D213`, retain `D212` and the Ruff formatter's summary-first layout: put a
+docstring's complete summary on its first physical line. `D213` requires an
+opening blank line and therefore the inverse layout, and Ruff automatically
+ignores it when both incompatible rules are selected; do not add it to
+`ignore`. Do not add an opening blank line, disable `D212`, or add a local
+`noqa` to work around the pair; use the formatter-compatible `D212` form for
+every new or edited docstring.
+
 For `N815`, keep Python DTO field names in snake_case even when the public JSON
 contract uses camelCase. Pydantic DTOs should declare the public name with
 `Field(alias="...")`, accept internal construction through `populate_by_name`,

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -263,6 +263,13 @@ plan's progress update for that rule.
   when the D prefix selects both rules, so this stage removes the redundant
   global ignore, documents the formatter-compatible D211 convention, and
   protects the built-in resolution with a focused Ruff policy test.
+- [x] 2026-08-22: Prepared the D213 policy stage on
+  `sunner/ruff-d213-rebuild`, stacked on D203. The direct D213 census reports
+  677 formatter-fixable findings while selected D212 is clean, proving their
+  mutually exclusive summary layouts. Ruff automatically ignores D213 when the
+  D prefix selects both rules, so this stage removes the redundant global
+  ignore, documents the formatter-compatible D212 convention, and protects the
+  built-in resolution with a focused Ruff policy test.
 - [ ] Re-run the census after each merged rule unit and choose the next smallest
   behaviorally safe unit.
 - [ ] Collapse the explicit selection to `select = ["ALL"]` once every stable

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -316,13 +316,13 @@ plan's progress update for that rule.
   learner-route specifications contain invalid YAML; the new parser test
   freezes their exact identities without changing them in this rule PR, while
   rejecting any additional unparseable specification.
-- D203 conflicts with the formatter-compatible D211 layout. When the `D`
-  prefix selects that pair, Ruff emits its incompatibility warning and resolves
-  D203 in favor of D211. The project deliberately accepts that built-in
-  resolution instead of retaining a redundant global ignore; the focused D203
-  policy test runs the normal configuration against a violating fixture so
-  D211 cannot silently stop being enforced. The following D213 stage owns the
-  corresponding D212/D213 confirmation.
+- D203 and D213 conflict with the formatter-compatible D211 and D212 layouts.
+  When the `D` prefix selects either pair, Ruff emits its incompatibility
+  warning and resolves D203/D213 in favor of D211/D212. The project
+  deliberately accepts that built-in resolution instead of retaining redundant
+  global ignores; focused D203 and D213 policy tests run the normal
+  configuration against D211- and D212-violating fixtures so neither selected
+  formatter-compatible rule can silently stop being enforced.
 - Adding the final D107 docstring to the no-op Langfuse client made its old
   `pass` statement redundant under the already-selected PIE790 rule. Removing
   that no-op preserves the configured baseline and runtime behavior; it does

--- a/ruff.toml
+++ b/ruff.toml
@@ -228,7 +228,6 @@ select = [
 ]
 ignore = [
     "E501",    # line length is owned by the formatter
-    "D213",    # summary on the second line -- conflicts with D212
     "DTZ001",  # naive datetime() -- naive UTC is the house convention
     "PLC0415", # import not at top of file -- deliberate lazy imports (~1.2k)
 ]

--- a/src/api/tests/scripts/test_ruff_d213_policy.py
+++ b/src/api/tests/scripts/test_ruff_d213_policy.py
@@ -1,0 +1,82 @@
+"""Verify that Ruff resolves the D213 docstring-summary rule conflict."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SUMMARY_FIRST_SOURCE = '''"""Fixture module used to verify the D213 policy."""
+
+
+def public_function() -> int:
+    """Return using the formatter-compatible summary-first layout.
+
+    Preserve a detail line so both competing multiline rules are exercised.
+    """
+    return 1
+'''
+
+
+class RuffD213PolicyTest(unittest.TestCase):
+    """Protect the D212 summary-first convention selected by this project."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Resolve the same Ruff executable used by local and CI checks."""
+        cls.ruff = os.environ.get("RUFF_BIN") or shutil.which("ruff")
+        if cls.ruff is None:
+            message = "ruff is not installed"
+            raise unittest.SkipTest(message)
+
+    def run_ruff(self, *extra_args: str) -> subprocess.CompletedProcess[str]:
+        """Run configured Ruff against a docstring-summary fixture."""
+        return subprocess.run(
+            [
+                self.ruff,
+                "check",
+                "--config",
+                str(REPO_ROOT / "ruff.toml"),
+                *extra_args,
+                "--stdin-filename",
+                "src/api/flaskr/docstring_summary_fixture.py",
+                "-",
+            ],
+            cwd=REPO_ROOT,
+            input=SUMMARY_FIRST_SOURCE,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_ruff_resolves_the_d212_and_d213_summary_conflict(self) -> None:
+        """Keep both summary rules selected without a redundant global ignore."""
+        with (REPO_ROOT / "ruff.toml").open("rb") as ruff_file:
+            config = tomllib.load(ruff_file)
+
+        ignored_codes = config["lint"]["ignore"]
+        assert "D213" not in ignored_codes
+        assert "D212" not in ignored_codes
+
+        configured_result = self.run_ruff()
+        assert configured_result.returncode == 0, (
+            configured_result.stdout + configured_result.stderr
+        )
+        configured_output = configured_result.stdout + configured_result.stderr
+        assert "D212" in configured_output
+        assert "D213" in configured_output
+
+        d213_result = self.run_ruff("--select", "D213")
+        assert d213_result.returncode == 1, d213_result.stdout + d213_result.stderr
+        assert "D213" in d213_result.stdout
+
+        d212_result = self.run_ruff("--select", "D212")
+        assert d212_result.returncode == 0, d212_result.stdout + d212_result.stderr
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/api/tests/scripts/test_ruff_d213_policy.py
+++ b/src/api/tests/scripts/test_ruff_d213_policy.py
@@ -20,6 +20,17 @@ def public_function() -> int:
     """
     return 1
 '''
+SUMMARY_SECOND_LINE_SOURCE = '''"""Fixture module used to verify the D213 policy."""
+
+
+def public_function() -> int:
+    """
+    Return a fixture value with a summary that starts on the second line.
+
+    Preserve a detail line so both competing multiline rules are exercised.
+    """
+    return 1
+'''
 
 
 class RuffD213PolicyTest(unittest.TestCase):
@@ -33,7 +44,9 @@ class RuffD213PolicyTest(unittest.TestCase):
             message = "ruff is not installed"
             raise unittest.SkipTest(message)
 
-    def run_ruff(self, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    def run_ruff(
+        self, source: str, *extra_args: str
+    ) -> subprocess.CompletedProcess[str]:
         """Run configured Ruff against a docstring-summary fixture."""
         return subprocess.run(
             [
@@ -47,7 +60,7 @@ class RuffD213PolicyTest(unittest.TestCase):
                 "-",
             ],
             cwd=REPO_ROOT,
-            input=SUMMARY_FIRST_SOURCE,
+            input=source,
             capture_output=True,
             text=True,
             check=False,
@@ -62,7 +75,7 @@ class RuffD213PolicyTest(unittest.TestCase):
         assert "D213" not in ignored_codes
         assert "D212" not in ignored_codes
 
-        configured_result = self.run_ruff()
+        configured_result = self.run_ruff(SUMMARY_FIRST_SOURCE)
         assert configured_result.returncode == 0, (
             configured_result.stdout + configured_result.stderr
         )
@@ -70,11 +83,17 @@ class RuffD213PolicyTest(unittest.TestCase):
         assert "D212" in configured_output
         assert "D213" in configured_output
 
-        d213_result = self.run_ruff("--select", "D213")
+        configured_violation_result = self.run_ruff(SUMMARY_SECOND_LINE_SOURCE)
+        assert configured_violation_result.returncode == 1, (
+            configured_violation_result.stdout + configured_violation_result.stderr
+        )
+        assert "D212" in configured_violation_result.stdout
+
+        d213_result = self.run_ruff(SUMMARY_FIRST_SOURCE, "--select", "D213")
         assert d213_result.returncode == 1, d213_result.stdout + d213_result.stderr
         assert "D213" in d213_result.stdout
 
-        d212_result = self.run_ruff("--select", "D212")
+        d212_result = self.run_ruff(SUMMARY_FIRST_SOURCE, "--select", "D212")
         assert d212_result.returncode == 0, d212_result.stdout + d212_result.stderr
 
 


### PR DESCRIPTION
## Summary

- Remove the redundant D213 global ignore from ruff.toml.
- Keep D212's formatter-compatible summary-first convention; Ruff 0.16.3 automatically resolves the incompatible D212/D213 pair when both are selected.
- Test the normal configured policy with both compliant and D212-violating fixtures, so a future selection regression fails without relying on `--select`.
- Carry forward the reconciled D203/D213 decision record from the parent PR.

## Validation

- Direct census: D213 reports 677 formatter-fixable findings; D212 reports none.
- Configured D-family scan: Ruff reports the D212/D213 conflict and passes without a manual ignore.
- D213 policy test passed, including the configured D212-negative fixture.
- Ruff check and Ruff format checks passed.
- Repository harness, architecture boundary check, fixed-toolchain dev check, and staged pre-commit gate passed.
