### PR TITLE
feat: strengthen runtime harness feedback

### DIFF
--- a/.github/workflows/runtime-harness.yml
+++ b/.github/workflows/runtime-harness.yml
@@ -46,6 +46,7 @@ jobs:
       AI_SHIFU_COMPOSE_PROJECT: ai-shifu-runtime-harness
       AI_SHIFU_COMPOSE_FILE: docker/docker-compose.runtime-harness.yml
       AI_SHIFU_RUNTIME_TIMELINE: artifacts/runtime-harness/timeline.json
+      AI_SHIFU_HARNESS_RUN_ID: gha-${{ github.run_id }}-${{ github.run_attempt }}
       AI_SHIFU_API_PORT: "5800"
       AI_SHIFU_WEB_PORT: "8080"
       AI_SHIFU_MYSQL_PORT: "3306"
@@ -195,12 +196,24 @@ jobs:
             --output "../../$AI_SHIFU_RUNTIME_TIMELINE" \
             --name frontend-test-dependencies \
             --status started
+          set +e
           npm ci
-          npx playwright install --with-deps chromium
+          exit_code=$?
+          if [ "$exit_code" -eq 0 ]; then
+            npx playwright install --with-deps chromium
+            exit_code=$?
+          fi
+          set -e
+          dependency_status=finished
+          if [ "$exit_code" -ne 0 ]; then
+            dependency_status=failed
+          fi
           python ../../scripts/harness/runtime_timeline.py mark \
             --output "../../$AI_SHIFU_RUNTIME_TIMELINE" \
             --name frontend-test-dependencies \
-            --status finished
+            --status "$dependency_status" \
+            --detail "exit_code=$exit_code"
+          exit "$exit_code"
 
       - name: Run fast value smoke harness
         working-directory: src/cook-web

--- a/.github/workflows/runtime-harness.yml
+++ b/.github/workflows/runtime-harness.yml
@@ -1,4 +1,4 @@
-name: Runtime Harness
+name: Critical Path Runtime Checks
 
 on:
   pull_request:
@@ -153,17 +153,32 @@ jobs:
             --status "$build_status" \
             --detail "outcome=$BUILD_OUTCOME"
 
-      - name: Start fast value stack
+      - name: Record fast value stack start
         run: |
           python scripts/harness/runtime_timeline.py mark \
             --output "$AI_SHIFU_RUNTIME_TIMELINE" \
             --name fast-value-stack \
             --status started
+
+      - name: Start fast value stack
+        id: start-fast-value-stack
+        run: |
           docker compose --env-file docker/.env -p "$AI_SHIFU_COMPOSE_PROJECT" -f "$AI_SHIFU_COMPOSE_FILE" up -d
+
+      - name: Record fast value stack outcome
+        if: always()
+        env:
+          STACK_OUTCOME: ${{ steps.start-fast-value-stack.outcome }}
+        run: |
+          stack_status=finished
+          if [ "$STACK_OUTCOME" != "success" ]; then
+            stack_status=failed
+          fi
           python scripts/harness/runtime_timeline.py mark \
             --output "$AI_SHIFU_RUNTIME_TIMELINE" \
             --name fast-value-stack \
-            --status finished
+            --status "$stack_status" \
+            --detail "outcome=$STACK_OUTCOME"
 
       - name: Wait for fast value endpoints
         run: |

--- a/.github/workflows/runtime-harness.yml
+++ b/.github/workflows/runtime-harness.yml
@@ -110,6 +110,12 @@ jobs:
             --name runtime-env \
             --status finished
 
+      - name: Validate runtime Compose configuration
+        run: |
+          docker compose --env-file docker/.env \
+            -p "$AI_SHIFU_COMPOSE_PROJECT" \
+            -f "$AI_SHIFU_COMPOSE_FILE" config --quiet
+
       - name: Record image build start
         run: |
           python scripts/harness/runtime_timeline.py mark \
@@ -203,11 +209,20 @@ jobs:
             --output "../../$AI_SHIFU_RUNTIME_TIMELINE" \
             --name fast-value-smoke \
             --status started
-          npm run test:e2e
+          set +e
+          npm run test:e2e -- --project=runtime-harness-smoke
+          exit_code=$?
+          set -e
+          smoke_status=finished
+          if [ "$exit_code" -ne 0 ]; then
+            smoke_status=failed
+          fi
           python ../../scripts/harness/runtime_timeline.py mark \
             --output "../../$AI_SHIFU_RUNTIME_TIMELINE" \
             --name fast-value-smoke \
-            --status finished
+            --status "$smoke_status" \
+            --detail "exit_code=$exit_code"
+          exit "$exit_code"
 
       - name: Capture service diagnostics
         if: always()

--- a/.github/workflows/runtime-harness.yml
+++ b/.github/workflows/runtime-harness.yml
@@ -41,22 +41,28 @@ concurrency:
 jobs:
   runtime-harness:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     env:
       AI_SHIFU_COMPOSE_PROJECT: ai-shifu-runtime-harness
+      AI_SHIFU_COMPOSE_FILE: docker/docker-compose.runtime-harness.yml
+      AI_SHIFU_RUNTIME_TIMELINE: artifacts/runtime-harness/timeline.json
       AI_SHIFU_API_PORT: "5800"
       AI_SHIFU_WEB_PORT: "8080"
-      AI_SHIFU_LOKI_PORT: "3100"
-      AI_SHIFU_TEMPO_PORT: "3200"
-      AI_SHIFU_TEMPO_OTLP_HTTP_PORT: "4318"
-      AI_SHIFU_OTEL_GRPC_PORT: "4317"
-      AI_SHIFU_PROMETHEUS_PORT: "9090"
-      AI_SHIFU_GRAFANA_PORT: "3001"
       AI_SHIFU_MYSQL_PORT: "3306"
       AI_SHIFU_REDIS_PORT: "6379"
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+
+      - name: Initialize runtime timeline
+        run: |
+          mkdir -p artifacts/runtime-harness
+          python scripts/harness/runtime_timeline.py mark \
+            --output "$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name workflow \
+            --status started \
+            --detail "run_id=${{ github.run_id }}" \
+            --detail "sha=${{ github.sha }}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -70,9 +76,18 @@ jobs:
 
       - name: Prepare runtime harness env
         run: |
-          cat > docker/.env <<'EOF'
-          SQLALCHEMY_DATABASE_URI=mysql://root:ai-shifu@ai-shifu-mysql:3306/ai-shifu?charset=utf8mb4
-          SECRET_KEY=ci-runtime-harness-secret
+          python scripts/harness/runtime_timeline.py mark \
+            --output "$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name runtime-env \
+            --status started
+          mysql_password="$(openssl rand -hex 16)"
+          encryption_key="$(openssl rand -base64 32 | tr -d '\n')"
+          secret_key="$(openssl rand -hex 32)"
+          cat > docker/.env <<EOF
+          AI_SHIFU_MYSQL_PASSWORD=${mysql_password}
+          AI_SHIFU_CREATOR_INTEGRATION_ENCRYPTION_KEY=${encryption_key}
+          SQLALCHEMY_DATABASE_URI=mysql://root:${mysql_password}@ai-shifu-mysql:3306/ai-shifu?charset=utf8mb4
+          SECRET_KEY=${secret_key}
           OPENAI_API_KEY=ci-runtime-harness-placeholder
           UNIVERSAL_VERIFICATION_CODE=1024
           ENV=development
@@ -90,12 +105,23 @@ jobs:
           CELERY_BROKER_URL=redis://ai-shifu-redis:6379/0
           CELERY_RESULT_BACKEND=redis://ai-shifu-redis:6379/1
           EOF
+          python scripts/harness/runtime_timeline.py mark \
+            --output "$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name runtime-env \
+            --status finished
+
+      - name: Record image build start
+        run: |
+          python scripts/harness/runtime_timeline.py mark \
+            --output "$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name image-build \
+            --status started
 
       - name: Build runtime images with cache
         uses: docker/bake-action@v7
         with:
           source: docker
-          files: docker-compose.dev.yml
+          files: docker-compose.runtime-harness.yml
           targets: ai-shifu-api-dev,ai-shifu-cook-web-dev
           load: true
           set: |
@@ -104,31 +130,50 @@ jobs:
             ai-shifu-cook-web-dev.cache-from=type=gha,scope=runtime-cook-web
             ai-shifu-cook-web-dev.cache-to=type=gha,scope=runtime-cook-web,mode=min
 
-      - name: Start dev stack
-        working-directory: docker
-        run: docker compose -p "$AI_SHIFU_COMPOSE_PROJECT" -f docker-compose.dev.yml up -d
-
-      - name: Wait for API and observability health
+      - name: Record image build finish
         run: |
-          for attempt in $(seq 1 60); do
-            if curl -fsS "http://127.0.0.1:${AI_SHIFU_API_PORT}/health" >/dev/null && \
-               curl -fsS "http://127.0.0.1:${AI_SHIFU_API_PORT}/internal/observability/health" >/dev/null && \
-               curl -fsS "http://127.0.0.1:${AI_SHIFU_LOKI_PORT}/ready" >/dev/null && \
-               curl -fsS "http://127.0.0.1:${AI_SHIFU_TEMPO_PORT}/ready" >/dev/null && \
-               curl -fsS "http://127.0.0.1:${AI_SHIFU_PROMETHEUS_PORT}/-/ready" >/dev/null && \
-               curl -fsS "http://127.0.0.1:${AI_SHIFU_GRAFANA_PORT}/api/health" >/dev/null; then
-              exit 0
-            fi
-            sleep 5
-          done
-          docker compose -p "$AI_SHIFU_COMPOSE_PROJECT" -f docker/docker-compose.dev.yml ps
-          docker compose -p "$AI_SHIFU_COMPOSE_PROJECT" -f docker/docker-compose.dev.yml logs ai-shifu-api-dev
-          exit 1
+          python scripts/harness/runtime_timeline.py mark \
+            --output "$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name image-build \
+            --status finished
+
+      - name: Start fast value stack
+        run: |
+          python scripts/harness/runtime_timeline.py mark \
+            --output "$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name fast-value-stack \
+            --status started
+          docker compose --env-file docker/.env -p "$AI_SHIFU_COMPOSE_PROJECT" -f "$AI_SHIFU_COMPOSE_FILE" up -d
+          python scripts/harness/runtime_timeline.py mark \
+            --output "$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name fast-value-stack \
+            --status finished
+
+      - name: Wait for fast value endpoints
+        run: |
+          python scripts/harness/runtime_timeline.py mark \
+            --output "$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name fast-value-health \
+            --status started
+          python scripts/harness/runtime_timeline.py wait \
+            --output "$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name api-health \
+            --url "http://127.0.0.1:${AI_SHIFU_API_PORT}/health" \
+            --timeout-seconds 180
+          python scripts/harness/runtime_timeline.py wait \
+            --output "$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name web-login \
+            --url "http://127.0.0.1:${AI_SHIFU_WEB_PORT}/login" \
+            --timeout-seconds 120
+          python scripts/harness/runtime_timeline.py mark \
+            --output "$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name fast-value-health \
+            --status finished
 
       - name: Resolve Playwright version
         id: playwright-version
         working-directory: src/cook-web
-        run: echo "version=$(node -p "require('./package-lock.json').packages['node_modules/playwright'].version")" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(node -p 'require("./package-lock.json").packages["node_modules/playwright"].version')" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         id: playwright-cache
@@ -140,20 +185,46 @@ jobs:
       - name: Install frontend dependencies
         working-directory: src/cook-web
         run: |
+          python ../../scripts/harness/runtime_timeline.py mark \
+            --output "../../$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name frontend-test-dependencies \
+            --status started
           npm ci
           npx playwright install --with-deps chromium
+          python ../../scripts/harness/runtime_timeline.py mark \
+            --output "../../$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name frontend-test-dependencies \
+            --status finished
 
-      - name: Run smoke harness
+      - name: Run fast value smoke harness
         working-directory: src/cook-web
-        run: npm run test:e2e
+        run: |
+          python ../../scripts/harness/runtime_timeline.py mark \
+            --output "../../$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name fast-value-smoke \
+            --status started
+          npm run test:e2e
+          python ../../scripts/harness/runtime_timeline.py mark \
+            --output "../../$AI_SHIFU_RUNTIME_TIMELINE" \
+            --name fast-value-smoke \
+            --status finished
 
-      - name: Capture compose logs
+      - name: Capture service diagnostics
         if: always()
-        run: docker compose -p "$AI_SHIFU_COMPOSE_PROJECT" -f docker/docker-compose.dev.yml logs > runtime-harness.log
+        run: |
+          docker compose --env-file docker/.env -p "$AI_SHIFU_COMPOSE_PROJECT" -f "$AI_SHIFU_COMPOSE_FILE" ps --format json > artifacts/runtime-harness/compose-ps.json || true
+          docker compose --env-file docker/.env -p "$AI_SHIFU_COMPOSE_PROJECT" -f "$AI_SHIFU_COMPOSE_FILE" logs --no-color > artifacts/runtime-harness/compose.log || true
 
-      - name: Stop dev stack
+      - name: Write runtime timeline summary
         if: always()
-        run: docker compose -p "$AI_SHIFU_COMPOSE_PROJECT" -f docker/docker-compose.dev.yml down -v
+        run: |
+          python scripts/harness/runtime_timeline.py summary \
+            --input "$AI_SHIFU_RUNTIME_TIMELINE" \
+            --output "$GITHUB_STEP_SUMMARY" || true
+
+      - name: Stop fast value stack
+        if: always()
+        run: docker compose --env-file docker/.env -p "$AI_SHIFU_COMPOSE_PROJECT" -f "$AI_SHIFU_COMPOSE_FILE" down -v
 
       - name: Upload runtime harness artifacts
         if: always()
@@ -162,4 +233,4 @@ jobs:
           name: runtime-harness-artifacts
           path: |
             src/cook-web/test-results
-            runtime-harness.log
+            artifacts/runtime-harness

--- a/.github/workflows/runtime-harness.yml
+++ b/.github/workflows/runtime-harness.yml
@@ -125,6 +125,7 @@ jobs:
             --status started
 
       - name: Build runtime images with cache
+        id: build-runtime-images
         uses: docker/bake-action@v7
         with:
           source: docker
@@ -137,12 +138,20 @@ jobs:
             ai-shifu-cook-web-dev.cache-from=type=gha,scope=runtime-cook-web
             ai-shifu-cook-web-dev.cache-to=type=gha,scope=runtime-cook-web,mode=min
 
-      - name: Record image build finish
+      - name: Record image build outcome
+        if: always()
+        env:
+          BUILD_OUTCOME: ${{ steps.build-runtime-images.outcome }}
         run: |
+          build_status=finished
+          if [ "$BUILD_OUTCOME" != "success" ]; then
+            build_status=failed
+          fi
           python scripts/harness/runtime_timeline.py mark \
             --output "$AI_SHIFU_RUNTIME_TIMELINE" \
             --name image-build \
-            --status finished
+            --status "$build_status" \
+            --detail "outcome=$BUILD_OUTCOME"
 
       - name: Start fast value stack
         run: |

--- a/docker/Dockerfile.cook-web.runtime-harness
+++ b/docker/Dockerfile.cook-web.runtime-harness
@@ -1,0 +1,19 @@
+FROM node:22.16.0
+
+WORKDIR /app
+
+RUN corepack enable
+
+COPY src/cook-web/package*.json ./
+RUN npm ci --ignore-scripts
+
+COPY src/cook-web ./
+COPY src/i18n ./src/i18n
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN npm run build
+
+EXPOSE 5000
+
+CMD ["npm", "run", "start", "--", "-H", "0.0.0.0", "-p", "5000"]

--- a/docker/docker-compose.runtime-harness.yml
+++ b/docker/docker-compose.runtime-harness.yml
@@ -1,0 +1,77 @@
+services:
+  ai-shifu-api-dev:
+    build:
+      context: ..
+      dockerfile: src/api/Dockerfile
+    image: ai-shifu-api-dev:latest
+    command:
+      - sh
+      - -c
+      - >-
+        until timeout 1 bash -c 'cat < /dev/null > /dev/tcp/ai-shifu-mysql/3306'; do sleep 1; done
+        && python scripts/repair_dev_migration_state.py
+        && flask db upgrade
+        && flask console update_demo_shifu
+        && cd /app
+        && exec gunicorn -k gevent -w 1 -b 0.0.0.0:5800 'app:app'
+        --timeout 300 --log-level info --access-logfile /var/log/app.log --capture-output
+    env_file:
+      - ./.env
+    environment:
+      OBSERVABILITY_TRACES_ENABLED: "false"
+      INTERNAL_METRICS_PATH: /internal/metrics
+      INTERNAL_OBSERVABILITY_HEALTH_PATH: /internal/observability/health
+      LOGIN_METHODS_ENABLED: phone
+      DEFAULT_LOGIN_METHOD: phone
+      CAPTCHA_CODE_OVERRIDE: "0000"
+      CREATOR_INTEGRATION_ENCRYPTION_KEY: ${AI_SHIFU_CREATOR_INTEGRATION_ENCRYPTION_KEY:?runtime harness encryption key is required}
+      SAAS_DB_URI: mysql://root:${AI_SHIFU_MYSQL_PASSWORD:?runtime harness MySQL password is required}@ai-shifu-mysql:3306/ai-shifu?charset=utf8mb4
+      REDIS_HOST: ai-shifu-redis
+      REDIS_PORT: 6379
+      SKIP_LOAD_DOTENV: "1"
+      CELERY_BROKER_URL: redis://ai-shifu-redis:6379/0
+      CELERY_RESULT_BACKEND: redis://ai-shifu-redis:6379/1
+    ports:
+      - "127.0.0.1:${AI_SHIFU_API_PORT:-5800}:5800"
+    depends_on:
+      - ai-shifu-mysql
+      - ai-shifu-redis
+
+  ai-shifu-cook-web-dev:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.cook-web.runtime-harness
+    image: ai-shifu-cook-web-runtime-harness:latest
+    env_file:
+      - ./.env
+    environment:
+      I18N_ROOT: /app/src/i18n
+      NEXT_TELEMETRY_DISABLED: "1"
+      NODE_OPTIONS: --max-old-space-size=2048
+      NEXT_PUBLIC_LOGIN_METHODS_ENABLED: phone
+      NEXT_PUBLIC_DEFAULT_LOGIN_METHOD: phone
+    depends_on:
+      - ai-shifu-api-dev
+
+  ai-shifu-nginx-dev-dev:
+    image: nginx:latest
+    ports:
+      - "127.0.0.1:${AI_SHIFU_WEB_PORT:-8080}:8080"
+    depends_on:
+      - ai-shifu-cook-web-dev
+      - ai-shifu-api-dev
+    volumes:
+      - ./nginx.dev.conf:/etc/nginx/nginx.conf:ro
+
+  ai-shifu-mysql:
+    environment:
+      MYSQL_ROOT_PASSWORD: ${AI_SHIFU_MYSQL_PASSWORD:?runtime harness MySQL password is required}
+      MYSQL_DATABASE: ai-shifu
+    image: mysql:8.0
+    ports:
+      - "127.0.0.1:${AI_SHIFU_MYSQL_PORT:-3306}:3306"
+
+  ai-shifu-redis:
+    image: redis:7-alpine
+    ports:
+      - "127.0.0.1:${AI_SHIFU_REDIS_PORT:-6379}:6379"

--- a/docs/exec-plans/completed/runtime-harness-fast-value-gate.md
+++ b/docs/exec-plans/completed/runtime-harness-fast-value-gate.md
@@ -1,0 +1,82 @@
+# Runtime Harness Fast Value Gate
+
+## Purpose / Big Picture
+
+The existing Runtime Harness starts the full local development stack, waits for API and all observability services, then runs three browser smoke checks. This provides broad local-stack confidence but makes every applicable pull request pay for Celery, Loki, Tempo, Prometheus, and Grafana even though the smoke suite only requires the API, frontend, database, Redis, and reverse proxy.
+
+This plan delivers the first executable increment of the runtime-harness optimization proposal. It introduces a minimal Compose stack for the required pull-request gate, structured startup and health timeline artifacts, service-scoped failure diagnostics, and reusable authenticated Playwright state. The resulting default gate remains named `runtime-harness`, preserves the existing trigger intent, and verifies login, authenticated administration entry, and learner course entry while removing duplicate browser login work and unrelated service readiness from its critical path.
+
+The full observability stack and asynchronous workers are not deleted. They remain part of the developer stack and are explicitly deferred to a subsequent deep-runtime/observability contract workflow. Deterministic provider-backed learner generation is also deferred: it needs a reviewed CI-only provider seam and must not be improvised in the browser suite.
+
+## Progress
+
+- [x] 2026-08-22 11:00 CST: Inspected the current Runtime Harness workflow, Compose stack, browser smoke suite, and repository workflow rules.
+- [x] 2026-08-22 11:10 CST: Created this ExecPlan and selected a minimal, standalone Compose file rather than changing default local-development profiles.
+- [x] 2026-08-22 11:45 CST: Added reusable timeline and health-wait script with four focused standard-library tests.
+- [x] 2026-08-22 11:47 CST: Added the minimal API/web/MySQL/Redis/Nginx Compose configuration and wired it into the Runtime Harness workflow.
+- [x] 2026-08-22 11:48 CST: Extracted reusable phone login, added Playwright authenticated setup state, and changed read-only smoke assertions to reuse that state.
+- [x] 2026-08-22 11:51 CST: Regenerated knowledge documents and passed `lefthook run pre-commit --all-files` (all 20 checks).
+- [x] 2026-08-22 11:55 CST: Pushed branch and created PR #2643; the first remote run exposed a connection-reset retry defect in the new readiness helper.
+- [x] 2026-08-22 12:03 CST: Pushed retry fix; the minimal stack health check passed in the second remote run, which then exposed a shell-quoting error in Playwright version resolution.
+- [x] 2026-08-22 12:09 CST: Pushed the version-resolution fix and passed Runtime Harness run 32550726976 in 4m41s; it completed API/Web health checks, Playwright dependency setup, authentication setup, and all fast-value smoke scenarios.
+
+## Surprises & Discoveries
+
+- The current development Compose command keeps API startup coupled to the OTEL collector and starts all observability services and Celery workers by default. Re-profiling that file would change existing local developer behavior and create profile-dependent dependency rules, so the fast gate uses a new, explicit Compose definition.
+- The current browser smoke tests duplicate the phone/OTP login flow for every scenario, while Playwright is configured with `fullyParallel: false`.
+- The current runner cache setup separates API and Cook Web BuildKit cache scopes, but the default gate still has no durable, machine-readable breakdown of service readiness or scenario timing.
+- Docker is unavailable in the implementation sandbox, so Compose execution and GitHub Actions wall-clock validation must be completed by the remote workflow; Prettier is used locally to parse the changed YAML files.
+- The first remote Runtime Harness attempt reached the minimal stack health phase but encountered a transient `ConnectionResetError`; the readiness helper initially treated that startup race as fatal instead of retryable. The helper now records the error and keeps polling, with focused regression coverage.
+- The second remote Runtime Harness attempt passed minimal-stack health checks. It then failed while resolving the Playwright version because nested double quotes reached Bash unescaped. The expression is now kept inside single quotes and is validated locally against the committed lockfile.
+
+## Decision Log
+
+- Decision: preserve the public workflow name and existing path filters. Rationale: branch protection and existing CI expectations should continue to see the same `runtime-harness` required check.
+- Decision: add `docker-compose.runtime-harness.yml` instead of modifying the default development Compose service set. Rationale: the fast CI gate needs only a subset, while local developers retain the full observability-enabled stack unchanged.
+- Decision: use one standard-library Python helper to record start/end events and wait for endpoints. Rationale: workflow shell loops currently hide which endpoint is slow; a shared helper produces deterministic JSON and GitHub job-summary output without introducing a new package dependency.
+- Decision: use a Playwright setup project and persisted storage state. Rationale: it preserves an actual login assertion while removing repeated phone/OTP interactions from authenticated read-only scenarios.
+- Decision: do not add browser-level generated-answer assertions in this increment. Rationale: CI has a placeholder API key; validating streaming generated content requires a reviewed deterministic LLM adapter and belongs in the next product-contract batch.
+
+## Outcomes & Retrospective
+
+The fast-gate implementation now includes a minimal Compose definition, an artifact-producing time-line helper, service-scoped compose logs/status, and Playwright storage-state reuse. Focused Python tests, TypeScript checking, Playwright test enumeration, YAML formatting validation, and `lefthook run pre-commit --all-files` passed. GitHub Actions run 32550726976 passed in 4m41s after the two targeted startup/workflow fixes recorded above. Its measured major phases were image build 105s, stack start 15s, endpoint readiness 45s, frontend test dependencies 36s, and fast-value browser smoke 32s. The baseline remains provisional because this is one successful post-change run, but the fast gate is now implemented and verified; deterministic generated-answer, observability-contract, and full deep-runtime work remain intentionally separate follow-ups.
+
+## Context and Orientation
+
+`.github/workflows/runtime-harness.yml` is the current GitHub Actions job. It builds `ai-shifu-api-dev` and `ai-shifu-cook-web-dev`, starts `docker/docker-compose.runtime-harness.yml`, records a timeline artifact, waits for API and web endpoints, and executes the Playwright setup plus smoke projects.
+
+`docker/docker-compose.dev.yml` is the full local development stack. The new `docker/docker-compose.runtime-harness.yml` must use the same image tags and Nginx configuration but only defines the service names Nginx expects: `ai-shifu-api-dev`, `ai-shifu-cook-web-dev`, `ai-shifu-nginx-dev-dev`, `ai-shifu-mysql`, and `ai-shifu-redis`.
+
+`scripts/harness/runtime_timeline.py` is the new standard-library CLI. Its `wait` command receives named endpoint specifications, appends attempt/ready events to a JSON artifact, writes a concise GitHub Actions summary when `GITHUB_STEP_SUMMARY` is present, and exits with diagnostics when a timeout occurs.
+
+`src/cook-web/e2e/harness-auth.ts` owns the existing deterministic phone login helper. `auth.setup.ts` logs in once and writes storage state under Playwright output. `smoke.spec.ts` retains authenticated product-entry assertions. `playwright.config.ts` creates an explicit setup project and the dependent smoke project.
+
+## Plan of Work
+
+First, create the ExecPlan and the timeline utility with isolated automated checks. Second, use the timeline helper to make image-build, stack-start, endpoint readiness, dependency installation, and browser-run timing visible. Third, move the default runtime gate to a minimal Compose stack; the deep stack remains preserved in the current development Compose configuration. Fourth, make browser authentication a setup dependency so read-only assertions can run with independent contexts and later be safely parallelized. Fifth, run local static validation and commit the change on a dedicated branch.
+
+## Concrete Steps
+
+1. Create `scripts/harness/runtime_timeline.py` with `mark`, `wait`, and `summary` subcommands. Make output path configurable, keep JSON output atomic, and avoid shell-specific parsing.
+2. Add focused tests for timestamped event recording, successful endpoint readiness, and endpoint timeout reports using a local HTTP server.
+3. Add `docker/docker-compose.runtime-harness.yml` with the API, Cook Web, Nginx, MySQL, and Redis configuration necessary for existing smoke paths. Do not attach source mounts, reload flags, Celery, or observability services.
+4. Update `runtime-harness.yml` to use the minimal Compose file, create `artifacts/runtime-harness`, record each phase, wait for API and web endpoints using the helper, record Compose status/logs, and upload the timeline with existing test artifacts.
+5. Extract the phone login routine to `e2e/harness-auth.ts`, add `e2e/auth.setup.ts`, and configure setup + smoke projects with generated storage state. Retain an explicit assertion that setup reaches the authenticated admin route.
+6. Run focused tests and structural checks. Update Progress and Outcomes with exact commands and any Docker limitation. Regenerate knowledge docs if the harness/index check requires it.
+
+## Validation and Acceptance
+
+- `python -m pytest scripts/harness/tests/test_runtime_timeline.py` proves that event writes, healthy endpoints, timed-out endpoints, request-deadline handling, and interval validation create the expected timeline schema.
+- `docker compose -f docker/docker-compose.runtime-harness.yml config` validates the minimal Compose file when Docker is available.
+- The workflow YAML parses and contains the original pull-request/push path filters, `runtime-harness` job name, the minimal Compose path, and the uploaded timeline artifact.
+- `cd src/cook-web && npm run type-check` accepts the Playwright setup/state configuration. **Passed locally on 2026-08-22.**
+- `python scripts/check_repo_harness.py` and `python scripts/check_architecture_boundaries.py` remain green after generated knowledge documents are refreshed.
+- GitHub Actions run 32550726976 is the final acceptance evidence for this increment: it preserved login, authenticated administration, learner entry, and zero-5xx browser assertions while no longer waits for Grafana/Loki/Tempo/Prometheus/Celery. It completed successfully in 4m41s.
+
+## Idempotence and Recovery
+
+The timeline script creates or appends to a configured JSON file; repeated `mark` commands produce additional explicit events rather than corrupting prior data. The workflow removes only its named Compose project during cleanup. The new Compose file has a distinct purpose and does not modify `docker-compose.dev.yml`, so reverting the workflow change restores the former full-stack gate without affecting local development. The Playwright authentication file is generated under test output and is not committed.
+
+## Interfaces and Dependencies
+
+The implementation depends on Python standard-library modules, Docker Compose, GitHub Actions, Playwright, the existing deterministic phone verification configuration, the current API and Cook Web image tags, and `docker/nginx.dev.conf`. It does not change public HTTP APIs, database schemas, credentials, provider routing, or production Compose files.

--- a/docs/exec-plans/completed/runtime-harness-fast-value-gate.md
+++ b/docs/exec-plans/completed/runtime-harness-fast-value-gate.md
@@ -10,15 +10,15 @@ The full observability stack and asynchronous workers are not deleted. They rema
 
 ## Progress
 
-- [x] 2026-08-22 11:00 CST: Inspected the current Runtime Harness workflow, Compose stack, browser smoke suite, and repository workflow rules.
-- [x] 2026-08-22 11:10 CST: Created this ExecPlan and selected a minimal, standalone Compose file rather than changing default local-development profiles.
-- [x] 2026-08-22 11:45 CST: Added reusable timeline and health-wait script with four focused standard-library tests.
-- [x] 2026-08-22 11:47 CST: Added the minimal API/web/MySQL/Redis/Nginx Compose configuration and wired it into the Runtime Harness workflow.
-- [x] 2026-08-22 11:48 CST: Extracted reusable phone login, added Playwright authenticated setup state, and changed read-only smoke assertions to reuse that state.
-- [x] 2026-08-22 11:51 CST: Regenerated knowledge documents and passed `lefthook run pre-commit --all-files` (all 20 checks).
-- [x] 2026-08-22 11:55 CST: Pushed branch and created PR #2643; the first remote run exposed a connection-reset retry defect in the new readiness helper.
-- [x] 2026-08-22 12:03 CST: Pushed retry fix; the minimal stack health check passed in the second remote run, which then exposed a shell-quoting error in Playwright version resolution.
-- [x] 2026-08-22 12:09 CST: Pushed the version-resolution fix and passed Runtime Harness run 32550726976 in 4m41s; it completed API/Web health checks, Playwright dependency setup, authentication setup, and all fast-value smoke scenarios.
+- [x] 2026-08-22T03:00:00Z: Inspected the current Runtime Harness workflow, Compose stack, browser smoke suite, and repository workflow rules.
+- [x] 2026-08-22T03:10:00Z: Created this ExecPlan and selected a minimal, standalone Compose file rather than changing default local-development profiles.
+- [x] 2026-08-22T03:45:00Z: Added reusable timeline and health-wait script with four focused standard-library tests.
+- [x] 2026-08-22T03:47:00Z: Added the minimal API/web/MySQL/Redis/Nginx Compose configuration and wired it into the Runtime Harness workflow.
+- [x] 2026-08-22T03:48:00Z: Extracted reusable phone login, added Playwright authenticated setup state, and changed read-only smoke assertions to reuse that state.
+- [x] 2026-08-22T03:51:00Z: Regenerated knowledge documents and passed `lefthook run pre-commit --all-files` (all 20 checks).
+- [x] 2026-08-22T03:55:00Z: Pushed branch and created PR #2643; the first remote run exposed a connection-reset retry defect in the new readiness helper.
+- [x] 2026-08-22T04:03:00Z: Pushed retry fix; the minimal stack health check passed in the second remote run, which then exposed a shell-quoting error in Playwright version resolution.
+- [x] 2026-08-22T04:09:00Z: Pushed the version-resolution fix and passed Runtime Harness run 32550726976 in 4m41s; it completed API/Web health checks, Playwright dependency setup, authentication setup, and all fast-value smoke scenarios.
 
 ## Surprises & Discoveries
 

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -40,6 +40,7 @@ Active and completed ExecPlans live here. The structure and required sections ar
 - [Operator Course B Optimization](./completed/operator-course-b-optimization.md)
 - [Operator Course Detail Tab Splitting](./completed/operator-course-detail-tab-splitting.md)
 - [Operator User Detail Page Slimming](./completed/operator-user-detail-page-slimming.md)
+- [Runtime Harness Fast Value Gate](./completed/runtime-harness-fast-value-gate.md)
 
 ## Supporting Tracker
 

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -53,6 +53,7 @@
 | `docs/exec-plans/completed/operator-course-b-optimization.md` | Operator Course B Optimization | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/operator-course-detail-tab-splitting.md` | Operator Course Detail Tab Splitting | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/operator-user-detail-page-slimming.md` | Operator User Detail Page Slimming | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
+| `docs/exec-plans/completed/runtime-harness-fast-value-gate.md` | Runtime Harness Fast Value Gate | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/tech-debt-tracker.md` | Tech Debt Tracker | `exec-plan-support` | `active` | `repo` | `2026-04-17` | `true` |
 | `docs/generated/harness-gardening-summary.md` | Harness Gardening Summary | `generated-doc` | `reference` | `repo` | `2026-04-17` | `true` |
 | `docs/generated/harness-health.md` | Harness Health | `generated-doc` | `reference` | `repo` | `2026-04-17` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -10,7 +10,7 @@ This generated report summarizes the repository harness control plane.
 - Product specs: `10`
 - References: `3`
 - Active ExecPlans: `20`
-- Completed ExecPlans: `11`
+- Completed ExecPlans: `12`
 
 ## Boundary Baseline
 

--- a/scripts/harness/runtime_timeline.py
+++ b/scripts/harness/runtime_timeline.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Record Runtime Harness phase timing and endpoint-readiness evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+SCHEMA_VERSION = 1
+DEFAULT_TIMEOUT_SECONDS = 120.0
+DEFAULT_INTERVAL_SECONDS = 2.0
+MAX_REQUEST_TIMEOUT_SECONDS = 10.0
+
+
+def positive_float(raw: str) -> float:
+    """Parse a strictly positive duration for a wait argument."""
+    value = float(raw)
+    if value <= 0:
+        message = "duration must be greater than zero"
+        raise argparse.ArgumentTypeError(message)
+    return value
+
+
+def utc_now() -> str:
+    """Return the current UTC time in ISO-8601 format with a trailing Z."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def parse_key_value(raw: str) -> tuple[str, str]:
+    """Parse a KEY=VALUE detail argument."""
+    key, separator, value = raw.partition("=")
+    if not separator or not key.strip():
+        message = "details must use KEY=VALUE format"
+        raise argparse.ArgumentTypeError(message)
+    return key.strip(), value
+
+
+def details_from_args(raw_details: list[tuple[str, str]]) -> dict[str, str]:
+    """Convert repeated parser detail values into a JSON-safe mapping."""
+    return dict(raw_details)
+
+
+def empty_timeline() -> dict[str, Any]:
+    """Return an empty runtime-harness timeline document."""
+    return {"schema_version": SCHEMA_VERSION, "events": []}
+
+
+def load_timeline(path: Path) -> dict[str, Any]:
+    """Load a timeline document or return the initial document when absent."""
+    if not path.exists():
+        return empty_timeline()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        message = f"timeline is not valid JSON: {path}"
+        raise ValueError(message) from exc
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        message = f"unsupported timeline schema in {path}"
+        raise ValueError(message)
+    events = payload.get("events")
+    if not isinstance(events, list):
+        message = f"timeline events must be a list: {path}"
+        raise TypeError(message)
+    return payload
+
+
+def write_timeline(path: Path, payload: dict[str, Any]) -> None:
+    """Atomically write a timeline document to its destination path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=path.parent, delete=False
+    ) as temporary:
+        json.dump(payload, temporary, ensure_ascii=False, indent=2, sort_keys=True)
+        temporary.write("\n")
+        temporary_path = Path(temporary.name)
+    temporary_path.replace(path)
+
+
+def append_event(
+    path: Path,
+    *,
+    name: str,
+    status: str,
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Append a timestamped event and return its JSON-ready representation."""
+    timeline = load_timeline(path)
+    event: dict[str, Any] = {
+        "name": name,
+        "status": status,
+        "timestamp": utc_now(),
+    }
+    if details:
+        event["details"] = details
+    timeline["events"].append(event)
+    write_timeline(path, timeline)
+    return event
+
+
+def request_endpoint(url: str, *, timeout_seconds: float) -> tuple[int, str]:
+    """Request an endpoint and return its status code with a short detail string."""
+    try:
+        with urlopen(  # noqa: S310 - CI URLs are explicit
+            url, timeout=min(timeout_seconds, MAX_REQUEST_TIMEOUT_SECONDS)
+        ) as response:
+            return response.status, ""
+    except HTTPError as exc:
+        return exc.code, f"HTTP {exc.code}"
+    except URLError as exc:
+        return 0, str(exc.reason)
+    except TimeoutError:
+        return 0, "request timed out"
+    except OSError as exc:
+        return 0, str(exc)
+
+
+def wait_for_endpoint(
+    path: Path,
+    *,
+    name: str,
+    url: str,
+    timeout_seconds: float,
+    interval_seconds: float,
+) -> bool:
+    """Wait until an HTTP endpoint succeeds, recording ready or timeout evidence."""
+    if timeout_seconds <= 0:
+        message = "timeout_seconds must be greater than zero"
+        raise ValueError(message)
+    if interval_seconds <= 0:
+        message = "interval_seconds must be greater than zero"
+        raise ValueError(message)
+
+    started = time.monotonic()
+    deadline = started + timeout_seconds
+    attempts = 0
+    last_status = 0
+    last_error = "not requested"
+    while True:
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            elapsed_seconds = round(time.monotonic() - started, 3)
+            append_event(
+                path,
+                name=name,
+                status="timeout",
+                details={
+                    "attempts": attempts,
+                    "elapsed_seconds": elapsed_seconds,
+                    "last_error": last_error,
+                    "last_status_code": last_status,
+                    "timeout_seconds": timeout_seconds,
+                    "url": url,
+                },
+            )
+            return False
+
+        attempts += 1
+        last_status, last_error = request_endpoint(
+            url, timeout_seconds=remaining_seconds
+        )
+        elapsed_seconds = round(time.monotonic() - started, 3)
+        if 200 <= last_status < 400:
+            append_event(
+                path,
+                name=name,
+                status="ready",
+                details={
+                    "attempts": attempts,
+                    "elapsed_seconds": elapsed_seconds,
+                    "status_code": last_status,
+                    "url": url,
+                },
+            )
+            return True
+        if elapsed_seconds >= timeout_seconds:
+            append_event(
+                path,
+                name=name,
+                status="timeout",
+                details={
+                    "attempts": attempts,
+                    "elapsed_seconds": elapsed_seconds,
+                    "last_error": last_error,
+                    "last_status_code": last_status,
+                    "timeout_seconds": timeout_seconds,
+                    "url": url,
+                },
+            )
+            return False
+        remaining_seconds = max(deadline - time.monotonic(), 0)
+        time.sleep(min(interval_seconds, remaining_seconds))
+
+
+def write_summary(path: Path, destination: Path) -> None:
+    """Write a concise GitHub Actions-friendly summary from a timeline document."""
+    timeline = load_timeline(path)
+    lines = [
+        "## Runtime Harness timeline",
+        "",
+        "| Time (UTC) | Event | Status | Details |",
+        "| --- | --- | --- | --- |",
+    ]
+    for event in timeline["events"]:
+        details = event.get("details", {})
+        rendered_details = ", ".join(
+            f"{key}={value}" for key, value in sorted(details.items())
+        )
+        lines.append(
+            "| {timestamp} | {name} | {status} | {details} |".format(
+                timestamp=event["timestamp"],
+                name=event["name"],
+                status=event["status"],
+                details=rendered_details or "-",
+            )
+        )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("a", encoding="utf-8") as summary:
+        summary.write("\n".join(lines))
+        summary.write("\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser for timeline operations."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    mark = subparsers.add_parser("mark", help="Record a timestamped phase event")
+    mark.add_argument("--output", required=True, type=Path)
+    mark.add_argument("--name", required=True)
+    mark.add_argument("--status", required=True)
+    mark.add_argument("--detail", action="append", default=[], type=parse_key_value)
+
+    wait = subparsers.add_parser("wait", help="Wait for one HTTP endpoint")
+    wait.add_argument("--output", required=True, type=Path)
+    wait.add_argument("--name", required=True)
+    wait.add_argument("--url", required=True)
+    wait.add_argument(
+        "--timeout-seconds", type=positive_float, default=DEFAULT_TIMEOUT_SECONDS
+    )
+    wait.add_argument(
+        "--interval-seconds", type=positive_float, default=DEFAULT_INTERVAL_SECONDS
+    )
+
+    summary = subparsers.add_parser(
+        "summary", help="Append a Markdown timeline summary"
+    )
+    summary.add_argument("--input", required=True, type=Path)
+    summary.add_argument(
+        "--output",
+        type=Path,
+        default=Path(
+            os.environ.get("GITHUB_STEP_SUMMARY", "runtime-harness-summary.md")
+        ),
+    )
+    return parser
+
+
+def main() -> int:
+    """Run the requested timeline operation."""
+    args = build_parser().parse_args()
+    if args.command == "mark":
+        append_event(
+            args.output,
+            name=args.name,
+            status=args.status,
+            details=details_from_args(args.detail),
+        )
+        return 0
+    if args.command == "wait":
+        return int(
+            not wait_for_endpoint(
+                args.output,
+                name=args.name,
+                url=args.url,
+                timeout_seconds=args.timeout_seconds,
+                interval_seconds=args.interval_seconds,
+            )
+        )
+    if args.command == "summary":
+        write_summary(args.input, args.output)
+        return 0
+    message = f"unsupported command: {args.command}"
+    raise ValueError(message)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/harness/tests/__init__.py
+++ b/scripts/harness/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Runtime Harness helper scripts."""

--- a/scripts/harness/tests/test_runtime_timeline.py
+++ b/scripts/harness/tests/test_runtime_timeline.py
@@ -1,0 +1,181 @@
+"""Regression tests for Runtime Harness timeline reporting."""
+
+# ruff: noqa: S101 -- pytest assertions are the expected test contract.
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import pytest
+
+from scripts.harness import runtime_timeline
+
+
+class _HealthyHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        """Silence HTTP server diagnostics during tests."""
+
+
+def test_append_event_writes_schema_and_details() -> None:
+    """Events are persisted with the expected schema and metadata."""
+    with TemporaryDirectory() as directory:
+        timeline_path = Path(directory) / "timeline.json"
+        runtime_timeline.append_event(
+            timeline_path,
+            name="images",
+            status="started",
+            details={"target": "api"},
+        )
+
+        timeline = json.loads(timeline_path.read_text(encoding="utf-8"))
+
+    assert timeline["schema_version"] == runtime_timeline.SCHEMA_VERSION
+    assert timeline["events"][0] == {
+        "details": {"target": "api"},
+        "name": "images",
+        "status": "started",
+        "timestamp": timeline["events"][0]["timestamp"],
+    }
+    assert timeline["events"][0]["timestamp"].endswith("Z")
+
+
+def test_wait_for_healthy_endpoint_records_ready_event() -> None:
+    """A healthy endpoint records attempts, elapsed time, and HTTP status."""
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _HealthyHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with TemporaryDirectory() as directory:
+            timeline_path = Path(directory) / "timeline.json"
+            is_ready = runtime_timeline.wait_for_endpoint(
+                timeline_path,
+                name="api",
+                url=f"http://127.0.0.1:{server.server_port}/health",
+                timeout_seconds=1,
+                interval_seconds=0.01,
+            )
+            timeline = json.loads(timeline_path.read_text(encoding="utf-8"))
+    finally:
+        server.shutdown()
+        thread.join(timeout=1)
+        server.server_close()
+
+    assert is_ready
+    assert timeline["events"][0]["status"] == "ready"
+    assert timeline["events"][0]["details"]["status_code"] == 200
+
+
+def test_request_endpoint_handles_connection_reset() -> None:
+    """Transient connection resets become retryable endpoint diagnostics."""
+    with patch(
+        "scripts.harness.runtime_timeline.urlopen",
+        side_effect=ConnectionResetError("connection reset"),
+    ):
+        status_code, detail = runtime_timeline.request_endpoint(
+            "http://127.0.0.1:5800/health", timeout_seconds=1
+        )
+
+    assert status_code == 0
+    assert "connection reset" in detail
+
+
+def test_wait_caps_request_timeout_to_the_remaining_budget() -> None:
+    """A short overall timeout is forwarded to the endpoint request unchanged."""
+    with TemporaryDirectory() as directory:
+        timeline_path = Path(directory) / "timeline.json"
+        with patch(
+            "scripts.harness.runtime_timeline.urlopen", side_effect=TimeoutError
+        ) as urlopen:
+            is_ready = runtime_timeline.wait_for_endpoint(
+                timeline_path,
+                name="api",
+                url="http://127.0.0.1:5800/health",
+                timeout_seconds=0.02,
+                interval_seconds=0.01,
+            )
+
+    assert not is_ready
+    assert urlopen.call_args.kwargs["timeout"] <= 0.02
+
+
+@pytest.mark.parametrize("interval_seconds", [0, -1])
+def test_wait_rejects_non_positive_intervals(interval_seconds: float) -> None:
+    """The API boundary rejects values that would busy-loop or break sleep."""
+    with (
+        TemporaryDirectory() as directory,
+        pytest.raises(ValueError, match="interval_seconds"),
+    ):
+        runtime_timeline.wait_for_endpoint(
+            Path(directory) / "timeline.json",
+            name="api",
+            url="http://127.0.0.1:5800/health",
+            timeout_seconds=1,
+            interval_seconds=interval_seconds,
+        )
+
+
+@pytest.mark.parametrize("interval_seconds", ["0", "-1"])
+def test_cli_rejects_non_positive_intervals(interval_seconds: str) -> None:
+    """The CLI boundary rejects invalid polling intervals before execution."""
+    parser = runtime_timeline.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "wait",
+                "--output",
+                "timeline.json",
+                "--name",
+                "api",
+                "--url",
+                "http://127.0.0.1:5800/health",
+                "--interval-seconds",
+                interval_seconds,
+            ]
+        )
+
+
+def test_wait_for_unavailable_endpoint_records_timeout() -> None:
+    """An unavailable endpoint records the timeout evidence before failing."""
+    with TemporaryDirectory() as directory:
+        timeline_path = Path(directory) / "timeline.json"
+        is_ready = runtime_timeline.wait_for_endpoint(
+            timeline_path,
+            name="api",
+            url="http://127.0.0.1:1/health",
+            timeout_seconds=0.02,
+            interval_seconds=0.01,
+        )
+        timeline = json.loads(timeline_path.read_text(encoding="utf-8"))
+
+    assert not is_ready
+    assert timeline["events"][0]["status"] == "timeout"
+    assert timeline["events"][0]["name"] == "api"
+    assert timeline["events"][0]["details"]["attempts"] >= 1
+
+
+def test_write_summary_renders_events() -> None:
+    """Summary output includes a readable table for the GitHub job page."""
+    with TemporaryDirectory() as directory:
+        timeline_path = Path(directory) / "timeline.json"
+        summary_path = Path(directory) / "summary.md"
+        runtime_timeline.append_event(
+            timeline_path,
+            name="smoke",
+            status="finished",
+            details={"exit_code": 0},
+        )
+        runtime_timeline.write_summary(timeline_path, summary_path)
+        summary = summary_path.read_text(encoding="utf-8")
+
+    assert "## Runtime Harness timeline" in summary
+    assert "smoke" in summary
+    assert "exit_code=0" in summary

--- a/src/cook-web/.gitignore
+++ b/src/cook-web/.gitignore
@@ -13,6 +13,7 @@
 # testing
 /coverage
 /playwright-report
+/playwright/.auth
 /test-results
 
 # next.js

--- a/src/cook-web/e2e/auth.setup.ts
+++ b/src/cook-web/e2e/auth.setup.ts
@@ -1,23 +1,28 @@
 import { expect, test } from '@playwright/test';
 import { mkdir } from 'node:fs/promises';
 
-import { attachRuntimeHarnessDiagnostics } from './harness-diagnostics';
+import {
+  attachRuntimeHarnessDiagnostics,
+  type RuntimeHarnessDiagnostics,
+} from './harness-diagnostics';
 import { loginWithPhone } from './harness-auth';
 
 const authStatePath = 'playwright/.auth/runtime-harness-user.json';
 
-test('runtime harness authenticates the shared test user', async ({
-  page,
-}, testInfo) => {
-  const diagnostics = await attachRuntimeHarnessDiagnostics(page, testInfo);
+let diagnostics: RuntimeHarnessDiagnostics;
 
-  try {
-    await loginWithPhone(page, '/admin/operations');
-    await page.waitForURL('**/admin/operations');
-    await expect(page.getByTestId('admin-operations-page')).toBeVisible();
-    await mkdir('playwright/.auth', { recursive: true });
-    await page.context().storageState({ path: authStatePath });
-  } finally {
-    await diagnostics.captureFailure(testInfo);
-  }
+test.beforeEach(async ({ page }, testInfo) => {
+  diagnostics = await attachRuntimeHarnessDiagnostics(page, testInfo);
+});
+
+test.afterEach(async ({}, testInfo) => {
+  await diagnostics.captureFailure(testInfo);
+});
+
+test('runtime harness authenticates the shared test user', async ({ page }) => {
+  await loginWithPhone(page, '/admin/operations');
+  await page.waitForURL('**/admin/operations');
+  await expect(page.getByTestId('admin-operations-page')).toBeVisible();
+  await mkdir('playwright/.auth', { recursive: true });
+  await page.context().storageState({ path: authStatePath });
 });

--- a/src/cook-web/e2e/auth.setup.ts
+++ b/src/cook-web/e2e/auth.setup.ts
@@ -9,14 +9,15 @@ import { loginWithPhone } from './harness-auth';
 
 const authStatePath = 'playwright/.auth/runtime-harness-user.json';
 
-let diagnostics: RuntimeHarnessDiagnostics;
+let diagnostics: RuntimeHarnessDiagnostics | undefined;
 
 test.beforeEach(async ({ page }, testInfo) => {
+  diagnostics = undefined;
   diagnostics = await attachRuntimeHarnessDiagnostics(page, testInfo);
 });
 
 test.afterEach(async ({}, testInfo) => {
-  await diagnostics.captureFailure(testInfo);
+  await diagnostics?.captureFailure(testInfo);
 });
 
 test('runtime harness authenticates the shared test user', async ({ page }) => {

--- a/src/cook-web/e2e/auth.setup.ts
+++ b/src/cook-web/e2e/auth.setup.ts
@@ -1,14 +1,23 @@
 import { expect, test } from '@playwright/test';
 import { mkdir } from 'node:fs/promises';
 
+import { attachRuntimeHarnessDiagnostics } from './harness-diagnostics';
 import { loginWithPhone } from './harness-auth';
 
 const authStatePath = 'playwright/.auth/runtime-harness-user.json';
 
-test('runtime harness authenticates the shared test user', async ({ page }) => {
-  await loginWithPhone(page, '/admin/operations');
-  await page.waitForURL('**/admin/operations');
-  await expect(page.getByTestId('admin-operations-page')).toBeVisible();
-  await mkdir('playwright/.auth', { recursive: true });
-  await page.context().storageState({ path: authStatePath });
+test('runtime harness authenticates the shared test user', async ({
+  page,
+}, testInfo) => {
+  const diagnostics = await attachRuntimeHarnessDiagnostics(page, testInfo);
+
+  try {
+    await loginWithPhone(page, '/admin/operations');
+    await page.waitForURL('**/admin/operations');
+    await expect(page.getByTestId('admin-operations-page')).toBeVisible();
+    await mkdir('playwright/.auth', { recursive: true });
+    await page.context().storageState({ path: authStatePath });
+  } finally {
+    await diagnostics.captureFailure(testInfo);
+  }
 });

--- a/src/cook-web/e2e/auth.setup.ts
+++ b/src/cook-web/e2e/auth.setup.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+
+import { loginWithPhone } from './harness-auth';
+
+const authStatePath = 'playwright/.auth/runtime-harness-user.json';
+
+test('runtime harness authenticates the shared test user', async ({ page }) => {
+  await loginWithPhone(page, '/admin/operations');
+  await page.waitForURL('**/admin/operations');
+  await expect(page.getByTestId('admin-operations-page')).toBeVisible();
+  await mkdir('playwright/.auth', { recursive: true });
+  await page.context().storageState({ path: authStatePath });
+});

--- a/src/cook-web/e2e/harness-auth.ts
+++ b/src/cook-web/e2e/harness-auth.ts
@@ -1,0 +1,61 @@
+import { expect, Page } from '@playwright/test';
+
+const DEFAULT_PHONE = process.env.AI_SHIFU_TEST_PHONE || '13800138000';
+const DEFAULT_OTP = process.env.AI_SHIFU_TEST_OTP || '1024';
+const DEFAULT_CAPTCHA = process.env.AI_SHIFU_TEST_CAPTCHA || '0000';
+
+const ensurePhoneLoginVisible = async (page: Page) => {
+  const phoneInput = page.locator('#phone');
+  if (await phoneInput.isVisible()) {
+    return phoneInput;
+  }
+
+  const tabs = page.getByRole('tab');
+  const tabCount = await tabs.count();
+  for (let index = 0; index < tabCount; index += 1) {
+    await tabs.nth(index).click();
+    if (await phoneInput.isVisible().catch(() => false)) {
+      return phoneInput;
+    }
+  }
+
+  await expect(phoneInput).toBeVisible();
+  return phoneInput;
+};
+
+export const loginWithPhone = async (page: Page, redirectPath: string) => {
+  await page.goto(`/login?redirect=${encodeURIComponent(redirectPath)}`);
+  await expect(page.getByTestId('login-page')).toBeVisible();
+
+  const phoneInput = await ensurePhoneLoginVisible(page);
+  await phoneInput.fill(DEFAULT_PHONE);
+
+  const termsCheckbox = page.locator('#terms');
+  if (await termsCheckbox.isVisible()) {
+    await termsCheckbox.click();
+  }
+
+  const captchaInput = page.getByTestId('captcha-input');
+  await expect(captchaInput).toBeVisible();
+  await captchaInput.fill(DEFAULT_CAPTCHA);
+
+  const sendOtpButton = page
+    .locator('#otp')
+    .locator('xpath=ancestor::div[1]/following-sibling::button[1]');
+  await sendOtpButton.click();
+
+  const otpInput = page.locator('#otp');
+  if (
+    await page
+      .getByRole('alertdialog')
+      .isVisible()
+      .catch(() => false)
+  ) {
+    const buttons = page.getByRole('alertdialog').getByRole('button');
+    await buttons.last().click();
+  }
+
+  await expect(otpInput).toBeEnabled();
+  await otpInput.fill(DEFAULT_OTP);
+  await otpInput.press('Enter');
+};

--- a/src/cook-web/e2e/harness-diagnostics.ts
+++ b/src/cook-web/e2e/harness-diagnostics.ts
@@ -119,7 +119,13 @@ export const attachRuntimeHarnessDiagnostics = async (
 
       await mkdir(failedTestInfo.outputDir, { recursive: true });
       const screenshotPath = failedTestInfo.outputPath('failure.png');
-      await page.screenshot({ path: screenshotPath, fullPage: true });
+      let screenshotError: string | undefined;
+      try {
+        await page.screenshot({ path: screenshotPath, fullPage: true });
+      } catch (error) {
+        screenshotError =
+          error instanceof Error ? error.message : String(error);
+      }
       const diagnosticsPath = failedTestInfo.outputPath(
         'harness-diagnostics.json',
       );
@@ -132,7 +138,8 @@ export const attachRuntimeHarnessDiagnostics = async (
             lastRequestId: lastObservedRequestId,
             console: consoleEntries,
             network: networkEntries.slice(-25),
-            screenshot: screenshotPath,
+            screenshot: screenshotError ? undefined : screenshotPath,
+            screenshotError,
             runtimeHarness: buildRuntimeHarnessHints(
               lastObservedRequestId,
               diagnosticsPath,

--- a/src/cook-web/e2e/harness-diagnostics.ts
+++ b/src/cook-web/e2e/harness-diagnostics.ts
@@ -1,0 +1,148 @@
+import type { Page, TestInfo } from '@playwright/test';
+import { mkdir, writeFile } from 'node:fs/promises';
+
+export type ConsoleEntry = {
+  type: string;
+  text: string;
+};
+
+export type NetworkEntry = {
+  method: string;
+  resourceType: string;
+  status: number | null;
+  url: string;
+  requestId: string;
+  harnessRunId: string;
+};
+
+const HARNESS_RUN_ID =
+  process.env.AI_SHIFU_HARNESS_RUN_ID || `pw-run-${Date.now()}`;
+
+const createRequestId = (testInfo: TestInfo) =>
+  `pw-${Date.now()}-${testInfo.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 32)}`;
+
+const buildRuntimeHarnessHints = (
+  requestId: string,
+  diagnosticsPath: string,
+) => ({
+  requestId,
+  harnessRunId: HARNESS_RUN_ID,
+  browserDiagnostics: diagnosticsPath,
+  composeLog: 'artifacts/runtime-harness/compose.log',
+  composeStatus: 'artifacts/runtime-harness/compose-ps.json',
+  investigation: 'Review the uploaded runtime-harness-artifacts bundle.',
+});
+
+export type RuntimeHarnessDiagnostics = {
+  captureFailure: (testInfo: TestInfo) => Promise<void>;
+  networkEntries: NetworkEntry[];
+  serverErrorEntries: NetworkEntry[];
+};
+
+export const attachRuntimeHarnessDiagnostics = async (
+  page: Page,
+  testInfo: TestInfo,
+): Promise<RuntimeHarnessDiagnostics> => {
+  const consoleEntries: ConsoleEntry[] = [];
+  const networkEntries: NetworkEntry[] = [];
+  const serverErrorEntries: NetworkEntry[] = [];
+  let lastObservedRequestId = createRequestId(testInfo);
+
+  await page.context().setExtraHTTPHeaders({
+    'X-Request-ID': lastObservedRequestId,
+    'X-Harness-Run-ID': HARNESS_RUN_ID,
+  });
+  await page.addInitScript(harnessRunId => {
+    (window as any).__HARNESS_RUN_ID__ = harnessRunId;
+    window.sessionStorage.setItem('harness_run_id', String(harnessRunId));
+  }, HARNESS_RUN_ID);
+
+  page.on('console', message => {
+    consoleEntries.push({
+      type: message.type(),
+      text: message.text(),
+    });
+    if (consoleEntries.length > 40) {
+      consoleEntries.splice(0, consoleEntries.length - 40);
+    }
+  });
+
+  page.on('response', response => {
+    const request = response.request();
+    const headers = request.headers();
+    const requestIdHeader = headers['x-request-id'];
+    if (requestIdHeader) {
+      lastObservedRequestId = requestIdHeader;
+    }
+    const entry = {
+      method: request.method(),
+      resourceType: request.resourceType(),
+      status: response.status(),
+      url: response.url(),
+      requestId: requestIdHeader || lastObservedRequestId,
+      harnessRunId: headers['x-harness-run-id'] || HARNESS_RUN_ID,
+    };
+    networkEntries.push(entry);
+    if (entry.url.includes('/api/') && entry.status >= 500) {
+      serverErrorEntries.push(entry);
+    }
+    if (networkEntries.length > 60) {
+      networkEntries.splice(0, networkEntries.length - 60);
+    }
+  });
+
+  page.on('requestfailed', request => {
+    networkEntries.push({
+      method: request.method(),
+      resourceType: request.resourceType(),
+      status: null,
+      url: request.url(),
+      requestId: lastObservedRequestId,
+      harnessRunId: HARNESS_RUN_ID,
+    });
+    if (networkEntries.length > 60) {
+      networkEntries.splice(0, networkEntries.length - 60);
+    }
+  });
+
+  return {
+    networkEntries,
+    serverErrorEntries,
+    async captureFailure(failedTestInfo: TestInfo) {
+      if (failedTestInfo.status === failedTestInfo.expectedStatus) {
+        return;
+      }
+
+      await mkdir(failedTestInfo.outputDir, { recursive: true });
+      const screenshotPath = failedTestInfo.outputPath('failure.png');
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+      const diagnosticsPath = failedTestInfo.outputPath(
+        'harness-diagnostics.json',
+      );
+      await writeFile(
+        diagnosticsPath,
+        JSON.stringify(
+          {
+            pageUrl: page.url(),
+            harnessRunId: HARNESS_RUN_ID,
+            lastRequestId: lastObservedRequestId,
+            console: consoleEntries,
+            network: networkEntries.slice(-25),
+            screenshot: screenshotPath,
+            runtimeHarness: buildRuntimeHarnessHints(
+              lastObservedRequestId,
+              diagnosticsPath,
+            ),
+          },
+          null,
+          2,
+        ),
+        'utf-8',
+      );
+    },
+  };
+};

--- a/src/cook-web/e2e/smoke.spec.ts
+++ b/src/cook-web/e2e/smoke.spec.ts
@@ -22,15 +22,17 @@ const waitForLearnerBootstrap = (page: Page, courseId: string) => {
 
   return Promise.all([
     page.waitForResponse(
-      response => matchesCourseRequest(response.url(), 'false'),
+      response =>
+        matchesCourseRequest(response.url(), 'false') && response.ok(),
       { timeout: 20_000 },
     ),
     page.waitForResponse(
-      response => matchesCourseRequest(response.url(), 'true'),
+      response => matchesCourseRequest(response.url(), 'true') && response.ok(),
       { timeout: 20_000 },
     ),
     page.waitForResponse(
-      response => new URL(response.url()).pathname === outlinePath,
+      response =>
+        new URL(response.url()).pathname === outlinePath && response.ok(),
       { timeout: 20_000 },
     ),
   ]);

--- a/src/cook-web/e2e/smoke.spec.ts
+++ b/src/cook-web/e2e/smoke.spec.ts
@@ -1,44 +1,13 @@
-import { expect, Page, TestInfo, test } from '@playwright/test';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { expect, Page, test } from '@playwright/test';
 
-type ConsoleEntry = {
-  type: string;
-  text: string;
-};
-
-type NetworkEntry = {
-  method: string;
-  resourceType: string;
-  status: number | null;
-  url: string;
-  requestId: string;
-  harnessRunId: string;
-};
+import {
+  attachRuntimeHarnessDiagnostics,
+  type NetworkEntry,
+  type RuntimeHarnessDiagnostics,
+} from './harness-diagnostics';
 
 const DEFAULT_DEMO_SHIFU_BID =
   process.env.AI_SHIFU_DEMO_SHIFU_BID || 'b5d7844387e940ed9480a6f945a6db6a';
-const HARNESS_RUN_ID =
-  process.env.AI_SHIFU_HARNESS_RUN_ID || `pw-run-${Date.now()}`;
-
-const createRequestId = (testInfo: TestInfo) =>
-  `pw-${Date.now()}-${testInfo.title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, 32)}`;
-
-const buildRuntimeHarnessHints = (
-  requestId: string,
-  harnessRunId: string,
-  diagnosticsPath: string,
-) => ({
-  requestId,
-  harnessRunId,
-  browserDiagnostics: diagnosticsPath,
-  composeLog: 'artifacts/runtime-harness/compose.log',
-  composeStatus: 'artifacts/runtime-harness/compose-ps.json',
-  investigation: 'Review the uploaded runtime-harness-artifacts bundle.',
-});
 
 const waitForCourseData = async (page: Page, entries: NetworkEntry[]) => {
   if (
@@ -83,108 +52,14 @@ const expectNoServerErrors = (serverErrorEntries: NetworkEntry[]) => {
 };
 
 test.describe('agent-first smoke harness', () => {
-  let consoleEntries: ConsoleEntry[] = [];
-  let networkEntries: NetworkEntry[] = [];
-  let serverErrorEntries: NetworkEntry[] = [];
-  let lastObservedRequestId = '';
+  let diagnostics: RuntimeHarnessDiagnostics;
 
   test.beforeEach(async ({ page }, testInfo) => {
-    consoleEntries = [];
-    networkEntries = [];
-    serverErrorEntries = [];
-
-    const requestId = createRequestId(testInfo);
-    lastObservedRequestId = requestId;
-    await page.context().setExtraHTTPHeaders({
-      'X-Request-ID': requestId,
-      'X-Harness-Run-ID': HARNESS_RUN_ID,
-    });
-    await page.addInitScript(harnessRunId => {
-      (window as any).__HARNESS_RUN_ID__ = harnessRunId;
-      window.sessionStorage.setItem('harness_run_id', String(harnessRunId));
-    }, HARNESS_RUN_ID);
-
-    page.on('console', message => {
-      consoleEntries.push({
-        type: message.type(),
-        text: message.text(),
-      });
-      if (consoleEntries.length > 40) {
-        consoleEntries = consoleEntries.slice(-40);
-      }
-    });
-
-    page.on('response', response => {
-      const request = response.request();
-      const headers = request.headers();
-      const requestIdHeader = headers['x-request-id'];
-      if (requestIdHeader) {
-        lastObservedRequestId = requestIdHeader;
-      }
-      const entry = {
-        method: request.method(),
-        resourceType: request.resourceType(),
-        status: response.status(),
-        url: response.url(),
-        requestId: requestIdHeader || lastObservedRequestId,
-        harnessRunId: headers['x-harness-run-id'] || HARNESS_RUN_ID,
-      };
-      networkEntries.push(entry);
-      if (entry.url.includes('/api/') && entry.status >= 500) {
-        serverErrorEntries.push(entry);
-      }
-      if (networkEntries.length > 60) {
-        networkEntries = networkEntries.slice(-60);
-      }
-    });
-
-    page.on('requestfailed', request => {
-      networkEntries.push({
-        method: request.method(),
-        resourceType: request.resourceType(),
-        status: null,
-        url: request.url(),
-        requestId: lastObservedRequestId,
-        harnessRunId: HARNESS_RUN_ID,
-      });
-      if (networkEntries.length > 60) {
-        networkEntries = networkEntries.slice(-60);
-      }
-    });
+    diagnostics = await attachRuntimeHarnessDiagnostics(page, testInfo);
   });
 
-  test.afterEach(async ({ page }, testInfo) => {
-    if (testInfo.status === testInfo.expectedStatus) {
-      return;
-    }
-
-    await mkdir(testInfo.outputDir, { recursive: true });
-
-    const screenshotPath = testInfo.outputPath('failure.png');
-    await page.screenshot({ path: screenshotPath, fullPage: true });
-
-    const diagnosticsPath = testInfo.outputPath('harness-diagnostics.json');
-    await writeFile(
-      diagnosticsPath,
-      JSON.stringify(
-        {
-          pageUrl: page.url(),
-          harnessRunId: HARNESS_RUN_ID,
-          lastRequestId: lastObservedRequestId,
-          console: consoleEntries,
-          network: networkEntries.slice(-25),
-          screenshot: screenshotPath,
-          runtimeHarness: buildRuntimeHarnessHints(
-            lastObservedRequestId,
-            HARNESS_RUN_ID,
-            diagnosticsPath,
-          ),
-        },
-        null,
-        2,
-      ),
-      'utf-8',
-    );
+  test.afterEach(async ({}, testInfo) => {
+    await diagnostics.captureFailure(testInfo);
   });
 
   test('authenticated admin operations page loads without server errors', async ({
@@ -196,7 +71,7 @@ test.describe('agent-first smoke harness', () => {
     await expect(page.getByTestId('admin-operations-header')).toBeVisible();
     await expect(page.getByTestId('admin-operations-filters')).toBeVisible();
     await adminBootstrap;
-    expectNoServerErrors(serverErrorEntries);
+    expectNoServerErrors(diagnostics.serverErrorEntries);
   });
 
   test('learner course shell loads its first data request without server errors', async ({
@@ -205,7 +80,7 @@ test.describe('agent-first smoke harness', () => {
     const coursePath = `/c/${DEFAULT_DEMO_SHIFU_BID}`;
     await page.goto(coursePath);
     await expect(page.getByTestId('course-chat-page')).toBeVisible();
-    await waitForCourseData(page, networkEntries);
-    expectNoServerErrors(serverErrorEntries);
+    await waitForCourseData(page, diagnostics.networkEntries);
+    expectNoServerErrors(diagnostics.serverErrorEntries);
   });
 });

--- a/src/cook-web/e2e/smoke.spec.ts
+++ b/src/cook-web/e2e/smoke.spec.ts
@@ -17,14 +17,6 @@ type NetworkEntry = {
 
 const DEFAULT_DEMO_SHIFU_BID =
   process.env.AI_SHIFU_DEMO_SHIFU_BID || 'b5d7844387e940ed9480a6f945a6db6a';
-const DEFAULT_GRAFANA_URL =
-  process.env.AI_SHIFU_GRAFANA_URL || 'http://127.0.0.1:3001';
-const DEFAULT_LOKI_URL =
-  process.env.AI_SHIFU_LOKI_URL || 'http://127.0.0.1:3100';
-const DEFAULT_TEMPO_URL =
-  process.env.AI_SHIFU_TEMPO_URL || 'http://127.0.0.1:3200';
-const DEFAULT_PROMETHEUS_URL =
-  process.env.AI_SHIFU_PROMETHEUS_URL || 'http://127.0.0.1:9090';
 const HARNESS_RUN_ID =
   process.env.AI_SHIFU_HARNESS_RUN_ID || `pw-run-${Date.now()}`;
 
@@ -35,21 +27,17 @@ const createRequestId = (testInfo: TestInfo) =>
     .replace(/^-|-$/g, '')
     .slice(0, 32)}`;
 
-const buildObservabilityHints = (
+const buildRuntimeHarnessHints = (
   requestId: string,
   harnessRunId: string,
-  diagnosticsPath?: string,
+  diagnosticsPath: string,
 ) => ({
-  grafana: DEFAULT_GRAFANA_URL,
-  loki: DEFAULT_LOKI_URL,
-  tempo: DEFAULT_TEMPO_URL,
-  prometheus: DEFAULT_PROMETHEUS_URL,
   requestId,
   harnessRunId,
-  diagnosticsCommand: `cd src/api && python scripts/harness_diagnostics.py --request-id ${requestId}`,
-  traceRunCommand: diagnosticsPath
-    ? `python scripts/harness/trace_run.py --run-id ${harnessRunId} --request-id ${requestId} --browser-diagnostics ${diagnosticsPath}`
-    : `python scripts/harness/trace_run.py --run-id ${harnessRunId} --request-id ${requestId}`,
+  browserDiagnostics: diagnosticsPath,
+  composeLog: 'artifacts/runtime-harness/compose.log',
+  composeStatus: 'artifacts/runtime-harness/compose-ps.json',
+  investigation: 'Review the uploaded runtime-harness-artifacts bundle.',
 });
 
 const waitForCourseData = async (page: Page, entries: NetworkEntry[]) => {
@@ -73,30 +61,22 @@ const waitForCourseData = async (page: Page, entries: NetworkEntry[]) => {
   );
 };
 
-const isAdminCourseResponse = (url: string) => {
-  const pathname = new URL(url).pathname;
-  return pathname.endsWith('/shifu/admin/operations/courses');
-};
+const ADMIN_BOOTSTRAP_PATHS = [
+  '/api/shifu/admin/operations/courses',
+  '/api/shifu/admin/operations/courses/overview',
+  '/api/llm/model-list',
+  '/api/shifu/tts/config',
+];
 
-const waitForAdminCourseData = async (page: Page, entries: NetworkEntry[]) => {
-  if (
-    entries.some(
-      entry =>
-        entry.status !== null &&
-        entry.url.includes('/api/') &&
-        isAdminCourseResponse(entry.url),
-    )
-  ) {
-    return;
-  }
-
-  await page.waitForResponse(
-    response => isAdminCourseResponse(response.url()),
-    {
-      timeout: 20_000,
-    },
+const waitForAdminBootstrap = (page: Page) =>
+  Promise.all(
+    ADMIN_BOOTSTRAP_PATHS.map(pathname =>
+      page.waitForResponse(
+        response => new URL(response.url()).pathname === pathname,
+        { timeout: 20_000 },
+      ),
+    ),
   );
-};
 
 const expectNoServerErrors = (serverErrorEntries: NetworkEntry[]) => {
   expect(serverErrorEntries).toEqual([]);
@@ -194,7 +174,7 @@ test.describe('agent-first smoke harness', () => {
           console: consoleEntries,
           network: networkEntries.slice(-25),
           screenshot: screenshotPath,
-          observability: buildObservabilityHints(
+          runtimeHarness: buildRuntimeHarnessHints(
             lastObservedRequestId,
             HARNESS_RUN_ID,
             diagnosticsPath,
@@ -210,11 +190,12 @@ test.describe('agent-first smoke harness', () => {
   test('authenticated admin operations page loads without server errors', async ({
     page,
   }) => {
+    const adminBootstrap = waitForAdminBootstrap(page);
     await page.goto('/admin/operations');
     await expect(page.getByTestId('admin-operations-page')).toBeVisible();
     await expect(page.getByTestId('admin-operations-header')).toBeVisible();
     await expect(page.getByTestId('admin-operations-filters')).toBeVisible();
-    await waitForAdminCourseData(page, networkEntries);
+    await adminBootstrap;
     expectNoServerErrors(serverErrorEntries);
   });
 

--- a/src/cook-web/e2e/smoke.spec.ts
+++ b/src/cook-web/e2e/smoke.spec.ts
@@ -9,25 +9,31 @@ import {
 const DEFAULT_DEMO_SHIFU_BID =
   process.env.AI_SHIFU_DEMO_SHIFU_BID || 'b5d7844387e940ed9480a6f945a6db6a';
 
-const waitForCourseData = async (page: Page, entries: NetworkEntry[]) => {
-  if (
-    entries.some(
-      entry =>
-        entry.url.includes('/api/') &&
-        (entry.url.includes('/shifu/') || entry.url.includes('/learn/')) &&
-        entry.status !== null,
-    )
-  ) {
-    return;
-  }
+const waitForLearnerBootstrap = (page: Page, courseId: string) => {
+  const coursePath = `/api/learn/shifu/${courseId}`;
+  const outlinePath = `${coursePath}/outline-item-tree`;
+  const matchesCourseRequest = (url: string, previewMode: string) => {
+    const parsedUrl = new URL(url);
+    return (
+      parsedUrl.pathname === coursePath &&
+      parsedUrl.searchParams.get('preview_mode') === previewMode
+    );
+  };
 
-  await page.waitForResponse(
-    response =>
-      response.url().includes('/api/') &&
-      (response.url().includes('/shifu/') ||
-        response.url().includes('/learn/')),
-    { timeout: 20_000 },
-  );
+  return Promise.all([
+    page.waitForResponse(
+      response => matchesCourseRequest(response.url(), 'false'),
+      { timeout: 20_000 },
+    ),
+    page.waitForResponse(
+      response => matchesCourseRequest(response.url(), 'true'),
+      { timeout: 20_000 },
+    ),
+    page.waitForResponse(
+      response => new URL(response.url()).pathname === outlinePath,
+      { timeout: 20_000 },
+    ),
+  ]);
 };
 
 const ADMIN_BOOTSTRAP_PATHS = [
@@ -77,10 +83,13 @@ test.describe('agent-first smoke harness', () => {
   test('learner course shell loads its first data request without server errors', async ({
     page,
   }) => {
-    const coursePath = `/c/${DEFAULT_DEMO_SHIFU_BID}`;
-    await page.goto(coursePath);
+    const learnerBootstrap = waitForLearnerBootstrap(
+      page,
+      DEFAULT_DEMO_SHIFU_BID,
+    );
+    await page.goto(`/c/${DEFAULT_DEMO_SHIFU_BID}`);
     await expect(page.getByTestId('course-chat-page')).toBeVisible();
-    await waitForCourseData(page, diagnostics.networkEntries);
+    await learnerBootstrap;
     expectNoServerErrors(diagnostics.serverErrorEntries);
   });
 });

--- a/src/cook-web/e2e/smoke.spec.ts
+++ b/src/cook-web/e2e/smoke.spec.ts
@@ -15,9 +15,6 @@ type NetworkEntry = {
   harnessRunId: string;
 };
 
-const DEFAULT_PHONE = process.env.AI_SHIFU_TEST_PHONE || '13800138000';
-const DEFAULT_OTP = process.env.AI_SHIFU_TEST_OTP || '1024';
-const DEFAULT_CAPTCHA = process.env.AI_SHIFU_TEST_CAPTCHA || '0000';
 const DEFAULT_DEMO_SHIFU_BID =
   process.env.AI_SHIFU_DEMO_SHIFU_BID || 'b5d7844387e940ed9480a6f945a6db6a';
 const DEFAULT_GRAFANA_URL =
@@ -38,25 +35,6 @@ const createRequestId = (testInfo: TestInfo) =>
     .replace(/^-|-$/g, '')
     .slice(0, 32)}`;
 
-const ensurePhoneLoginVisible = async (page: Page) => {
-  const phoneInput = page.locator('#phone');
-  if (await phoneInput.isVisible()) {
-    return phoneInput;
-  }
-
-  const tabs = page.getByRole('tab');
-  const tabCount = await tabs.count();
-  for (let index = 0; index < tabCount; index += 1) {
-    await tabs.nth(index).click();
-    if (await phoneInput.isVisible().catch(() => false)) {
-      return phoneInput;
-    }
-  }
-
-  await expect(phoneInput).toBeVisible();
-  return phoneInput;
-};
-
 const buildObservabilityHints = (
   requestId: string,
   harnessRunId: string,
@@ -73,43 +51,6 @@ const buildObservabilityHints = (
     ? `python scripts/harness/trace_run.py --run-id ${harnessRunId} --request-id ${requestId} --browser-diagnostics ${diagnosticsPath}`
     : `python scripts/harness/trace_run.py --run-id ${harnessRunId} --request-id ${requestId}`,
 });
-
-const loginWithPhone = async (page: Page, redirectPath: string) => {
-  await page.goto(`/login?redirect=${encodeURIComponent(redirectPath)}`);
-  await expect(page.getByTestId('login-page')).toBeVisible();
-
-  const phoneInput = await ensurePhoneLoginVisible(page);
-  await phoneInput.fill(DEFAULT_PHONE);
-
-  const termsCheckbox = page.locator('#terms');
-  if (await termsCheckbox.isVisible()) {
-    await termsCheckbox.click();
-  }
-
-  const captchaInput = page.getByTestId('captcha-input');
-  await expect(captchaInput).toBeVisible();
-  await captchaInput.fill(DEFAULT_CAPTCHA);
-
-  const sendOtpButton = page
-    .locator('#otp')
-    .locator('xpath=ancestor::div[1]/following-sibling::button[1]');
-  await sendOtpButton.click();
-
-  const otpInput = page.locator('#otp');
-  if (
-    await page
-      .getByRole('alertdialog')
-      .isVisible()
-      .catch(() => false)
-  ) {
-    const buttons = page.getByRole('alertdialog').getByRole('button');
-    await buttons.last().click();
-  }
-
-  await expect(otpInput).toBeEnabled();
-  await otpInput.fill(DEFAULT_OTP);
-  await otpInput.press('Enter');
-};
 
 const waitForCourseData = async (page: Page, entries: NetworkEntry[]) => {
   if (
@@ -132,14 +73,45 @@ const waitForCourseData = async (page: Page, entries: NetworkEntry[]) => {
   );
 };
 
+const isAdminCourseResponse = (url: string) => {
+  const pathname = new URL(url).pathname;
+  return pathname.endsWith('/shifu/admin/operations/courses');
+};
+
+const waitForAdminCourseData = async (page: Page, entries: NetworkEntry[]) => {
+  if (
+    entries.some(
+      entry =>
+        entry.status !== null &&
+        entry.url.includes('/api/') &&
+        isAdminCourseResponse(entry.url),
+    )
+  ) {
+    return;
+  }
+
+  await page.waitForResponse(
+    response => isAdminCourseResponse(response.url()),
+    {
+      timeout: 20_000,
+    },
+  );
+};
+
+const expectNoServerErrors = (serverErrorEntries: NetworkEntry[]) => {
+  expect(serverErrorEntries).toEqual([]);
+};
+
 test.describe('agent-first smoke harness', () => {
   let consoleEntries: ConsoleEntry[] = [];
   let networkEntries: NetworkEntry[] = [];
+  let serverErrorEntries: NetworkEntry[] = [];
   let lastObservedRequestId = '';
 
   test.beforeEach(async ({ page }, testInfo) => {
     consoleEntries = [];
     networkEntries = [];
+    serverErrorEntries = [];
 
     const requestId = createRequestId(testInfo);
     lastObservedRequestId = requestId;
@@ -162,27 +134,25 @@ test.describe('agent-first smoke harness', () => {
       }
     });
 
-    page.on('response', async response => {
+    page.on('response', response => {
       const request = response.request();
-      let headers: Record<string, string> = {};
-      try {
-        headers = await request.allHeaders();
-      } catch {
-        // Response callbacks can still settle while Playwright is closing the page.
-        headers = {};
-      }
+      const headers = request.headers();
       const requestIdHeader = headers['x-request-id'];
       if (requestIdHeader) {
         lastObservedRequestId = requestIdHeader;
       }
-      networkEntries.push({
+      const entry = {
         method: request.method(),
         resourceType: request.resourceType(),
         status: response.status(),
         url: response.url(),
         requestId: requestIdHeader || lastObservedRequestId,
         harnessRunId: headers['x-harness-run-id'] || HARNESS_RUN_ID,
-      });
+      };
+      networkEntries.push(entry);
+      if (entry.url.includes('/api/') && entry.status >= 500) {
+        serverErrorEntries.push(entry);
+      }
       if (networkEntries.length > 60) {
         networkEntries = networkEntries.slice(-60);
       }
@@ -237,26 +207,24 @@ test.describe('agent-first smoke harness', () => {
     );
   });
 
-  test('login flow reaches the admin main flow', async ({ page }) => {
-    await loginWithPhone(page, '/admin/operations');
-    await page.waitForURL('**/admin/operations');
+  test('authenticated admin operations page loads without server errors', async ({
+    page,
+  }) => {
+    await page.goto('/admin/operations');
     await expect(page.getByTestId('admin-operations-page')).toBeVisible();
-  });
-
-  test('admin operations page loads', async ({ page }) => {
-    await loginWithPhone(page, '/admin/operations');
-    await page.waitForURL('**/admin/operations');
     await expect(page.getByTestId('admin-operations-header')).toBeVisible();
     await expect(page.getByTestId('admin-operations-filters')).toBeVisible();
+    await waitForAdminCourseData(page, networkEntries);
+    expectNoServerErrors(serverErrorEntries);
   });
 
-  test('learner chat shell renders and completes the first key request', async ({
+  test('learner course shell loads its first data request without server errors', async ({
     page,
   }) => {
     const coursePath = `/c/${DEFAULT_DEMO_SHIFU_BID}`;
-    await loginWithPhone(page, coursePath);
-    await page.waitForURL(`**${coursePath}`);
+    await page.goto(coursePath);
     await expect(page.getByTestId('course-chat-page')).toBeVisible();
     await waitForCourseData(page, networkEntries);
+    expectNoServerErrors(serverErrorEntries);
   });
 });

--- a/src/cook-web/playwright.config.ts
+++ b/src/cook-web/playwright.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from '@playwright/test';
 
 const baseURL = process.env.AI_SHIFU_BASE_URL || 'http://localhost:8080';
+const authStatePath = 'playwright/.auth/runtime-harness-user.json';
 
 export default defineConfig({
   testDir: './e2e',
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: 'list',
@@ -16,4 +17,22 @@ export default defineConfig({
     baseURL,
     trace: 'retain-on-failure',
   },
+  projects: [
+    {
+      name: 'runtime-harness-auth',
+      testMatch: /auth\.setup\.ts/,
+    },
+    {
+      name: 'runtime-harness-smoke',
+      testMatch: /smoke\.spec\.ts/,
+      dependencies: ['runtime-harness-auth'],
+      use: {
+        storageState: authStatePath,
+      },
+    },
+    {
+      name: 'e2e',
+      testIgnore: [/auth\.setup\.ts/, /smoke\.spec\.ts/],
+    },
+  ],
 });


### PR DESCRIPTION
## Summary

- replace the default full-stack Runtime Harness path with an explicit minimal API/Web/MySQL/Redis/Nginx stack
- record phase and endpoint-readiness evidence in an uploaded timeline artifact and job summary
- reuse a verified Playwright phone-login storage state for authenticated smoke paths, while adding zero-5xx assertions
- retain the existing full development stack; deterministic generated-answer and deep observability contracts remain deliberately deferred

## Validation

- `python3 -m pytest scripts/harness/tests/test_runtime_timeline.py`
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npx playwright test --list`
- `lefthook run pre-commit --all-files`

Docker is unavailable in the implementation sandbox, so this PR’s Runtime Harness run is the required final Compose and wall-clock validation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated runtime environment for validating the API, web app, database, and caching services together.
  - Added readiness tracking, endpoint checks, diagnostics, and downloadable execution summaries.

- **Bug Fixes**
  - Improved startup validation, migration handling, and failure reporting.
  - Added clearer diagnostics for failed browser checks.

- **Tests**
  - Added reusable authenticated browser sessions and expanded smoke coverage.

- **Documentation**
  - Documented runtime validation criteria and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->