### PR TITLE
chore: enforce Ruff ANN202

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -186,6 +186,7 @@ select = [
     "ANN002",  # missing type for *args
     "ANN003",  # missing type for **kwargs
     "ANN201",  # missing return type for a public function
+    "ANN202",  # missing return type for a private function
     "ANN204",  # missing return type on a special method
     "ANN205",  # missing return type on a staticmethod
     "ANN206",  # missing return type on a classmethod

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -43,7 +43,7 @@ def load_json(path: Path) -> dict:
 def flatten_translation(data: object, namespace: str) -> dict[str, str]:
     """Flatten nested translation JSON to dot-separated keys."""
 
-    def _flatten(obj: object, prefix: str):
+    def _flatten(obj: object, prefix: str) -> dict[str, str]:
         items: dict[str, str] = {}
         if isinstance(obj, dict):
             # __flat__ allows specifying exact keys without additional nesting

--- a/scripts/update_i18n.py
+++ b/scripts/update_i18n.py
@@ -33,7 +33,7 @@ def load_json(path: Path) -> dict[str, object]:
 def flatten_translation(data: object, namespace: str) -> dict[str, str]:
     """Flatten translation."""
 
-    def _flatten(obj: object, prefix: str, acc: dict[str, str]):
+    def _flatten(obj: object, prefix: str, acc: dict[str, str]) -> dict[str, str]:
         if isinstance(obj, dict):
             flat_section = obj.get("__flat__")
             if isinstance(flat_section, dict):

--- a/src/api/flaskr/api/check/__init__.py
+++ b/src/api/flaskr/api/check/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 
-def check_text(app: Flask, data_id: str, text: str, user_id: str):
+def check_text(app: Flask, data_id: str, text: str, user_id: str) -> CheckResultDTO:
     check_provider = app.config.get("CHECK_PROVIDER")
     if check_provider == "ilivedata":
         return ilivedata_check(app, data_id, text, user_id)

--- a/src/api/flaskr/api/langfuse.py
+++ b/src/api/flaskr/api/langfuse.py
@@ -71,7 +71,7 @@ class MockClient:
     def __getattr__(self, name: object) -> Any:
         """Return a no-op callable for any Langfuse operation."""
 
-        def method(*args: object, **kwargs: object):
+        def method(*args: object, **kwargs: object) -> object:
             _ = (args, kwargs)
             return self
 

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -20,6 +20,7 @@ os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
 
 import litellm
 from flask import Flask, current_app
+from litellm.types.utils import ModelResponseStream
 
 from flaskr.api.langfuse import (
     LangfuseObservationHandle,
@@ -62,7 +63,7 @@ _original_asyncio_run = asyncio.run
 _background_asyncio_tasks: set[asyncio.Task] = set()
 
 
-def _safe_asyncio_run(coro: object, *args: object, **kwargs: object):
+def _safe_asyncio_run(coro: object, *args: object, **kwargs: object) -> Any | None:
     try:
         return _original_asyncio_run(coro, *args, **kwargs)
     except RuntimeError as exc:
@@ -446,7 +447,7 @@ def _stream_litellm_completion(
     messages: list,
     params: dict,
     kwargs: dict,
-):
+) -> Any:
     try:
         # Routed ids are the application-level identity. LiteLLM completion uses
         # the stripped provider model id, which can collide across routes (for
@@ -517,7 +518,7 @@ def _iter_stream_with_precontent_retry(
     messages: list,
     params: dict,
     kwargs: dict,
-):
+) -> Generator[ModelResponseStream, None, None]:
     """Yield litellm stream chunks, re-issuing the request when the stream dies on a connection-level error before any content token arrived.
 
     The built-in openai/litellm retries only cover request setup; an

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -120,7 +120,9 @@ def _resolve_provider_name(provider_name: str = "") -> str:
     return normalized or _auto_detect_provider_name()
 
 
-def _iter_provider_classes(*, include_explicit_only: bool = True) -> Iterator[tuple[str, type[BaseTTSProvider]]]:
+def _iter_provider_classes(
+    *, include_explicit_only: bool = True
+) -> Iterator[tuple[str, type[BaseTTSProvider]]]:
     provider_priority = (
         _PROVIDER_PRIORITY if include_explicit_only else _AUTO_DETECT_PROVIDER_PRIORITY
     )

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -14,6 +14,7 @@ The provider can be selected per-Shifu configuration.
 import contextlib
 import json
 import logging
+from collections.abc import Iterator
 from decimal import Decimal, InvalidOperation
 
 from flask import has_request_context, request
@@ -119,7 +120,7 @@ def _resolve_provider_name(provider_name: str = "") -> str:
     return normalized or _auto_detect_provider_name()
 
 
-def _iter_provider_classes(*, include_explicit_only: bool = True):
+def _iter_provider_classes(*, include_explicit_only: bool = True) -> Iterator[tuple[str, type[BaseTTSProvider]]]:
     provider_priority = (
         _PROVIDER_PRIORITY if include_explicit_only else _AUTO_DETECT_PROVIDER_PRIORITY
     )
@@ -297,7 +298,7 @@ def _parse_tts_display_names() -> dict:
     return normalized
 
 
-def _iter_tts_display_language_candidates():
+def _iter_tts_display_language_candidates() -> Iterator[str]:
     if has_request_context():
         for value in (
             request.args.get("language"),

--- a/src/api/flaskr/api/tts/volcengine_provider.py
+++ b/src/api/flaskr/api/tts/volcengine_provider.py
@@ -512,7 +512,7 @@ class VolcengineTTSProvider(BaseTTSProvider):
 
         protocol = VolcengineProtocol()
 
-        def on_message(ws: object, message: object):
+        def on_message(ws: object, message: object) -> None:
             _ = ws
             nonlocal error_message, total_duration_ms
 
@@ -596,7 +596,7 @@ class VolcengineTTSProvider(BaseTTSProvider):
                 session_started.set()
                 session_finished.set()
 
-        def on_error(ws: object, error: object):
+        def on_error(ws: object, error: object) -> None:
             _ = ws
             nonlocal error_message
             error_message = str(error)
@@ -605,13 +605,13 @@ class VolcengineTTSProvider(BaseTTSProvider):
             session_started.set()
             session_finished.set()
 
-        def on_close(ws: object, close_status_code: object, close_msg: object):
+        def on_close(ws: object, close_status_code: object, close_msg: object) -> None:
             _ = ws
             logger.debug("WebSocket closed: %s - %s", close_status_code, close_msg)
             connection_established.set()
             session_finished.set()
 
-        def on_open(ws: object):
+        def on_open(ws: object) -> None:
             logger.debug("WebSocket opened, sending StartConnection")
             # Send StartConnection
             ws.send(

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -36,7 +36,7 @@ def enable_commands(app: Flask) -> None:
     """Register the application's command-line commands."""
 
     @app.cli.group()
-    def console():
+    def console() -> None:
         """AI Shifu Console management commands."""
 
     register_billing_commands(console)
@@ -49,7 +49,7 @@ def enable_commands(app: Flask) -> None:
     @click.argument("user_nick_name")
     def import_user_command(
         mobile: object, course_id: object, discount_code: object, user_nick_name: object
-    ):
+    ) -> None:
         """Import user and enable course."""
         import_user(app, mobile, course_id, discount_code, user_nick_name)
 
@@ -71,7 +71,7 @@ def enable_commands(app: Flask) -> None:
         force_full: object,
         output_file: object,
         dry_run: object,
-    ):
+    ) -> None:
         """Run unified legacy data migration."""
         setup_migration_logging()
         logger = logging.getLogger(__name__)
@@ -190,7 +190,7 @@ def enable_commands(app: Flask) -> None:
             raise click.ClickException(error_message)
 
     @console.command(name="verify")
-    def verify_command():
+    def verify_command() -> None:
         """Verify data consistency between old and new tables."""
         setup_migration_logging()
         logger = logging.getLogger(__name__)
@@ -246,7 +246,7 @@ def enable_commands(app: Flask) -> None:
                 migration_task.close()
 
     @console.command(name="status")
-    def status_command():
+    def status_command() -> None:
         """Show migration status and table counts."""
         setup_migration_logging()
         logger = logging.getLogger(__name__)
@@ -333,7 +333,7 @@ def enable_commands(app: Flask) -> None:
     @console.command(name="export_shifu")
     @click.argument("shifu_id")
     @click.argument("file_path")
-    def export_shifu_command(shifu_id: object, file_path: object):
+    def export_shifu_command(shifu_id: object, file_path: object) -> None:
         """Export a shifu to a JSON file.
 
         Args:
@@ -371,7 +371,7 @@ def enable_commands(app: Flask) -> None:
     @click.option(
         "--user-id", required=True, help="User ID for creating/updating the shifu"
     )
-    def import_shifu_command(file_path: object, shifu_id: object, user_id: object):
+    def import_shifu_command(file_path: object, shifu_id: object, user_id: object) -> None:
         """Import a shifu from a JSON file.
 
         Args:
@@ -425,7 +425,7 @@ def enable_commands(app: Flask) -> None:
             raise click.ClickException(message) from e
 
     @console.command(name="update_demo_shifu")
-    def update_demo_shifu_command():
+    def update_demo_shifu_command() -> None:
         """Update demo shifu."""
         app.logger.info("Updating demo shifu...")
         update_demo_shifu(app)

--- a/src/api/flaskr/command/__init__.py
+++ b/src/api/flaskr/command/__init__.py
@@ -371,7 +371,9 @@ def enable_commands(app: Flask) -> None:
     @click.option(
         "--user-id", required=True, help="User ID for creating/updating the shifu"
     )
-    def import_shifu_command(file_path: object, shifu_id: object, user_id: object) -> None:
+    def import_shifu_command(
+        file_path: object, shifu_id: object, user_id: object
+    ) -> None:
         """Import a shifu from a JSON file.
 
         Args:

--- a/src/api/flaskr/command/unified_migration_task.py
+++ b/src/api/flaskr/command/unified_migration_task.py
@@ -894,7 +894,7 @@ class UnifiedMigrationTask:
             logger.warning("Error getting last synced ID: %s", e)
             return 0
 
-    def _update_sync_time(self, sync_type: str, sync_time: datetime):
+    def _update_sync_time(self, sync_type: str, sync_time: datetime) -> None:
         """Update sync time in log table."""
         session = self.SessionClass()
         try:
@@ -904,7 +904,7 @@ class UnifiedMigrationTask:
 
     def _update_sync_time_with_session(
         self, session: object, sync_type: str, sync_time: datetime
-    ):
+    ) -> None:
         """Update sync time in log table using provided session."""
         try:
             self._ensure_sync_log_table_with_session(session)
@@ -921,7 +921,7 @@ class UnifiedMigrationTask:
 
     def _update_last_synced_id_with_session(
         self, session: object, sync_type: str, last_synced_id: int
-    ):
+    ) -> None:
         """Update last synced ID in log table using provided session."""
         try:
             self._ensure_sync_log_table_with_session(session)
@@ -936,7 +936,7 @@ class UnifiedMigrationTask:
         except Exception as e:
             logger.warning("Error updating last synced ID: %s", e)
 
-    def _ensure_sync_log_table(self):
+    def _ensure_sync_log_table(self) -> None:
         """Ensure sync log table exists."""
         session = self.SessionClass()
         try:
@@ -944,7 +944,7 @@ class UnifiedMigrationTask:
         finally:
             session.close()
 
-    def _ensure_sync_log_table_with_session(self, session: object):
+    def _ensure_sync_log_table_with_session(self, session: object) -> None:
         """Ensure sync log table exists using provided session."""
         try:
             session.execute(

--- a/src/api/flaskr/command/update_shifu_demo.py
+++ b/src/api/flaskr/command/update_shifu_demo.py
@@ -98,7 +98,7 @@ def _process_demo_shifu(
     return shifu_bid
 
 
-def _ensure_creator_permissions(app: Flask, shifu_bid: str):
+def _ensure_creator_permissions(app: Flask, shifu_bid: str) -> None:
     """Ensure all creator users have permissions for the given shifu.
 
     Args:

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -152,7 +152,9 @@ class _InMemoryLock:
         self._lock = lock
         self._held = False
 
-    def acquire(self, blocking: bool = True, blocking_timeout: int | None = None) -> bool:
+    def acquire(
+        self, blocking: bool = True, blocking_timeout: int | None = None
+    ) -> bool:
         if not blocking:
             acquired = self._lock.acquire(blocking=False)
         elif blocking_timeout is None:

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -124,8 +124,8 @@ class _DynamicRedisCacheProvider:
     def delete(self, *keys: str) -> int:
         return int(self._client().delete(*keys))
 
-    def incr(self, key: str, amount: int = 1) -> object:
-        return self._client().incr(key, amount)
+    def incr(self, key: str, amount: int = 1) -> int:
+        return int(self._client().incr(key, amount))
 
     def ttl(self, key: str) -> int:
         return int(self._client().ttl(key))
@@ -268,7 +268,7 @@ class InMemoryCacheProvider:
                     self._store.pop(key, None)
         return deleted
 
-    def incr(self, key: str, amount: int = 1) -> object:
+    def incr(self, key: str, amount: int = 1) -> int:
         """Increment the integer stored under a cache key."""
         with self._mu:
             self._purge_if_expired(key)
@@ -368,9 +368,9 @@ class FallbackCacheProvider:
         """Delete values for the supplied keys."""
         return int(self._call("delete", *keys))
 
-    def incr(self, key: str, amount: int = 1) -> object:
+    def incr(self, key: str, amount: int = 1) -> int:
         """Increment the integer stored under a cache key."""
-        return self._call("incr", key, amount)
+        return int(self._call("incr", key, amount))
 
     def ttl(self, key: str) -> int:
         """Return the remaining lifetime of a cache key."""

--- a/src/api/flaskr/common/cache_provider.py
+++ b/src/api/flaskr/common/cache_provider.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from redis import Redis
 
 
 @runtime_checkable
@@ -80,7 +83,7 @@ class CacheUnavailableError(RuntimeError):
 
 
 class _DynamicRedisCacheProvider:
-    def _client(self):
+    def _client(self) -> Redis:
         try:
             from flaskr.dao import get_redis_client
         except Exception as exc:  # pragma: no cover - defensive
@@ -93,10 +96,10 @@ class _DynamicRedisCacheProvider:
             raise CacheUnavailableError(message)
         return redis_client
 
-    def get(self, key: str):
+    def get(self, key: str) -> object:
         return self._client().get(key)
 
-    def getex(self, key: str, ex: int | None = None, px: int | None = None):
+    def getex(self, key: str, ex: int | None = None, px: int | None = None) -> object:
         return self._client().getex(key, ex=ex, px=px)
 
     def set(
@@ -109,19 +112,19 @@ class _DynamicRedisCacheProvider:
         xx: bool = False,
         *args: object,
         **kwargs: object,
-    ):
+    ) -> object:
         if ex is None and args:
             ex = args[0]
             args = ()
         return self._client().set(key, value, ex=ex, px=px, nx=nx, xx=xx, **kwargs)
 
-    def setex(self, key: str, time_in_seconds: int, value: Any):
+    def setex(self, key: str, time_in_seconds: int, value: Any) -> object:
         return self._client().setex(key, time_in_seconds, value)
 
     def delete(self, *keys: str) -> int:
         return int(self._client().delete(*keys))
 
-    def incr(self, key: str, amount: int = 1):
+    def incr(self, key: str, amount: int = 1) -> object:
         return self._client().incr(key, amount)
 
     def ttl(self, key: str) -> int:
@@ -132,7 +135,7 @@ class _DynamicRedisCacheProvider:
         key: str,
         timeout: int | None = None,
         blocking_timeout: int | None = None,
-    ):
+    ) -> CacheLock:
         return self._client().lock(
             key, timeout=timeout, blocking_timeout=blocking_timeout
         )
@@ -149,7 +152,7 @@ class _InMemoryLock:
         self._lock = lock
         self._held = False
 
-    def acquire(self, blocking: bool = True, blocking_timeout: int | None = None):
+    def acquire(self, blocking: bool = True, blocking_timeout: int | None = None) -> bool:
         if not blocking:
             acquired = self._lock.acquire(blocking=False)
         elif blocking_timeout is None:
@@ -312,7 +315,7 @@ class FallbackCacheProvider:
         self._primary = primary
         self._fallback = fallback
 
-    def _call(self, method: str, *args: object, **kwargs: object):
+    def _call(self, method: str, *args: object, **kwargs: object) -> object:
         primary_fn = getattr(self._primary, method)
         fallback_fn = getattr(self._fallback, method)
         try:

--- a/src/api/flaskr/common/celery_app.py
+++ b/src/api/flaskr/common/celery_app.py
@@ -203,7 +203,7 @@ def _resolve_billing_crontab(
     flask_app: Flask,
     config_key: str,
     default_expression: str,
-):
+) -> crontab:
     # Raw env fallback for Flask apps not backed by the registry Config; the
     # BILLING_*_CRON keys are declared in flaskr/common/config.py.
     raw_expression = str(
@@ -226,7 +226,7 @@ def _resolve_billing_crontab(
     return fallback_schedule
 
 
-def _parse_crontab_expression(expression: str):
+def _parse_crontab_expression(expression: str) -> crontab | None:
     normalized_expression = " ".join(str(expression or "").split())
     parts = normalized_expression.split(" ")
     if len(parts) != 5 or any(not part for part in parts):

--- a/src/api/flaskr/common/gevent_hub_observer.py
+++ b/src/api/flaskr/common/gevent_hub_observer.py
@@ -55,7 +55,7 @@ def install_hub_error_observer(logger: object, hub: object = None) -> bool:
 
     original_handle_error = hub.handle_error
 
-    def handle_error(context: object, exc_type: object, value: object, tb: object):
+    def handle_error(context: object, exc_type: object, value: object, tb: object) -> object:
         # Log BEFORE delegating: the original handler may re-raise for
         # system errors. Nothing in here may raise or block - a failure in
         # the error path would take down the hub itself.

--- a/src/api/flaskr/common/gevent_hub_observer.py
+++ b/src/api/flaskr/common/gevent_hub_observer.py
@@ -55,7 +55,9 @@ def install_hub_error_observer(logger: object, hub: object = None) -> bool:
 
     original_handle_error = hub.handle_error
 
-    def handle_error(context: object, exc_type: object, value: object, tb: object) -> object:
+    def handle_error(
+        context: object, exc_type: object, value: object, tb: object
+    ) -> object:
         # Log BEFORE delegating: the original handler may re-raise for
         # system errors. Nothing in here may raise or block - a failure in
         # the error path would take down the hub itself.

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -13,7 +13,7 @@ from typing import Any
 import colorlog
 import pytz
 import requests
-from flask import Flask, request
+from flask import Flask, Response, request
 
 from .observability import current_trace_ids
 from .request_context import thread_local
@@ -206,7 +206,7 @@ def init_log(app: Flask) -> Flask:
             app.logger.info("Request method: %s", request.method)
 
     @app.after_request
-    def after_request(response: object) -> object:
+    def after_request(response: Response) -> Response:
         try:
             _update_request_timing(response.status_code)
             if response.headers.get(

--- a/src/api/flaskr/common/log.py
+++ b/src/api/flaskr/common/log.py
@@ -172,7 +172,7 @@ def init_log(app: Flask) -> Flask:
     """Configure request-aware application logging."""
 
     @app.before_request
-    def setup_logging():
+    def setup_logging() -> None:
         request_id = request.headers.get("X-Request-ID", uuid.uuid4().hex)
         thread_local.request_id = request_id
         thread_local.url = request.path
@@ -206,7 +206,7 @@ def init_log(app: Flask) -> Flask:
             app.logger.info("Request method: %s", request.method)
 
     @app.after_request
-    def after_request(response: object):
+    def after_request(response: object) -> object:
         try:
             _update_request_timing(response.status_code)
             if response.headers.get(
@@ -215,7 +215,7 @@ def init_log(app: Flask) -> Flask:
                 app.logger.info("Response: <SSE streaming response>")
 
                 @response.call_on_close
-                def log_sse_end():
+                def log_sse_end() -> None:
                     app.logger.info("SSE Response: <streaming ended>")
 
                 return response

--- a/src/api/flaskr/common/observability.py
+++ b/src/api/flaskr/common/observability.py
@@ -84,7 +84,7 @@ def init_observability(app: Flask) -> Flask:
         tracer = None
 
     @app.before_request
-    def _start_request_observability():
+    def _start_request_observability() -> None:
         request_id = request.headers.get("X-Request-ID", "") or getattr(
             thread_local, "request_id", ""
         )
@@ -114,7 +114,7 @@ def init_observability(app: Flask) -> Flask:
         set_thread_local_trace_ids()
 
     @app.after_request
-    def _finalize_request_observability(response: object):
+    def _finalize_request_observability(response: object) -> object:
         duration_ms = _record_request_metrics(response.status_code)
         span = getattr(g, "_ai_shifu_observability_span", None)
         if span is not None:
@@ -136,7 +136,7 @@ def init_observability(app: Flask) -> Flask:
         return response
 
     @app.teardown_request
-    def _teardown_request_observability(error: Exception | None):
+    def _teardown_request_observability(error: Exception | None) -> None:
         if error is None:
             return
         span = getattr(g, "_ai_shifu_observability_span", None)
@@ -145,11 +145,11 @@ def init_observability(app: Flask) -> Flask:
             span.set_status(Status(StatusCode.ERROR, str(error)))
 
     @app.route(metrics_path, methods=["GET"])
-    def metrics_handler():
+    def metrics_handler() -> object:
         return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
 
     @app.route(health_path, methods=["GET"])
-    def observability_health_handler():
+    def observability_health_handler() -> object:
         return jsonify(
             {
                 "ok": True,

--- a/src/api/flaskr/common/observability.py
+++ b/src/api/flaskr/common/observability.py
@@ -114,7 +114,7 @@ def init_observability(app: Flask) -> Flask:
         set_thread_local_trace_ids()
 
     @app.after_request
-    def _finalize_request_observability(response: object) -> object:
+    def _finalize_request_observability(response: Response) -> Response:
         duration_ms = _record_request_metrics(response.status_code)
         span = getattr(g, "_ai_shifu_observability_span", None)
         if span is not None:
@@ -145,11 +145,11 @@ def init_observability(app: Flask) -> Flask:
             span.set_status(Status(StatusCode.ERROR, str(error)))
 
     @app.route(metrics_path, methods=["GET"])
-    def metrics_handler() -> object:
+    def metrics_handler() -> Response:
         return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
 
     @app.route(health_path, methods=["GET"])
-    def observability_health_handler() -> object:
+    def observability_health_handler() -> Response:
         return jsonify(
             {
                 "ok": True,

--- a/src/api/flaskr/common/shifu_context.py
+++ b/src/api/flaskr/common/shifu_context.py
@@ -173,7 +173,7 @@ def with_shifu_context(
 
     def decorator(func: Callable) -> Callable:
         @wraps(func)
-        def wrapper(*args: object, **kwargs: object):
+        def wrapper(*args: object, **kwargs: object) -> object:
             try:
                 from flask import current_app, request
             except Exception:

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -137,7 +137,7 @@ def _socket_has_unread_data(dbapi_connection: object, timeout: float = 0) -> boo
 _CHECKIN_PROBE_GRACE_SECONDS = 0.002
 
 
-def _server_thread_id(dbapi_connection: object) -> object:
+def _server_thread_id(dbapi_connection: object) -> int | None:
     """Best-effort MySQL server-side connection id for log correlation."""
     try:
         return dbapi_connection.thread_id()
@@ -335,7 +335,7 @@ MYSQL_DEADLOCK_ERRNO = 1213
 MYSQL_LOCK_WAIT_TIMEOUT_ERRNO = 1205
 
 
-def _operational_errno(exc: OperationalError) -> object:
+def _operational_errno(exc: OperationalError) -> int | None:
     orig = getattr(exc, "orig", None)
     args = getattr(orig, "args", None)
     return args[0] if args else None

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -533,7 +533,7 @@ def retry_on_deadlock(
     that connection.
     """
 
-    def decorator(func: object) -> Callable[P, R]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @functools.wraps(func)
         def wrapper(*args: object, **kwargs: object) -> R:
             attempt = 0

--- a/src/api/flaskr/dao/__init__.py
+++ b/src/api/flaskr/dao/__init__.py
@@ -137,7 +137,7 @@ def _socket_has_unread_data(dbapi_connection: object, timeout: float = 0) -> boo
 _CHECKIN_PROBE_GRACE_SECONDS = 0.002
 
 
-def _server_thread_id(dbapi_connection: object):
+def _server_thread_id(dbapi_connection: object) -> object:
     """Best-effort MySQL server-side connection id for log correlation."""
     try:
         return dbapi_connection.thread_id()
@@ -145,7 +145,7 @@ def _server_thread_id(dbapi_connection: object):
         return None
 
 
-def _pool_diagnostics_logger():
+def _pool_diagnostics_logger() -> logging.Logger:
     """Log through the app logger when available.
 
     The app logger carries the RequestFormatter (request-id / trace context)
@@ -166,7 +166,7 @@ def _pool_diagnostics_logger():
 @event.listens_for(sa_pool.Pool, "checkin")
 def _invalidate_desynced_connection_on_checkin(
     dbapi_connection: object, connection_record: object
-):
+) -> None:
     if dbapi_connection is None:
         return
     if _socket_has_unread_data(dbapi_connection, timeout=_CHECKIN_PROBE_GRACE_SECONDS):
@@ -190,7 +190,7 @@ def _invalidate_desynced_connection_on_checkin(
 @event.listens_for(sa_pool.Pool, "checkout")
 def _reject_desynced_connection_on_checkout(
     dbapi_connection: object, connection_record: object, connection_proxy: object
-):
+) -> None:
     _ = connection_proxy
     if _socket_has_unread_data(dbapi_connection):
         _pool_diagnostics_logger().warning(
@@ -279,7 +279,7 @@ def _intercept_desync_before_execute(
     parameters: object,
     context: object,
     executemany: object,
-):
+) -> None:
     _ = (cursor, parameters, context, executemany)
     dbapi_connection = getattr(conn.connection, "dbapi_connection", None)
     if dbapi_connection is None:
@@ -316,7 +316,7 @@ def _journal_statement_after_execute(
     parameters: object,
     context: object,
     executemany: object,
-):
+) -> None:
     _ = (parameters, context, executemany)
     with contextlib.suppress(Exception):
         _statement_journal(conn).append(
@@ -335,7 +335,7 @@ MYSQL_DEADLOCK_ERRNO = 1213
 MYSQL_LOCK_WAIT_TIMEOUT_ERRNO = 1205
 
 
-def _operational_errno(exc: OperationalError):
+def _operational_errno(exc: OperationalError) -> object:
     orig = getattr(exc, "orig", None)
     args = getattr(orig, "args", None)
     return args[0] if args else None
@@ -533,9 +533,9 @@ def retry_on_deadlock(
     that connection.
     """
 
-    def decorator(func: object):
+    def decorator(func: object) -> Callable[P, R]:
         @functools.wraps(func)
-        def wrapper(*args: object, **kwargs: object):
+        def wrapper(*args: object, **kwargs: object) -> R:
             attempt = 0
             while True:
                 try:
@@ -642,14 +642,14 @@ def init_db(app: Flask) -> None:
     # REVERSE registration order, so registering AFTER db.init_app makes
     # this run BEFORE the extension's session removal.
     @app.teardown_appcontext
-    def _invalidate_session_on_interrupted_teardown(exc: object):
+    def _invalidate_session_on_interrupted_teardown(exc: object) -> None:
         if exc is not None and is_abnormal_stream_termination(exc):
             invalidate_session(source="appcontext teardown interrupt")
 
     # Enable formatted SQL output in the development environment
     if app.debug:
 
-        def setup_sql_logging():
+        def setup_sql_logging() -> None:
             @event.listens_for(db.engine, "before_cursor_execute")
             def before_cursor_execute(
                 conn: object,
@@ -658,7 +658,7 @@ def init_db(app: Flask) -> None:
                 parameters: object,
                 context: object,
                 executemany: object,
-            ):
+            ) -> None:
                 _ = (conn, cursor, context, executemany)
                 stack = traceback.extract_stack()
                 project_root = str((Path(__file__).parent / "../../../").resolve())

--- a/src/api/flaskr/framework/plugin/base.py
+++ b/src/api/flaskr/framework/plugin/base.py
@@ -20,7 +20,7 @@ class BasePlugin:
         if self.migration_dir:
             self._run_migrations()
 
-    def _run_migrations(self):
+    def _run_migrations(self) -> None:
         """Run the plugin migrations."""
         from alembic import command
         from alembic.config import Config

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -96,7 +96,9 @@ def enable_plugins(app: Flask) -> None:
 
         return alembic_cfg
 
-    def get_plugin_include_object(plugin_name: str) -> Callable[[object, object, object, object, object], bool]:
+    def get_plugin_include_object(
+        plugin_name: str,
+    ) -> Callable[[object, object, object, object, object], bool]:
         """Generate plugin model filter function."""
 
         def include_object(

--- a/src/api/flaskr/framework/plugin/enable_plugin.py
+++ b/src/api/flaskr/framework/plugin/enable_plugin.py
@@ -2,6 +2,7 @@
 
 import shutil
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 
 import click
@@ -10,6 +11,7 @@ from alembic.config import Config
 from flask import Flask
 from flask.cli import with_appcontext
 
+from .base import BasePlugin
 from .plugin_manager import get_plugin_manager
 
 
@@ -21,12 +23,12 @@ def enable_plugins(app: Flask) -> None:
         raise RuntimeError(message)
 
     @app.cli.group()
-    def plugin():
+    def plugin() -> None:
         """Plugin management commands."""
 
     @plugin.command(name="add")
     @click.argument("repo_url")
-    def add(repo_url: str):
+    def add(repo_url: str) -> None:
         """Add a plugin by cloning the repository."""
         repo_name = repo_url.rsplit("/", maxsplit=1)[-1].replace(".git", "")
         dest_dir = str(Path("flaskr") / "plugins" / repo_name)
@@ -41,7 +43,7 @@ def enable_plugins(app: Flask) -> None:
 
     @plugin.command(name="delete")
     @click.argument("repo_name")
-    def delete(repo_name: str):
+    def delete(repo_name: str) -> None:
         """Delete a plugin by its repository name."""
         dest_dir = str(Path("flaskr") / "plugins" / repo_name)
         if not Path(dest_dir).exists():
@@ -49,7 +51,7 @@ def enable_plugins(app: Flask) -> None:
         shutil.rmtree(dest_dir)
 
     @plugin.command(name="list")
-    def list_plugins():
+    def list_plugins() -> None:
         """List all plugins."""
         plugins_dir = str(Path("flaskr") / "plugins")
         plugins = [path.name for path in Path(plugins_dir).iterdir() if path.is_dir()]
@@ -57,7 +59,7 @@ def enable_plugins(app: Flask) -> None:
             if plugin == "__pycache__":
                 continue
 
-    def get_plugin_migrations():
+    def get_plugin_migrations() -> list[BasePlugin]:
         """Get plugin migrations."""
         plugins = []
         app.logger.info(
@@ -72,7 +74,7 @@ def enable_plugins(app: Flask) -> None:
         return plugins
 
     @plugin.group(name="db")
-    def plugin_db():
+    def plugin_db() -> None:
         """Manage the plugin database."""
 
     def get_version_table_name(plugin_name: str) -> str:
@@ -94,7 +96,7 @@ def enable_plugins(app: Flask) -> None:
 
         return alembic_cfg
 
-    def get_plugin_include_object(plugin_name: str):
+    def get_plugin_include_object(plugin_name: str) -> Callable[[object, object, object, object, object], bool]:
         """Generate plugin model filter function."""
 
         def include_object(
@@ -103,7 +105,7 @@ def enable_plugins(app: Flask) -> None:
             type_: object,
             reflected: object,
             compare_to: object,
-        ):
+        ) -> bool:
             _ = (name, reflected, compare_to)
             if type_ == "table":
                 return db_object.__module__.startswith(f"flaskr.plugins.{plugin_name}")
@@ -114,7 +116,7 @@ def enable_plugins(app: Flask) -> None:
     @plugin_db.command(name="upgrade")
     @click.argument("plugin_name", required=False)
     @with_appcontext
-    def upgrade(plugin_name: object):
+    def upgrade(plugin_name: object) -> None:
         """Upgrade the plugin database to the latest version."""
         plugins = get_plugin_migrations()
 
@@ -131,7 +133,7 @@ def enable_plugins(app: Flask) -> None:
     @plugin_db.command(name="history")
     @click.argument("plugin_name")
     @with_appcontext
-    def history(plugin_name: object):
+    def history(plugin_name: object) -> None:
         """View the migration history of the plugin."""
         plugins = get_plugin_migrations()
         for plugin in plugins:
@@ -147,7 +149,7 @@ def enable_plugins(app: Flask) -> None:
     @plugin_db.command(name="migrate")
     @click.argument("plugin_name")
     @with_appcontext
-    def migrate(plugin_name: object):
+    def migrate(plugin_name: object) -> None:
         """Migrate the plugin database to the latest version."""
         plugins = get_plugin_migrations()
         for plugin in plugins:

--- a/src/api/flaskr/framework/plugin/hot_reload.py
+++ b/src/api/flaskr/framework/plugin/hot_reload.py
@@ -53,7 +53,7 @@ class PluginHotReloader:
         except Exception:
             self.app.logger.exception("Hot reload plugin failed: %s", plugin_path)
 
-    def _unload_plugin(self, plugin_path: str):
+    def _unload_plugin(self, plugin_path: str) -> None:
         """Unload a plugin and clean up its resources.
 
         Args:
@@ -102,7 +102,7 @@ class PluginHotReloader:
         except Exception:
             self.app.logger.exception("Failed to unload plugin %s", plugin_path)
 
-    def _register_plugin(self, module: object):
+    def _register_plugin(self, module: object) -> None:
         """Register a newly loaded plugin.
 
         Args:

--- a/src/api/flaskr/framework/plugin/inject.py
+++ b/src/api/flaskr/framework/plugin/inject.py
@@ -13,7 +13,7 @@ def inject(func: Callable[P, R]) -> Callable[P, R]:
     """Inject a plugin callback at the requested extension point."""
 
     @wraps(func)
-    def wrapper(*args: object, **kwargs: object):
+    def wrapper(*args: object, **kwargs: object) -> R:
         app = kwargs.get("app")
         if app:
             with app.app_context():

--- a/src/api/flaskr/framework/plugin/load_plugin.py
+++ b/src/api/flaskr/framework/plugin/load_plugin.py
@@ -25,7 +25,7 @@ def load_plugins_from_dir(
     plugins = []
     app.logger.info("load modules from: %s", plugins_dir)
 
-    def load_from_directory(directory: object, plugin_manager: PluginManager = None):
+    def load_from_directory(directory: object, plugin_manager: PluginManager = None) -> None:
         files = [path.name for path in Path(directory).iterdir()]
         plugin_obj = None
         if SRC_DIR in files:

--- a/src/api/flaskr/framework/plugin/load_plugin.py
+++ b/src/api/flaskr/framework/plugin/load_plugin.py
@@ -25,7 +25,9 @@ def load_plugins_from_dir(
     plugins = []
     app.logger.info("load modules from: %s", plugins_dir)
 
-    def load_from_directory(directory: object, plugin_manager: PluginManager = None) -> None:
+    def load_from_directory(
+        directory: object, plugin_manager: PluginManager = None
+    ) -> None:
         files = [path.name for path in Path(directory).iterdir()]
         plugin_obj = None
         if SRC_DIR in files:

--- a/src/api/flaskr/framework/plugin/plugin_manager.py
+++ b/src/api/flaskr/framework/plugin/plugin_manager.py
@@ -144,7 +144,7 @@ def disable_plugin_manager(app: Flask) -> Flask:
 def extension(target_func_name: object) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorate a function with registered extension callbacks."""
 
-    def decorator(func: object) -> Callable[P, R]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         manager = get_plugin_manager()
         if manager is None:
             message = "Plugin manager is not enabled"

--- a/src/api/flaskr/framework/plugin/plugin_manager.py
+++ b/src/api/flaskr/framework/plugin/plugin_manager.py
@@ -144,7 +144,7 @@ def disable_plugin_manager(app: Flask) -> Flask:
 def extension(target_func_name: object) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorate a function with registered extension callbacks."""
 
-    def decorator(func: object):
+    def decorator(func: object) -> Callable[P, R]:
         manager = get_plugin_manager()
         if manager is None:
             message = "Plugin manager is not enabled"
@@ -160,7 +160,7 @@ def extensible_generic_register(
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Register a generic extension point."""
 
-    def decorator(func: object):
+    def decorator(func: object) -> Callable[P, R]:
         manager = get_plugin_manager()
         if manager is None:
             message = "Plugin manager is not enabled"
@@ -176,7 +176,7 @@ def extensible(func: Callable[P, R]) -> Callable[P, R]:
     """Decorate a function as an extension point."""
 
     @wraps(func)
-    def wrapper(*args: object, **kwargs: object):
+    def wrapper(*args: object, **kwargs: object) -> R:
         result = func(*args, **kwargs)
         manager = get_plugin_manager()
         if manager is None:
@@ -200,7 +200,7 @@ def extensible_generic(
         pass
 
     @wraps(func)
-    def wrapper(*args: object, **kwargs: object):
+    def wrapper(*args: object, **kwargs: object) -> Generator[object, None, None]:
         result = func(*args, **kwargs)
         if result:
             yield from result

--- a/src/api/flaskr/i18n/__init__.py
+++ b/src/api/flaskr/i18n/__init__.py
@@ -43,7 +43,7 @@ def _shared_json_root() -> Path:
     return Path(__file__).resolve().parents[2] / "i18n"
 
 
-def _flatten_dict(data: object, prefix: str = ""):
+def _flatten_dict(data: object, prefix: str = "") -> dict[str, object]:
     if not isinstance(data, dict):
         key = prefix or ""
         return {key: data} if key else {}
@@ -59,14 +59,14 @@ def _flatten_dict(data: object, prefix: str = ""):
     return flattened
 
 
-def _store_translation(lang: str, key: str, value: object):
+def _store_translation(lang: str, key: str, value: object) -> None:
     if value is None:
         return
     _translations[lang][key] = value
     _translations[lang][key.upper()] = value
 
 
-def _load_json_translations(app: Flask, root: Path):
+def _load_json_translations(app: Flask, root: Path) -> None:
     if not root.exists():
         app.logger.debug("i18n JSON directory not found: %s", root)
         return
@@ -148,7 +148,7 @@ def _load_json_translations(app: Flask, root: Path):
                     _store_translation(lang, key, value)
 
 
-def _validate_json_translations(root: Path):
+def _validate_json_translations(root: Path) -> None:
     if not root.exists():
         message = f"Missing shared i18n directory at '{root}'. Run the migration checklist to generate JSON translations."
         raise FileNotFoundError(message)
@@ -216,7 +216,7 @@ def _validate_json_translations(root: Path):
         raise RuntimeError(details)
 
 
-def _load_python_translations(app: Flask, translations_dir: Path):
+def _load_python_translations(app: Flask, translations_dir: Path) -> None:
     if not translations_dir.exists():
         return
 
@@ -282,11 +282,11 @@ def translate_for_language(text: str, language: str | None = None) -> str:
     )
 
 
-def _(text: str):
+def _(text: str) -> str:
     return translate_for_language(text)
 
 
-def get_current_language():
+def get_current_language() -> str:
     return getattr(_thread_local, "language", "en-US")
 
 

--- a/src/api/flaskr/route/callback.py
+++ b/src/api/flaskr/route/callback.py
@@ -1,6 +1,6 @@
 """Expose callback HTTP routes."""
 
-from flask import Flask, jsonify, make_response, request
+from flask import Flask, Response, jsonify, make_response, request
 
 from flaskr.service.billing.customization import (
     build_provider_config_overrides,
@@ -28,7 +28,7 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route("/api/order/webhooks/<provider_name>/<callback_token>", methods=["POST"])
     @bypass_token_validation
-    def scoped_payment_webhook(provider_name: str, callback_token: str):
+    def scoped_payment_webhook(provider_name: str, callback_token: str) -> object:
         context = resolve_provider_credential_context(
             app,
             provider=provider_name,
@@ -87,7 +87,7 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
     # pingxx支付回调
     @app.route(path_prefix + "/pingxx-callback", methods=["POST"])
     @bypass_token_validation
-    def pingxx_callback():
+    def pingxx_callback() -> object:
         body = request.get_json()
         app.logger.info("pingxx-callback: %s", body)
         event_type = body.get("type", "")
@@ -107,7 +107,7 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/alipay-notify", methods=["POST"])
     @bypass_token_validation
-    def alipay_notify():
+    def alipay_notify() -> object:
         form_payload = request.form.to_dict(flat=True)
         app.logger.info("alipay-notify: %s", form_payload)
         provider = get_payment_provider("alipay")
@@ -144,7 +144,7 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/wechatpay-notify", methods=["POST"])
     @bypass_token_validation
-    def wechatpay_notify():
+    def wechatpay_notify() -> object:
         raw_body = request.get_data() or b""
         app.logger.info("wechatpay-notify: %s", raw_body)
         provider = get_payment_provider("wechatpay")
@@ -183,7 +183,7 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
     return app
 
 
-def _plain_text_response(value: str):
+def _plain_text_response(value: str) -> Response:
     response = make_response(value)
     response.mimetype = "text/plain"
     return response

--- a/src/api/flaskr/route/callback.py
+++ b/src/api/flaskr/route/callback.py
@@ -28,7 +28,9 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route("/api/order/webhooks/<provider_name>/<callback_token>", methods=["POST"])
     @bypass_token_validation
-    def scoped_payment_webhook(provider_name: str, callback_token: str) -> object:
+    def scoped_payment_webhook(
+        provider_name: str, callback_token: str
+    ) -> Response | tuple[Response, int]:
         context = resolve_provider_credential_context(
             app,
             provider=provider_name,
@@ -87,7 +89,7 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
     # pingxx支付回调
     @app.route(path_prefix + "/pingxx-callback", methods=["POST"])
     @bypass_token_validation
-    def pingxx_callback() -> object:
+    def pingxx_callback() -> Response:
         body = request.get_json()
         app.logger.info("pingxx-callback: %s", body)
         event_type = body.get("type", "")
@@ -107,7 +109,7 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/alipay-notify", methods=["POST"])
     @bypass_token_validation
-    def alipay_notify() -> object:
+    def alipay_notify() -> Response:
         form_payload = request.form.to_dict(flat=True)
         app.logger.info("alipay-notify: %s", form_payload)
         provider = get_payment_provider("alipay")
@@ -144,7 +146,7 @@ def register_callback_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/wechatpay-notify", methods=["POST"])
     @bypass_token_validation
-    def wechatpay_notify() -> object:
+    def wechatpay_notify() -> Response | tuple[Response, int]:
         raw_body = request.get_data() or b""
         app.logger.info("wechatpay-notify: %s", raw_body)
         provider = get_payment_provider("wechatpay")

--- a/src/api/flaskr/route/common.py
+++ b/src/api/flaskr/route/common.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from functools import wraps
 from typing import ParamSpec, TypeVar
 
-from flask import Flask, jsonify, request
+from flask import Flask, Response, jsonify, request
 from werkzeug.exceptions import HTTPException
 
 from flaskr.common.shifu_context import clear_shifu_context
@@ -70,7 +70,7 @@ def bypass_token_validation(func: Callable[P, R]) -> Callable[P, R]:
     by_pass_login_func.append(func.__name__)
 
     @wraps(func)
-    def wrapper(*args: object, **kwargs: object):
+    def wrapper(*args: object, **kwargs: object) -> R:
         return func(*args, **kwargs)
 
     return wrapper
@@ -80,20 +80,20 @@ def register_common_handler(app: Flask) -> Flask:
     """Register the common routes on the Flask application."""
 
     @app.errorhandler(AppError)
-    def handle_invalid_usage(error: AppError):
+    def handle_invalid_usage(error: AppError) -> Response:
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response
 
     @app.errorhandler(HTTPException)
-    def handle_invalid_http(error: HTTPException):
+    def handle_invalid_http(error: HTTPException) -> Response:
         app.logger.info(error)
         response = jsonify({"code": error.code, "message": error.description})
         response.status_code = 200
         return response
 
     @app.errorhandler(Exception)
-    def handle_invalid_exception(error: Exception):
+    def handle_invalid_exception(error: Exception) -> Response:
         del error
         app.logger.error(traceback.format_exc())
         language = _extract_request_language()
@@ -104,7 +104,7 @@ def register_common_handler(app: Flask) -> Flask:
         return response
 
     @app.teardown_request
-    def teardown_shifu_context(exception: object):
+    def teardown_shifu_context(exception: object) -> None:
         # Ensure shifu context does not leak between requests on the same worker thread
         del exception
         clear_shifu_context()

--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -75,7 +75,7 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/runtime-config", methods=["GET"])
     @bypass_token_validation
     @with_shifu_context()
-    def get_runtime_config() -> object:
+    def get_runtime_config() -> str:
         # An explicit creator_bid lets surfaces without a shifu in the path
         # (e.g. the /admin backend) fetch a creator's branding. Falls back to
         # the shifu-context creator when absent, so existing callers are

--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -41,7 +41,7 @@ def _to_bool(value: object, default: object = False) -> bool:
     return default
 
 
-def _to_list(value: object, default: object = None):
+def _to_list(value: object, default: object = None) -> list[str]:
     default = default or []
     if value is None:
         return default
@@ -75,7 +75,7 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/runtime-config", methods=["GET"])
     @bypass_token_validation
     @with_shifu_context()
-    def get_runtime_config():
+    def get_runtime_config() -> object:
         # An explicit creator_bid lets surfaces without a shifu in the path
         # (e.g. the /admin backend) fetch a creator's branding. Falls back to
         # the shifu-context creator when absent, so existing callers are

--- a/src/api/flaskr/route/creator_analytics.py
+++ b/src/api/flaskr/route/creator_analytics.py
@@ -13,7 +13,7 @@ def register_creator_analytics_handler(app: Flask, path_prefix: str) -> Flask:
     """Register the creator analytics routes on the Flask application."""
 
     @app.route(path_prefix + "/query", methods=["POST"])
-    def creator_analytics_query() -> object:
+    def creator_analytics_query() -> str:
         """Run a creator-analytics DSL query.
 
         ---
@@ -89,7 +89,7 @@ def register_creator_analytics_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(result)
 
     @app.route(path_prefix + "/credit-detail", methods=["POST"])
-    def creator_analytics_credit_detail() -> object:
+    def creator_analytics_credit_detail() -> str:
         """Fetch joined credit consumption detail for one shifu.
 
         Server-side joins ``bill_usage`` and ``credit_ledger_entries`` on

--- a/src/api/flaskr/route/creator_analytics.py
+++ b/src/api/flaskr/route/creator_analytics.py
@@ -13,7 +13,7 @@ def register_creator_analytics_handler(app: Flask, path_prefix: str) -> Flask:
     """Register the creator analytics routes on the Flask application."""
 
     @app.route(path_prefix + "/query", methods=["POST"])
-    def creator_analytics_query():
+    def creator_analytics_query() -> object:
         """Run a creator-analytics DSL query.
 
         ---
@@ -89,7 +89,7 @@ def register_creator_analytics_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(result)
 
     @app.route(path_prefix + "/credit-detail", methods=["POST"])
-    def creator_analytics_credit_detail():
+    def creator_analytics_credit_detail() -> object:
         """Fetch joined credit consumption detail for one shifu.
 
         Server-side joins ``bill_usage`` and ``credit_ledger_entries`` on

--- a/src/api/flaskr/route/dicts.py
+++ b/src/api/flaskr/route/dicts.py
@@ -13,7 +13,7 @@ def register_dict_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/dicts", methods=["GET"])
     @bypass_token_validation
-    def get_dicts():
+    def get_dicts() -> object:
         """Get all dictionaries.
 
         ---
@@ -24,7 +24,7 @@ def register_dict_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/models", methods=["GET"])
     @bypass_token_validation
-    def get_models():
+    def get_models() -> object:
         """Get all models.
 
         ---

--- a/src/api/flaskr/route/dicts.py
+++ b/src/api/flaskr/route/dicts.py
@@ -13,7 +13,7 @@ def register_dict_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/dicts", methods=["GET"])
     @bypass_token_validation
-    def get_dicts() -> object:
+    def get_dicts() -> str:
         """Get all dictionaries.
 
         ---
@@ -24,7 +24,7 @@ def register_dict_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/models", methods=["GET"])
     @bypass_token_validation
-    def get_models() -> object:
+    def get_models() -> str:
         """Get all models.
 
         ---

--- a/src/api/flaskr/route/open_api.py
+++ b/src/api/flaskr/route/open_api.py
@@ -24,7 +24,7 @@ def require_api_key(f: Callable[P, R]) -> Callable[P, R]:
     """Authenticate Open API requests via X-User-Uid + X-Api-Key headers."""
 
     @wraps(f)
-    def wrapper(*args: object, **kwargs: object):
+    def wrapper(*args: object, **kwargs: object) -> R:
         user_uid = request.headers.get("X-User-Uid", "").strip()
         api_key = request.headers.get("X-Api-Key", "").strip()
 
@@ -43,7 +43,7 @@ def require_api_key(f: Callable[P, R]) -> Callable[P, R]:
     return wrapper
 
 
-def _extract_params():
+def _extract_params() -> tuple[str, str, str]:
     """Extract and validate common request parameters."""
     payload = request.get_json(silent=True) or request.form.to_dict() or {}
     shifu_bid = str(payload.get("shifu_bid", "")).strip()
@@ -66,7 +66,7 @@ def register_open_api_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/order/query", methods=["POST"])
     @bypass_token_validation
     @require_api_key
-    def open_api_order_query():
+    def open_api_order_query() -> str:
         shifu_bid, user_identify, user_identify_type = _extract_params()
         owner_bid = request.open_api_user_bid
         result = open_api_query_order(
@@ -77,7 +77,7 @@ def register_open_api_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/order/grant", methods=["POST"])
     @bypass_token_validation
     @require_api_key
-    def open_api_order_grant():
+    def open_api_order_grant() -> str:
         shifu_bid, user_identify, user_identify_type = _extract_params()
         owner_bid = request.open_api_user_bid
         result = open_api_grant_order(
@@ -88,7 +88,7 @@ def register_open_api_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/order/revoke", methods=["POST"])
     @bypass_token_validation
     @require_api_key
-    def open_api_order_revoke():
+    def open_api_order_revoke() -> str:
         shifu_bid, user_identify, user_identify_type = _extract_params()
         owner_bid = request.open_api_user_bid
         result = open_api_revoke_order(

--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -45,7 +45,7 @@ from flaskr.util.datetime import parse_naive_utc
 def register_order_handler(app: Flask, path_prefix: str) -> Flask:
     """Register the order routes on the Flask application."""
 
-    def _require_creator():
+    def _require_creator() -> None:
         if not request.user.is_creator:
             raise_error("server.shifu.noPermission")
 
@@ -92,7 +92,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
             parsed = parsed.astimezone(UTC).replace(tzinfo=None)
         return parsed
 
-    def _parse_admin_pagination():
+    def _parse_admin_pagination() -> tuple[int, int]:
         page_index = request.args.get("page_index", 1)
         page_size = request.args.get("page_size", 20)
         try:
@@ -128,7 +128,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return None
 
     @app.route(path_prefix + "/reqiure-to-pay", methods=["POST"])
-    def reqiure_to_pay():
+    def reqiure_to_pay() -> object:
         """Request payment.
 
         ---
@@ -183,7 +183,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/init-order", methods=["POST"])
     @with_shifu_context()
-    def init_order():
+    def init_order() -> object:
         """Initialize an order.
 
         ---
@@ -221,7 +221,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(init_buy_record(app, user_id, course_id))
 
     @app.route(path_prefix + "/query-order", methods=["POST"])
-    def query_order():
+    def query_order() -> object:
         """Query an order.
 
         ---
@@ -258,7 +258,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(query_buy_record(app, order_id))
 
     @app.route(path_prefix + "/apply-discount", methods=["POST"])
-    def apply_discount():
+    def apply_discount() -> object:
         """Apply a discount code.
 
         ---
@@ -305,7 +305,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/payment-detail", methods=["POST"])
-    def payment_detail():
+    def payment_detail() -> object:
         """Query payment details.
 
         ---
@@ -341,7 +341,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(get_payment_details(app, order_id))
 
     @app.route(path_prefix + "/stripe/sync", methods=["POST"])
-    def stripe_sync():
+    def stripe_sync() -> object:
         """Sync the Stripe payment status.
 
         ---
@@ -380,7 +380,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/payment/sync", methods=["POST"])
-    def payment_sync():
+    def payment_sync() -> object:
         """Sync the payment status.
 
         ---
@@ -418,7 +418,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/stripe/webhook", methods=["POST"])
-    def stripe_webhook():
+    def stripe_webhook() -> object:
         """Stripe webhook placeholder.
 
         ---
@@ -435,7 +435,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return app.response_class(body, status=status_code, mimetype="application/json")
 
     @app.route(path_prefix + "/admin/orders", methods=["GET"])
-    def admin_order_list():
+    def admin_order_list() -> object:
         """Admin order list.
 
         ---
@@ -513,7 +513,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/admin/orders/shifus", methods=["GET"])
-    def admin_order_shifu_list():
+    def admin_order_shifu_list() -> object:
         """List created shifus for order admin filters.
 
         ---
@@ -593,7 +593,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/admin/orders/import-activation", methods=["POST"])
-    def admin_import_activation():
+    def admin_import_activation() -> object:
         """Admin import activation order.
 
         ---
@@ -711,7 +711,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/admin/orders/redemption-codes", methods=["GET"])
-    def admin_creator_redemption_code_list():
+    def admin_creator_redemption_code_list() -> object:
         """List course redemption code batches created by the current creator."""
         _require_creator()
         page_index, page_size = _parse_admin_pagination()
@@ -742,7 +742,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/admin/orders/redemption-codes", methods=["POST"])
-    def admin_create_creator_redemption_code():
+    def admin_create_creator_redemption_code() -> object:
         """Create a course redemption code for the current creator's published course."""
         _require_creator()
         payload = _parse_required_json_payload()
@@ -754,7 +754,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>/usages",
         methods=["GET"],
     )
-    def admin_creator_redemption_code_usage_list(coupon_bid: str):
+    def admin_creator_redemption_code_usage_list(coupon_bid: str) -> object:
         """List usage records for a course redemption code owned by the current creator."""
         _require_creator()
         page_index, page_size = _parse_admin_pagination()
@@ -773,7 +773,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>/codes",
         methods=["GET"],
     )
-    def admin_creator_redemption_code_code_list(coupon_bid: str):
+    def admin_creator_redemption_code_code_list(coupon_bid: str) -> object:
         """List generated sub-codes for a course redemption code owned by the current creator."""
         _require_creator()
         page_index, page_size = _parse_admin_pagination()
@@ -791,7 +791,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>",
         methods=["GET"],
     )
-    def admin_creator_redemption_code_detail(coupon_bid: str):
+    def admin_creator_redemption_code_detail(coupon_bid: str) -> object:
         """Get detail for a course redemption code owned by the current creator."""
         _require_creator()
         return make_common_response(
@@ -804,7 +804,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>",
         methods=["POST"],
     )
-    def admin_update_creator_redemption_code(coupon_bid: str):
+    def admin_update_creator_redemption_code(coupon_bid: str) -> object:
         """Update a course redemption code owned by the current creator."""
         _require_creator()
         payload = _parse_required_json_payload()
@@ -818,7 +818,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>/status",
         methods=["POST"],
     )
-    def admin_update_creator_redemption_code_status(coupon_bid: str):
+    def admin_update_creator_redemption_code_status(coupon_bid: str) -> object:
         """Update status for a course redemption code owned by the current creator."""
         _require_creator()
         payload = _parse_required_json_payload()
@@ -832,7 +832,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response({"enabled": bool(result.get("enabled"))})
 
     @app.route(path_prefix + "/admin/orders/<order_bid>", methods=["GET"])
-    def admin_order_detail(order_bid: str):
+    def admin_order_detail(order_bid: str) -> object:
         """Admin order detail.
 
         ---

--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-from flask import Flask, request
+from flask import Flask, Response, request
 
 from flaskr.common.shifu_context import with_shifu_context
 from flaskr.route.common import make_common_response
@@ -128,7 +128,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return None
 
     @app.route(path_prefix + "/reqiure-to-pay", methods=["POST"])
-    def reqiure_to_pay() -> object:
+    def reqiure_to_pay() -> str:
         """Request payment.
 
         ---
@@ -183,7 +183,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/init-order", methods=["POST"])
     @with_shifu_context()
-    def init_order() -> object:
+    def init_order() -> str:
         """Initialize an order.
 
         ---
@@ -221,7 +221,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(init_buy_record(app, user_id, course_id))
 
     @app.route(path_prefix + "/query-order", methods=["POST"])
-    def query_order() -> object:
+    def query_order() -> str:
         """Query an order.
 
         ---
@@ -258,7 +258,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(query_buy_record(app, order_id))
 
     @app.route(path_prefix + "/apply-discount", methods=["POST"])
-    def apply_discount() -> object:
+    def apply_discount() -> str:
         """Apply a discount code.
 
         ---
@@ -305,7 +305,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/payment-detail", methods=["POST"])
-    def payment_detail() -> object:
+    def payment_detail() -> str:
         """Query payment details.
 
         ---
@@ -341,7 +341,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(get_payment_details(app, order_id))
 
     @app.route(path_prefix + "/stripe/sync", methods=["POST"])
-    def stripe_sync() -> object:
+    def stripe_sync() -> str:
         """Sync the Stripe payment status.
 
         ---
@@ -380,7 +380,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/payment/sync", methods=["POST"])
-    def payment_sync() -> object:
+    def payment_sync() -> str:
         """Sync the payment status.
 
         ---
@@ -418,7 +418,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/stripe/webhook", methods=["POST"])
-    def stripe_webhook() -> object:
+    def stripe_webhook() -> Response:
         """Stripe webhook placeholder.
 
         ---
@@ -435,7 +435,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return app.response_class(body, status=status_code, mimetype="application/json")
 
     @app.route(path_prefix + "/admin/orders", methods=["GET"])
-    def admin_order_list() -> object:
+    def admin_order_list() -> str:
         """Admin order list.
 
         ---
@@ -513,7 +513,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/admin/orders/shifus", methods=["GET"])
-    def admin_order_shifu_list() -> object:
+    def admin_order_shifu_list() -> str:
         """List created shifus for order admin filters.
 
         ---
@@ -593,7 +593,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/admin/orders/import-activation", methods=["POST"])
-    def admin_import_activation() -> object:
+    def admin_import_activation() -> str:
         """Admin import activation order.
 
         ---
@@ -711,7 +711,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/admin/orders/redemption-codes", methods=["GET"])
-    def admin_creator_redemption_code_list() -> object:
+    def admin_creator_redemption_code_list() -> str:
         """List course redemption code batches created by the current creator."""
         _require_creator()
         page_index, page_size = _parse_admin_pagination()
@@ -742,7 +742,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/admin/orders/redemption-codes", methods=["POST"])
-    def admin_create_creator_redemption_code() -> object:
+    def admin_create_creator_redemption_code() -> str:
         """Create a course redemption code for the current creator's published course."""
         _require_creator()
         payload = _parse_required_json_payload()
@@ -754,7 +754,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>/usages",
         methods=["GET"],
     )
-    def admin_creator_redemption_code_usage_list(coupon_bid: str) -> object:
+    def admin_creator_redemption_code_usage_list(coupon_bid: str) -> str:
         """List usage records for a course redemption code owned by the current creator."""
         _require_creator()
         page_index, page_size = _parse_admin_pagination()
@@ -773,7 +773,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>/codes",
         methods=["GET"],
     )
-    def admin_creator_redemption_code_code_list(coupon_bid: str) -> object:
+    def admin_creator_redemption_code_code_list(coupon_bid: str) -> str:
         """List generated sub-codes for a course redemption code owned by the current creator."""
         _require_creator()
         page_index, page_size = _parse_admin_pagination()
@@ -791,7 +791,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>",
         methods=["GET"],
     )
-    def admin_creator_redemption_code_detail(coupon_bid: str) -> object:
+    def admin_creator_redemption_code_detail(coupon_bid: str) -> str:
         """Get detail for a course redemption code owned by the current creator."""
         _require_creator()
         return make_common_response(
@@ -804,7 +804,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>",
         methods=["POST"],
     )
-    def admin_update_creator_redemption_code(coupon_bid: str) -> object:
+    def admin_update_creator_redemption_code(coupon_bid: str) -> str:
         """Update a course redemption code owned by the current creator."""
         _require_creator()
         payload = _parse_required_json_payload()
@@ -818,7 +818,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         path_prefix + "/admin/orders/redemption-codes/<coupon_bid>/status",
         methods=["POST"],
     )
-    def admin_update_creator_redemption_code_status(coupon_bid: str) -> object:
+    def admin_update_creator_redemption_code_status(coupon_bid: str) -> str:
         """Update status for a course redemption code owned by the current creator."""
         _require_creator()
         payload = _parse_required_json_payload()
@@ -832,7 +832,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response({"enabled": bool(result.get("enabled"))})
 
     @app.route(path_prefix + "/admin/orders/<order_bid>", methods=["GET"])
-    def admin_order_detail(order_bid: str) -> object:
+    def admin_order_detail(order_bid: str) -> str:
         """Admin order detail.
 
         ---

--- a/src/api/flaskr/route/order.py
+++ b/src/api/flaskr/route/order.py
@@ -593,7 +593,7 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/admin/orders/import-activation", methods=["POST"])
-    def admin_import_activation() -> str:
+    def admin_import_activation() -> Response:
         """Admin import activation order.
 
         ---
@@ -685,10 +685,13 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
             # Validate course exists before iterating mobiles to avoid repeated errors
             get_shifu_info(app, course_id, preview_mode=False)
 
-            return make_common_response(
-                import_activation_orders_from_entries(
-                    app, entries, course_id, contact_type=contact_type
-                )
+            return app.response_class(
+                make_common_response(
+                    import_activation_orders_from_entries(
+                        app, entries, course_id, contact_type=contact_type
+                    )
+                ),
+                mimetype="application/json",
             )
 
         mobile_field = str(payload.get("mobile", "")).strip()
@@ -704,10 +707,13 @@ def register_order_handler(app: Flask, path_prefix: str) -> Flask:
         # Validate course exists before iterating mobiles to avoid repeated errors
         get_shifu_info(app, course_id, preview_mode=False)
 
-        return make_common_response(
-            import_activation_orders(
-                app, mobiles, course_id, user_nick_name, contact_type=contact_type
-            )
+        return app.response_class(
+            make_common_response(
+                import_activation_orders(
+                    app, mobiles, course_id, user_nick_name, contact_type=contact_type
+                )
+            ),
+            mimetype="application/json",
         )
 
     @app.route(path_prefix + "/admin/orders/redemption-codes", methods=["GET"])

--- a/src/api/flaskr/route/storage.py
+++ b/src/api/flaskr/route/storage.py
@@ -46,7 +46,7 @@ def register_storage_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/storage/<profile>/<path:object_key>", methods=["GET"])
     @bypass_token_validation
-    def serve_local_storage(profile: str, object_key: str) -> object:
+    def serve_local_storage(profile: str, object_key: str) -> Response:
         try:
             file_path = get_local_storage_path(profile, object_key)
         except ValueError:

--- a/src/api/flaskr/route/storage.py
+++ b/src/api/flaskr/route/storage.py
@@ -46,7 +46,7 @@ def register_storage_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/storage/<profile>/<path:object_key>", methods=["GET"])
     @bypass_token_validation
-    def serve_local_storage(profile: str, object_key: str):
+    def serve_local_storage(profile: str, object_key: str) -> object:
         try:
             file_path = get_local_storage_path(profile, object_key)
         except ValueError:

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from functools import wraps
 from typing import ParamSpec, TypeVar
 
-from flask import Flask, current_app, make_response, request
+from flask import Flask, Response, current_app, make_response, request
 
 from flaskr.common.public_urls import resolve_request_origin
 from flaskr.common.shifu_context import with_shifu_context
@@ -45,7 +45,7 @@ from flaskr.service.user.captcha import (
 )
 from flaskr.service.user.common import update_user_info, validate_user
 from flaskr.service.user.consts import CREDENTIAL_STATE_VERIFIED
-from flaskr.service.user.models import AuthCredential
+from flaskr.service.user.models import AuthCredential, UserInfo
 from flaskr.service.user.onboarding import (
     ONBOARDING_VERSION,
     build_onboarding_status,
@@ -194,7 +194,7 @@ def optional_token_validation(f: Callable[P, R]) -> Callable[P, R]:
     """Allow a route to accept an optional authentication token."""
 
     @wraps(f)
-    def decorated_function(*args: object, **kwargs: object):
+    def decorated_function(*args: object, **kwargs: object) -> R:
         token = request.cookies.get("token", None)
         if not token:
             token = request.args.get("token", None)
@@ -213,7 +213,7 @@ def optional_token_validation(f: Callable[P, R]) -> Callable[P, R]:
     return decorated_function
 
 
-def _best_effort_password_login_user(app: Flask):
+def _best_effort_password_login_user(app: Flask) -> UserInfo | None:
     """Resolve the explicitly authenticated guest without blocking login."""
     token = request.headers.get("Token", None)
     if not token:
@@ -229,7 +229,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     """Register the user routes on the Flask application."""
 
     @app.before_request
-    def before_request():
+    def before_request() -> None:
         if request.path.startswith("/internal/"):
             return
         if (
@@ -258,7 +258,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         request.user = user
 
     @app.route(path_prefix + "/info", methods=["GET"])
-    def info():
+    def info() -> str:
         """Get user information.
 
         ---
@@ -283,7 +283,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(request.user)
 
     @app.route(path_prefix + "/ensure_admin_creator", methods=["POST"])
-    def ensure_admin_creator():
+    def ensure_admin_creator() -> str:
         """Ensure admin creator permissions for the current user.
 
         ---
@@ -315,7 +315,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response({"granted": True})
 
     @app.route(path_prefix + "/onboarding/status", methods=["GET"])
-    def onboarding_status():
+    def onboarding_status() -> str:
         return make_common_response(
             build_onboarding_status(
                 app,
@@ -325,7 +325,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/onboarding/complete", methods=["POST"])
-    def complete_onboarding():
+    def complete_onboarding() -> str:
         payload = request.get_json(silent=True)
         if not isinstance(payload, dict):
             payload = {}
@@ -341,7 +341,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/update_info", methods=["POST"])
-    def update_info():
+    def update_info() -> str:
         """Update user information.
 
         ---
@@ -395,7 +395,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/profile-onboarding", methods=["GET"])
-    def profile_onboarding_status_api():
+    def profile_onboarding_status_api() -> str:
         """Get platform-level profile onboarding state for current user.
 
         ---
@@ -410,7 +410,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/profile-onboarding/complete", methods=["POST"])
-    def complete_profile_onboarding_api():
+    def complete_profile_onboarding_api() -> str:
         """Complete or skip platform-level profile onboarding.
 
         ---
@@ -433,12 +433,12 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(result)
 
     @app.route(path_prefix + "/learner-profile", methods=["GET"])
-    def learner_profile_api():
+    def learner_profile_api() -> str:
         """Return the current user's canonical learning profile."""
         return make_common_response(get_learner_profile(user_id=request.user.user_id))
 
     @app.route(path_prefix + "/learner-profile", methods=["PUT"])
-    def update_learner_profile_api():
+    def update_learner_profile_api() -> str:
         """Replace the current user's canonical learning profile."""
         payload = _request_json_object("learner_profile")
         _reject_unknown_fields(
@@ -462,12 +462,12 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/learner-profile", methods=["DELETE"])
-    def clear_learner_profile_api():
+    def clear_learner_profile_api() -> str:
         """Clear the profile while keeping profile-v2 handled."""
         return make_common_response(clear_learner_profile(user_id=request.user.user_id))
 
     @app.route(path_prefix + "/learner-profile/optimize", methods=["POST"])
-    def optimize_learner_profile_api():
+    def optimize_learner_profile_api() -> str:
         """Return an LLM-optimized draft without saving profile state."""
         payload = _request_json_object("learner_profile")
         _reject_unknown_fields(
@@ -493,7 +493,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/require_tmp", methods=["POST"])
     @bypass_token_validation
     @with_shifu_context()
-    def require_tmp():
+    def require_tmp() -> Response:
         """Temp login user.
 
         ---
@@ -556,7 +556,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/captcha", methods=["GET"])
     @bypass_token_validation
-    def captcha_api():
+    def captcha_api() -> str:
         """Create image captcha.
 
         ---
@@ -568,7 +568,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/captcha/verify", methods=["POST"])
     @bypass_token_validation
-    def captcha_verify_api():
+    def captcha_verify_api() -> str:
         """Verify image captcha and return one-time ticket.
 
         ---
@@ -593,7 +593,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/send_sms_code", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation
-    def send_sms_code_api():
+    def send_sms_code_api() -> str:
         """Send SMS Captcha.
 
         ---
@@ -658,7 +658,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/console_send_sms_code", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation
-    def console_send_sms_code_api():
+    def console_send_sms_code_api() -> str:
         """Send SMS verification code for console clients without image captcha.
 
         ---
@@ -682,7 +682,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/send_email_code", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation
-    def send_email_code_api():
+    def send_email_code_api() -> str:
         """Send email verification code.
 
         ---
@@ -706,7 +706,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
         return make_common_response(send_email_code(app, email, client_ip, language))
 
-    def _handle_sms_login():
+    def _handle_sms_login() -> Response:
         with app.app_context():
             payload = request.get_json(silent=True)
             payload = payload if isinstance(payload, dict) else {}
@@ -765,7 +765,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/login_sms", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation
-    def login_sms_api():
+    def login_sms_api() -> Response:
         """Login through SMS verification code for web clients.
 
         ---
@@ -775,7 +775,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         return _handle_sms_login()
 
     @app.route(path_prefix + "/get_profile", methods=["GET"])
-    def get_profile():
+    def get_profile() -> str:
         """Get user profile.
 
         ---
@@ -812,7 +812,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         )
 
     @app.route(path_prefix + "/update_profile", methods=["POST"])
-    def update_profile():
+    def update_profile() -> str:
         """Update user profile.
 
         ---
@@ -874,7 +874,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             return make_common_response(ret.__json__())
 
     @app.route(path_prefix + "/upload_avatar", methods=["POST"])
-    def upload_avatar():
+    def upload_avatar() -> str:
         """Upload avatar.
 
         ---
@@ -912,7 +912,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/update_openid", methods=["POST"])
     @with_shifu_context()
-    def update_wechat_openid():
+    def update_wechat_openid() -> str:
         """Update Wechat OpenID.
 
         ---
@@ -957,7 +957,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/submit-feedback", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation
-    def sumbit_feedback_api():
+    def sumbit_feedback_api() -> str:
         """Submit feedback.
 
         ---
@@ -1007,7 +1007,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/oauth/google", methods=["GET"])
     @bypass_token_validation
     @optional_token_validation
-    def google_oauth_start():
+    def google_oauth_start() -> str:
         provider = get_provider("google")
         metadata = {}
         redirect_uri = request.args.get("redirect_uri")
@@ -1038,7 +1038,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/oauth/google/callback-origin", methods=["GET"])
     @bypass_token_validation
-    def google_oauth_callback_origin():
+    def google_oauth_callback_origin() -> str:
         """Resolve which domain a pending Google login should return to.
 
         Every domain shares one Google callback, so the page that receives it
@@ -1055,7 +1055,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/oauth/google/callback", methods=["GET"])
     @bypass_token_validation
     @optional_token_validation
-    def google_oauth_callback():
+    def google_oauth_callback() -> str:
         provider = get_provider("google")
         current_user = getattr(request, "user", None)
         current_user_id = None
@@ -1094,7 +1094,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/login_password", methods=["POST"])
     @bypass_token_validation
-    def login_password():
+    def login_password() -> str:
         """Login with password.
 
         ---
@@ -1151,7 +1151,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response(auth_result.token)
 
     @app.route(path_prefix + "/set_password", methods=["POST"])
-    def set_password():
+    def set_password() -> str:
         """Set password for logged-in user (first time only).
 
         ---
@@ -1234,7 +1234,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         return make_common_response({"success": True})
 
     @app.route(path_prefix + "/change_password", methods=["POST"])
-    def change_password():
+    def change_password() -> str:
         """Change password for logged-in user (requires old password).
 
         ---
@@ -1269,7 +1269,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
 
     @app.route(path_prefix + "/reset_password", methods=["POST"])
     @bypass_token_validation
-    def reset_password():
+    def reset_password() -> str:
         """Reset password via verification code.
 
         ---
@@ -1338,7 +1338,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     # health check
     @app.route("/health", methods=["GET"])
     @bypass_token_validation
-    def health():
+    def health() -> str:
         app.logger.info("health")
         return make_common_response("ok")
 

--- a/src/api/flaskr/service/billing/campaigns.py
+++ b/src/api/flaskr/service/billing/campaigns.py
@@ -36,6 +36,7 @@ from .consts import (
 )
 from .dtos import (
     AdminBillingCampaignDetailDTO,
+    AdminBillingCampaignDTO,
     AdminBillingCampaignProductOptionsDTO,
     AdminBillingCampaignsPageDTO,
 )
@@ -1110,7 +1111,7 @@ def _serialize_admin_campaign_row(
     product_types: list[str],
     bindings: list[BillingCampaignProduct],
     hit_order_count: int,
-):
+) -> AdminBillingCampaignDTO:
     campaign_rule_snapshot = _resolve_campaign_rule_snapshot_from_bindings(
         row,
         bindings=bindings,

--- a/src/api/flaskr/service/billing/cli.py
+++ b/src/api/flaskr/service/billing/cli.py
@@ -374,7 +374,7 @@ def register_billing_commands(console: object) -> None:
     """Register offline billing maintenance commands under ``flask console``."""
 
     @console.group(name="billing")
-    def billing_group():
+    def billing_group() -> None:
         """Billing maintenance commands for offline repair and replay."""
 
     @billing_group.command(name="seed-bootstrap-data")

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -3104,7 +3104,7 @@ def _is_notification_not_sent_status(status: str) -> bool:
     )
 
 
-def _notification_not_sent_condition() -> object:
+def _notification_not_sent_condition() -> ColumnElement[bool]:
     return or_(
         NotificationRecord.status.like("skipped%"),
         NotificationRecord.status == CREDIT_NOTIFICATION_STATUS_SUPPRESSED_DUPLICATE,
@@ -3155,7 +3155,9 @@ def _notification_delivery_status_condition(
     return None
 
 
-def _notification_skip_reason_condition(skip_reason: str) -> object:
+def _notification_skip_reason_condition(
+    skip_reason: str,
+) -> ColumnElement[bool] | None:
     contact_condition = (
         NotificationRecord.status == CREDIT_NOTIFICATION_STATUS_SKIPPED_NO_MOBILE
     )

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -67,6 +67,7 @@ from .primitives import to_decimal as _to_decimal
 
 if TYPE_CHECKING:
     from flask import Flask
+    from sqlalchemy.sql.elements import ColumnElement
 
 TASK_NAME = "billing.send_credit_notification"
 SOURCE_TYPE_LEDGER = "ledger"
@@ -3140,7 +3141,9 @@ def _resolve_notification_skip_reason(status: str, error_code: str = "") -> str:
     return ""
 
 
-def _notification_delivery_status_condition(delivery_status: str) -> object:
+def _notification_delivery_status_condition(
+    delivery_status: str,
+) -> ColumnElement[bool] | None:
     if delivery_status == CREDIT_NOTIFICATION_STATUS_PENDING:
         return NotificationRecord.status == CREDIT_NOTIFICATION_STATUS_PENDING
     if delivery_status == CREDIT_NOTIFICATION_STATUS_SENT:

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -3103,7 +3103,7 @@ def _is_notification_not_sent_status(status: str) -> bool:
     )
 
 
-def _notification_not_sent_condition():
+def _notification_not_sent_condition() -> object:
     return or_(
         NotificationRecord.status.like("skipped%"),
         NotificationRecord.status == CREDIT_NOTIFICATION_STATUS_SUPPRESSED_DUPLICATE,
@@ -3140,7 +3140,7 @@ def _resolve_notification_skip_reason(status: str, error_code: str = "") -> str:
     return ""
 
 
-def _notification_delivery_status_condition(delivery_status: str):
+def _notification_delivery_status_condition(delivery_status: str) -> object:
     if delivery_status == CREDIT_NOTIFICATION_STATUS_PENDING:
         return NotificationRecord.status == CREDIT_NOTIFICATION_STATUS_PENDING
     if delivery_status == CREDIT_NOTIFICATION_STATUS_SENT:
@@ -3152,7 +3152,7 @@ def _notification_delivery_status_condition(delivery_status: str):
     return None
 
 
-def _notification_skip_reason_condition(skip_reason: str):
+def _notification_skip_reason_condition(skip_reason: str) -> object:
     contact_condition = (
         NotificationRecord.status == CREDIT_NOTIFICATION_STATUS_SKIPPED_NO_MOBILE
     )

--- a/src/api/flaskr/service/billing/customization.py
+++ b/src/api/flaskr/service/billing/customization.py
@@ -1310,7 +1310,7 @@ def _save_logo_image(image: Image.Image, *, suffix: str) -> bytes:
     return output.getvalue()
 
 
-def _saas_funcs(*, required: bool = True):
+def _saas_funcs(*, required: bool = True) -> Any | None:
     try:
         module = import_module(
             "flaskr.plugins.ai_shifu_saas_plugin.src.service.config.funcs"
@@ -1335,7 +1335,7 @@ def _saas_funcs(*, required: bool = True):
     return module
 
 
-def _saas_model():
+def _saas_model() -> object:
     return import_module(
         "flaskr.plugins.ai_shifu_saas_plugin.src.service.config.models"
     ).SaasUserConfig

--- a/src/api/flaskr/service/billing/customization.py
+++ b/src/api/flaskr/service/billing/customization.py
@@ -10,7 +10,7 @@ import json
 from dataclasses import dataclass
 from importlib import import_module
 from io import BytesIO
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 from urllib.parse import urlsplit
 
 from cryptography import x509
@@ -40,6 +40,17 @@ from .primitives import normalize_bid
 
 if TYPE_CHECKING:
     from werkzeug.datastructures import FileStorage
+
+
+class _SaasUserConfigModel(Protocol):
+    query: ClassVar[Any]
+    user_bid: ClassVar[Any]
+    key: ClassVar[Any]
+    config_bid: ClassVar[Any]
+    deleted: ClassVar[Any]
+    created_at: ClassVar[Any]
+    id: ClassVar[Any]
+
 
 BRANDING_KEY = "CUSTOMIZATION.BRANDING"
 ADMIN_DRAFT_KEY = "CUSTOMIZATION.ADMIN_DRAFT"
@@ -1335,7 +1346,7 @@ def _saas_funcs(*, required: bool = True) -> Any | None:
     return module
 
 
-def _saas_model() -> object:
+def _saas_model() -> type[_SaasUserConfigModel]:
     return import_module(
         "flaskr.plugins.ai_shifu_saas_plugin.src.service.config.models"
     ).SaasUserConfig

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -176,6 +176,7 @@ from .wallets import (
 
 if TYPE_CHECKING:
     from flask import Flask
+    from flask_sqlalchemy.query import Query
 
 _OPERATOR_PRODUCT_FILTER_LANGUAGES = ("zh-CN", "en-US", "fr-FR")
 _ADMIN_BILLING_FOCUS_ATTENTION_REASON_ORDER = (
@@ -188,7 +189,7 @@ _ADMIN_BILLING_FOCUS_ATTENTION_REASON_ORDER = (
 )
 
 
-def _filter_out_reserved_credit_grant_ledgers(query: object):
+def _filter_out_reserved_credit_grant_ledgers(query: object) -> Query:
     bucket_credit_state_expr = db.func.lower(
         db.func.trim(
             db.func.coalesce(
@@ -493,7 +494,7 @@ def _load_credit_order_product_map(
 def _load_credit_order_grant_map(
     app: Flask,
     order_bids: list[str],
-):
+) -> dict[str, object]:
     normalized_order_bids = [_normalize_bid(bid) for bid in order_bids if bid]
     if not normalized_order_bids:
         return {}

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -189,7 +189,7 @@ _ADMIN_BILLING_FOCUS_ATTENTION_REASON_ORDER = (
 )
 
 
-def _filter_out_reserved_credit_grant_ledgers(query: object) -> Query:
+def _filter_out_reserved_credit_grant_ledgers(query: Query) -> Query:
     bucket_credit_state_expr = db.func.lower(
         db.func.trim(
             db.func.coalesce(

--- a/src/api/flaskr/service/billing/read_models.py
+++ b/src/api/flaskr/service/billing/read_models.py
@@ -77,6 +77,7 @@ from .dtos import (
     BillingTopupProductDTO,
     BillingWalletBucketListDTO,
     OperatorCreditOrderDetailDTO,
+    OperatorCreditOrderGrantDTO,
     OperatorCreditOrderOverviewDTO,
     OperatorCreditOrdersPageDTO,
 )
@@ -494,7 +495,7 @@ def _load_credit_order_product_map(
 def _load_credit_order_grant_map(
     app: Flask,
     order_bids: list[str],
-) -> dict[str, object]:
+) -> dict[str, OperatorCreditOrderGrantDTO]:
     normalized_order_bids = [_normalize_bid(bid) for bid in order_bids if bid]
     if not normalized_order_bids:
         return {}
@@ -511,7 +512,7 @@ def _load_credit_order_grant_map(
         )
         .all()
     )
-    payload = {}
+    payload: dict[str, OperatorCreditOrderGrantDTO] = {}
     for row in rows:
         source_bid = str(row.source_bid or "").strip()
         if not source_bid or source_bid in payload:

--- a/src/api/flaskr/service/billing/referral_plan_rewards.py
+++ b/src/api/flaskr/service/billing/referral_plan_rewards.py
@@ -87,6 +87,18 @@ class _BillingModelsModule(Protocol):
     CreditWalletBucket: type[CreditWalletBucket]
 
 
+class _BillingConstantsModule(Protocol):
+    BILLING_PRODUCT_TYPE_PLAN: int
+    BILLING_PRODUCT_STATUS_ACTIVE: int
+    BILLING_SUBSCRIPTION_STATUS_DRAFT: int
+    BILLING_ORDER_TYPE_SUBSCRIPTION_START: int
+    BILLING_ORDER_TYPE_SUBSCRIPTION_RENEWAL: int
+    BILLING_ORDER_STATUS_PAID: int
+    BILLING_TRIAL_PRODUCT_BID: str
+    BILLING_TRIAL_PRODUCT_CODE: str
+    BILLING_TRIAL_PRODUCT_METADATA_PUBLIC_FLAG: str
+
+
 def _with_app_context(app: Flask) -> AbstractContextManager[None]:
     return _NullContext() if has_app_context() else app.app_context()
 
@@ -99,7 +111,7 @@ def _normalize_bid(value: object) -> str:
     return str(value or "").strip()
 
 
-def _billing_consts() -> object:
+def _billing_consts() -> _BillingConstantsModule:
     from . import consts
 
     return consts

--- a/src/api/flaskr/service/billing/referral_plan_rewards.py
+++ b/src/api/flaskr/service/billing/referral_plan_rewards.py
@@ -138,7 +138,7 @@ def _load_reward_product(product_code: str) -> BillingProduct | None:
     )
 
 
-def _load_product_by_bid(product_bid: str) -> object:
+def _load_product_by_bid(product_bid: str) -> BillingProduct | None:
     consts = _billing_consts()
     models = _billing_models()
     return (

--- a/src/api/flaskr/service/billing/referral_plan_rewards.py
+++ b/src/api/flaskr/service/billing/referral_plan_rewards.py
@@ -13,7 +13,10 @@ from flaskr.util.datetime import now_utc
 from flaskr.util.uuid import generate_id
 
 if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
     from datetime import datetime
+
+    from .models import BillingSubscription
 
 _MANUAL_PROVIDER_NAME = "manual"
 _CHECKOUT_TYPE = "referral_invitation_reward"
@@ -70,7 +73,7 @@ class _NullContext:
         return False
 
 
-def _with_app_context(app: Flask):
+def _with_app_context(app: Flask) -> AbstractContextManager[None]:
     return _NullContext() if has_app_context() else app.app_context()
 
 
@@ -82,19 +85,19 @@ def _normalize_bid(value: object) -> str:
     return str(value or "").strip()
 
 
-def _billing_consts():
+def _billing_consts() -> object:
     from . import consts
 
     return consts
 
 
-def _billing_models():
+def _billing_models() -> object:
     from . import models
 
     return models
 
 
-def _load_reward_product(product_code: str):
+def _load_reward_product(product_code: str) -> object:
     consts = _billing_consts()
     models = _billing_models()
     return (
@@ -109,7 +112,7 @@ def _load_reward_product(product_code: str):
     )
 
 
-def _load_product_by_bid(product_bid: str):
+def _load_product_by_bid(product_bid: str) -> object:
     consts = _billing_consts()
     models = _billing_models()
     return (
@@ -166,7 +169,9 @@ def _load_existing_order(
     )
 
 
-def _load_primary_active_subscription(creator_bid: str, *, as_of: datetime):
+def _load_primary_active_subscription(
+    creator_bid: str, *, as_of: datetime
+) -> BillingSubscription | None:
     from .queries import load_primary_active_subscription
 
     return load_primary_active_subscription(creator_bid, as_of=as_of)
@@ -176,7 +181,7 @@ def _calculate_self_managed_billing_cycle_end(
     product: object,
     *,
     cycle_start_at: datetime,
-):
+) -> datetime | None:
     from .queries import calculate_self_managed_billing_cycle_end
 
     return calculate_self_managed_billing_cycle_end(
@@ -189,7 +194,7 @@ def _calculate_self_managed_billing_cycle_end_after_boundary(
     product: object,
     *,
     cycle_boundary_at: datetime,
-):
+) -> object:
     from .queries import calculate_self_managed_billing_cycle_end_after_boundary
 
     return calculate_self_managed_billing_cycle_end_after_boundary(

--- a/src/api/flaskr/service/billing/referral_plan_rewards.py
+++ b/src/api/flaskr/service/billing/referral_plan_rewards.py
@@ -208,7 +208,7 @@ def _calculate_self_managed_billing_cycle_end_after_boundary(
     product: object,
     *,
     cycle_boundary_at: datetime,
-) -> object:
+) -> datetime | None:
     from .queries import calculate_self_managed_billing_cycle_end_after_boundary
 
     return calculate_self_managed_billing_cycle_end_after_boundary(

--- a/src/api/flaskr/service/billing/referral_plan_rewards.py
+++ b/src/api/flaskr/service/billing/referral_plan_rewards.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from flask import Flask, has_app_context
 from flaskr.dao import db
@@ -16,7 +16,13 @@ if TYPE_CHECKING:
     from contextlib import AbstractContextManager
     from datetime import datetime
 
-    from .models import BillingSubscription
+    from .models import (
+        BillingOrder,
+        BillingProduct,
+        BillingSubscription,
+        CreditLedgerEntry,
+        CreditWalletBucket,
+    )
 
 _MANUAL_PROVIDER_NAME = "manual"
 _CHECKOUT_TYPE = "referral_invitation_reward"
@@ -73,6 +79,14 @@ class _NullContext:
         return False
 
 
+class _BillingModelsModule(Protocol):
+    BillingOrder: type[BillingOrder]
+    BillingProduct: type[BillingProduct]
+    BillingSubscription: type[BillingSubscription]
+    CreditLedgerEntry: type[CreditLedgerEntry]
+    CreditWalletBucket: type[CreditWalletBucket]
+
+
 def _with_app_context(app: Flask) -> AbstractContextManager[None]:
     return _NullContext() if has_app_context() else app.app_context()
 
@@ -91,7 +105,7 @@ def _billing_consts() -> object:
     return consts
 
 
-def _billing_models() -> object:
+def _billing_models() -> _BillingModelsModule:
     from . import models
 
     return models

--- a/src/api/flaskr/service/billing/referral_plan_rewards.py
+++ b/src/api/flaskr/service/billing/referral_plan_rewards.py
@@ -123,7 +123,7 @@ def _billing_models() -> _BillingModelsModule:
     return models
 
 
-def _load_reward_product(product_code: str) -> object:
+def _load_reward_product(product_code: str) -> BillingProduct | None:
     consts = _billing_consts()
     models = _billing_models()
     return (

--- a/src/api/flaskr/service/billing/routes.py
+++ b/src/api/flaskr/service/billing/routes.py
@@ -162,17 +162,17 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     admin_path_prefix = "/api/admin/billing"
 
     @app.route(path_prefix, methods=["GET"])
-    def billing_bootstrap_api() -> object:
+    def billing_bootstrap_api() -> str:
         _require_billing_access(app)
         return make_common_response(build_billing_route_bootstrap(path_prefix))
 
     @app.route(path_prefix + "/catalog", methods=["GET"])
-    def billing_catalog_api() -> object:
+    def billing_catalog_api() -> str:
         _require_billing_access(app)
         return make_common_response(build_billing_catalog(app))
 
     @app.route(path_prefix + "/overview", methods=["GET"])
-    def billing_overview_api() -> object:
+    def billing_overview_api() -> str:
         _require_billing_access(app)
         return make_common_response(
             build_billing_overview(
@@ -182,7 +182,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/trial-offer/welcome/ack", methods=["POST"])
-    def billing_trial_offer_welcome_ack_api() -> object:
+    def billing_trial_offer_welcome_ack_api() -> str:
         _require_billing_access(app)
         return make_common_response(
             acknowledge_trial_welcome_dialog(
@@ -192,7 +192,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/wallet-buckets", methods=["GET"])
-    def billing_wallet_buckets_api() -> object:
+    def billing_wallet_buckets_api() -> str:
         _require_billing_access(app)
         return make_common_response(
             build_billing_wallet_buckets(
@@ -202,7 +202,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/ledger", methods=["GET"])
-    def billing_ledger_api() -> object:
+    def billing_ledger_api() -> str:
         _require_billing_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -215,7 +215,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/orders/<bill_order_bid>/sync", methods=["POST"])
-    def billing_order_sync_api(bill_order_bid: str) -> object:
+    def billing_order_sync_api(bill_order_bid: str) -> str:
         _require_billing_access(app)
         return make_common_response(
             sync_billing_order(
@@ -227,7 +227,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/orders/<bill_order_bid>/checkout", methods=["POST"])
-    def billing_order_checkout_api(bill_order_bid: str) -> object:
+    def billing_order_checkout_api(bill_order_bid: str) -> str:
         _require_billing_access(app)
         return make_common_response(
             create_billing_order_checkout(
@@ -239,7 +239,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/orders/<bill_order_bid>/refund", methods=["POST"])
-    def billing_order_refund_api(bill_order_bid: str) -> object:
+    def billing_order_refund_api(bill_order_bid: str) -> str:
         _require_billing_access(app)
         return make_common_response(
             refund_billing_order(
@@ -251,7 +251,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/subscriptions/checkout", methods=["POST"])
-    def billing_subscription_checkout_api() -> object:
+    def billing_subscription_checkout_api() -> str:
         _require_billing_access(app)
         return make_common_response(
             create_billing_subscription_checkout(
@@ -262,7 +262,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/subscriptions/cancel", methods=["POST"])
-    def billing_subscription_cancel_api() -> object:
+    def billing_subscription_cancel_api() -> str:
         _require_billing_access(app)
         return make_common_response(
             cancel_billing_subscription(
@@ -273,7 +273,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/subscriptions/resume", methods=["POST"])
-    def billing_subscription_resume_api() -> object:
+    def billing_subscription_resume_api() -> str:
         _require_billing_access(app)
         return make_common_response(
             resume_billing_subscription(
@@ -284,7 +284,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/topups/checkout", methods=["POST"])
-    def billing_topup_checkout_api() -> object:
+    def billing_topup_checkout_api() -> str:
         _require_billing_access(app)
         return make_common_response(
             create_billing_topup_checkout(
@@ -295,14 +295,14 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/customization", methods=["GET"])
-    def billing_customization_api() -> object:
+    def billing_customization_api() -> str:
         _require_billing_access(app)
         return make_common_response(
             build_creator_customization(app, _get_creator_bid())
         )
 
     @app.route(path_prefix + "/customization/branding", methods=["PUT"])
-    def billing_customization_branding_api() -> object:
+    def billing_customization_branding_api() -> str:
         _require_customization_access(app)
         return make_common_response(
             save_creator_branding(
@@ -311,7 +311,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/customization/branding/logo", methods=["POST"])
-    def billing_customization_branding_logo_api() -> object:
+    def billing_customization_branding_logo_api() -> str:
         _require_customization_access(app)
         file = request.files.get("file")
         if file is None:
@@ -326,7 +326,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/customization/domains", methods=["POST"])
-    def billing_customization_domain_create_api() -> object:
+    def billing_customization_domain_create_api() -> str:
         _require_customization_access(app)
         payload = dict(request.get_json(silent=True) or {})
         payload["action"] = "bind"
@@ -338,7 +338,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         path_prefix + "/customization/domains/<domain_binding_bid>/verify",
         methods=["POST"],
     )
-    def billing_customization_domain_verify_api(domain_binding_bid: str) -> object:
+    def billing_customization_domain_verify_api(domain_binding_bid: str) -> str:
         _require_customization_access(app)
         payload = dict(request.get_json(silent=True) or {})
         payload.update(action="verify", domain_binding_bid=domain_binding_bid)
@@ -350,7 +350,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         path_prefix + "/customization/domains/<domain_binding_bid>",
         methods=["DELETE"],
     )
-    def billing_customization_domain_disable_api(domain_binding_bid: str) -> object:
+    def billing_customization_domain_disable_api(domain_binding_bid: str) -> str:
         _require_customization_access(app)
         return make_common_response(
             manage_creator_domain_binding(
@@ -361,7 +361,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/customization/integrations/<provider>", methods=["PUT"])
-    def billing_customization_integration_save_api(provider: str) -> object:
+    def billing_customization_integration_save_api(provider: str) -> str:
         _require_customization_access(app)
         return make_common_response(
             save_creator_integration(
@@ -376,7 +376,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         path_prefix + "/customization/integrations/<provider>/verify",
         methods=["POST"],
     )
-    def billing_customization_integration_verify_api(provider: str) -> object:
+    def billing_customization_integration_verify_api(provider: str) -> str:
         _require_customization_access(app)
         payload = request.get_json(silent=True) or {}
         return make_common_response(
@@ -391,14 +391,14 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     @app.route(
         path_prefix + "/customization/integrations/<provider>", methods=["DELETE"]
     )
-    def billing_customization_integration_disable_api(provider: str) -> object:
+    def billing_customization_integration_disable_api(provider: str) -> str:
         _require_customization_access(app)
         return make_common_response(
             disable_creator_integration(app, _get_creator_bid(), provider)
         )
 
     @app.route(admin_path_prefix + "/subscriptions", methods=["GET"])
-    def admin_bill_subscriptions_api() -> object:
+    def admin_bill_subscriptions_api() -> str:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -414,7 +414,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/entitlements", methods=["GET"])
-    def admin_bill_entitlements_api() -> object:
+    def admin_bill_entitlements_api() -> str:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -428,7 +428,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/entitlements/grants", methods=["POST"])
-    def admin_bill_entitlement_grant_api() -> object:
+    def admin_bill_entitlement_grant_api() -> str:
         _require_billing_operator_access(app)
         payload = request.get_json(silent=True) or {}
         allowed_fields = {
@@ -486,7 +486,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         return make_common_response(response_payload)
 
     @app.route(admin_path_prefix + "/entitlements/<creator_bid>", methods=["POST"])
-    def admin_bill_entitlement_grant_legacy_api(creator_bid: str) -> object:
+    def admin_bill_entitlement_grant_legacy_api(creator_bid: str) -> str:
         _require_billing_operator_access(app)
         payload = request.get_json(silent=True) or {}
         allowed_fields = {
@@ -509,12 +509,12 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         return make_common_response(serialize_creator_entitlements(state))
 
     @app.route(admin_path_prefix + "/ops-state", methods=["GET"])
-    def admin_billing_ops_state_api() -> object:
+    def admin_billing_ops_state_api() -> str:
         _require_billing_operator_access(app)
         return make_common_response(build_admin_billing_ops_state(app))
 
     @app.route(admin_path_prefix + "/ops-state/config-status", methods=["POST"])
-    def admin_billing_config_status_api() -> object:
+    def admin_billing_config_status_api() -> str:
         _require_billing_operator_access(app)
         payload = request.get_json(silent=True) or {}
         return make_common_response(
@@ -526,7 +526,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/customization/<creator_bid>", methods=["GET"])
-    def admin_billing_customization_api(creator_bid: str) -> object:
+    def admin_billing_customization_api(creator_bid: str) -> str:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             build_creator_customization(
@@ -540,7 +540,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/customization-draft", methods=["GET"])
-    def admin_billing_customization_draft_api() -> object:
+    def admin_billing_customization_draft_api() -> str:
         _require_billing_customization_operator_access(app)
         creator_bid = str(request.args.get("creator_bid") or "").strip()
         creator_mobile = str(request.args.get("creator_mobile") or "").strip()
@@ -553,7 +553,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/customization-draft", methods=["PUT"])
-    def admin_billing_customization_draft_save_api() -> object:
+    def admin_billing_customization_draft_save_api() -> str:
         _require_billing_customization_operator_access(app)
         payload = dict(request.get_json(silent=True) or {})
         return make_common_response(
@@ -566,7 +566,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/customization-draft", methods=["DELETE"])
-    def admin_billing_customization_draft_delete_api() -> object:
+    def admin_billing_customization_draft_delete_api() -> str:
         _require_billing_customization_operator_access(app)
         creator_bid = str(request.args.get("creator_bid") or "").strip()
         creator_mobile = str(request.args.get("creator_mobile") or "").strip()
@@ -581,7 +581,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         admin_path_prefix + "/customization-draft/branding/logo",
         methods=["POST"],
     )
-    def admin_billing_customization_draft_logo_api() -> object:
+    def admin_billing_customization_draft_logo_api() -> str:
         _require_billing_customization_operator_access(app)
         file = request.files.get("file")
         if file is None:
@@ -600,7 +600,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         admin_path_prefix + "/customization/<creator_bid>/branding",
         methods=["PUT"],
     )
-    def admin_billing_customization_branding_api(creator_bid: str) -> object:
+    def admin_billing_customization_branding_api(creator_bid: str) -> str:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             save_creator_branding(
@@ -618,7 +618,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         admin_path_prefix + "/customization/<creator_bid>/branding/logo",
         methods=["POST"],
     )
-    def admin_billing_customization_branding_logo_api(creator_bid: str) -> object:
+    def admin_billing_customization_branding_logo_api(creator_bid: str) -> str:
         _require_billing_customization_operator_access(app)
         file = request.files.get("file")
         if file is None:
@@ -640,7 +640,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         admin_path_prefix + "/customization/<creator_bid>/domains",
         methods=["POST"],
     )
-    def admin_billing_customization_domain_create_api(creator_bid: str) -> object:
+    def admin_billing_customization_domain_create_api(creator_bid: str) -> str:
         _require_billing_customization_operator_access(app)
         payload = dict(request.get_json(silent=True) or {})
         payload["action"] = "bind"
@@ -662,7 +662,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_domain_verify_api(
         creator_bid: str, domain_binding_bid: str
-    ) -> object:
+    ) -> str:
         _require_billing_customization_operator_access(app)
         payload = dict(request.get_json(silent=True) or {})
         payload.update(action="verify", domain_binding_bid=domain_binding_bid)
@@ -683,7 +683,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_domain_disable_api(
         creator_bid: str, domain_binding_bid: str
-    ) -> object:
+    ) -> str:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             manage_creator_domain_binding(
@@ -702,7 +702,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_integration_save_api(
         creator_bid: str, provider: str
-    ) -> object:
+    ) -> str:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             save_creator_integration(
@@ -724,7 +724,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_integration_verify_api(
         creator_bid: str, provider: str
-    ) -> object:
+    ) -> str:
         _require_billing_customization_operator_access(app)
         payload = request.get_json(silent=True) or {}
         return make_common_response(
@@ -745,7 +745,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_integration_disable_api(
         creator_bid: str, provider: str
-    ) -> object:
+    ) -> str:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             disable_creator_integration(
@@ -759,7 +759,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/reports/usage-daily", methods=["GET"])
-    def admin_billing_daily_usage_reports_api() -> object:
+    def admin_billing_daily_usage_reports_api() -> str:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -774,7 +774,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/reports/focus-teachers", methods=["GET"])
-    def admin_billing_focus_teachers_reports_api() -> object:
+    def admin_billing_focus_teachers_reports_api() -> str:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -786,7 +786,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/reports/ledger-daily", methods=["GET"])
-    def admin_billing_daily_ledger_reports_api() -> object:
+    def admin_billing_daily_ledger_reports_api() -> str:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -801,7 +801,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/ledger/adjust", methods=["POST"])
-    def admin_billing_ledger_adjust_api() -> object:
+    def admin_billing_ledger_adjust_api() -> str:
         _require_billing_operator_access(app)
         payload = request.get_json(silent=True) or {}
         target_creator_bid = _resolve_existing_admin_billing_target_user_bid(
@@ -817,12 +817,12 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/products/options", methods=["GET"])
-    def admin_billing_campaign_product_options_api() -> object:
+    def admin_billing_campaign_product_options_api() -> str:
         _require_billing_operator_access(app)
         return make_common_response(build_admin_billing_campaign_product_options(app))
 
     @app.route(admin_path_prefix + "/campaigns", methods=["GET"])
-    def admin_billing_campaigns_api() -> object:
+    def admin_billing_campaigns_api() -> str:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -840,7 +840,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/campaigns", methods=["POST"])
-    def admin_billing_campaign_create_api() -> object:
+    def admin_billing_campaign_create_api() -> str:
         _require_billing_operator_access(app)
         return make_common_response(
             create_admin_billing_campaign(
@@ -851,7 +851,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/campaigns/<campaign_bid>", methods=["GET"])
-    def admin_billing_campaign_detail_api(campaign_bid: str) -> object:
+    def admin_billing_campaign_detail_api(campaign_bid: str) -> str:
         _require_billing_operator_access(app)
         return make_common_response(
             build_admin_billing_campaign_detail(
@@ -861,7 +861,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/campaigns/<campaign_bid>", methods=["POST"])
-    def admin_billing_campaign_update_api(campaign_bid: str) -> object:
+    def admin_billing_campaign_update_api(campaign_bid: str) -> str:
         _require_billing_operator_access(app)
         return make_common_response(
             update_admin_billing_campaign(
@@ -873,7 +873,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/campaigns/<campaign_bid>/status", methods=["POST"])
-    def admin_billing_campaign_status_api(campaign_bid: str) -> object:
+    def admin_billing_campaign_status_api(campaign_bid: str) -> str:
         _require_billing_operator_access(app)
         return make_common_response(
             update_admin_billing_campaign_status(

--- a/src/api/flaskr/service/billing/routes.py
+++ b/src/api/flaskr/service/billing/routes.py
@@ -162,17 +162,17 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     admin_path_prefix = "/api/admin/billing"
 
     @app.route(path_prefix, methods=["GET"])
-    def billing_bootstrap_api():
+    def billing_bootstrap_api() -> object:
         _require_billing_access(app)
         return make_common_response(build_billing_route_bootstrap(path_prefix))
 
     @app.route(path_prefix + "/catalog", methods=["GET"])
-    def billing_catalog_api():
+    def billing_catalog_api() -> object:
         _require_billing_access(app)
         return make_common_response(build_billing_catalog(app))
 
     @app.route(path_prefix + "/overview", methods=["GET"])
-    def billing_overview_api():
+    def billing_overview_api() -> object:
         _require_billing_access(app)
         return make_common_response(
             build_billing_overview(
@@ -182,7 +182,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/trial-offer/welcome/ack", methods=["POST"])
-    def billing_trial_offer_welcome_ack_api():
+    def billing_trial_offer_welcome_ack_api() -> object:
         _require_billing_access(app)
         return make_common_response(
             acknowledge_trial_welcome_dialog(
@@ -192,7 +192,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/wallet-buckets", methods=["GET"])
-    def billing_wallet_buckets_api():
+    def billing_wallet_buckets_api() -> object:
         _require_billing_access(app)
         return make_common_response(
             build_billing_wallet_buckets(
@@ -202,7 +202,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/ledger", methods=["GET"])
-    def billing_ledger_api():
+    def billing_ledger_api() -> object:
         _require_billing_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -215,7 +215,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/orders/<bill_order_bid>/sync", methods=["POST"])
-    def billing_order_sync_api(bill_order_bid: str):
+    def billing_order_sync_api(bill_order_bid: str) -> object:
         _require_billing_access(app)
         return make_common_response(
             sync_billing_order(
@@ -227,7 +227,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/orders/<bill_order_bid>/checkout", methods=["POST"])
-    def billing_order_checkout_api(bill_order_bid: str):
+    def billing_order_checkout_api(bill_order_bid: str) -> object:
         _require_billing_access(app)
         return make_common_response(
             create_billing_order_checkout(
@@ -239,7 +239,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/orders/<bill_order_bid>/refund", methods=["POST"])
-    def billing_order_refund_api(bill_order_bid: str):
+    def billing_order_refund_api(bill_order_bid: str) -> object:
         _require_billing_access(app)
         return make_common_response(
             refund_billing_order(
@@ -251,7 +251,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/subscriptions/checkout", methods=["POST"])
-    def billing_subscription_checkout_api():
+    def billing_subscription_checkout_api() -> object:
         _require_billing_access(app)
         return make_common_response(
             create_billing_subscription_checkout(
@@ -262,7 +262,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/subscriptions/cancel", methods=["POST"])
-    def billing_subscription_cancel_api():
+    def billing_subscription_cancel_api() -> object:
         _require_billing_access(app)
         return make_common_response(
             cancel_billing_subscription(
@@ -273,7 +273,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/subscriptions/resume", methods=["POST"])
-    def billing_subscription_resume_api():
+    def billing_subscription_resume_api() -> object:
         _require_billing_access(app)
         return make_common_response(
             resume_billing_subscription(
@@ -284,7 +284,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/topups/checkout", methods=["POST"])
-    def billing_topup_checkout_api():
+    def billing_topup_checkout_api() -> object:
         _require_billing_access(app)
         return make_common_response(
             create_billing_topup_checkout(
@@ -295,14 +295,14 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/customization", methods=["GET"])
-    def billing_customization_api():
+    def billing_customization_api() -> object:
         _require_billing_access(app)
         return make_common_response(
             build_creator_customization(app, _get_creator_bid())
         )
 
     @app.route(path_prefix + "/customization/branding", methods=["PUT"])
-    def billing_customization_branding_api():
+    def billing_customization_branding_api() -> object:
         _require_customization_access(app)
         return make_common_response(
             save_creator_branding(
@@ -311,7 +311,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/customization/branding/logo", methods=["POST"])
-    def billing_customization_branding_logo_api():
+    def billing_customization_branding_logo_api() -> object:
         _require_customization_access(app)
         file = request.files.get("file")
         if file is None:
@@ -326,7 +326,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/customization/domains", methods=["POST"])
-    def billing_customization_domain_create_api():
+    def billing_customization_domain_create_api() -> object:
         _require_customization_access(app)
         payload = dict(request.get_json(silent=True) or {})
         payload["action"] = "bind"
@@ -338,7 +338,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         path_prefix + "/customization/domains/<domain_binding_bid>/verify",
         methods=["POST"],
     )
-    def billing_customization_domain_verify_api(domain_binding_bid: str):
+    def billing_customization_domain_verify_api(domain_binding_bid: str) -> object:
         _require_customization_access(app)
         payload = dict(request.get_json(silent=True) or {})
         payload.update(action="verify", domain_binding_bid=domain_binding_bid)
@@ -350,7 +350,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         path_prefix + "/customization/domains/<domain_binding_bid>",
         methods=["DELETE"],
     )
-    def billing_customization_domain_disable_api(domain_binding_bid: str):
+    def billing_customization_domain_disable_api(domain_binding_bid: str) -> object:
         _require_customization_access(app)
         return make_common_response(
             manage_creator_domain_binding(
@@ -361,7 +361,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(path_prefix + "/customization/integrations/<provider>", methods=["PUT"])
-    def billing_customization_integration_save_api(provider: str):
+    def billing_customization_integration_save_api(provider: str) -> object:
         _require_customization_access(app)
         return make_common_response(
             save_creator_integration(
@@ -376,7 +376,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         path_prefix + "/customization/integrations/<provider>/verify",
         methods=["POST"],
     )
-    def billing_customization_integration_verify_api(provider: str):
+    def billing_customization_integration_verify_api(provider: str) -> object:
         _require_customization_access(app)
         payload = request.get_json(silent=True) or {}
         return make_common_response(
@@ -391,14 +391,14 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     @app.route(
         path_prefix + "/customization/integrations/<provider>", methods=["DELETE"]
     )
-    def billing_customization_integration_disable_api(provider: str):
+    def billing_customization_integration_disable_api(provider: str) -> object:
         _require_customization_access(app)
         return make_common_response(
             disable_creator_integration(app, _get_creator_bid(), provider)
         )
 
     @app.route(admin_path_prefix + "/subscriptions", methods=["GET"])
-    def admin_bill_subscriptions_api():
+    def admin_bill_subscriptions_api() -> object:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -414,7 +414,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/entitlements", methods=["GET"])
-    def admin_bill_entitlements_api():
+    def admin_bill_entitlements_api() -> object:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -428,7 +428,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/entitlements/grants", methods=["POST"])
-    def admin_bill_entitlement_grant_api():
+    def admin_bill_entitlement_grant_api() -> object:
         _require_billing_operator_access(app)
         payload = request.get_json(silent=True) or {}
         allowed_fields = {
@@ -486,7 +486,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         return make_common_response(response_payload)
 
     @app.route(admin_path_prefix + "/entitlements/<creator_bid>", methods=["POST"])
-    def admin_bill_entitlement_grant_legacy_api(creator_bid: str):
+    def admin_bill_entitlement_grant_legacy_api(creator_bid: str) -> object:
         _require_billing_operator_access(app)
         payload = request.get_json(silent=True) or {}
         allowed_fields = {
@@ -509,12 +509,12 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         return make_common_response(serialize_creator_entitlements(state))
 
     @app.route(admin_path_prefix + "/ops-state", methods=["GET"])
-    def admin_billing_ops_state_api():
+    def admin_billing_ops_state_api() -> object:
         _require_billing_operator_access(app)
         return make_common_response(build_admin_billing_ops_state(app))
 
     @app.route(admin_path_prefix + "/ops-state/config-status", methods=["POST"])
-    def admin_billing_config_status_api():
+    def admin_billing_config_status_api() -> object:
         _require_billing_operator_access(app)
         payload = request.get_json(silent=True) or {}
         return make_common_response(
@@ -526,7 +526,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/customization/<creator_bid>", methods=["GET"])
-    def admin_billing_customization_api(creator_bid: str):
+    def admin_billing_customization_api(creator_bid: str) -> object:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             build_creator_customization(
@@ -540,7 +540,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/customization-draft", methods=["GET"])
-    def admin_billing_customization_draft_api():
+    def admin_billing_customization_draft_api() -> object:
         _require_billing_customization_operator_access(app)
         creator_bid = str(request.args.get("creator_bid") or "").strip()
         creator_mobile = str(request.args.get("creator_mobile") or "").strip()
@@ -553,7 +553,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/customization-draft", methods=["PUT"])
-    def admin_billing_customization_draft_save_api():
+    def admin_billing_customization_draft_save_api() -> object:
         _require_billing_customization_operator_access(app)
         payload = dict(request.get_json(silent=True) or {})
         return make_common_response(
@@ -566,7 +566,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/customization-draft", methods=["DELETE"])
-    def admin_billing_customization_draft_delete_api():
+    def admin_billing_customization_draft_delete_api() -> object:
         _require_billing_customization_operator_access(app)
         creator_bid = str(request.args.get("creator_bid") or "").strip()
         creator_mobile = str(request.args.get("creator_mobile") or "").strip()
@@ -581,7 +581,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         admin_path_prefix + "/customization-draft/branding/logo",
         methods=["POST"],
     )
-    def admin_billing_customization_draft_logo_api():
+    def admin_billing_customization_draft_logo_api() -> object:
         _require_billing_customization_operator_access(app)
         file = request.files.get("file")
         if file is None:
@@ -600,7 +600,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         admin_path_prefix + "/customization/<creator_bid>/branding",
         methods=["PUT"],
     )
-    def admin_billing_customization_branding_api(creator_bid: str):
+    def admin_billing_customization_branding_api(creator_bid: str) -> object:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             save_creator_branding(
@@ -618,7 +618,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         admin_path_prefix + "/customization/<creator_bid>/branding/logo",
         methods=["POST"],
     )
-    def admin_billing_customization_branding_logo_api(creator_bid: str):
+    def admin_billing_customization_branding_logo_api(creator_bid: str) -> object:
         _require_billing_customization_operator_access(app)
         file = request.files.get("file")
         if file is None:
@@ -640,7 +640,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         admin_path_prefix + "/customization/<creator_bid>/domains",
         methods=["POST"],
     )
-    def admin_billing_customization_domain_create_api(creator_bid: str):
+    def admin_billing_customization_domain_create_api(creator_bid: str) -> object:
         _require_billing_customization_operator_access(app)
         payload = dict(request.get_json(silent=True) or {})
         payload["action"] = "bind"
@@ -662,7 +662,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_domain_verify_api(
         creator_bid: str, domain_binding_bid: str
-    ):
+    ) -> object:
         _require_billing_customization_operator_access(app)
         payload = dict(request.get_json(silent=True) or {})
         payload.update(action="verify", domain_binding_bid=domain_binding_bid)
@@ -683,7 +683,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_domain_disable_api(
         creator_bid: str, domain_binding_bid: str
-    ):
+    ) -> object:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             manage_creator_domain_binding(
@@ -702,7 +702,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_integration_save_api(
         creator_bid: str, provider: str
-    ):
+    ) -> object:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             save_creator_integration(
@@ -724,7 +724,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_integration_verify_api(
         creator_bid: str, provider: str
-    ):
+    ) -> object:
         _require_billing_customization_operator_access(app)
         payload = request.get_json(silent=True) or {}
         return make_common_response(
@@ -745,7 +745,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
     )
     def admin_billing_customization_integration_disable_api(
         creator_bid: str, provider: str
-    ):
+    ) -> object:
         _require_billing_customization_operator_access(app)
         return make_common_response(
             disable_creator_integration(
@@ -759,7 +759,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/reports/usage-daily", methods=["GET"])
-    def admin_billing_daily_usage_reports_api():
+    def admin_billing_daily_usage_reports_api() -> object:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -774,7 +774,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/reports/focus-teachers", methods=["GET"])
-    def admin_billing_focus_teachers_reports_api():
+    def admin_billing_focus_teachers_reports_api() -> object:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -786,7 +786,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/reports/ledger-daily", methods=["GET"])
-    def admin_billing_daily_ledger_reports_api():
+    def admin_billing_daily_ledger_reports_api() -> object:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -801,7 +801,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/ledger/adjust", methods=["POST"])
-    def admin_billing_ledger_adjust_api():
+    def admin_billing_ledger_adjust_api() -> object:
         _require_billing_operator_access(app)
         payload = request.get_json(silent=True) or {}
         target_creator_bid = _resolve_existing_admin_billing_target_user_bid(
@@ -817,12 +817,12 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/products/options", methods=["GET"])
-    def admin_billing_campaign_product_options_api():
+    def admin_billing_campaign_product_options_api() -> object:
         _require_billing_operator_access(app)
         return make_common_response(build_admin_billing_campaign_product_options(app))
 
     @app.route(admin_path_prefix + "/campaigns", methods=["GET"])
-    def admin_billing_campaigns_api():
+    def admin_billing_campaigns_api() -> object:
         _require_billing_operator_access(app)
         page_index, page_size = _get_page_args()
         return make_common_response(
@@ -840,7 +840,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/campaigns", methods=["POST"])
-    def admin_billing_campaign_create_api():
+    def admin_billing_campaign_create_api() -> object:
         _require_billing_operator_access(app)
         return make_common_response(
             create_admin_billing_campaign(
@@ -851,7 +851,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/campaigns/<campaign_bid>", methods=["GET"])
-    def admin_billing_campaign_detail_api(campaign_bid: str):
+    def admin_billing_campaign_detail_api(campaign_bid: str) -> object:
         _require_billing_operator_access(app)
         return make_common_response(
             build_admin_billing_campaign_detail(
@@ -861,7 +861,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/campaigns/<campaign_bid>", methods=["POST"])
-    def admin_billing_campaign_update_api(campaign_bid: str):
+    def admin_billing_campaign_update_api(campaign_bid: str) -> object:
         _require_billing_operator_access(app)
         return make_common_response(
             update_admin_billing_campaign(
@@ -873,7 +873,7 @@ def register_billing_routes(app: Flask, path_prefix: str = "/api/billing") -> No
         )
 
     @app.route(admin_path_prefix + "/campaigns/<campaign_bid>/status", methods=["POST"])
-    def admin_billing_campaign_status_api(campaign_bid: str):
+    def admin_billing_campaign_status_api(campaign_bid: str) -> object:
         _require_billing_operator_access(app)
         return make_common_response(
             update_admin_billing_campaign_status(

--- a/src/api/flaskr/service/billing/settlement.py
+++ b/src/api/flaskr/service/billing/settlement.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator  # noqa: TC003 - annotation must resolve at runtime
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from decimal import Decimal
@@ -558,7 +559,7 @@ def backfill_bill_usage_settlement(
 
 
 @contextmanager
-def _usage_settlement_lock(app: Flask, *, creator_bid: str, usage_bid: str):
+def _usage_settlement_lock(app: Flask, *, creator_bid: str, usage_bid: str) -> Iterator[None]:
     normalized_creator_bid = str(creator_bid or "").strip()
     normalized_usage_bid = str(usage_bid or "").strip()
     lock_scope = normalized_creator_bid or f"usage:{normalized_usage_bid}"

--- a/src/api/flaskr/service/billing/settlement.py
+++ b/src/api/flaskr/service/billing/settlement.py
@@ -559,7 +559,9 @@ def backfill_bill_usage_settlement(
 
 
 @contextmanager
-def _usage_settlement_lock(app: Flask, *, creator_bid: str, usage_bid: str) -> Iterator[None]:
+def _usage_settlement_lock(
+    app: Flask, *, creator_bid: str, usage_bid: str
+) -> Iterator[None]:
     normalized_creator_bid = str(creator_bid or "").strip()
     normalized_usage_bid = str(usage_bid or "").strip()
     lock_scope = normalized_creator_bid or f"usage:{normalized_usage_bid}"

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -13,7 +13,11 @@ from flaskr.service.config import get_config
 from flaskr.util.datetime import now_utc
 from sqlalchemy import and_, or_
 
-from .checkout import reconcile_billing_provider_reference, sync_billing_order
+from .checkout import (
+    ProviderReferenceReconcileResult,
+    reconcile_billing_provider_reference,
+    sync_billing_order,
+)
 from .consts import (
     BILL_CONFIG_KEY_RENEWAL_TASK_CONFIG,
     BILLING_ORDER_STATUS_PENDING,
@@ -294,14 +298,14 @@ def dispatch_due_renewal_events(
 
 
 def _run_reconcile_provider_reference(
-    app: object,
+    app: Flask,
     *,
     creator_bid: str = "",
     payment_provider: str = "",
     provider_reference_id: str = "",
     bill_order_bid: str = "",
     session_id: str = "",
-) -> object:
+) -> ProviderReferenceReconcileResult:
     normalized_creator_bid = _normalize_bid(creator_bid)
     normalized_payment_provider = _normalize_bid(payment_provider)
     normalized_provider_reference_id = _normalize_bid(provider_reference_id)

--- a/src/api/flaskr/service/billing/tasks.py
+++ b/src/api/flaskr/service/billing/tasks.py
@@ -66,6 +66,8 @@ from .wallets import expire_credit_wallet_buckets
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from flask import Flask
+
 try:  # pragma: no cover - exercised indirectly when Celery is installed
     from celery import shared_task
 except ImportError:  # pragma: no cover - local fallback for non-Celery test envs
@@ -95,7 +97,7 @@ class CreditNotificationRetryableError(RuntimeError):
     """Raised when the credit notification worker should use Celery autoretry."""
 
 
-def _create_task_app():
+def _create_task_app() -> Flask:
     os.environ.setdefault("SKIP_APP_AUTOCREATE", "1")
     from app import create_app
 
@@ -299,7 +301,7 @@ def _run_reconcile_provider_reference(
     provider_reference_id: str = "",
     bill_order_bid: str = "",
     session_id: str = "",
-):
+) -> object:
     normalized_creator_bid = _normalize_bid(creator_bid)
     normalized_payment_provider = _normalize_bid(payment_provider)
     normalized_provider_reference_id = _normalize_bid(provider_reference_id)

--- a/src/api/flaskr/service/billing/trials.py
+++ b/src/api/flaskr/service/billing/trials.py
@@ -50,6 +50,7 @@ from .primitives import safe_to_positive_int as _safe_to_positive_int
 from .subscriptions import grant_paid_order_credits as _grant_paid_order_credits
 
 if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
     from decimal import Decimal
 
 _ACTIVE_SUBSCRIPTION_STATUSES = (
@@ -61,7 +62,7 @@ _ACTIVE_SUBSCRIPTION_STATUSES = (
 _TRIAL_WELCOME_ACK_KEY = "welcome_trial_dialog_acknowledged_at"
 
 
-def _maybe_app_context(app: Flask):
+def _maybe_app_context(app: Flask) -> AbstractContextManager[None]:
     return nullcontext() if has_app_context() else app.app_context()
 
 

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     from flask import Flask
     from sqlalchemy.sql import Select
     from sqlalchemy.sql.elements import ColumnElement
+    from sqlalchemy.sql.selectable import Join
 
 # Reuse the DSL-path error names so the HTTP wrapper maps them consistently
 # (the error name → HTTP code mapping lives in error_codes.json).
@@ -275,7 +276,7 @@ def _parse_int(raw: Any, field_name: str, *, default: int) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _join_conditions() -> object:
+def _join_conditions() -> Join:
     """Build the bill_usage x credit_ledger_entries ON clause.
 
     ``source_type = USAGE`` is part of the JOIN (not the WHERE) so the

--- a/src/api/flaskr/service/creator_analytics/credit_detail.py
+++ b/src/api/flaskr/service/creator_analytics/credit_detail.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
 
     from flask import Flask
     from sqlalchemy.sql import Select
+    from sqlalchemy.sql.elements import ColumnElement
 
 # Reuse the DSL-path error names so the HTTP wrapper maps them consistently
 # (the error name → HTTP code mapping lives in error_codes.json).
@@ -274,7 +275,7 @@ def _parse_int(raw: Any, field_name: str, *, default: int) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _join_conditions():
+def _join_conditions() -> object:
     """Build the bill_usage x credit_ledger_entries ON clause.
 
     ``source_type = USAGE`` is part of the JOIN (not the WHERE) so the
@@ -296,7 +297,7 @@ def _join_conditions():
     )
 
 
-def _where_clauses(params: _Params):
+def _where_clauses(params: _Params) -> list[ColumnElement[bool]]:
     """Build the WHERE predicates shared by detail + summary queries."""
     bu = BillUsageRecord.__table__
     clauses = [bu.c.shifu_bid == bindparam("__shifu_bid", value=params.shifu_bid)]

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from flask import Flask
+    from sqlalchemy.sql.elements import ColumnElement
     from sqlalchemy.sql.selectable import Subquery
 
 
@@ -146,7 +147,7 @@ def _dashboard_learner_keyword_matches(
 def _build_dashboard_learner_keyword_filter(
     user_bid_column: object,
     keyword: str,
-) -> object:
+) -> ColumnElement[bool] | None:
     normalized_keyword = _normalize_dashboard_identifier(keyword).strip()
     if not normalized_keyword:
         return None

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from flask import Flask
+    from sqlalchemy.sql.selectable import Subquery
 
 
 @dataclass(frozen=True)
@@ -145,7 +146,7 @@ def _dashboard_learner_keyword_matches(
 def _build_dashboard_learner_keyword_filter(
     user_bid_column: object,
     keyword: str,
-):
+) -> object:
     normalized_keyword = _normalize_dashboard_identifier(keyword).strip()
     if not normalized_keyword:
         return None
@@ -278,7 +279,7 @@ def _build_course_outline_context_map(
     return context_map
 
 
-def _build_course_follow_up_base_subquery(shifu_bid: str):
+def _build_course_follow_up_base_subquery(shifu_bid: str) -> Subquery:
     return (
         db.session.query(
             LearnGeneratedBlock.id.label("id"),
@@ -312,7 +313,7 @@ def _build_course_follow_up_base_subquery(shifu_bid: str):
 def _build_follow_up_user_keyword_filter(
     user_bid_column: object,
     keyword: str,
-):
+) -> object:
     normalized = _normalize_dashboard_identifier(keyword)
     if not normalized:
         return None

--- a/src/api/flaskr/service/dashboard/funcs.py
+++ b/src/api/flaskr/service/dashboard/funcs.py
@@ -314,7 +314,7 @@ def _build_course_follow_up_base_subquery(shifu_bid: str) -> Subquery:
 def _build_follow_up_user_keyword_filter(
     user_bid_column: object,
     keyword: str,
-) -> object:
+) -> ColumnElement[bool] | None:
     normalized = _normalize_dashboard_identifier(keyword)
     if not normalized:
         return None

--- a/src/api/flaskr/service/dashboard/routes.py
+++ b/src/api/flaskr/service/dashboard/routes.py
@@ -43,7 +43,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
     app.logger.info("register dashboard routes %s", path_prefix)
 
     @app.route(path_prefix + "/entry", methods=["GET"])
-    def dashboard_entry_api():
+    def dashboard_entry_api() -> object:
         user_id = request.user.user_id
         page_index, page_size = _get_pagination_args()
         timezone_name = _get_timezone_name()
@@ -61,7 +61,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
         )
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/detail", methods=["GET"])
-    def dashboard_course_detail_api(shifu_bid: str):
+    def dashboard_course_detail_api(shifu_bid: str) -> object:
         user_id = request.user.user_id
         return make_common_response(
             build_dashboard_course_detail(
@@ -73,7 +73,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
         )
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/learners", methods=["GET"])
-    def dashboard_course_learners_api(shifu_bid: str):
+    def dashboard_course_learners_api(shifu_bid: str) -> object:
         user_id = request.user.user_id
         page_index, page_size = _get_pagination_args()
         return make_common_response(
@@ -92,7 +92,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
         )
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/follow-ups", methods=["GET"])
-    def dashboard_course_follow_ups_api(shifu_bid: str):
+    def dashboard_course_follow_ups_api(shifu_bid: str) -> object:
         user_id = request.user.user_id
         page_index, page_size = _get_pagination_args()
         return make_common_response(
@@ -113,7 +113,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
         )
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/ratings", methods=["GET"])
-    def dashboard_course_ratings_api(shifu_bid: str):
+    def dashboard_course_ratings_api(shifu_bid: str) -> object:
         user_id = request.user.user_id
         page_index, page_size = _get_pagination_args()
         return make_common_response(
@@ -140,7 +140,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
     def dashboard_course_follow_up_detail_api(
         shifu_bid: str,
         generated_block_bid: str,
-    ):
+    ) -> object:
         user_id = request.user.user_id
         return make_common_response(
             build_dashboard_course_follow_up_detail(

--- a/src/api/flaskr/service/dashboard/routes.py
+++ b/src/api/flaskr/service/dashboard/routes.py
@@ -43,7 +43,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
     app.logger.info("register dashboard routes %s", path_prefix)
 
     @app.route(path_prefix + "/entry", methods=["GET"])
-    def dashboard_entry_api() -> object:
+    def dashboard_entry_api() -> str:
         user_id = request.user.user_id
         page_index, page_size = _get_pagination_args()
         timezone_name = _get_timezone_name()
@@ -61,7 +61,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
         )
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/detail", methods=["GET"])
-    def dashboard_course_detail_api(shifu_bid: str) -> object:
+    def dashboard_course_detail_api(shifu_bid: str) -> str:
         user_id = request.user.user_id
         return make_common_response(
             build_dashboard_course_detail(
@@ -73,7 +73,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
         )
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/learners", methods=["GET"])
-    def dashboard_course_learners_api(shifu_bid: str) -> object:
+    def dashboard_course_learners_api(shifu_bid: str) -> str:
         user_id = request.user.user_id
         page_index, page_size = _get_pagination_args()
         return make_common_response(
@@ -92,7 +92,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
         )
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/follow-ups", methods=["GET"])
-    def dashboard_course_follow_ups_api(shifu_bid: str) -> object:
+    def dashboard_course_follow_ups_api(shifu_bid: str) -> str:
         user_id = request.user.user_id
         page_index, page_size = _get_pagination_args()
         return make_common_response(
@@ -113,7 +113,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
         )
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/ratings", methods=["GET"])
-    def dashboard_course_ratings_api(shifu_bid: str) -> object:
+    def dashboard_course_ratings_api(shifu_bid: str) -> str:
         user_id = request.user.user_id
         page_index, page_size = _get_pagination_args()
         return make_common_response(
@@ -140,7 +140,7 @@ def register_dashboard_routes(app: Flask, path_prefix: str = "/api/dashboard") -
     def dashboard_course_follow_up_detail_api(
         shifu_bid: str,
         generated_block_bid: str,
-    ) -> object:
+    ) -> str:
         user_id = request.user.user_id
         return make_common_response(
             build_dashboard_course_follow_up_detail(

--- a/src/api/flaskr/service/learn/context_v2.py
+++ b/src/api/flaskr/service/learn/context_v2.py
@@ -6,11 +6,11 @@ import inspect
 import json
 import queue
 import threading
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable, Generator, Iterable, Iterator
 from dataclasses import dataclass, replace
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from flask import Flask
 from flaskr.api.langfuse import (
@@ -133,6 +133,9 @@ from markdown_flow import (
 )
 from markdown_flow.llm import LLMResult
 from markdown_flow.models import Block
+
+if TYPE_CHECKING:
+    from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
 context_local = threading.local()
 
@@ -1757,7 +1760,7 @@ class RunScriptContextV2:
         position: int = 0,
         stream_element_number: int | None = None,
         stream_element_type: str | None = None,
-    ):
+    ) -> "StreamingTTSProcessor | None":
         """Create StreamingTTSProcessor if TTS is configured, else return None."""
         try:
             from flaskr.common.config import get_config
@@ -3402,7 +3405,7 @@ class RunScriptContextV2:
         def _switch_tts_processor(
             stream_element_type: str | None = None,
             stream_element_number: int | None = None,
-        ):
+        ) -> None:
             nonlocal \
                 tts_processor, \
                 tts_enabled, \
@@ -3436,7 +3439,7 @@ class RunScriptContextV2:
             chunk_content: str,
             stream_element_type: str | None = None,
             stream_element_number: int | None = None,
-        ):
+        ) -> Iterator[RunMarkdownFlowDTO]:
             nonlocal \
                 generated_content, \
                 tts_processor, \
@@ -3489,7 +3492,7 @@ class RunScriptContextV2:
             )
             _disable_all_tts()
 
-        def _drain_current_tts_ready_events():
+        def _drain_current_tts_ready_events() -> Iterator[RunMarkdownFlowDTO]:
             if not tts_processor:
                 return
             if not hasattr(tts_processor, "drain_ready_segments"):
@@ -3499,7 +3502,7 @@ class RunScriptContextV2:
             except Exception as exc:
                 _handle_current_tts_drain_error(exc)
 
-        def _drain_tts_ready_events():
+        def _drain_tts_ready_events() -> Iterator[RunMarkdownFlowDTO]:
             yield from tts_finalize_drainer.drain()
             yield from _drain_current_tts_ready_events()
             yield from tts_finalize_drainer.drain()

--- a/src/api/flaskr/service/learn/handle_input_ask.py
+++ b/src/api/flaskr/service/learn/handle_input_ask.py
@@ -598,7 +598,9 @@ def handle_input_ask(
         apply_knowledge_to_messages,
     )
 
-    def _chat_llm_stream(stream_messages: list[dict[str, Any]]) -> Generator[Any, None, None]:
+    def _chat_llm_stream(
+        stream_messages: list[dict[str, Any]],
+    ) -> Generator[Any, None, None]:
         return chat_llm_func(
             app,
             user_info.user_id,

--- a/src/api/flaskr/service/learn/handle_input_ask.py
+++ b/src/api/flaskr/service/learn/handle_input_ask.py
@@ -65,7 +65,7 @@ stream_ask_provider_response = None
 chat_llm = None
 
 
-def _is_valid_asks(asks: object) -> object:
+def _is_valid_asks(asks: object) -> bool:
     """Check if asks list has at least one complete student+teacher pair."""
     if not asks or not isinstance(asks, list):
         return False
@@ -161,7 +161,7 @@ def _create_ask_block(
     user_bid: object,
     input_text: object,
     last_position: object,
-) -> object:
+) -> LearnGeneratedBlock:
     ask_block = init_generated_block(
         app,
         shifu_bid=outline_item_info.shifu_bid,

--- a/src/api/flaskr/service/learn/handle_input_ask.py
+++ b/src/api/flaskr/service/learn/handle_input_ask.py
@@ -65,7 +65,7 @@ stream_ask_provider_response = None
 chat_llm = None
 
 
-def _is_valid_asks(asks: object):
+def _is_valid_asks(asks: object) -> object:
     """Check if asks list has at least one complete student+teacher pair."""
     if not asks or not isinstance(asks, list):
         return False
@@ -76,7 +76,7 @@ def _is_valid_asks(asks: object):
 
 def _load_legacy_ask_context(
     anchor_element: object, ask_element: object, ask_max_history_len: object
-):
+) -> list[dict[str, object]] | None:
     if anchor_element is None or ask_element is None:
         return None
 
@@ -108,7 +108,7 @@ def _load_legacy_ask_context(
 
 def _load_ask_context(
     anchor_element: object, follow_up_elements: object, ask_max_history_len: object
-):
+) -> list[dict[str, object]] | None:
     """Load ask context from ask/answer sidecar elements first."""
     if anchor_element is None or not follow_up_elements:
         return None
@@ -161,7 +161,7 @@ def _create_ask_block(
     user_bid: object,
     input_text: object,
     last_position: object,
-):
+) -> object:
     ask_block = init_generated_block(
         app,
         shifu_bid=outline_item_info.shifu_bid,
@@ -187,7 +187,7 @@ def _create_answer_block(
     user_bid: object,
     response_text: object,
     last_position: object,
-):
+) -> LearnGeneratedBlock:
     answer_block = init_generated_block(
         app,
         shifu_bid=outline_item_info.shifu_bid,
@@ -219,7 +219,7 @@ def _run_guardrail(
     usage_context: object,
     chapter_title: object,
     ask_scene: object,
-):
+) -> list[str]:
     check_text_func = globals().get("check_text_with_llm_response")
     llm_settings_cls = globals().get("LLMSettings")
     if check_text_func is None or llm_settings_cls is None:
@@ -598,7 +598,7 @@ def handle_input_ask(
         apply_knowledge_to_messages,
     )
 
-    def _chat_llm_stream(stream_messages: list[dict[str, Any]]):
+    def _chat_llm_stream(stream_messages: list[dict[str, Any]]) -> Generator[Any, None, None]:
         return chat_llm_func(
             app,
             user_info.user_id,

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -388,7 +388,9 @@ def get_outline_item_tree(
                     progress_record
                 )
 
-        def build_outline_item_tree(item: HistoryItem) -> object:
+        def build_outline_item_tree(
+            item: HistoryItem,
+        ) -> LearnOutlineItemInfoDTO | None:
             outline_item: DraftOutlineItem | PublishedOutlineItem = next(
                 (i for i in outline_items_dbs if i.id == item.id), None
             )
@@ -1602,7 +1604,7 @@ def stream_generated_block_audio(
             )
         )
 
-        def _resolve_existing_single_block_audio() -> object:
+        def _resolve_existing_single_block_audio() -> LearnGeneratedAudio | None:
             existing_audios = (
                 LearnGeneratedAudio.query.filter(
                     LearnGeneratedAudio.generated_block_bid == generated_block_bid,
@@ -1631,7 +1633,7 @@ def stream_generated_block_audio(
 
         def _yield_existing_single_block_audio(
             existing_audio: LearnGeneratedAudio,
-        ) -> object:
+        ) -> Iterator[object]:
             yield _build_audio_complete_message(
                 outline_bid=generated_block.outline_item_bid or "",
                 generated_block_bid=generated_block_bid,
@@ -1676,7 +1678,7 @@ def stream_generated_block_audio(
                 body=_generate_single_audio,
             )
 
-        def _yield_preview_single_block_audio() -> object:
+        def _yield_preview_single_block_audio() -> Iterator[object]:
             cleaned_text = preprocess_for_tts(raw_text)
             if not cleaned_text or len(cleaned_text.strip()) < 2:
                 raise_error_with_args(
@@ -1703,7 +1705,7 @@ def stream_generated_block_audio(
             audio_parts: list[bytes] = []
             subtitle_cues: list[dict] = []
 
-            def _generate_preview_audio() -> object:
+            def _generate_preview_audio() -> Iterator[object]:
                 yield from _yield_stream_tts_audio_segments(
                     app=app,
                     text=raw_text,
@@ -1816,7 +1818,7 @@ def stream_generated_block_audio(
                     )
                     return
 
-                def _generate_legacy_audio() -> object:
+                def _generate_legacy_audio() -> Iterator[object]:
                     yield from _yield_run_tts_audio_events(
                         app=app,
                         text=raw_text,
@@ -1909,7 +1911,7 @@ def stream_generated_block_audio(
                 )
                 return
 
-            def _generate_av_audio() -> object:
+            def _generate_av_audio() -> Iterator[object]:
                 for position, element in enumerate(speakable_elements):
                     speakable_text = str(element.content_text or "")
                     # Skip before the cache lookup so historical records for
@@ -2009,7 +2011,7 @@ def stream_preview_tts_audio(
         audio_parts: list[bytes] = []
         subtitle_cues: list[dict] = []
 
-        def _generate_preview_audio() -> object:
+        def _generate_preview_audio() -> Iterator[object]:
             yield from _yield_stream_tts_audio_segments(
                 app=app,
                 text=text or "",

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -12,6 +12,8 @@ from datetime import UTC, datetime
 
 from flask import Flask, has_request_context, request
 from flaskr.api.tts import (
+    AudioSettings,
+    VoiceSettings,
     get_default_audio_settings,
     get_default_voice_settings,
     get_tts_provider,
@@ -386,7 +388,7 @@ def get_outline_item_tree(
                     progress_record
                 )
 
-        def build_outline_item_tree(item: HistoryItem):
+        def build_outline_item_tree(item: HistoryItem) -> object:
             outline_item: DraftOutlineItem | PublishedOutlineItem = next(
                 (i for i in outline_items_dbs if i.id == item.id), None
             )
@@ -816,7 +818,7 @@ def _resolve_shifu_tts_settings(
     *,
     shifu_bid: str,
     preview_mode: bool,
-):
+) -> tuple[str, str, VoiceSettings, AudioSettings]:
     shifu_model = DraftShifu if preview_mode else PublishedShifu
     shifu = (
         shifu_model.query.filter(
@@ -873,7 +875,7 @@ def _yield_tts_segments(
     tts_model: str,
     voice_settings: object,
     audio_settings: object,
-):
+) -> Iterator[tuple[int, bytes, int, str, int, int, int]]:
     provider_name = (provider or "").strip().lower()
     if not provider_name:
         error_message = "TTS provider is required"
@@ -1006,7 +1008,7 @@ def _yield_with_tts_error_mapping(
     *,
     unknown_error_log: str,
     body: object,
-):
+) -> Iterator[object]:
     try:
         yield from body()
     except ValueError as exc:
@@ -1155,7 +1157,7 @@ def _yield_tts_synthesis(
     outline_bid: str,
     unknown_error_log: str,
     body: object,
-):
+) -> Iterator[object]:
     """Run a TTS synthesis body under a per-(user, outline) concurrency slot.
 
     Cache-hit paths never reach here, so they do not consume a slot. When the
@@ -1198,7 +1200,7 @@ def _record_stream_segment_usage(
     parent_usage_bid: str,
     segment_index: int,
     usage_metadata: dict,
-):
+) -> None:
     segment_length = len(segment_text or "")
     output_chars = resolve_tts_billable_chars(segment_text, usage_characters)
     record_tts_usage(
@@ -1235,7 +1237,7 @@ def _record_stream_summary_usage(
     duration_ms: int,
     segment_count: int,
     usage_metadata: dict,
-):
+) -> None:
     raw_length = len(raw_text or "")
     cleaned_length = len(cleaned_text or "")
     output_chars = total_output_chars or cleaned_length
@@ -1450,7 +1452,7 @@ def _yield_stream_tts_audio_segments(
     stats: dict,
     position: int | None = None,
     av_contract: dict | None = None,
-):
+) -> Iterator[RunMarkdownFlowDTO]:
     for (
         index,
         audio_data,
@@ -1525,7 +1527,7 @@ def _yield_run_tts_audio_events(
     position: int | None = None,
     stream_element_number: int | None = None,
     stream_element_type: str | None = None,
-):
+) -> Iterator[RunMarkdownFlowDTO]:
     from flaskr.common.config import get_config
 
     max_segment_chars = get_config("TTS_MAX_SEGMENT_CHARS") or 300
@@ -1600,7 +1602,7 @@ def stream_generated_block_audio(
             )
         )
 
-        def _resolve_existing_single_block_audio():
+        def _resolve_existing_single_block_audio() -> object:
             existing_audios = (
                 LearnGeneratedAudio.query.filter(
                     LearnGeneratedAudio.generated_block_bid == generated_block_bid,
@@ -1627,7 +1629,7 @@ def stream_generated_block_audio(
                 None,
             )
 
-        def _yield_existing_single_block_audio(existing_audio: LearnGeneratedAudio):
+        def _yield_existing_single_block_audio(existing_audio: LearnGeneratedAudio) -> object:
             yield _build_audio_complete_message(
                 outline_bid=generated_block.outline_item_bid or "",
                 generated_block_bid=generated_block_bid,
@@ -1643,7 +1645,7 @@ def stream_generated_block_audio(
                 yield from _yield_existing_single_block_audio(existing_audio)
                 return
 
-        def _yield_single_block_audio():
+        def _yield_single_block_audio() -> object:
             cleaned_text = preprocess_for_tts(raw_text)
             if not cleaned_text or len(cleaned_text.strip()) < 2:
                 raise_error_with_args(
@@ -1651,7 +1653,7 @@ def stream_generated_block_audio(
                     param_message="No speakable text available for TTS synthesis",
                 )
 
-            def _generate_single_audio():
+            def _generate_single_audio() -> object:
                 yield from _yield_run_tts_audio_events(
                     app=app,
                     text=raw_text,
@@ -1672,7 +1674,7 @@ def stream_generated_block_audio(
                 body=_generate_single_audio,
             )
 
-        def _yield_preview_single_block_audio():
+        def _yield_preview_single_block_audio() -> object:
             cleaned_text = preprocess_for_tts(raw_text)
             if not cleaned_text or len(cleaned_text.strip()) < 2:
                 raise_error_with_args(
@@ -1699,7 +1701,7 @@ def stream_generated_block_audio(
             audio_parts: list[bytes] = []
             subtitle_cues: list[dict] = []
 
-            def _generate_preview_audio():
+            def _generate_preview_audio() -> object:
                 yield from _yield_stream_tts_audio_segments(
                     app=app,
                     text=raw_text,
@@ -1812,7 +1814,7 @@ def stream_generated_block_audio(
                     )
                     return
 
-                def _generate_legacy_audio():
+                def _generate_legacy_audio() -> object:
                     yield from _yield_run_tts_audio_events(
                         app=app,
                         text=raw_text,
@@ -1905,7 +1907,7 @@ def stream_generated_block_audio(
                 )
                 return
 
-            def _generate_av_audio():
+            def _generate_av_audio() -> object:
                 for position, element in enumerate(speakable_elements):
                     speakable_text = str(element.content_text or "")
                     # Skip before the cache lookup so historical records for
@@ -2005,7 +2007,7 @@ def stream_preview_tts_audio(
         audio_parts: list[bytes] = []
         subtitle_cues: list[dict] = []
 
-        def _generate_preview_audio():
+        def _generate_preview_audio() -> object:
             yield from _yield_stream_tts_audio_segments(
                 app=app,
                 text=text or "",

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -1655,7 +1655,7 @@ def stream_generated_block_audio(
                     param_message="No speakable text available for TTS synthesis",
                 )
 
-            def _generate_single_audio() -> object:
+            def _generate_single_audio() -> Iterator[object]:
                 yield from _yield_run_tts_audio_events(
                     app=app,
                     text=raw_text,

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -1647,7 +1647,7 @@ def stream_generated_block_audio(
                 yield from _yield_existing_single_block_audio(existing_audio)
                 return
 
-        def _yield_single_block_audio() -> object:
+        def _yield_single_block_audio() -> Iterator[object]:
             cleaned_text = preprocess_for_tts(raw_text)
             if not cleaned_text or len(cleaned_text.strip()) < 2:
                 raise_error_with_args(

--- a/src/api/flaskr/service/learn/learn_funcs.py
+++ b/src/api/flaskr/service/learn/learn_funcs.py
@@ -1629,7 +1629,9 @@ def stream_generated_block_audio(
                 None,
             )
 
-        def _yield_existing_single_block_audio(existing_audio: LearnGeneratedAudio) -> object:
+        def _yield_existing_single_block_audio(
+            existing_audio: LearnGeneratedAudio,
+        ) -> object:
             yield _build_audio_complete_message(
                 outline_bid=generated_block.outline_item_bid or "",
                 generated_block_bid=generated_block_bid,

--- a/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
+++ b/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
@@ -6,6 +6,9 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any
 
+if TYPE_CHECKING:
+    from flask_sqlalchemy.query import Query
+
 try:
     from markdown_flow import format_content
 except ImportError:
@@ -256,7 +259,7 @@ def _make_adapter(
     outline_bid: str,
     user_bid: str,
     run_session_bid: str,
-):
+) -> object:
     from flaskr.service.learn.listen_elements import ListenElementRunAdapter
 
     return ListenElementRunAdapter(
@@ -271,7 +274,7 @@ def _make_adapter(
 def _iter_active_group_rows(
     progress_record_bid: str,
     generated_block_bid: str,
-):
+) -> Query:
     return LearnGeneratedElement.query.filter(
         LearnGeneratedElement.progress_record_bid == progress_record_bid,
         LearnGeneratedElement.generated_block_bid == generated_block_bid,

--- a/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
+++ b/src/api/flaskr/service/learn/listen_element_mdflow_backfill.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from flask_sqlalchemy.query import Query
+    from flaskr.service.learn.listen_elements import ListenElementRunAdapter
 
 try:
     from markdown_flow import format_content
@@ -259,7 +260,7 @@ def _make_adapter(
     outline_bid: str,
     user_bid: str,
     run_session_bid: str,
-) -> object:
+) -> ListenElementRunAdapter:
     from flaskr.service.learn.listen_elements import ListenElementRunAdapter
 
     return ListenElementRunAdapter(

--- a/src/api/flaskr/service/learn/routes.py
+++ b/src/api/flaskr/service/learn/routes.py
@@ -3,6 +3,7 @@
 import json
 import sys
 import uuid
+from collections.abc import Iterator
 
 from flask import Flask, Response, request, stream_with_context
 from flaskr.common.shifu_context import get_shifu_context_snapshot, with_shifu_context
@@ -54,7 +55,7 @@ from pydantic import ValidationError
 from sqlalchemy import select
 
 
-def _normalize_user_input(value: object):
+def _normalize_user_input(value: object) -> object:
     if value is None:
         return None
     if isinstance(value, dict):
@@ -107,7 +108,7 @@ def _stream_sse_response(
     error_event_factory: object = None,
     terminal_event_factory: object = None,
 ) -> Response:
-    def event_stream():
+    def event_stream() -> Iterator[str]:
         try:
             for message in message_iter_factory():
                 yield _to_sse_data_line(message)
@@ -152,7 +153,7 @@ def _stream_passthrough_response(
     close_log: str,
     error_log: str,
 ) -> Response:
-    def event_stream():
+    def event_stream() -> Iterator[str]:
         try:
             yield from message_iter_factory()
         except GeneratorExit:
@@ -238,7 +239,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     @app.route(path_prefix + "/shifu/<shifu_bid>", methods=["GET"])
     @bypass_token_validation
     @with_shifu_context()
-    def get_shifu_api(shifu_bid: str):
+    def get_shifu_api(shifu_bid: str) -> object:
         """Get shifu.
 
         ---
@@ -281,7 +282,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
 
     @app.route(path_prefix + "/shifu/<shifu_bid>/outline-item-tree", methods=["GET"])
     @with_shifu_context()
-    def get_outline_item_tree_api(shifu_bid: str):
+    def get_outline_item_tree_api(shifu_bid: str) -> object:
         """Get outline item tree.
 
         ---
@@ -326,7 +327,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
 
     @app.route(path_prefix + "/shifu/<shifu_bid>/run/<outline_bid>", methods=["PUT"])
     @with_shifu_context()
-    def run_outline_item_api(shifu_bid: str, outline_bid: str):
+    def run_outline_item_api(shifu_bid: str, outline_bid: str) -> object:
         """Run the MarkdownFlow of the outline.
 
         ---
@@ -433,7 +434,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["POST"],
     )
     @with_shifu_context()
-    def preview_outline_block_api(shifu_bid: str, outline_bid: str):
+    def preview_outline_block_api(shifu_bid: str, outline_bid: str) -> object:
         """Preview a specific outline block.
 
         ---
@@ -589,7 +590,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["GET"],
     )
     @with_shifu_context()
-    def get_run_status_api(shifu_bid: str, outline_bid: str):
+    def get_run_status_api(shifu_bid: str, outline_bid: str) -> object:
         """Get run status.
 
         ---
@@ -628,7 +629,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         path_prefix + "/shifu/<shifu_bid>/records/<outline_bid>", methods=["GET"]
     )
     @with_shifu_context()
-    def get_record_api(shifu_bid: str, outline_bid: str):
+    def get_record_api(shifu_bid: str, outline_bid: str) -> object:
         """Get learn records of the outline.
 
         ---
@@ -692,7 +693,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         path_prefix + "/shifu/<shifu_bid>/records/<outline_bid>", methods=["DELETE"]
     )
     @with_shifu_context()
-    def delete_record_api(shifu_bid: str, outline_bid: str):
+    def delete_record_api(shifu_bid: str, outline_bid: str) -> object:
         """Reset the record of the outline.
 
         ---
@@ -729,7 +730,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["POST"],
     )
     @with_shifu_context()
-    def submit_lesson_feedback_api(shifu_bid: str, outline_bid: str):
+    def submit_lesson_feedback_api(shifu_bid: str, outline_bid: str) -> object:
         """Submit lesson feedback.
 
         ---
@@ -791,7 +792,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
 
     @app.route(path_prefix + "/shifu/<shifu_bid>/lesson-feedbacks", methods=["GET"])
     @with_shifu_context()
-    def list_lesson_feedbacks_api(shifu_bid: str):
+    def list_lesson_feedbacks_api(shifu_bid: str) -> object:
         """List lesson feedbacks for a course (teacher/authoring side).
 
         ---
@@ -845,7 +846,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["POST"],
     )
     @with_shifu_context()
-    def generate_content_api(shifu_bid: str, generated_block_bid: str, action: str):
+    def generate_content_api(shifu_bid: str, generated_block_bid: str, action: str) -> object:
         """Generate the content of the generated block.
 
         ---
@@ -890,7 +891,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["GET"],
     )
     @with_shifu_context()
-    def get_generated_content_api(shifu_bid: str, generated_block_bid: str):
+    def get_generated_content_api(shifu_bid: str, generated_block_bid: str) -> object:
         """Get the content of the generated block.
 
         ---
@@ -941,7 +942,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["POST"],
     )
     @with_shifu_context()
-    def synthesize_generated_block_audio_api(shifu_bid: str, generated_block_bid: str):
+    def synthesize_generated_block_audio_api(shifu_bid: str, generated_block_bid: str) -> object:
         """Synthesize audio for a generated block (C-end, persisted).
 
         ---
@@ -1009,7 +1010,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
 
     @app.route(path_prefix + "/shifu/<shifu_bid>/tts/preview", methods=["POST"])
     @with_shifu_context()
-    def synthesize_preview_tts_audio_api(shifu_bid: str):
+    def synthesize_preview_tts_audio_api(shifu_bid: str) -> object:
         """Synthesize audio for an arbitrary text (editor preview, not persisted).
 
         ---

--- a/src/api/flaskr/service/learn/routes.py
+++ b/src/api/flaskr/service/learn/routes.py
@@ -846,7 +846,9 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["POST"],
     )
     @with_shifu_context()
-    def generate_content_api(shifu_bid: str, generated_block_bid: str, action: str) -> object:
+    def generate_content_api(
+        shifu_bid: str, generated_block_bid: str, action: str
+    ) -> object:
         """Generate the content of the generated block.
 
         ---
@@ -942,7 +944,9 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["POST"],
     )
     @with_shifu_context()
-    def synthesize_generated_block_audio_api(shifu_bid: str, generated_block_bid: str) -> object:
+    def synthesize_generated_block_audio_api(
+        shifu_bid: str, generated_block_bid: str
+    ) -> object:
         """Synthesize audio for a generated block (C-end, persisted).
 
         ---

--- a/src/api/flaskr/service/learn/routes.py
+++ b/src/api/flaskr/service/learn/routes.py
@@ -55,7 +55,7 @@ from pydantic import ValidationError
 from sqlalchemy import select
 
 
-def _normalize_user_input(value: object) -> object:
+def _normalize_user_input(value: object) -> dict[str, list[str]] | None:
     if value is None:
         return None
     if isinstance(value, dict):
@@ -239,7 +239,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     @app.route(path_prefix + "/shifu/<shifu_bid>", methods=["GET"])
     @bypass_token_validation
     @with_shifu_context()
-    def get_shifu_api(shifu_bid: str) -> object:
+    def get_shifu_api(shifu_bid: str) -> str:
         """Get shifu.
 
         ---
@@ -282,7 +282,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
 
     @app.route(path_prefix + "/shifu/<shifu_bid>/outline-item-tree", methods=["GET"])
     @with_shifu_context()
-    def get_outline_item_tree_api(shifu_bid: str) -> object:
+    def get_outline_item_tree_api(shifu_bid: str) -> str:
         """Get outline item tree.
 
         ---
@@ -327,7 +327,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
 
     @app.route(path_prefix + "/shifu/<shifu_bid>/run/<outline_bid>", methods=["PUT"])
     @with_shifu_context()
-    def run_outline_item_api(shifu_bid: str, outline_bid: str) -> object:
+    def run_outline_item_api(shifu_bid: str, outline_bid: str) -> Response:
         """Run the MarkdownFlow of the outline.
 
         ---
@@ -434,7 +434,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["POST"],
     )
     @with_shifu_context()
-    def preview_outline_block_api(shifu_bid: str, outline_bid: str) -> object:
+    def preview_outline_block_api(shifu_bid: str, outline_bid: str) -> Response:
         """Preview a specific outline block.
 
         ---
@@ -590,7 +590,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["GET"],
     )
     @with_shifu_context()
-    def get_run_status_api(shifu_bid: str, outline_bid: str) -> object:
+    def get_run_status_api(shifu_bid: str, outline_bid: str) -> str:
         """Get run status.
 
         ---
@@ -629,7 +629,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         path_prefix + "/shifu/<shifu_bid>/records/<outline_bid>", methods=["GET"]
     )
     @with_shifu_context()
-    def get_record_api(shifu_bid: str, outline_bid: str) -> object:
+    def get_record_api(shifu_bid: str, outline_bid: str) -> str:
         """Get learn records of the outline.
 
         ---
@@ -693,7 +693,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         path_prefix + "/shifu/<shifu_bid>/records/<outline_bid>", methods=["DELETE"]
     )
     @with_shifu_context()
-    def delete_record_api(shifu_bid: str, outline_bid: str) -> object:
+    def delete_record_api(shifu_bid: str, outline_bid: str) -> str:
         """Reset the record of the outline.
 
         ---
@@ -730,7 +730,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["POST"],
     )
     @with_shifu_context()
-    def submit_lesson_feedback_api(shifu_bid: str, outline_bid: str) -> object:
+    def submit_lesson_feedback_api(shifu_bid: str, outline_bid: str) -> str:
         """Submit lesson feedback.
 
         ---
@@ -792,7 +792,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
 
     @app.route(path_prefix + "/shifu/<shifu_bid>/lesson-feedbacks", methods=["GET"])
     @with_shifu_context()
-    def list_lesson_feedbacks_api(shifu_bid: str) -> object:
+    def list_lesson_feedbacks_api(shifu_bid: str) -> str:
         """List lesson feedbacks for a course (teacher/authoring side).
 
         ---
@@ -848,7 +848,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     @with_shifu_context()
     def generate_content_api(
         shifu_bid: str, generated_block_bid: str, action: str
-    ) -> object:
+    ) -> str:
         """Generate the content of the generated block.
 
         ---
@@ -893,7 +893,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
         methods=["GET"],
     )
     @with_shifu_context()
-    def get_generated_content_api(shifu_bid: str, generated_block_bid: str) -> object:
+    def get_generated_content_api(shifu_bid: str, generated_block_bid: str) -> str:
         """Get the content of the generated block.
 
         ---
@@ -946,7 +946,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
     @with_shifu_context()
     def synthesize_generated_block_audio_api(
         shifu_bid: str, generated_block_bid: str
-    ) -> object:
+    ) -> Response:
         """Synthesize audio for a generated block (C-end, persisted).
 
         ---
@@ -1014,7 +1014,7 @@ def register_learn_routes(app: Flask, path_prefix: str = "/api/learn") -> Flask:
 
     @app.route(path_prefix + "/shifu/<shifu_bid>/tts/preview", methods=["POST"])
     @with_shifu_context()
-    def synthesize_preview_tts_audio_api(shifu_bid: str) -> object:
+    def synthesize_preview_tts_audio_api(shifu_bid: str) -> Response:
         """Synthesize audio for an arbitrary text (editor preview, not persisted).
 
         ---

--- a/src/api/flaskr/service/learn/run/state.py
+++ b/src/api/flaskr/service/learn/run/state.py
@@ -31,7 +31,7 @@ PR3 scope notes (mirroring the emitter's PR1 conventions):
 """
 
 import queue
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from flaskr.dao import db
 from flaskr.service.common import raise_error
@@ -59,7 +59,7 @@ def _find_outline_path_or_raise(
     return path
 
 
-def _runtime():
+def _runtime() -> Any:
     """Resolve the context_v2 module lazily.
 
     Lazy for two reasons: ``context_v2`` imports this module at load time
@@ -99,7 +99,7 @@ class RunStateResolver:
         return self._context._preview_mode
 
     @property
-    def _outline_model(self):
+    def _outline_model(self) -> object:
         return self._context._outline_model
 
     @property
@@ -107,7 +107,7 @@ class RunStateResolver:
         return self._context._user_info.user_id
 
     @property
-    def _current_outline_item(self):
+    def _current_outline_item(self) -> object:
         return self._context._current_outline_item
 
     @property
@@ -216,7 +216,7 @@ class RunStateResolver:
 
         def _mark_sub_node_completed(
             outline_item_info: HistoryItem, res: list[OutlineItemUpdateDTO]
-        ):
+        ) -> None:
             q = queue.Queue()
             q.put(self._struct)
             if ctx._is_leaf_outline_item(outline_item_info):
@@ -283,7 +283,7 @@ class RunStateResolver:
 
         def _mark_sub_node_start(
             outline_item_info: HistoryItem, res: list[OutlineItemUpdateDTO]
-        ):
+        ) -> None:
             path = _find_outline_path_or_raise(self._struct, outline_item_info.bid)
             for item in path:
                 if item.type == "outline":

--- a/src/api/flaskr/service/learn/run/state.py
+++ b/src/api/flaskr/service/learn/run/state.py
@@ -41,6 +41,7 @@ from flaskr.service.order.consts import (
     LEARN_STATUS_NOT_STARTED,
     LEARN_STATUS_RESET,
 )
+from flaskr.service.shifu.models import DraftOutlineItem, PublishedOutlineItem
 from flaskr.service.shifu.shifu_history_manager import HistoryItem
 from flaskr.service.shifu.struct_utils import find_node_with_parents
 
@@ -99,7 +100,9 @@ class RunStateResolver:
         return self._context._preview_mode
 
     @property
-    def _outline_model(self) -> object:
+    def _outline_model(
+        self,
+    ) -> type[DraftOutlineItem] | type[PublishedOutlineItem]:
         return self._context._outline_model
 
     @property

--- a/src/api/flaskr/service/learn/run/state.py
+++ b/src/api/flaskr/service/learn/run/state.py
@@ -107,7 +107,7 @@ class RunStateResolver:
         return self._context._user_info.user_id
 
     @property
-    def _current_outline_item(self) -> object:
+    def _current_outline_item(self) -> HistoryItem | None:
         return self._context._current_outline_item
 
     @property

--- a/src/api/flaskr/service/learn/runscript_v2.py
+++ b/src/api/flaskr/service/learn/runscript_v2.py
@@ -424,7 +424,7 @@ def run_script_inner(
             def _iter_run_events(
                 events: object,
                 ready_element_bids_by_block_bid: dict[str, list[str]],
-            ):
+            ) -> Generator[object, None, None]:
                 if element_adapter is None:
                     for event in events:
                         _remember_audio_backfill_ready_element(
@@ -442,7 +442,7 @@ def run_script_inner(
 
             def _iter_audio_backfill_ready_events(
                 ready_element_bids_by_block_bid: dict[str, list[str]],
-            ):
+            ) -> Generator[object, None, None]:
                 if input_type == INPUT_TYPE_ASK:
                     return
                 for (
@@ -764,7 +764,7 @@ def run_script(
         parent_shifu_context = shifu_context_snapshot or get_shifu_context_snapshot()
         producer_thread: threading.Thread | None = None
 
-        def producer():
+        def producer() -> None:
             # Propagate logging thread-local context into this background thread
             if parent_request_id:
                 log_thread_local.request_id = parent_request_id

--- a/src/api/flaskr/service/learn/utils_v2.py
+++ b/src/api/flaskr/service/learn/utils_v2.py
@@ -80,7 +80,7 @@ def safe_format_template(template: str, variables: dict) -> str:
     # Replace {xxx} or {{xxx}} with values from variables dict, keep original if not found
     pattern = re.compile(r"(\{{1,2})([^{}]+)(\}{1,2})")
 
-    def replacer(match: re.Match[str]):
+    def replacer(match: re.Match[str]) -> str:
         _, var, _ = match.groups()
         var_name = var.strip()
         # Only process variable names with letters, digits, underscore, hyphen

--- a/src/api/flaskr/service/llm/route.py
+++ b/src/api/flaskr/service/llm/route.py
@@ -12,7 +12,7 @@ def register_llm_routes(app: Flask, path_prefix: str = "/api/llm") -> Flask:
     app.logger.info("register llm routes %s", path_prefix)
 
     @app.route(path_prefix + "/model-list", methods=["GET"])
-    def model_list_api() -> object:
+    def model_list_api() -> str:
         """Get model list.
 
         ---

--- a/src/api/flaskr/service/llm/route.py
+++ b/src/api/flaskr/service/llm/route.py
@@ -12,7 +12,7 @@ def register_llm_routes(app: Flask, path_prefix: str = "/api/llm") -> Flask:
     app.logger.info("register llm routes %s", path_prefix)
 
     @app.route(path_prefix + "/model-list", methods=["GET"])
-    def model_list_api():
+    def model_list_api() -> object:
         """Get model list.
 
         ---

--- a/src/api/flaskr/service/metering/routes.py
+++ b/src/api/flaskr/service/metering/routes.py
@@ -28,7 +28,7 @@ def register_metering_routes(app: Flask, path_prefix: str = "/api/metering") -> 
     """Register metering routes."""
 
     @app.route(path_prefix + "/usage-summary", methods=["GET"])
-    def get_usage_summary() -> object:
+    def get_usage_summary() -> str:
         start_date = request.args.get("start_date", "")
         end_date = request.args.get("end_date", "")
         user_bid = request.args.get("user_bid", "")

--- a/src/api/flaskr/service/metering/routes.py
+++ b/src/api/flaskr/service/metering/routes.py
@@ -28,7 +28,7 @@ def register_metering_routes(app: Flask, path_prefix: str = "/api/metering") -> 
     """Register metering routes."""
 
     @app.route(path_prefix + "/usage-summary", methods=["GET"])
-    def get_usage_summary():
+    def get_usage_summary() -> object:
         start_date = request.args.get("start_date", "")
         end_date = request.args.get("end_date", "")
         user_bid = request.args.get("user_bid", "")

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -77,6 +77,7 @@ from sqlalchemy import case
 if TYPE_CHECKING:
     from flask import Flask
     from flask_sqlalchemy.query import Query
+    from sqlalchemy.sql.elements import ColumnElement
     from sqlalchemy.sql.selectable import Subquery
 
 ORDER_STATUS_KEY_MAP = {
@@ -556,7 +557,7 @@ def _load_matching_shifu_bids_for_course_name(course_name: str) -> list[str]:
     return sorted(matched_shifu_bids)
 
 
-def _build_course_query_shifu_bid_filter(course_query: str) -> object:
+def _build_course_query_shifu_bid_filter(course_query: str) -> ColumnElement[bool]:
     normalized_course_query = str(course_query or "").strip()
     like_value = f"%{normalized_course_query}%"
     draft_course_bids = db.session.query(DraftShifu.shifu_bid).filter(

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -76,6 +76,7 @@ from sqlalchemy import case
 
 if TYPE_CHECKING:
     from flask import Flask
+    from sqlalchemy.sql.selectable import Subquery
 
 ORDER_STATUS_KEY_MAP = {
     ORDER_STATUS_INIT: "server.order.orderStatusInit",
@@ -453,7 +454,7 @@ def _load_coupon_code_map(order_bids: list[str]) -> dict[str, list[str]]:
     return dict(coupon_map)
 
 
-def _build_coupon_usage_order_bid_subquery():
+def _build_coupon_usage_order_bid_subquery() -> Subquery:
     return (
         db.session.query(CouponUsage.order_bid.label("order_bid"))
         .filter(
@@ -554,7 +555,7 @@ def _load_matching_shifu_bids_for_course_name(course_name: str) -> list[str]:
     return sorted(matched_shifu_bids)
 
 
-def _build_course_query_shifu_bid_filter(course_query: str):
+def _build_course_query_shifu_bid_filter(course_query: str) -> object:
     normalized_course_query = str(course_query or "").strip()
     like_value = f"%{normalized_course_query}%"
     draft_course_bids = db.session.query(DraftShifu.shifu_bid).filter(
@@ -572,7 +573,7 @@ def _build_course_query_shifu_bid_filter(course_query: str):
     )
 
 
-def _apply_order_source_filter(query: object, order_source: str):
+def _apply_order_source_filter(query: object, order_source: str) -> object:
     normalized_order_source = str(order_source or "").strip()
     if not normalized_order_source:
         return query

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -76,6 +76,7 @@ from sqlalchemy import case
 
 if TYPE_CHECKING:
     from flask import Flask
+    from flask_sqlalchemy.query import Query
     from sqlalchemy.sql.selectable import Subquery
 
 ORDER_STATUS_KEY_MAP = {
@@ -573,7 +574,7 @@ def _build_course_query_shifu_bid_filter(course_query: str) -> object:
     )
 
 
-def _apply_order_source_filter(query: object, order_source: str) -> object:
+def _apply_order_source_filter(query: object, order_source: str) -> Query:
     normalized_order_source = str(order_source or "").strip()
     if not normalized_order_source:
         return query

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -575,7 +575,7 @@ def _build_course_query_shifu_bid_filter(course_query: str) -> ColumnElement[boo
     )
 
 
-def _apply_order_source_filter(query: object, order_source: str) -> Query:
+def _apply_order_source_filter(query: Query, order_source: str) -> Query:
     normalized_order_source = str(order_source or "").strip()
     if not normalized_order_source:
         return query

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -5,7 +5,7 @@ import decimal
 import json
 import re
 from collections.abc import Iterator
-from contextlib import contextmanager, nullcontext, suppress
+from contextlib import AbstractContextManager, contextmanager, nullcontext, suppress
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
@@ -168,7 +168,7 @@ class AICourseBuyRecordDTO:
     def __json__(self) -> dict:
         """Return the AI course buy record as JSON-compatible data."""
 
-        def format_decimal(value: object):
+        def format_decimal(value: object) -> str:
             # Convert to a string with two decimal places
             formatted_value = value if isinstance(value, str) else f"{value:.2f}"
             # If the decimal part is .00, remove it
@@ -677,7 +677,7 @@ def generate_charge(
     return None
 
 
-def _order_credential_scope(app: Flask, order: Order, context: object = None):
+def _order_credential_scope(app: Flask, order: Order, context: object = None) -> AbstractContextManager[None]:
     """Use the immutable credential version snapshotted on the order."""
     integration_bid = str(order.payment_integration_bid or "")
     if not integration_bid:
@@ -1322,7 +1322,7 @@ def _update_stripe_order_snapshot(
     stripe_order: StripeOrder,
     session: dict[str, Any],
     intent: dict[str, Any] | None,
-):
+) -> None:
     if session:
         stripe_order.checkout_session_id = session.get(
             "id", stripe_order.checkout_session_id

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -677,7 +677,9 @@ def generate_charge(
     return None
 
 
-def _order_credential_scope(app: Flask, order: Order, context: object = None) -> AbstractContextManager[None]:
+def _order_credential_scope(
+    app: Flask, order: Order, context: object = None
+) -> AbstractContextManager[None]:
     """Use the immutable credential version snapshotted on the order."""
     integration_bid = str(order.payment_integration_bid or "")
     if not integration_bid:

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -6,6 +6,9 @@ import base64
 import json
 import re
 import threading
+from collections.abc import (
+    Callable,  # noqa: TC003 - decorator annotation is resolved at runtime
+)
 from dataclasses import dataclass, field
 from functools import wraps
 from pathlib import Path
@@ -40,9 +43,9 @@ class _PingppClientState:
 _pingpp_client_state = _PingppClientState()
 
 
-def _serialized_pingpp_config(func: object):
+def _serialized_pingpp_config(func: object) -> Callable[..., Any]:
     @wraps(func)
-    def wrapped(*args: object, **kwargs: object):
+    def wrapped(*args: object, **kwargs: object) -> Any:
         with _PINGPP_CONFIG_LOCK:
             return func(*args, **kwargs)
 

--- a/src/api/flaskr/service/order/payment_providers/pingxx.py
+++ b/src/api/flaskr/service/order/payment_providers/pingxx.py
@@ -12,7 +12,7 @@ from collections.abc import (
 from dataclasses import dataclass, field
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
     from flask import Flask
 
 _PINGPP_CONFIG_LOCK = threading.RLock()
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 @dataclass(slots=True)
@@ -43,9 +45,9 @@ class _PingppClientState:
 _pingpp_client_state = _PingppClientState()
 
 
-def _serialized_pingpp_config(func: object) -> Callable[..., Any]:
+def _serialized_pingpp_config(func: Callable[P, R]) -> Callable[P, R]:
     @wraps(func)
-    def wrapped(*args: object, **kwargs: object) -> Any:
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
         with _PINGPP_CONFIG_LOCK:
             return func(*args, **kwargs)
 

--- a/src/api/flaskr/service/order/payment_providers/stripe.py
+++ b/src/api/flaskr/service/order/payment_providers/stripe.py
@@ -27,7 +27,7 @@ class StripeProvider(PaymentProvider):
 
     channel = "stripe"
 
-    def _ensure_client(self, app: Flask):
+    def _ensure_client(self, app: Flask) -> object:
         return get_stripe_client_options(app)[0]
 
     def _client_options(self, app: Flask) -> tuple[Any, dict[str, Any]]:

--- a/src/api/flaskr/service/order/payment_providers/wechatpay.py
+++ b/src/api/flaskr/service/order/payment_providers/wechatpay.py
@@ -29,6 +29,10 @@ from .base import (
 )
 
 if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.rsa import (
+        RSAPrivateKey,
+        RSAPublicKey,
+    )
     from flask import Flask
 
 
@@ -341,7 +345,7 @@ def _sign_with_merchant_key(message: str) -> str:
     return base64.b64encode(signature).decode("utf-8")
 
 
-def _load_private_key():
+def _load_private_key() -> RSAPrivateKey:
     inline = str(get_config("WECHATPAY_PRIVATE_KEY", "") or "").strip()
     pem = (
         inline.encode("utf-8")
@@ -351,7 +355,7 @@ def _load_private_key():
     return serialization.load_pem_private_key(pem, password=None)
 
 
-def _load_public_key_from_certificate():
+def _load_public_key_from_certificate() -> RSAPublicKey:
     inline = str(get_config("WECHATPAY_PLATFORM_CERT", "") or "").strip()
     pem = (
         inline.encode("utf-8")

--- a/src/api/flaskr/service/profile/funcs.py
+++ b/src/api/flaskr/service/profile/funcs.py
@@ -92,7 +92,9 @@ def _update_aggregate_field(
         aggregate.birthday = value
 
 
-def _normalize_core_value(mapping: str, value: object) -> object:
+def _normalize_core_value(
+    mapping: str, value: str | datetime.date | None
+) -> str | datetime.date | None:
     if mapping == "user_birth":
         if isinstance(value, datetime.date):
             return value
@@ -105,7 +107,9 @@ def _normalize_core_value(mapping: str, value: object) -> object:
     return value or ""
 
 
-def _apply_core_mapping(user_id: str, mapping: str, value: object) -> object:
+def _apply_core_mapping(
+    user_id: str, mapping: str, value: str | datetime.date | None
+) -> str | datetime.date | None:
     entity = ensure_user_entity(user_id)
     normalized = _normalize_core_value(mapping, value)
     if mapping == "name":
@@ -119,7 +123,9 @@ def _apply_core_mapping(user_id: str, mapping: str, value: object) -> object:
     return normalized
 
 
-def _current_core_value(aggregate: UserAggregate | None, mapping: str) -> object:
+def _current_core_value(
+    aggregate: UserAggregate | None, mapping: str
+) -> str | datetime.date | None:
     if not aggregate:
         return None
     if mapping == "name":

--- a/src/api/flaskr/service/profile/funcs.py
+++ b/src/api/flaskr/service/profile/funcs.py
@@ -92,7 +92,7 @@ def _update_aggregate_field(
         aggregate.birthday = value
 
 
-def _normalize_core_value(mapping: str, value: object):
+def _normalize_core_value(mapping: str, value: object) -> object:
     if mapping == "user_birth":
         if isinstance(value, datetime.date):
             return value
@@ -105,7 +105,7 @@ def _normalize_core_value(mapping: str, value: object):
     return value or ""
 
 
-def _apply_core_mapping(user_id: str, mapping: str, value: object):
+def _apply_core_mapping(user_id: str, mapping: str, value: object) -> object:
     entity = ensure_user_entity(user_id)
     normalized = _normalize_core_value(mapping, value)
     if mapping == "name":
@@ -119,7 +119,7 @@ def _apply_core_mapping(user_id: str, mapping: str, value: object):
     return normalized
 
 
-def _current_core_value(aggregate: UserAggregate | None, mapping: str):
+def _current_core_value(aggregate: UserAggregate | None, mapping: str) -> object:
     if not aggregate:
         return None
     if mapping == "name":

--- a/src/api/flaskr/service/profile/learner_profile_optimizer.py
+++ b/src/api/flaskr/service/profile/learner_profile_optimizer.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import (
+    Iterator,  # noqa: TC003 - private annotation is inspected at runtime
+)
 from typing import TYPE_CHECKING, Any
 
 from flaskr.api.langfuse import (
@@ -39,7 +42,7 @@ def _parse_optimized_profile(raw_response: str) -> str:
     return raw_response
 
 
-def _exception_chain(exc: BaseException):
+def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
     seen: set[int] = set()
     current: BaseException | None = exc
     while current is not None and id(current) not in seen:

--- a/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
+++ b/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
@@ -69,7 +69,7 @@ def _admission_key(app: Flask, *, user_id: str) -> str:
     )
 
 
-def _redis_client():
+def _redis_client() -> object:
     from flaskr.dao import get_redis_client
 
     return get_redis_client()

--- a/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
+++ b/src/api/flaskr/service/profile/learner_profile_optimizer_admission.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from flask import Flask
+    from redis import Redis
 
 IN_FLIGHT_TTL_SECONDS = 360
 
@@ -69,7 +70,7 @@ def _admission_key(app: Flask, *, user_id: str) -> str:
     )
 
 
-def _redis_client() -> object:
+def _redis_client() -> Redis | None:
     from flaskr.dao import get_redis_client
 
     return get_redis_client()

--- a/src/api/flaskr/service/profile/routes.py
+++ b/src/api/flaskr/service/profile/routes.py
@@ -20,7 +20,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
     """Register learner-profile routes on the Flask application."""
 
     @app.route(f"{path_prefix}/get-profile-item-definitions", methods=["GET"])
-    def get_profile_item_defination_api() -> object:
+    def get_profile_item_defination_api() -> str:
         """Get profile item defination.
 
         ---
@@ -67,7 +67,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/hide-unused-profile-items", methods=["POST"])
-    def hide_unused_profile_items_api() -> object:
+    def hide_unused_profile_items_api() -> str:
         """Hide all unused custom profile items under a shifu.
 
         ---
@@ -97,7 +97,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/profile-variable-usage", methods=["GET"])
-    def get_profile_variable_usage_api() -> object:
+    def get_profile_variable_usage_api() -> str:
         """Get variable usage across all outlines for a shifu.
 
         ---
@@ -121,7 +121,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/update-profile-hidden-state", methods=["POST"])
-    def update_profile_hidden_state_api() -> object:
+    def update_profile_hidden_state_api() -> str:
         """Hide or restore specific custom profile items.
 
         ---
@@ -165,7 +165,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/add-profile-item-quick", methods=["POST"])
-    def add_profile_item_quick_api() -> object:
+    def add_profile_item_quick_api() -> str:
         """Add profile item.
 
         ---
@@ -209,7 +209,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/save-profile-item", methods=["POST"])
-    def save_profile_item_api() -> object:
+    def save_profile_item_api() -> str:
         """Save profile item.
 
         ---
@@ -280,7 +280,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/delete-profile-item", methods=["POST"])
-    def delete_profile_item_api() -> object:
+    def delete_profile_item_api() -> str:
         """Delete profile item.
 
         ---

--- a/src/api/flaskr/service/profile/routes.py
+++ b/src/api/flaskr/service/profile/routes.py
@@ -20,7 +20,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
     """Register learner-profile routes on the Flask application."""
 
     @app.route(f"{path_prefix}/get-profile-item-definitions", methods=["GET"])
-    def get_profile_item_defination_api():
+    def get_profile_item_defination_api() -> object:
         """Get profile item defination.
 
         ---
@@ -67,7 +67,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/hide-unused-profile-items", methods=["POST"])
-    def hide_unused_profile_items_api():
+    def hide_unused_profile_items_api() -> object:
         """Hide all unused custom profile items under a shifu.
 
         ---
@@ -97,7 +97,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/profile-variable-usage", methods=["GET"])
-    def get_profile_variable_usage_api():
+    def get_profile_variable_usage_api() -> object:
         """Get variable usage across all outlines for a shifu.
 
         ---
@@ -121,7 +121,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/update-profile-hidden-state", methods=["POST"])
-    def update_profile_hidden_state_api():
+    def update_profile_hidden_state_api() -> object:
         """Hide or restore specific custom profile items.
 
         ---
@@ -165,7 +165,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/add-profile-item-quick", methods=["POST"])
-    def add_profile_item_quick_api():
+    def add_profile_item_quick_api() -> object:
         """Add profile item.
 
         ---
@@ -209,7 +209,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/save-profile-item", methods=["POST"])
-    def save_profile_item_api():
+    def save_profile_item_api() -> object:
         """Save profile item.
 
         ---
@@ -280,7 +280,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         )
 
     @app.route(f"{path_prefix}/delete-profile-item", methods=["POST"])
-    def delete_profile_item_api():
+    def delete_profile_item_api() -> object:
         """Delete profile item.
 
         ---
@@ -323,7 +323,7 @@ def register_profile_routes(app: Flask, path_prefix: str = "/api/profiles") -> F
         return make_common_response(delete_profile_item(app, user_id, profile_id))
 
     @app.route(f"{path_prefix}/get-profile-item", methods=["POST"])
-    def get_profile_item_api():
+    def get_profile_item_api() -> None:
         """Get profile item."""
 
     return app

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -72,6 +72,7 @@ from sqlalchemy import and_, case, func, not_, or_
 if TYPE_CHECKING:
     from flask import Flask
     from flask_sqlalchemy.query import Query
+    from sqlalchemy.sql.elements import ColumnElement
 
 PROMOTION_SCOPE_ALL_COURSES = "all_courses"
 PROMOTION_SCOPE_SINGLE_COURSE = "single_course"
@@ -275,7 +276,7 @@ def _build_user_keyword_query(keyword: str) -> Query:
 
 def _apply_keyword_filter(
     query: object, keyword: str, user_bid_field: object, *text_fields: object
-) -> object:
+) -> Query:
     normalized = str(keyword or "").strip().lower()
     if not normalized:
         return query
@@ -288,7 +289,7 @@ def _apply_keyword_filter(
     return query.filter(or_(*keyword_filters))
 
 
-def _build_coupon_status_filter(status: str) -> object:
+def _build_coupon_status_filter(status: str) -> ColumnElement[bool] | None:
     normalized = str(status or "").strip().lower()
     if not normalized:
         return None
@@ -316,7 +317,7 @@ def _build_coupon_status_filter(status: str) -> object:
     return None
 
 
-def _build_campaign_status_filter(status: str) -> object:
+def _build_campaign_status_filter(status: str) -> ColumnElement[bool] | None:
     normalized = str(status or "").strip().lower()
     if not normalized:
         return None

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -71,6 +71,7 @@ from sqlalchemy import and_, case, func, not_, or_
 
 if TYPE_CHECKING:
     from flask import Flask
+    from flask_sqlalchemy.query import Query
 
 PROMOTION_SCOPE_ALL_COURSES = "all_courses"
 PROMOTION_SCOPE_SINGLE_COURSE = "single_course"
@@ -240,7 +241,7 @@ def _build_like_pattern(keyword: str) -> str:
     return f"%{escaped}%"
 
 
-def _build_user_keyword_query(keyword: str) -> object:
+def _build_user_keyword_query(keyword: str) -> Query:
     like_pattern = _build_like_pattern(keyword)
     return (
         db.session.query(UserEntity.user_bid)

--- a/src/api/flaskr/service/promo/admin.py
+++ b/src/api/flaskr/service/promo/admin.py
@@ -240,7 +240,7 @@ def _build_like_pattern(keyword: str) -> str:
     return f"%{escaped}%"
 
 
-def _build_user_keyword_query(keyword: str):
+def _build_user_keyword_query(keyword: str) -> object:
     like_pattern = _build_like_pattern(keyword)
     return (
         db.session.query(UserEntity.user_bid)
@@ -274,7 +274,7 @@ def _build_user_keyword_query(keyword: str):
 
 def _apply_keyword_filter(
     query: object, keyword: str, user_bid_field: object, *text_fields: object
-):
+) -> object:
     normalized = str(keyword or "").strip().lower()
     if not normalized:
         return query
@@ -287,7 +287,7 @@ def _apply_keyword_filter(
     return query.filter(or_(*keyword_filters))
 
 
-def _build_coupon_status_filter(status: str):
+def _build_coupon_status_filter(status: str) -> object:
     normalized = str(status or "").strip().lower()
     if not normalized:
         return None
@@ -315,7 +315,7 @@ def _build_coupon_status_filter(status: str):
     return None
 
 
-def _build_campaign_status_filter(status: str):
+def _build_campaign_status_filter(status: str) -> object:
     normalized = str(status or "").strip().lower()
     if not normalized:
         return None

--- a/src/api/flaskr/service/promo/funcs.py
+++ b/src/api/flaskr/service/promo/funcs.py
@@ -56,7 +56,7 @@ def is_campaign_enabled_for_runtime(campaign: object) -> bool:
     )
 
 
-def _blank_legacy_bid_expression(column: object):
+def _blank_legacy_bid_expression(column: object) -> object:
     normalized = func.coalesce(column, "")
     normalized = func.replace(normalized, "\t", "")
     normalized = func.replace(normalized, "\n", "")
@@ -88,7 +88,7 @@ def build_campaign_enabled_expression(model_or_columns: object) -> ColumnElement
     )
 
 
-def _app_context_scope(app: Flask):
+def _app_context_scope(app: Flask) -> object:
     return nullcontext() if has_app_context() else app.app_context()
 
 

--- a/src/api/flaskr/service/promo/funcs.py
+++ b/src/api/flaskr/service/promo/funcs.py
@@ -56,7 +56,7 @@ def is_campaign_enabled_for_runtime(campaign: object) -> bool:
     )
 
 
-def _blank_legacy_bid_expression(column: object) -> object:
+def _blank_legacy_bid_expression(column: object) -> ColumnElement[bool]:
     normalized = func.coalesce(column, "")
     normalized = func.replace(normalized, "\t", "")
     normalized = func.replace(normalized, "\n", "")

--- a/src/api/flaskr/service/promo/funcs.py
+++ b/src/api/flaskr/service/promo/funcs.py
@@ -1,7 +1,7 @@
 """Promo functions."""
 
 import decimal
-from contextlib import nullcontext
+from contextlib import AbstractContextManager, nullcontext
 
 from flask import Flask, has_app_context
 from flaskr.dao import db
@@ -88,7 +88,7 @@ def build_campaign_enabled_expression(model_or_columns: object) -> ColumnElement
     )
 
 
-def _app_context_scope(app: Flask) -> object:
+def _app_context_scope(app: Flask) -> AbstractContextManager[None]:
     return nullcontext() if has_app_context() else app.app_context()
 
 

--- a/src/api/flaskr/service/referral/campaign_admin.py
+++ b/src/api/flaskr/service/referral/campaign_admin.py
@@ -697,7 +697,7 @@ def _assert_product_code_is_active_plan(product_code: str) -> None:
         raise_param_error("reward_product_code")
 
 
-def _apply_status_filter(query: object, status: str, *, now: datetime) -> Query:
+def _apply_status_filter(query: Query, status: str, *, now: datetime) -> Query:
     if status == "active":
         return query.filter(
             ReferralCampaign.campaign_status == REFERRAL_CAMPAIGN_STATUS_ACTIVE,

--- a/src/api/flaskr/service/referral/campaign_admin.py
+++ b/src/api/flaskr/service/referral/campaign_admin.py
@@ -49,6 +49,7 @@ from .models import (
 
 if TYPE_CHECKING:
     from flask import Flask
+    from flask_sqlalchemy.query import Query
 
 REFERRAL_CAMPAIGN_STATUS_FILTERS = {
     "active",
@@ -696,7 +697,7 @@ def _assert_product_code_is_active_plan(product_code: str) -> None:
         raise_param_error("reward_product_code")
 
 
-def _apply_status_filter(query: object, status: str, *, now: datetime) -> object:
+def _apply_status_filter(query: object, status: str, *, now: datetime) -> Query:
     if status == "active":
         return query.filter(
             ReferralCampaign.campaign_status == REFERRAL_CAMPAIGN_STATUS_ACTIVE,

--- a/src/api/flaskr/service/referral/campaign_admin.py
+++ b/src/api/flaskr/service/referral/campaign_admin.py
@@ -696,7 +696,7 @@ def _assert_product_code_is_active_plan(product_code: str) -> None:
         raise_param_error("reward_product_code")
 
 
-def _apply_status_filter(query: object, status: str, *, now: datetime):
+def _apply_status_filter(query: object, status: str, *, now: datetime) -> object:
     if status == "active":
         return query.filter(
             ReferralCampaign.campaign_status == REFERRAL_CAMPAIGN_STATUS_ACTIVE,

--- a/src/api/flaskr/service/referral/routes.py
+++ b/src/api/flaskr/service/referral/routes.py
@@ -18,7 +18,7 @@ def register_referral_routes(app: Flask, path_prefix: str = "/api/referral") -> 
     """Register referral routes."""
 
     @app.route(path_prefix + "/invite-profile", methods=["GET"])
-    def referral_invite_profile_api() -> object:
+    def referral_invite_profile_api() -> str:
         user = getattr(request, "user", None)
         user_bid = str(getattr(user, "user_id", "") or "").strip()
         if not user_bid:
@@ -28,7 +28,7 @@ def register_referral_routes(app: Flask, path_prefix: str = "/api/referral") -> 
 
     @app.route(path_prefix + "/invite-preview", methods=["GET"])
     @bypass_token_validation
-    def referral_invite_preview_api() -> object:
+    def referral_invite_preview_api() -> str:
         preview = build_invite_preview(
             app,
             invite_code=str(request.args.get("invite_code") or "").strip(),
@@ -37,7 +37,7 @@ def register_referral_routes(app: Flask, path_prefix: str = "/api/referral") -> 
 
     @app.route(path_prefix + "/invite-event", methods=["POST"])
     @bypass_token_validation
-    def referral_invite_event_api() -> object:
+    def referral_invite_event_api() -> str:
         payload = request.get_json(silent=True)
         payload = payload if isinstance(payload, dict) else {}
         result = record_invite_event(

--- a/src/api/flaskr/service/referral/routes.py
+++ b/src/api/flaskr/service/referral/routes.py
@@ -18,7 +18,7 @@ def register_referral_routes(app: Flask, path_prefix: str = "/api/referral") -> 
     """Register referral routes."""
 
     @app.route(path_prefix + "/invite-profile", methods=["GET"])
-    def referral_invite_profile_api():
+    def referral_invite_profile_api() -> object:
         user = getattr(request, "user", None)
         user_bid = str(getattr(user, "user_id", "") or "").strip()
         if not user_bid:
@@ -28,7 +28,7 @@ def register_referral_routes(app: Flask, path_prefix: str = "/api/referral") -> 
 
     @app.route(path_prefix + "/invite-preview", methods=["GET"])
     @bypass_token_validation
-    def referral_invite_preview_api():
+    def referral_invite_preview_api() -> object:
         preview = build_invite_preview(
             app,
             invite_code=str(request.args.get("invite_code") or "").strip(),
@@ -37,7 +37,7 @@ def register_referral_routes(app: Flask, path_prefix: str = "/api/referral") -> 
 
     @app.route(path_prefix + "/invite-event", methods=["POST"])
     @bypass_token_validation
-    def referral_invite_event_api():
+    def referral_invite_event_api() -> object:
         payload = request.get_json(silent=True)
         payload = payload if isinstance(payload, dict) else {}
         result = record_invite_event(

--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -53,6 +53,7 @@ from .models import (
 from .reward_queue import build_referral_reward_queue
 
 if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
     from datetime import datetime
 
 _INVITE_CODE_ALPHABET = string.ascii_uppercase + string.digits
@@ -119,7 +120,7 @@ def extract_referral_post_auth_fields(
     }
 
 
-def _with_app_context(app: Flask) -> object:
+def _with_app_context(app: Flask) -> AbstractContextManager[None]:
     return app.app_context() if not has_app_context() else _NullContext()
 
 

--- a/src/api/flaskr/service/referral/service.py
+++ b/src/api/flaskr/service/referral/service.py
@@ -119,7 +119,7 @@ def extract_referral_post_auth_fields(
     }
 
 
-def _with_app_context(app: Flask):
+def _with_app_context(app: Flask) -> object:
     return app.app_context() if not has_app_context() else _NullContext()
 
 

--- a/src/api/flaskr/service/shifu/admin_course_summaries.py
+++ b/src/api/flaskr/service/shifu/admin_course_summaries.py
@@ -851,9 +851,13 @@ def _build_outline_history_tree(
 
 
 def _merge_courses(
-    drafts: Iterable[DraftShifu],
-    published: Iterable[PublishedShifu],
-) -> object:
+    drafts: Iterable[DraftShifu | PublishedShifu | OperatorCourseListSeed],
+    published: Iterable[DraftShifu | PublishedShifu | OperatorCourseListSeed],
+) -> tuple[
+    list[DraftShifu | PublishedShifu | OperatorCourseListSeed],
+    set[str],
+    dict[str, str],
+]:
     course_map = {}
     published_bids: set[str] = set()
     selected_sources: dict[str, str] = {}
@@ -907,11 +911,11 @@ def _load_latest_course_versions(
 
 
 def _load_latest_courses_by_shifu_bids(
-    model: object,
+    model: type[DraftShifu | PublishedShifu],
     shifu_bids: Sequence[str],
     *,
     lightweight: bool = False,
-) -> object:
+) -> list[DraftShifu | PublishedShifu | OperatorCourseListSeed]:
     normalized_shifu_bids = [
         str(shifu_bid or "").strip() for shifu_bid in shifu_bids if shifu_bid
     ]

--- a/src/api/flaskr/service/shifu/admin_course_summaries.py
+++ b/src/api/flaskr/service/shifu/admin_course_summaries.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from flaskr.service.shifu.admin_dtos_courses import (
         AdminOperationCourseSummaryDTO,
     )
+    from sqlalchemy.sql.selectable import CTE
 
 
 def _format_average_score(value: Decimal | None) -> str:
@@ -150,7 +151,7 @@ def _build_operator_visible_course_filter(
     shifu_bid_column: object,
     title_column: object,
     created_user_bid_column: object,
-):
+) -> object:
     normalized_shifu_bid = db.func.trim(db.func.coalesce(shifu_bid_column, ""))
     normalized_title = db.func.trim(db.func.coalesce(title_column, ""))
     normalized_created_user_bid = db.func.trim(
@@ -179,7 +180,7 @@ def _build_latest_operator_course_rows_query(
     creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
-):
+) -> object:
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
     )
@@ -221,7 +222,7 @@ def _build_latest_operator_course_rows_subquery(
     start_time: datetime | None,
     end_time: datetime | None,
     alias_name: str,
-):
+) -> CTE | None:
     base_query = _build_latest_operator_course_rows_query(
         model,
         shifu_bid=shifu_bid,
@@ -243,7 +244,7 @@ def _build_operator_course_candidate_query(
     start_time: datetime | None,
     end_time: datetime | None,
     include_activity: bool = False,
-):
+) -> object:
     draft_rows_subquery = _build_latest_operator_course_rows_subquery(
         DraftShifu,
         shifu_bid=shifu_bid,
@@ -403,7 +404,7 @@ def _build_latest_outline_activity_subquery(
     candidate_bids_subquery: object,
     *,
     alias_name: str,
-):
+) -> object:
     latest_outline_rows_subquery = (
         db.session.query(
             model.shifu_bid.label("shifu_bid"),
@@ -462,7 +463,7 @@ def _build_operator_course_latest_activity_subquery(
     candidate_bids_subquery: object,
     draft_visible_subquery: object,
     published_visible_subquery: object,
-):
+) -> object:
     draft_outline_activity_subquery = _build_latest_outline_activity_subquery(
         DraftOutlineItem,
         candidate_bids_subquery,
@@ -543,7 +544,7 @@ def _build_latest_shifus_query(
     updated_start_time: datetime | None,
     updated_end_time: datetime | None,
     lightweight: bool = False,
-):
+) -> object:
     is_mapped_model = hasattr(model, "__mapper__")
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
@@ -585,7 +586,7 @@ def _load_latest_shifus(
     updated_end_time: datetime | None,
     attach_prompt_flags: bool = False,
     lightweight: bool = False,
-):
+) -> object:
     ordered_query = _build_latest_shifus_query(
         model,
         shifu_bid=shifu_bid,
@@ -746,7 +747,7 @@ def _load_course_activity_map(
     return load_course_activity_map(drafts, published)
 
 
-def _load_latest_course_for_transfer(shifu_bid: str):
+def _load_latest_course_for_transfer(shifu_bid: str) -> object:
     draft = (
         DraftShifu.query.filter(
             DraftShifu.shifu_bid == shifu_bid,
@@ -848,7 +849,7 @@ def _build_outline_history_tree(
 def _merge_courses(
     drafts: Iterable[DraftShifu],
     published: Iterable[PublishedShifu],
-):
+) -> object:
     course_map = {}
     published_bids: set[str] = set()
     selected_sources: dict[str, str] = {}
@@ -906,7 +907,7 @@ def _load_latest_courses_by_shifu_bids(
     shifu_bids: Sequence[str],
     *,
     lightweight: bool = False,
-):
+) -> object:
     normalized_shifu_bids = [
         str(shifu_bid or "").strip() for shifu_bid in shifu_bids if shifu_bid
     ]

--- a/src/api/flaskr/service/shifu/admin_course_summaries.py
+++ b/src/api/flaskr/service/shifu/admin_course_summaries.py
@@ -49,9 +49,11 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
     from decimal import Decimal
 
+    from flask_sqlalchemy.query import Query
     from flaskr.service.shifu.admin_dtos_courses import (
         AdminOperationCourseSummaryDTO,
     )
+    from sqlalchemy.sql.elements import ColumnElement
     from sqlalchemy.sql.selectable import CTE
 
 
@@ -151,7 +153,7 @@ def _build_operator_visible_course_filter(
     shifu_bid_column: object,
     title_column: object,
     created_user_bid_column: object,
-) -> object:
+) -> ColumnElement[bool]:
     normalized_shifu_bid = db.func.trim(db.func.coalesce(shifu_bid_column, ""))
     normalized_title = db.func.trim(db.func.coalesce(title_column, ""))
     normalized_created_user_bid = db.func.trim(
@@ -180,7 +182,7 @@ def _build_latest_operator_course_rows_query(
     creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
-) -> object:
+) -> Query | None:
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
     )
@@ -244,7 +246,7 @@ def _build_operator_course_candidate_query(
     start_time: datetime | None,
     end_time: datetime | None,
     include_activity: bool = False,
-) -> object:
+) -> Query | None:
     draft_rows_subquery = _build_latest_operator_course_rows_subquery(
         DraftShifu,
         shifu_bid=shifu_bid,
@@ -404,7 +406,7 @@ def _build_latest_outline_activity_subquery(
     candidate_bids_subquery: object,
     *,
     alias_name: str,
-) -> object:
+) -> CTE:
     latest_outline_rows_subquery = (
         db.session.query(
             model.shifu_bid.label("shifu_bid"),
@@ -463,7 +465,7 @@ def _build_operator_course_latest_activity_subquery(
     candidate_bids_subquery: object,
     draft_visible_subquery: object,
     published_visible_subquery: object,
-) -> object:
+) -> CTE:
     draft_outline_activity_subquery = _build_latest_outline_activity_subquery(
         DraftOutlineItem,
         candidate_bids_subquery,
@@ -544,7 +546,7 @@ def _build_latest_shifus_query(
     updated_start_time: datetime | None,
     updated_end_time: datetime | None,
     lightweight: bool = False,
-) -> object:
+) -> Query | list[DraftShifu | PublishedShifu]:
     is_mapped_model = hasattr(model, "__mapper__")
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
@@ -586,7 +588,7 @@ def _load_latest_shifus(
     updated_end_time: datetime | None,
     attach_prompt_flags: bool = False,
     lightweight: bool = False,
-) -> object:
+) -> list[DraftShifu | PublishedShifu | OperatorCourseListSeed]:
     ordered_query = _build_latest_shifus_query(
         model,
         shifu_bid=shifu_bid,
@@ -747,7 +749,9 @@ def _load_course_activity_map(
     return load_course_activity_map(drafts, published)
 
 
-def _load_latest_course_for_transfer(shifu_bid: str) -> object:
+def _load_latest_course_for_transfer(
+    shifu_bid: str,
+) -> DraftShifu | PublishedShifu | None:
     draft = (
         DraftShifu.query.filter(
             DraftShifu.shifu_bid == shifu_bid,

--- a/src/api/flaskr/service/shifu/admin_operations/config_rates.py
+++ b/src/api/flaskr/service/shifu/admin_operations/config_rates.py
@@ -37,6 +37,8 @@ from flaskr.util import generate_id
 from flaskr.util.datetime import now_utc, to_utc_iso
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from flask import Flask
 
 _RATE_METRICS = {
@@ -66,7 +68,7 @@ _CREDITS_PER_UNIT_MAX = Decimal("9999999999.9999999999")
 _ActiveRateIndex = dict[tuple[int, int, str, str], CreditUsageRate]
 
 
-def _rate_effective_now():
+def _rate_effective_now() -> datetime:
     # MySQL DATETIME columns in this schema do not keep fractional seconds.
     # Truncate before writing so a just-saved rate is immediately readable and
     # repeated saves in one second hit the same deterministic version.

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
@@ -404,7 +404,9 @@ def _build_course_credit_usage_learn_filter(
     )
 
 
-def _build_operator_course_credit_usage_ledger_totals_subquery(shifu_bid: str) -> object:
+def _build_operator_course_credit_usage_ledger_totals_subquery(
+    shifu_bid: str,
+) -> object:
     course_usage_bids = (
         db.session.query(BillUsageRecord.usage_bid.label("usage_bid"))
         .filter(

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
@@ -404,7 +404,7 @@ def _build_course_credit_usage_learn_filter(
     )
 
 
-def _build_operator_course_credit_usage_ledger_totals_subquery(shifu_bid: str):
+def _build_operator_course_credit_usage_ledger_totals_subquery(shifu_bid: str) -> object:
     course_usage_bids = (
         db.session.query(BillUsageRecord.usage_bid.label("usage_bid"))
         .filter(
@@ -446,7 +446,7 @@ def _build_operator_course_credit_usage_base_query(
     shifu_bid: str,
     *,
     outline_item_bids: Sequence[str] | None = None,
-):
+) -> object:
     ledger_totals = _build_operator_course_credit_usage_ledger_totals_subquery(
         shifu_bid
     )
@@ -789,7 +789,7 @@ def _build_course_credit_usage_covered_completed_user_subquery(
     *,
     shifu_bid: str,
     leaf_outline_bids: Sequence[str],
-):
+) -> object:
     normalized_leaf_outline_bids = [
         str(outline_item_bid or "").strip()
         for outline_item_bid in leaf_outline_bids
@@ -1416,7 +1416,7 @@ def _build_latest_bill_usage_record_subquery(
     *,
     user_bid: str = "",
     usage_bids: Sequence[str] | None = None,
-):
+) -> object:
     normalized_user_bid = str(user_bid or "").strip()
     normalized_usage_bids = [
         str(usage_bid or "").strip()

--- a/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_credit_usage.py
@@ -79,6 +79,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from flask import Flask
+    from flask_sqlalchemy.query import Query
+    from sqlalchemy.sql.selectable import Subquery
 
 
 def _resolve_course_credit_usage_mode(row: BillUsageRecord) -> str:
@@ -406,7 +408,7 @@ def _build_course_credit_usage_learn_filter(
 
 def _build_operator_course_credit_usage_ledger_totals_subquery(
     shifu_bid: str,
-) -> object:
+) -> Subquery:
     course_usage_bids = (
         db.session.query(BillUsageRecord.usage_bid.label("usage_bid"))
         .filter(
@@ -448,7 +450,7 @@ def _build_operator_course_credit_usage_base_query(
     shifu_bid: str,
     *,
     outline_item_bids: Sequence[str] | None = None,
-) -> object:
+) -> Query:
     ledger_totals = _build_operator_course_credit_usage_ledger_totals_subquery(
         shifu_bid
     )
@@ -791,7 +793,7 @@ def _build_course_credit_usage_covered_completed_user_subquery(
     *,
     shifu_bid: str,
     leaf_outline_bids: Sequence[str],
-) -> object:
+) -> Subquery | None:
     normalized_leaf_outline_bids = [
         str(outline_item_bid or "").strip()
         for outline_item_bid in leaf_outline_bids
@@ -1418,7 +1420,7 @@ def _build_latest_bill_usage_record_subquery(
     *,
     user_bid: str = "",
     usage_bids: Sequence[str] | None = None,
-) -> object:
+) -> Subquery:
     normalized_user_bid = str(user_bid or "").strip()
     normalized_usage_bids = [
         str(usage_bid or "").strip()

--- a/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     from flask import Flask
 
 
-def _build_course_follow_up_base_subquery(shifu_bid: str):
+def _build_course_follow_up_base_subquery(shifu_bid: str) -> object:
     return (
         db.session.query(
             LearnGeneratedBlock.id.label("id"),

--- a/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_follow_ups.py
@@ -57,9 +57,10 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from flask import Flask
+    from sqlalchemy.sql.selectable import Subquery
 
 
-def _build_course_follow_up_base_subquery(shifu_bid: str) -> object:
+def _build_course_follow_up_base_subquery(shifu_bid: str) -> Subquery:
     return (
         db.session.query(
             LearnGeneratedBlock.id.label("id"),

--- a/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
@@ -64,6 +64,10 @@ from sqlalchemy.orm import defer
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
+    from flask_sqlalchemy.query import Query
+    from sqlalchemy.sql.elements import ColumnElement
+    from sqlalchemy.sql.selectable import CTE
+
 
 @dataclass
 class OperatorCourseListSeed:
@@ -143,7 +147,7 @@ def _build_operator_visible_course_filter(
     shifu_bid_column: object,
     title_column: object,
     created_user_bid_column: object,
-) -> object:
+) -> ColumnElement[bool]:
     normalized_shifu_bid = db.func.trim(db.func.coalesce(shifu_bid_column, ""))
     normalized_title = db.func.trim(db.func.coalesce(title_column, ""))
     normalized_created_user_bid = db.func.trim(
@@ -174,7 +178,7 @@ def _build_latest_operator_course_rows_query(
     creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
-) -> object:
+) -> Query | None:
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
     )
@@ -270,7 +274,7 @@ def _build_latest_operator_course_rows_subquery(
     start_time: datetime | None,
     end_time: datetime | None,
     alias_name: str,
-) -> object:
+) -> CTE | None:
     base_query = _build_latest_operator_course_rows_query(
         model,
         shifu_bid=shifu_bid,
@@ -296,7 +300,7 @@ def _build_operator_course_candidate_query(
     start_time: datetime | None,
     end_time: datetime | None,
     include_activity: bool = False,
-) -> object:
+) -> Query | None:
     draft_rows_subquery = _build_latest_operator_course_rows_subquery(
         DraftShifu,
         shifu_bid=shifu_bid,
@@ -478,7 +482,7 @@ def _build_latest_outline_activity_subquery(
     candidate_bids_subquery: object,
     *,
     alias_name: str,
-) -> object:
+) -> CTE:
     latest_outline_rows_subquery = (
         db.session.query(
             model.shifu_bid.label("shifu_bid"),
@@ -537,7 +541,7 @@ def _build_operator_course_latest_activity_subquery(
     candidate_bids_subquery: object,
     draft_visible_subquery: object,
     published_visible_subquery: object,
-) -> object:
+) -> CTE:
     draft_outline_activity_subquery = _build_latest_outline_activity_subquery(
         DraftOutlineItem,
         candidate_bids_subquery,
@@ -620,7 +624,7 @@ def _build_latest_shifus_query(
     updated_start_time: datetime | None,
     updated_end_time: datetime | None,
     lightweight: bool = False,
-) -> object:
+) -> Query | list[DraftShifu | PublishedShifu]:
     is_mapped_model = hasattr(model, "__mapper__")
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0

--- a/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
@@ -143,7 +143,7 @@ def _build_operator_visible_course_filter(
     shifu_bid_column: object,
     title_column: object,
     created_user_bid_column: object,
-):
+) -> object:
     normalized_shifu_bid = db.func.trim(db.func.coalesce(shifu_bid_column, ""))
     normalized_title = db.func.trim(db.func.coalesce(title_column, ""))
     normalized_created_user_bid = db.func.trim(
@@ -174,7 +174,7 @@ def _build_latest_operator_course_rows_query(
     creator_bids: set[str] | None,
     start_time: datetime | None,
     end_time: datetime | None,
-):
+) -> object:
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
     )
@@ -270,7 +270,7 @@ def _build_latest_operator_course_rows_subquery(
     start_time: datetime | None,
     end_time: datetime | None,
     alias_name: str,
-):
+) -> object:
     base_query = _build_latest_operator_course_rows_query(
         model,
         shifu_bid=shifu_bid,
@@ -296,7 +296,7 @@ def _build_operator_course_candidate_query(
     start_time: datetime | None,
     end_time: datetime | None,
     include_activity: bool = False,
-):
+) -> object:
     draft_rows_subquery = _build_latest_operator_course_rows_subquery(
         DraftShifu,
         shifu_bid=shifu_bid,
@@ -478,7 +478,7 @@ def _build_latest_outline_activity_subquery(
     candidate_bids_subquery: object,
     *,
     alias_name: str,
-):
+) -> object:
     latest_outline_rows_subquery = (
         db.session.query(
             model.shifu_bid.label("shifu_bid"),
@@ -537,7 +537,7 @@ def _build_operator_course_latest_activity_subquery(
     candidate_bids_subquery: object,
     draft_visible_subquery: object,
     published_visible_subquery: object,
-):
+) -> object:
     draft_outline_activity_subquery = _build_latest_outline_activity_subquery(
         DraftOutlineItem,
         candidate_bids_subquery,
@@ -620,7 +620,7 @@ def _build_latest_shifus_query(
     updated_start_time: datetime | None,
     updated_end_time: datetime | None,
     lightweight: bool = False,
-):
+) -> object:
     is_mapped_model = hasattr(model, "__mapper__")
     latest_subquery = db.session.query(db.func.max(model.id).label("max_id")).filter(
         model.deleted == 0
@@ -730,7 +730,7 @@ def _load_latest_shifus(
     updated_end_time: datetime | None,
     attach_prompt_flags: bool = False,
     lightweight: bool = False,
-):
+) -> object:
     ordered_query = _build_latest_shifus_query(
         model,
         shifu_bid=shifu_bid,
@@ -886,7 +886,7 @@ def _apply_operator_course_list_filters(
     updated_start_time: datetime | None,
     updated_end_time: datetime | None,
     apply_updated_filters: bool,
-):
+) -> object:
     if course_status in {COURSE_STATUS_PUBLISHED, COURSE_STATUS_UNPUBLISHED}:
         query = query.filter(candidate_subquery.c.course_status == course_status)
     if quick_filter:
@@ -1008,7 +1008,7 @@ def _load_recent_paid_order_course_bids(
     }
 
 
-def _build_latest_billing_order_subquery(*, creator_bid: str):
+def _build_latest_billing_order_subquery(*, creator_bid: str) -> object:
     normalized_creator_bid = str(creator_bid or "").strip()
     return (
         db.session.query(

--- a/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:
 
     from flask_sqlalchemy.query import Query
     from sqlalchemy.sql.elements import ColumnElement
-    from sqlalchemy.sql.selectable import CTE
+    from sqlalchemy.sql.selectable import CTE, Subquery
 
 
 @dataclass
@@ -882,15 +882,15 @@ def _resolve_course_quick_filter(value: str) -> str:
 
 
 def _apply_operator_course_list_filters(
-    query: object,
-    candidate_subquery: object,
+    query: Query,
+    candidate_subquery: Subquery,
     *,
     course_status: str,
     quick_filter: str,
     updated_start_time: datetime | None,
     updated_end_time: datetime | None,
     apply_updated_filters: bool,
-) -> object:
+) -> Query:
     if course_status in {COURSE_STATUS_PUBLISHED, COURSE_STATUS_UNPUBLISHED}:
         query = query.filter(candidate_subquery.c.course_status == course_status)
     if quick_filter:
@@ -1012,7 +1012,7 @@ def _load_recent_paid_order_course_bids(
     }
 
 
-def _build_latest_billing_order_subquery(*, creator_bid: str) -> object:
+def _build_latest_billing_order_subquery(*, creator_bid: str) -> Subquery:
     normalized_creator_bid = str(creator_bid or "").strip()
     return (
         db.session.query(

--- a/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_listing.py
@@ -730,7 +730,7 @@ def _load_latest_shifus(
     updated_end_time: datetime | None,
     attach_prompt_flags: bool = False,
     lightweight: bool = False,
-) -> object:
+) -> list[DraftShifu | PublishedShifu | OperatorCourseListSeed]:
     ordered_query = _build_latest_shifus_query(
         model,
         shifu_bid=shifu_bid,

--- a/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
@@ -510,7 +510,7 @@ def _resolve_course_user_learning_status(
     return COURSE_USER_LEARNING_STATUS_NOT_STARTED
 
 
-def _build_course_order_amount_expr():
+def _build_course_order_amount_expr() -> object:
     return case(
         (Order.paid_price > 0, Order.paid_price),
         (Order.payable_price > 0, Order.payable_price),
@@ -592,7 +592,7 @@ def _is_operator_visible_course(course: object) -> bool:
 def _merge_courses(
     drafts: Iterable[DraftShifu],
     published: Iterable[PublishedShifu],
-):
+) -> tuple[list[DraftShifu | PublishedShifu], set[str], dict[str, str]]:
     course_map = {}
     published_bids: set[str] = set()
     selected_sources: dict[str, str] = {}
@@ -645,7 +645,7 @@ def _load_latest_course_versions(
     return draft, published
 
 
-def _load_operator_course_detail_source(shifu_bid: str):
+def _load_operator_course_detail_source(shifu_bid: str) -> object:
     draft, published = _load_latest_course_versions(shifu_bid)
     visible_draft = draft if draft and _is_operator_visible_course(draft) else None
     visible_published = (
@@ -662,7 +662,7 @@ def _load_operator_course_detail_source(shifu_bid: str):
     }
 
 
-def _load_latest_outline_items(model: object, shifu_bid: str):
+def _load_latest_outline_items(model: object, shifu_bid: str) -> object:
     latest_subquery = (
         db.session.query(db.func.max(model.id).label("max_id"))
         .filter(

--- a/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
@@ -645,7 +645,9 @@ def _load_latest_course_versions(
     return draft, published
 
 
-def _load_operator_course_detail_source(shifu_bid: str) -> object:
+def _load_operator_course_detail_source(
+    shifu_bid: str,
+) -> dict[str, object] | None:
     draft, published = _load_latest_course_versions(shifu_bid)
     visible_draft = draft if draft and _is_operator_visible_course(draft) else None
     visible_published = (

--- a/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
@@ -184,6 +184,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
     from decimal import Decimal
 
+    from sqlalchemy.sql.elements import ColumnElement
+
 COURSE_CREDIT_USAGE_VIEW_GROUPED = "grouped"
 
 COURSE_CREDIT_USAGE_VIEW_RAW = "raw"
@@ -510,7 +512,7 @@ def _resolve_course_user_learning_status(
     return COURSE_USER_LEARNING_STATUS_NOT_STARTED
 
 
-def _build_course_order_amount_expr() -> object:
+def _build_course_order_amount_expr() -> ColumnElement[Any]:
     return case(
         (Order.paid_price > 0, Order.paid_price),
         (Order.payable_price > 0, Order.payable_price),

--- a/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_shared.py
@@ -664,7 +664,9 @@ def _load_operator_course_detail_source(
     }
 
 
-def _load_latest_outline_items(model: object, shifu_bid: str) -> object:
+def _load_latest_outline_items(
+    model: object, shifu_bid: str
+) -> list[DraftOutlineItem | PublishedOutlineItem]:
     latest_subquery = (
         db.session.query(db.func.max(model.id).label("max_id"))
         .filter(

--- a/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
@@ -69,7 +69,9 @@ if TYPE_CHECKING:
     from datetime import datetime
 
 
-def _load_latest_course_for_transfer(shifu_bid: str) -> object:
+def _load_latest_course_for_transfer(
+    shifu_bid: str,
+) -> DraftShifu | PublishedShifu | None:
     draft = (
         DraftShifu.query.filter(
             DraftShifu.shifu_bid == shifu_bid,

--- a/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
+++ b/src/api/flaskr/service/shifu/admin_operations/courses_transfer_copy.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
     from datetime import datetime
 
 
-def _load_latest_course_for_transfer(shifu_bid: str):
+def _load_latest_course_for_transfer(shifu_bid: str) -> object:
     draft = (
         DraftShifu.query.filter(
             DraftShifu.shifu_bid == shifu_bid,

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -311,7 +311,7 @@ def register_admin_operations_routes(
     """Register operator admin operation routes."""
 
     @app.route(path_prefix + "/admin/operations/courses", methods=["GET"])
-    def admin_operations_courses() -> object:
+    def admin_operations_courses() -> str:
         """Operator course list.
 
         ---
@@ -437,7 +437,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/courses/overview", methods=["GET"])
-    def admin_operations_course_overview() -> object:
+    def admin_operations_course_overview() -> str:
         """Operator course overview.
 
         ---
@@ -461,7 +461,7 @@ def register_admin_operations_routes(
         return make_common_response(get_operator_course_overview(app))
 
     @app.route(path_prefix + "/admin/operations/users", methods=["GET"])
-    def admin_operations_users() -> object:
+    def admin_operations_users() -> str:
         """Operator user list.
 
         ---
@@ -576,7 +576,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/users/overview", methods=["GET"])
-    def admin_operations_user_overview() -> object:
+    def admin_operations_user_overview() -> str:
         """Operator user overview.
 
         ---
@@ -600,7 +600,7 @@ def register_admin_operations_routes(
         return make_common_response(get_operator_user_overview(app))
 
     @app.route(path_prefix + "/admin/operations/voice-clones", methods=["GET"])
-    def admin_operations_voice_clones() -> object:
+    def admin_operations_voice_clones() -> str:
         """Operator MiniMax cloned voice list.
 
         ---
@@ -721,7 +721,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/voice-clones", methods=["POST"])
-    def admin_operations_register_voice_clone() -> object:
+    def admin_operations_register_voice_clone() -> str:
         """Register a voice cloned on a provider console and assign it to a teacher.
 
         ---
@@ -763,7 +763,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/orders", methods=["GET"])
-    def admin_operations_orders() -> object:
+    def admin_operations_orders() -> str:
         """Operator global order list.
 
         ---
@@ -865,7 +865,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/orders/overview", methods=["GET"])
-    def admin_operations_order_overview() -> object:
+    def admin_operations_order_overview() -> str:
         """Operator learning order overview.
 
         ---
@@ -892,7 +892,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/overview",
         methods=["GET"],
     )
-    def admin_operation_credit_notifications_overview() -> object:
+    def admin_operation_credit_notifications_overview() -> str:
         """Return global operator credit notification overview."""
         _require_operator()
         return make_common_response(get_operator_credit_notification_overview(app))
@@ -901,7 +901,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications",
         methods=["GET"],
     )
-    def admin_operation_credit_notifications() -> object:
+    def admin_operation_credit_notifications() -> str:
         """List operator credit notification records."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -973,7 +973,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/<notification_bid>",
         methods=["GET"],
     )
-    def admin_operation_credit_notification_detail(notification_bid: str) -> object:
+    def admin_operation_credit_notification_detail(notification_bid: str) -> str:
         """Return one operator credit notification record detail."""
         _require_operator()
         return make_common_response(
@@ -987,7 +987,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/config",
         methods=["GET"],
     )
-    def admin_operation_credit_notification_config() -> object:
+    def admin_operation_credit_notification_config() -> str:
         """Get operator credit notification config."""
         _require_operator()
         return make_common_response(get_operator_credit_notification_config(app))
@@ -996,7 +996,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/config",
         methods=["POST"],
     )
-    def admin_operation_update_credit_notification_config() -> object:
+    def admin_operation_update_credit_notification_config() -> str:
         """Update operator credit notification config."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1014,7 +1014,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/profile-onboarding",
         methods=["GET"],
     )
-    def admin_operation_profile_onboarding_config() -> object:
+    def admin_operation_profile_onboarding_config() -> str:
         """Get operator profile onboarding config."""
         _require_operator()
         return make_common_response(get_operator_profile_onboarding_config(app))
@@ -1023,7 +1023,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/profile-onboarding",
         methods=["POST"],
     )
-    def admin_operation_update_profile_onboarding_config() -> object:
+    def admin_operation_update_profile_onboarding_config() -> str:
         """Update operator profile onboarding config."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1041,7 +1041,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/config/rates",
         methods=["GET"],
     )
-    def admin_operation_rate_config() -> object:
+    def admin_operation_rate_config() -> str:
         """Get operator-managed model and TTS credit rate config."""
         _require_operator()
         return make_common_response(get_operator_rate_config(app))
@@ -1050,7 +1050,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/config/rates",
         methods=["POST"],
     )
-    def admin_operation_update_rate_config() -> object:
+    def admin_operation_update_rate_config() -> str:
         """Update one operator-managed model or TTS credit rate config."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1068,7 +1068,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/templates/sync",
         methods=["POST"],
     )
-    def admin_operation_credit_notification_template_sync() -> object:
+    def admin_operation_credit_notification_template_sync() -> str:
         """Sync one SMS template for operator credit notification config."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1086,7 +1086,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/templates",
         methods=["GET"],
     )
-    def admin_operation_credit_notification_templates() -> object:
+    def admin_operation_credit_notification_templates() -> str:
         """List SMS templates for operator credit notification config."""
         _require_operator()
         return make_common_response(list_operator_credit_notification_templates(app))
@@ -1095,7 +1095,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/dry-run",
         methods=["POST"],
     )
-    def admin_operation_credit_notification_dry_run() -> object:
+    def admin_operation_credit_notification_dry_run() -> str:
         """Dry-run operator credit notification scans."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1114,7 +1114,7 @@ def register_admin_operations_routes(
         + "/admin/operations/credit-notifications/<notification_bid>/requeue",
         methods=["POST"],
     )
-    def admin_operation_credit_notification_requeue(notification_bid: str) -> object:
+    def admin_operation_credit_notification_requeue(notification_bid: str) -> str:
         """Requeue one failed provider credit notification."""
         _require_operator()
         return make_common_response(
@@ -1129,7 +1129,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/orders/<order_bid>/detail",
         methods=["GET"],
     )
-    def admin_operation_order_detail(order_bid: str) -> object:
+    def admin_operation_order_detail(order_bid: str) -> str:
         """Get operator order detail.
 
         ---
@@ -1151,7 +1151,7 @@ def register_admin_operations_routes(
         return make_common_response(get_operator_order_detail(app, order_bid))
 
     @app.route(path_prefix + "/admin/operations/orders/credits", methods=["GET"])
-    def admin_operations_credit_orders() -> object:
+    def admin_operations_credit_orders() -> str:
         """Operator global credit order list.
 
         ---
@@ -1256,7 +1256,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/orders/credits/overview",
         methods=["GET"],
     )
-    def admin_operations_credit_order_overview() -> object:
+    def admin_operations_credit_order_overview() -> str:
         """Operator credit order overview.
 
         ---
@@ -1280,7 +1280,7 @@ def register_admin_operations_routes(
         return make_common_response(build_operator_credit_orders_overview(app))
 
     @app.route(path_prefix + "/admin/operations/referrals", methods=["GET"])
-    def admin_operations_referrals() -> object:
+    def admin_operations_referrals() -> str:
         """List operator-visible referral invite relations."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1336,7 +1336,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/referrals/overview", methods=["GET"])
-    def admin_operations_referrals_overview() -> object:
+    def admin_operations_referrals_overview() -> str:
         """Return operator referral overview metrics."""
         _require_operator()
         return make_common_response(get_operator_referral_overview(app))
@@ -1345,7 +1345,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/referrals/<relation_bid>",
         methods=["GET"],
     )
-    def admin_operations_referral_detail(relation_bid: str) -> object:
+    def admin_operations_referral_detail(relation_bid: str) -> str:
         """Return one operator referral relation detail."""
         _require_operator()
         return make_common_response(
@@ -1356,7 +1356,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/referrals/<relation_bid>/status",
         methods=["POST"],
     )
-    def admin_operations_referral_status(relation_bid: str) -> object:
+    def admin_operations_referral_status(relation_bid: str) -> str:
         """Update one referral relation or reward operator status."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1375,7 +1375,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/referrals/<relation_bid>/adjustment",
         methods=["POST"],
     )
-    def admin_operations_referral_adjustment(relation_bid: str) -> object:
+    def admin_operations_referral_adjustment(relation_bid: str) -> str:
         """Apply an audited operator adjustment to one referral relation."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1394,7 +1394,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/referral-campaigns",
         methods=["GET"],
     )
-    def admin_operations_promotion_referral_campaigns() -> object:
+    def admin_operations_promotion_referral_campaigns() -> str:
         """Operator referral campaign configuration list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1443,7 +1443,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/referral-campaigns",
         methods=["POST"],
     )
-    def admin_create_operations_promotion_referral_campaign() -> object:
+    def admin_create_operations_promotion_referral_campaign() -> str:
         """Create operator referral campaign configuration."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1463,7 +1463,7 @@ def register_admin_operations_routes(
     )
     def admin_operations_promotion_referral_campaign_detail(
         campaign_bid: str,
-    ) -> object:
+    ) -> str:
         """Get operator referral campaign configuration detail."""
         _require_operator()
         return make_common_response(
@@ -1477,7 +1477,7 @@ def register_admin_operations_routes(
     )
     def admin_operations_promotion_referral_campaign_relations(
         campaign_bid: str,
-    ) -> object:
+    ) -> str:
         """List invite relations for one referral campaign."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1539,7 +1539,7 @@ def register_admin_operations_routes(
     )
     def admin_operations_promotion_referral_campaign_invitations(
         campaign_bid: str,
-    ) -> object:
+    ) -> str:
         """List invite-code funnel data for one referral campaign."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1593,7 +1593,7 @@ def register_admin_operations_routes(
     )
     def admin_update_operations_promotion_referral_campaign(
         campaign_bid: str,
-    ) -> object:
+    ) -> str:
         """Update operator referral campaign configuration."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1615,7 +1615,7 @@ def register_admin_operations_routes(
     )
     def admin_operations_promotion_referral_campaign_status(
         campaign_bid: str,
-    ) -> object:
+    ) -> str:
         """Update operator referral campaign configuration status."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1631,7 +1631,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/promotions/coupons", methods=["GET"])
-    def admin_operations_promotion_coupons() -> object:
+    def admin_operations_promotion_coupons() -> str:
         """Operator coupon batch list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1680,7 +1680,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/promotions/coupons", methods=["POST"])
-    def admin_create_operations_promotion_coupon() -> object:
+    def admin_create_operations_promotion_coupon() -> str:
         """Create operator coupon batch."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1692,7 +1692,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>",
         methods=["POST"],
     )
-    def admin_update_operations_promotion_coupon(coupon_bid: str) -> object:
+    def admin_update_operations_promotion_coupon(coupon_bid: str) -> str:
         """Update operator coupon batch."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1706,7 +1706,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/orders/credits/<bill_order_bid>/detail",
         methods=["GET"],
     )
-    def admin_operation_credit_order_detail(bill_order_bid: str) -> object:
+    def admin_operation_credit_order_detail(bill_order_bid: str) -> str:
         """Get operator credit order detail.
 
         ---
@@ -1736,7 +1736,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>",
         methods=["GET"],
     )
-    def admin_operations_promotion_coupon_detail(coupon_bid: str) -> object:
+    def admin_operations_promotion_coupon_detail(coupon_bid: str) -> str:
         """Get operator coupon batch detail."""
         _require_operator()
         return make_common_response(
@@ -1747,7 +1747,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>/status",
         methods=["POST"],
     )
-    def admin_operations_promotion_coupon_status(coupon_bid: str) -> object:
+    def admin_operations_promotion_coupon_status(coupon_bid: str) -> str:
         """Update operator coupon batch status."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1765,7 +1765,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>/usages",
         methods=["GET"],
     )
-    def admin_operations_promotion_coupon_usages(coupon_bid: str) -> object:
+    def admin_operations_promotion_coupon_usages(coupon_bid: str) -> str:
         """Get operator coupon usage list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1796,7 +1796,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>/codes",
         methods=["GET"],
     )
-    def admin_operations_promotion_coupon_codes(coupon_bid: str) -> object:
+    def admin_operations_promotion_coupon_codes(coupon_bid: str) -> str:
         """Get operator coupon code pool list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1819,7 +1819,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/promotions/campaigns", methods=["GET"])
-    def admin_operations_promotion_campaigns() -> object:
+    def admin_operations_promotion_campaigns() -> str:
         """Operator campaign list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1870,7 +1870,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns",
         methods=["POST"],
     )
-    def admin_create_operations_promotion_campaign() -> object:
+    def admin_create_operations_promotion_campaign() -> str:
         """Create operator campaign."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1882,7 +1882,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns/<promo_bid>",
         methods=["GET"],
     )
-    def admin_operations_promotion_campaign_detail(promo_bid: str) -> object:
+    def admin_operations_promotion_campaign_detail(promo_bid: str) -> str:
         """Get operator campaign detail."""
         _require_operator()
         return make_common_response(
@@ -1893,7 +1893,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns/<promo_bid>",
         methods=["POST"],
     )
-    def admin_update_operations_promotion_campaign(promo_bid: str) -> object:
+    def admin_update_operations_promotion_campaign(promo_bid: str) -> str:
         """Update operator campaign."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1907,7 +1907,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns/<promo_bid>/status",
         methods=["POST"],
     )
-    def admin_operations_promotion_campaign_status(promo_bid: str) -> object:
+    def admin_operations_promotion_campaign_status(promo_bid: str) -> str:
         """Update operator campaign status."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1925,7 +1925,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns/<promo_bid>/redemptions",
         methods=["GET"],
     )
-    def admin_operations_promotion_campaign_redemptions(promo_bid: str) -> object:
+    def admin_operations_promotion_campaign_redemptions(promo_bid: str) -> str:
         """Get operator campaign redemption list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1954,7 +1954,7 @@ def register_admin_operations_routes(
     @app.route(
         path_prefix + "/admin/operations/users/<user_bid>/detail", methods=["GET"]
     )
-    def admin_operation_user_detail(user_bid: str) -> object:
+    def admin_operation_user_detail(user_bid: str) -> str:
         """Get operator user detail.
 
         ---
@@ -1976,7 +1976,7 @@ def register_admin_operations_routes(
     @app.route(
         path_prefix + "/admin/operations/users/<user_bid>/credits", methods=["GET"]
     )
-    def admin_operation_user_credits(user_bid: str) -> object:
+    def admin_operation_user_credits(user_bid: str) -> str:
         """Get operator user credits detail.
 
         ---
@@ -2083,9 +2083,7 @@ def register_admin_operations_routes(
         + "/admin/operations/users/<user_bid>/credits/usages/<usage_bid>/detail",
         methods=["GET"],
     )
-    def admin_operation_user_credit_usage_detail(
-        user_bid: str, usage_bid: str
-    ) -> object:
+    def admin_operation_user_credit_usage_detail(user_bid: str, usage_bid: str) -> str:
         """Get operator user credit usage content detail.
 
         ---
@@ -2119,7 +2117,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/users/<user_bid>/credit-grant/bootstrap",
         methods=["GET"],
     )
-    def admin_operation_user_credit_grant_bootstrap(user_bid: str) -> object:
+    def admin_operation_user_credit_grant_bootstrap(user_bid: str) -> str:
         """Get operator user grant bootstrap.
 
         ---
@@ -2147,7 +2145,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/users/<user_bid>/credits/grant",
         methods=["POST"],
     )
-    def admin_operation_user_credit_grant(user_bid: str) -> object:
+    def admin_operation_user_credit_grant(user_bid: str) -> str:
         """Grant operator user credits.
 
         ---
@@ -2190,7 +2188,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/users/<user_bid>/packages/grant",
         methods=["POST"],
     )
-    def admin_operation_user_package_grant(user_bid: str) -> object:
+    def admin_operation_user_package_grant(user_bid: str) -> str:
         """Grant operator user package.
 
         ---
@@ -2233,7 +2231,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/prompt",
         methods=["GET"],
     )
-    def admin_operation_course_prompt(shifu_bid: str) -> object:
+    def admin_operation_course_prompt(shifu_bid: str) -> str:
         """Get operator course prompt."""
         _require_operator()
         return make_common_response(
@@ -2243,7 +2241,7 @@ def register_admin_operations_routes(
     @app.route(
         path_prefix + "/admin/operations/courses/<shifu_bid>/detail", methods=["GET"]
     )
-    def admin_operation_course_detail(shifu_bid: str) -> object:
+    def admin_operation_course_detail(shifu_bid: str) -> str:
         """Get operator course detail.
 
         ---
@@ -2284,7 +2282,7 @@ def register_admin_operations_routes(
     )
     def admin_operation_course_chapter_detail(
         shifu_bid: str, outline_item_bid: str
-    ) -> object:
+    ) -> str:
         """Get operator course chapter detail.
 
         ---
@@ -2327,7 +2325,7 @@ def register_admin_operations_routes(
     @app.route(
         path_prefix + "/admin/operations/courses/<shifu_bid>/users", methods=["GET"]
     )
-    def admin_operation_course_users(shifu_bid: str) -> object:
+    def admin_operation_course_users(shifu_bid: str) -> str:
         """Get operator course users.
 
         ---
@@ -2404,7 +2402,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/credit-usages",
         methods=["GET"],
     )
-    def admin_operation_course_credit_usages(shifu_bid: str) -> object:
+    def admin_operation_course_credit_usages(shifu_bid: str) -> str:
         """Get operator course credit usage list.
 
         ---
@@ -2506,7 +2504,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/credit-usages/details",
         methods=["GET"],
     )
-    def admin_operation_course_credit_usage_details(shifu_bid: str) -> object:
+    def admin_operation_course_credit_usage_details(shifu_bid: str) -> str:
         """Get operator course credit usage detail list.
 
         ---
@@ -2543,7 +2541,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/ratings",
         methods=["GET"],
     )
-    def admin_operation_course_ratings(shifu_bid: str) -> object:
+    def admin_operation_course_ratings(shifu_bid: str) -> str:
         """Get operator course rating list.
 
         ---
@@ -2668,7 +2666,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/follow-ups",
         methods=["GET"],
     )
-    def admin_operation_course_follow_ups(shifu_bid: str) -> object:
+    def admin_operation_course_follow_ups(shifu_bid: str) -> str:
         """Get operator course follow-up list.
 
         ---
@@ -2779,7 +2777,7 @@ def register_admin_operations_routes(
     def admin_operation_course_follow_up_detail(
         shifu_bid: str,
         generated_block_bid: str,
-    ) -> object:
+    ) -> str:
         """Get operator course follow-up detail.
 
         ---
@@ -2813,7 +2811,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/copy",
         methods=["POST"],
     )
-    def admin_copy_course(shifu_bid: str) -> object:
+    def admin_copy_course(shifu_bid: str) -> str:
         _require_operator()
         payload = request.get_json(silent=True) or {}
         if not isinstance(payload, dict):
@@ -2847,7 +2845,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/transfer-creator",
         methods=["POST"],
     )
-    def admin_transfer_course_creator(shifu_bid: str) -> object:
+    def admin_transfer_course_creator(shifu_bid: str) -> str:
         _require_operator()
         payload = request.get_json(silent=True) or {}
         if not isinstance(payload, dict):

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -1461,7 +1461,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/referral-campaigns/<campaign_bid>",
         methods=["GET"],
     )
-    def admin_operations_promotion_referral_campaign_detail(campaign_bid: str) -> object:
+    def admin_operations_promotion_referral_campaign_detail(
+        campaign_bid: str,
+    ) -> object:
         """Get operator referral campaign configuration detail."""
         _require_operator()
         return make_common_response(
@@ -1473,7 +1475,9 @@ def register_admin_operations_routes(
         + "/admin/operations/promotions/referral-campaigns/<campaign_bid>/relations",
         methods=["GET"],
     )
-    def admin_operations_promotion_referral_campaign_relations(campaign_bid: str) -> object:
+    def admin_operations_promotion_referral_campaign_relations(
+        campaign_bid: str,
+    ) -> object:
         """List invite relations for one referral campaign."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1533,7 +1537,9 @@ def register_admin_operations_routes(
         + "/admin/operations/promotions/referral-campaigns/<campaign_bid>/invitations",
         methods=["GET"],
     )
-    def admin_operations_promotion_referral_campaign_invitations(campaign_bid: str) -> object:
+    def admin_operations_promotion_referral_campaign_invitations(
+        campaign_bid: str,
+    ) -> object:
         """List invite-code funnel data for one referral campaign."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1585,7 +1591,9 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/referral-campaigns/<campaign_bid>",
         methods=["POST"],
     )
-    def admin_update_operations_promotion_referral_campaign(campaign_bid: str) -> object:
+    def admin_update_operations_promotion_referral_campaign(
+        campaign_bid: str,
+    ) -> object:
         """Update operator referral campaign configuration."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1605,7 +1613,9 @@ def register_admin_operations_routes(
         + "/admin/operations/promotions/referral-campaigns/<campaign_bid>/status",
         methods=["POST"],
     )
-    def admin_operations_promotion_referral_campaign_status(campaign_bid: str) -> object:
+    def admin_operations_promotion_referral_campaign_status(
+        campaign_bid: str,
+    ) -> object:
         """Update operator referral campaign configuration status."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -2073,7 +2083,9 @@ def register_admin_operations_routes(
         + "/admin/operations/users/<user_bid>/credits/usages/<usage_bid>/detail",
         methods=["GET"],
     )
-    def admin_operation_user_credit_usage_detail(user_bid: str, usage_bid: str) -> object:
+    def admin_operation_user_credit_usage_detail(
+        user_bid: str, usage_bid: str
+    ) -> object:
         """Get operator user credit usage content detail.
 
         ---
@@ -2270,7 +2282,9 @@ def register_admin_operations_routes(
         + "/admin/operations/courses/<shifu_bid>/chapters/<outline_item_bid>/detail",
         methods=["GET"],
     )
-    def admin_operation_course_chapter_detail(shifu_bid: str, outline_item_bid: str) -> object:
+    def admin_operation_course_chapter_detail(
+        shifu_bid: str, outline_item_bid: str
+    ) -> object:
         """Get operator course chapter detail.
 
         ---

--- a/src/api/flaskr/service/shifu/admin_operations/route.py
+++ b/src/api/flaskr/service/shifu/admin_operations/route.py
@@ -311,7 +311,7 @@ def register_admin_operations_routes(
     """Register operator admin operation routes."""
 
     @app.route(path_prefix + "/admin/operations/courses", methods=["GET"])
-    def admin_operations_courses():
+    def admin_operations_courses() -> object:
         """Operator course list.
 
         ---
@@ -437,7 +437,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/courses/overview", methods=["GET"])
-    def admin_operations_course_overview():
+    def admin_operations_course_overview() -> object:
         """Operator course overview.
 
         ---
@@ -461,7 +461,7 @@ def register_admin_operations_routes(
         return make_common_response(get_operator_course_overview(app))
 
     @app.route(path_prefix + "/admin/operations/users", methods=["GET"])
-    def admin_operations_users():
+    def admin_operations_users() -> object:
         """Operator user list.
 
         ---
@@ -576,7 +576,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/users/overview", methods=["GET"])
-    def admin_operations_user_overview():
+    def admin_operations_user_overview() -> object:
         """Operator user overview.
 
         ---
@@ -600,7 +600,7 @@ def register_admin_operations_routes(
         return make_common_response(get_operator_user_overview(app))
 
     @app.route(path_prefix + "/admin/operations/voice-clones", methods=["GET"])
-    def admin_operations_voice_clones():
+    def admin_operations_voice_clones() -> object:
         """Operator MiniMax cloned voice list.
 
         ---
@@ -721,7 +721,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/voice-clones", methods=["POST"])
-    def admin_operations_register_voice_clone():
+    def admin_operations_register_voice_clone() -> object:
         """Register a voice cloned on a provider console and assign it to a teacher.
 
         ---
@@ -763,7 +763,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/orders", methods=["GET"])
-    def admin_operations_orders():
+    def admin_operations_orders() -> object:
         """Operator global order list.
 
         ---
@@ -865,7 +865,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/orders/overview", methods=["GET"])
-    def admin_operations_order_overview():
+    def admin_operations_order_overview() -> object:
         """Operator learning order overview.
 
         ---
@@ -892,7 +892,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/overview",
         methods=["GET"],
     )
-    def admin_operation_credit_notifications_overview():
+    def admin_operation_credit_notifications_overview() -> object:
         """Return global operator credit notification overview."""
         _require_operator()
         return make_common_response(get_operator_credit_notification_overview(app))
@@ -901,7 +901,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications",
         methods=["GET"],
     )
-    def admin_operation_credit_notifications():
+    def admin_operation_credit_notifications() -> object:
         """List operator credit notification records."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -973,7 +973,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/<notification_bid>",
         methods=["GET"],
     )
-    def admin_operation_credit_notification_detail(notification_bid: str):
+    def admin_operation_credit_notification_detail(notification_bid: str) -> object:
         """Return one operator credit notification record detail."""
         _require_operator()
         return make_common_response(
@@ -987,7 +987,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/config",
         methods=["GET"],
     )
-    def admin_operation_credit_notification_config():
+    def admin_operation_credit_notification_config() -> object:
         """Get operator credit notification config."""
         _require_operator()
         return make_common_response(get_operator_credit_notification_config(app))
@@ -996,7 +996,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/config",
         methods=["POST"],
     )
-    def admin_operation_update_credit_notification_config():
+    def admin_operation_update_credit_notification_config() -> object:
         """Update operator credit notification config."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1014,7 +1014,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/profile-onboarding",
         methods=["GET"],
     )
-    def admin_operation_profile_onboarding_config():
+    def admin_operation_profile_onboarding_config() -> object:
         """Get operator profile onboarding config."""
         _require_operator()
         return make_common_response(get_operator_profile_onboarding_config(app))
@@ -1023,7 +1023,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/profile-onboarding",
         methods=["POST"],
     )
-    def admin_operation_update_profile_onboarding_config():
+    def admin_operation_update_profile_onboarding_config() -> object:
         """Update operator profile onboarding config."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1041,7 +1041,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/config/rates",
         methods=["GET"],
     )
-    def admin_operation_rate_config():
+    def admin_operation_rate_config() -> object:
         """Get operator-managed model and TTS credit rate config."""
         _require_operator()
         return make_common_response(get_operator_rate_config(app))
@@ -1050,7 +1050,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/config/rates",
         methods=["POST"],
     )
-    def admin_operation_update_rate_config():
+    def admin_operation_update_rate_config() -> object:
         """Update one operator-managed model or TTS credit rate config."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1068,7 +1068,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/templates/sync",
         methods=["POST"],
     )
-    def admin_operation_credit_notification_template_sync():
+    def admin_operation_credit_notification_template_sync() -> object:
         """Sync one SMS template for operator credit notification config."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1086,7 +1086,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/templates",
         methods=["GET"],
     )
-    def admin_operation_credit_notification_templates():
+    def admin_operation_credit_notification_templates() -> object:
         """List SMS templates for operator credit notification config."""
         _require_operator()
         return make_common_response(list_operator_credit_notification_templates(app))
@@ -1095,7 +1095,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/credit-notifications/dry-run",
         methods=["POST"],
     )
-    def admin_operation_credit_notification_dry_run():
+    def admin_operation_credit_notification_dry_run() -> object:
         """Dry-run operator credit notification scans."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1114,7 +1114,7 @@ def register_admin_operations_routes(
         + "/admin/operations/credit-notifications/<notification_bid>/requeue",
         methods=["POST"],
     )
-    def admin_operation_credit_notification_requeue(notification_bid: str):
+    def admin_operation_credit_notification_requeue(notification_bid: str) -> object:
         """Requeue one failed provider credit notification."""
         _require_operator()
         return make_common_response(
@@ -1129,7 +1129,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/orders/<order_bid>/detail",
         methods=["GET"],
     )
-    def admin_operation_order_detail(order_bid: str):
+    def admin_operation_order_detail(order_bid: str) -> object:
         """Get operator order detail.
 
         ---
@@ -1151,7 +1151,7 @@ def register_admin_operations_routes(
         return make_common_response(get_operator_order_detail(app, order_bid))
 
     @app.route(path_prefix + "/admin/operations/orders/credits", methods=["GET"])
-    def admin_operations_credit_orders():
+    def admin_operations_credit_orders() -> object:
         """Operator global credit order list.
 
         ---
@@ -1256,7 +1256,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/orders/credits/overview",
         methods=["GET"],
     )
-    def admin_operations_credit_order_overview():
+    def admin_operations_credit_order_overview() -> object:
         """Operator credit order overview.
 
         ---
@@ -1280,7 +1280,7 @@ def register_admin_operations_routes(
         return make_common_response(build_operator_credit_orders_overview(app))
 
     @app.route(path_prefix + "/admin/operations/referrals", methods=["GET"])
-    def admin_operations_referrals():
+    def admin_operations_referrals() -> object:
         """List operator-visible referral invite relations."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1336,7 +1336,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/referrals/overview", methods=["GET"])
-    def admin_operations_referrals_overview():
+    def admin_operations_referrals_overview() -> object:
         """Return operator referral overview metrics."""
         _require_operator()
         return make_common_response(get_operator_referral_overview(app))
@@ -1345,7 +1345,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/referrals/<relation_bid>",
         methods=["GET"],
     )
-    def admin_operations_referral_detail(relation_bid: str):
+    def admin_operations_referral_detail(relation_bid: str) -> object:
         """Return one operator referral relation detail."""
         _require_operator()
         return make_common_response(
@@ -1356,7 +1356,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/referrals/<relation_bid>/status",
         methods=["POST"],
     )
-    def admin_operations_referral_status(relation_bid: str):
+    def admin_operations_referral_status(relation_bid: str) -> object:
         """Update one referral relation or reward operator status."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1375,7 +1375,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/referrals/<relation_bid>/adjustment",
         methods=["POST"],
     )
-    def admin_operations_referral_adjustment(relation_bid: str):
+    def admin_operations_referral_adjustment(relation_bid: str) -> object:
         """Apply an audited operator adjustment to one referral relation."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1394,7 +1394,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/referral-campaigns",
         methods=["GET"],
     )
-    def admin_operations_promotion_referral_campaigns():
+    def admin_operations_promotion_referral_campaigns() -> object:
         """Operator referral campaign configuration list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1443,7 +1443,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/referral-campaigns",
         methods=["POST"],
     )
-    def admin_create_operations_promotion_referral_campaign():
+    def admin_create_operations_promotion_referral_campaign() -> object:
         """Create operator referral campaign configuration."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1461,7 +1461,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/referral-campaigns/<campaign_bid>",
         methods=["GET"],
     )
-    def admin_operations_promotion_referral_campaign_detail(campaign_bid: str):
+    def admin_operations_promotion_referral_campaign_detail(campaign_bid: str) -> object:
         """Get operator referral campaign configuration detail."""
         _require_operator()
         return make_common_response(
@@ -1473,7 +1473,7 @@ def register_admin_operations_routes(
         + "/admin/operations/promotions/referral-campaigns/<campaign_bid>/relations",
         methods=["GET"],
     )
-    def admin_operations_promotion_referral_campaign_relations(campaign_bid: str):
+    def admin_operations_promotion_referral_campaign_relations(campaign_bid: str) -> object:
         """List invite relations for one referral campaign."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1533,7 +1533,7 @@ def register_admin_operations_routes(
         + "/admin/operations/promotions/referral-campaigns/<campaign_bid>/invitations",
         methods=["GET"],
     )
-    def admin_operations_promotion_referral_campaign_invitations(campaign_bid: str):
+    def admin_operations_promotion_referral_campaign_invitations(campaign_bid: str) -> object:
         """List invite-code funnel data for one referral campaign."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1585,7 +1585,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/referral-campaigns/<campaign_bid>",
         methods=["POST"],
     )
-    def admin_update_operations_promotion_referral_campaign(campaign_bid: str):
+    def admin_update_operations_promotion_referral_campaign(campaign_bid: str) -> object:
         """Update operator referral campaign configuration."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1605,7 +1605,7 @@ def register_admin_operations_routes(
         + "/admin/operations/promotions/referral-campaigns/<campaign_bid>/status",
         methods=["POST"],
     )
-    def admin_operations_promotion_referral_campaign_status(campaign_bid: str):
+    def admin_operations_promotion_referral_campaign_status(campaign_bid: str) -> object:
         """Update operator referral campaign configuration status."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1621,7 +1621,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/promotions/coupons", methods=["GET"])
-    def admin_operations_promotion_coupons():
+    def admin_operations_promotion_coupons() -> object:
         """Operator coupon batch list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1670,7 +1670,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/promotions/coupons", methods=["POST"])
-    def admin_create_operations_promotion_coupon():
+    def admin_create_operations_promotion_coupon() -> object:
         """Create operator coupon batch."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1682,7 +1682,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>",
         methods=["POST"],
     )
-    def admin_update_operations_promotion_coupon(coupon_bid: str):
+    def admin_update_operations_promotion_coupon(coupon_bid: str) -> object:
         """Update operator coupon batch."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1696,7 +1696,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/orders/credits/<bill_order_bid>/detail",
         methods=["GET"],
     )
-    def admin_operation_credit_order_detail(bill_order_bid: str):
+    def admin_operation_credit_order_detail(bill_order_bid: str) -> object:
         """Get operator credit order detail.
 
         ---
@@ -1726,7 +1726,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>",
         methods=["GET"],
     )
-    def admin_operations_promotion_coupon_detail(coupon_bid: str):
+    def admin_operations_promotion_coupon_detail(coupon_bid: str) -> object:
         """Get operator coupon batch detail."""
         _require_operator()
         return make_common_response(
@@ -1737,7 +1737,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>/status",
         methods=["POST"],
     )
-    def admin_operations_promotion_coupon_status(coupon_bid: str):
+    def admin_operations_promotion_coupon_status(coupon_bid: str) -> object:
         """Update operator coupon batch status."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1755,7 +1755,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>/usages",
         methods=["GET"],
     )
-    def admin_operations_promotion_coupon_usages(coupon_bid: str):
+    def admin_operations_promotion_coupon_usages(coupon_bid: str) -> object:
         """Get operator coupon usage list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1786,7 +1786,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/coupons/<coupon_bid>/codes",
         methods=["GET"],
     )
-    def admin_operations_promotion_coupon_codes(coupon_bid: str):
+    def admin_operations_promotion_coupon_codes(coupon_bid: str) -> object:
         """Get operator coupon code pool list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1809,7 +1809,7 @@ def register_admin_operations_routes(
         )
 
     @app.route(path_prefix + "/admin/operations/promotions/campaigns", methods=["GET"])
-    def admin_operations_promotion_campaigns():
+    def admin_operations_promotion_campaigns() -> object:
         """Operator campaign list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1860,7 +1860,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns",
         methods=["POST"],
     )
-    def admin_create_operations_promotion_campaign():
+    def admin_create_operations_promotion_campaign() -> object:
         """Create operator campaign."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1872,7 +1872,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns/<promo_bid>",
         methods=["GET"],
     )
-    def admin_operations_promotion_campaign_detail(promo_bid: str):
+    def admin_operations_promotion_campaign_detail(promo_bid: str) -> object:
         """Get operator campaign detail."""
         _require_operator()
         return make_common_response(
@@ -1883,7 +1883,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns/<promo_bid>",
         methods=["POST"],
     )
-    def admin_update_operations_promotion_campaign(promo_bid: str):
+    def admin_update_operations_promotion_campaign(promo_bid: str) -> object:
         """Update operator campaign."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1897,7 +1897,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns/<promo_bid>/status",
         methods=["POST"],
     )
-    def admin_operations_promotion_campaign_status(promo_bid: str):
+    def admin_operations_promotion_campaign_status(promo_bid: str) -> object:
         """Update operator campaign status."""
         _require_operator()
         payload = request.get_json(silent=True) or {}
@@ -1915,7 +1915,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/promotions/campaigns/<promo_bid>/redemptions",
         methods=["GET"],
     )
-    def admin_operations_promotion_campaign_redemptions(promo_bid: str):
+    def admin_operations_promotion_campaign_redemptions(promo_bid: str) -> object:
         """Get operator campaign redemption list."""
         _require_operator()
         page_index = _parse_positive_query_int(
@@ -1944,7 +1944,7 @@ def register_admin_operations_routes(
     @app.route(
         path_prefix + "/admin/operations/users/<user_bid>/detail", methods=["GET"]
     )
-    def admin_operation_user_detail(user_bid: str):
+    def admin_operation_user_detail(user_bid: str) -> object:
         """Get operator user detail.
 
         ---
@@ -1966,7 +1966,7 @@ def register_admin_operations_routes(
     @app.route(
         path_prefix + "/admin/operations/users/<user_bid>/credits", methods=["GET"]
     )
-    def admin_operation_user_credits(user_bid: str):
+    def admin_operation_user_credits(user_bid: str) -> object:
         """Get operator user credits detail.
 
         ---
@@ -2073,7 +2073,7 @@ def register_admin_operations_routes(
         + "/admin/operations/users/<user_bid>/credits/usages/<usage_bid>/detail",
         methods=["GET"],
     )
-    def admin_operation_user_credit_usage_detail(user_bid: str, usage_bid: str):
+    def admin_operation_user_credit_usage_detail(user_bid: str, usage_bid: str) -> object:
         """Get operator user credit usage content detail.
 
         ---
@@ -2107,7 +2107,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/users/<user_bid>/credit-grant/bootstrap",
         methods=["GET"],
     )
-    def admin_operation_user_credit_grant_bootstrap(user_bid: str):
+    def admin_operation_user_credit_grant_bootstrap(user_bid: str) -> object:
         """Get operator user grant bootstrap.
 
         ---
@@ -2135,7 +2135,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/users/<user_bid>/credits/grant",
         methods=["POST"],
     )
-    def admin_operation_user_credit_grant(user_bid: str):
+    def admin_operation_user_credit_grant(user_bid: str) -> object:
         """Grant operator user credits.
 
         ---
@@ -2178,7 +2178,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/users/<user_bid>/packages/grant",
         methods=["POST"],
     )
-    def admin_operation_user_package_grant(user_bid: str):
+    def admin_operation_user_package_grant(user_bid: str) -> object:
         """Grant operator user package.
 
         ---
@@ -2221,7 +2221,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/prompt",
         methods=["GET"],
     )
-    def admin_operation_course_prompt(shifu_bid: str):
+    def admin_operation_course_prompt(shifu_bid: str) -> object:
         """Get operator course prompt."""
         _require_operator()
         return make_common_response(
@@ -2231,7 +2231,7 @@ def register_admin_operations_routes(
     @app.route(
         path_prefix + "/admin/operations/courses/<shifu_bid>/detail", methods=["GET"]
     )
-    def admin_operation_course_detail(shifu_bid: str):
+    def admin_operation_course_detail(shifu_bid: str) -> object:
         """Get operator course detail.
 
         ---
@@ -2270,7 +2270,7 @@ def register_admin_operations_routes(
         + "/admin/operations/courses/<shifu_bid>/chapters/<outline_item_bid>/detail",
         methods=["GET"],
     )
-    def admin_operation_course_chapter_detail(shifu_bid: str, outline_item_bid: str):
+    def admin_operation_course_chapter_detail(shifu_bid: str, outline_item_bid: str) -> object:
         """Get operator course chapter detail.
 
         ---
@@ -2313,7 +2313,7 @@ def register_admin_operations_routes(
     @app.route(
         path_prefix + "/admin/operations/courses/<shifu_bid>/users", methods=["GET"]
     )
-    def admin_operation_course_users(shifu_bid: str):
+    def admin_operation_course_users(shifu_bid: str) -> object:
         """Get operator course users.
 
         ---
@@ -2390,7 +2390,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/credit-usages",
         methods=["GET"],
     )
-    def admin_operation_course_credit_usages(shifu_bid: str):
+    def admin_operation_course_credit_usages(shifu_bid: str) -> object:
         """Get operator course credit usage list.
 
         ---
@@ -2492,7 +2492,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/credit-usages/details",
         methods=["GET"],
     )
-    def admin_operation_course_credit_usage_details(shifu_bid: str):
+    def admin_operation_course_credit_usage_details(shifu_bid: str) -> object:
         """Get operator course credit usage detail list.
 
         ---
@@ -2529,7 +2529,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/ratings",
         methods=["GET"],
     )
-    def admin_operation_course_ratings(shifu_bid: str):
+    def admin_operation_course_ratings(shifu_bid: str) -> object:
         """Get operator course rating list.
 
         ---
@@ -2654,7 +2654,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/follow-ups",
         methods=["GET"],
     )
-    def admin_operation_course_follow_ups(shifu_bid: str):
+    def admin_operation_course_follow_ups(shifu_bid: str) -> object:
         """Get operator course follow-up list.
 
         ---
@@ -2765,7 +2765,7 @@ def register_admin_operations_routes(
     def admin_operation_course_follow_up_detail(
         shifu_bid: str,
         generated_block_bid: str,
-    ):
+    ) -> object:
         """Get operator course follow-up detail.
 
         ---
@@ -2799,7 +2799,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/copy",
         methods=["POST"],
     )
-    def admin_copy_course(shifu_bid: str):
+    def admin_copy_course(shifu_bid: str) -> object:
         _require_operator()
         payload = request.get_json(silent=True) or {}
         if not isinstance(payload, dict):
@@ -2833,7 +2833,7 @@ def register_admin_operations_routes(
         path_prefix + "/admin/operations/courses/<shifu_bid>/transfer-creator",
         methods=["POST"],
     )
-    def admin_transfer_course_creator(shifu_bid: str):
+    def admin_transfer_course_creator(shifu_bid: str) -> object:
         _require_operator()
         payload = request.get_json(silent=True) or {}
         if not isinstance(payload, dict):

--- a/src/api/flaskr/service/shifu/admin_operations/users.py
+++ b/src/api/flaskr/service/shifu/admin_operations/users.py
@@ -62,9 +62,10 @@ from sqlalchemy import and_, case, or_
 
 if TYPE_CHECKING:
     from flask import Flask
+    from sqlalchemy.sql.elements import ColumnElement
 
 
-def _build_user_query_filter(user_query: str) -> object:
+def _build_user_query_filter(user_query: str) -> ColumnElement[bool]:
     normalized_query = str(user_query or "").strip()
     like_pattern = f"%{normalized_query}%"
     credential_user_bids = db.session.query(AuthCredential.user_bid).filter(

--- a/src/api/flaskr/service/shifu/admin_operations/users.py
+++ b/src/api/flaskr/service/shifu/admin_operations/users.py
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
     from flask import Flask
 
 
-def _build_user_query_filter(user_query: str):
+def _build_user_query_filter(user_query: str) -> object:
     normalized_query = str(user_query or "").strip()
     like_pattern = f"%{normalized_query}%"
     credential_user_bids = db.session.query(AuthCredential.user_bid).filter(

--- a/src/api/flaskr/service/shifu/admin_user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_user_credits.py
@@ -128,9 +128,11 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from datetime import datetime
 
+    from flask_sqlalchemy.query import Query
     from flaskr.service.user.models import (
         UserInfo as UserEntity,
     )
+    from sqlalchemy.sql.selectable import Subquery
 
 
 def _resolve_course_credit_usage_mode(row: BillUsageRecord) -> str:
@@ -339,7 +341,7 @@ def _build_course_credit_usage_learn_filter(
 
 def _build_operator_course_credit_usage_ledger_totals_subquery(
     shifu_bid: str,
-) -> object:
+) -> Subquery:
     course_usage_bids = (
         db.session.query(BillUsageRecord.usage_bid.label("usage_bid"))
         .filter(
@@ -381,7 +383,7 @@ def _build_operator_course_credit_usage_base_query(
     shifu_bid: str,
     *,
     outline_item_bids: Sequence[str] | None = None,
-) -> object:
+) -> Query:
     ledger_totals = _build_operator_course_credit_usage_ledger_totals_subquery(
         shifu_bid
     )
@@ -716,7 +718,7 @@ def _build_course_credit_usage_covered_completed_user_subquery(
     *,
     shifu_bid: str,
     leaf_outline_bids: Sequence[str],
-) -> object:
+) -> Subquery | None:
     normalized_leaf_outline_bids = [
         str(outline_item_bid or "").strip()
         for outline_item_bid in leaf_outline_bids

--- a/src/api/flaskr/service/shifu/admin_user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_user_credits.py
@@ -337,7 +337,9 @@ def _build_course_credit_usage_learn_filter(
     )
 
 
-def _build_operator_course_credit_usage_ledger_totals_subquery(shifu_bid: str) -> object:
+def _build_operator_course_credit_usage_ledger_totals_subquery(
+    shifu_bid: str,
+) -> object:
     course_usage_bids = (
         db.session.query(BillUsageRecord.usage_bid.label("usage_bid"))
         .filter(

--- a/src/api/flaskr/service/shifu/admin_user_credits.py
+++ b/src/api/flaskr/service/shifu/admin_user_credits.py
@@ -337,7 +337,7 @@ def _build_course_credit_usage_learn_filter(
     )
 
 
-def _build_operator_course_credit_usage_ledger_totals_subquery(shifu_bid: str):
+def _build_operator_course_credit_usage_ledger_totals_subquery(shifu_bid: str) -> object:
     course_usage_bids = (
         db.session.query(BillUsageRecord.usage_bid.label("usage_bid"))
         .filter(
@@ -379,7 +379,7 @@ def _build_operator_course_credit_usage_base_query(
     shifu_bid: str,
     *,
     outline_item_bids: Sequence[str] | None = None,
-):
+) -> object:
     ledger_totals = _build_operator_course_credit_usage_ledger_totals_subquery(
         shifu_bid
     )
@@ -714,7 +714,7 @@ def _build_course_credit_usage_covered_completed_user_subquery(
     *,
     shifu_bid: str,
     leaf_outline_bids: Sequence[str],
-):
+) -> object:
     normalized_leaf_outline_bids = [
         str(outline_item_bid or "").strip()
         for outline_item_bid in leaf_outline_bids

--- a/src/api/flaskr/service/shifu/admin_user_profiles.py
+++ b/src/api/flaskr/service/shifu/admin_user_profiles.py
@@ -73,6 +73,7 @@ from sqlalchemy import case, or_
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from sqlalchemy.sql.elements import ColumnElement
     from sqlalchemy.sql.selectable import Subquery
 
 
@@ -249,7 +250,7 @@ def _resolve_course_user_learning_status(
     return COURSE_USER_LEARNING_STATUS_NOT_STARTED
 
 
-def _build_course_order_amount_expr() -> object:
+def _build_course_order_amount_expr() -> ColumnElement[Any]:
     return case(
         (Order.paid_price > 0, Order.paid_price),
         (Order.payable_price > 0, Order.payable_price),
@@ -379,7 +380,7 @@ def _build_recent_learning_active_user_bid_subquery(
     *,
     since: datetime,
     until: datetime,
-) -> object:
+) -> Subquery:
     activity_at = db.func.coalesce(
         LearnProgressRecord.updated_at,
         LearnProgressRecord.created_at,
@@ -402,7 +403,7 @@ def _build_recent_paid_user_bid_subquery(
     *,
     since: datetime,
     until: datetime,
-) -> object:
+) -> Subquery:
     return (
         db.session.query(Order.user_bid.label("user_bid"))
         .filter(
@@ -417,7 +418,7 @@ def _build_recent_paid_user_bid_subquery(
     )
 
 
-def _build_registered_user_timestamp_subquery() -> object:
+def _build_registered_user_timestamp_subquery() -> Subquery:
     registered_states = [USER_STATE_REGISTERED, USER_STATE_TRAIL, USER_STATE_PAID]
     credential_subquery = (
         db.session.query(

--- a/src/api/flaskr/service/shifu/admin_user_profiles.py
+++ b/src/api/flaskr/service/shifu/admin_user_profiles.py
@@ -73,6 +73,8 @@ from sqlalchemy import case, or_
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from sqlalchemy.sql.selectable import Subquery
+
 
 def _load_course_user_contact_map(
     user_bids: Sequence[str],
@@ -353,7 +355,7 @@ def _resolve_operator_user_role(
     )[0]
 
 
-def _build_learner_user_bid_subquery() -> object:
+def _build_learner_user_bid_subquery() -> Subquery:
     order_query = db.session.query(Order.user_bid.label("user_bid")).filter(
         Order.deleted == 0,
         Order.status == ORDER_STATUS_SUCCESS,

--- a/src/api/flaskr/service/shifu/admin_user_profiles.py
+++ b/src/api/flaskr/service/shifu/admin_user_profiles.py
@@ -247,7 +247,7 @@ def _resolve_course_user_learning_status(
     return COURSE_USER_LEARNING_STATUS_NOT_STARTED
 
 
-def _build_course_order_amount_expr():
+def _build_course_order_amount_expr() -> object:
     return case(
         (Order.paid_price > 0, Order.paid_price),
         (Order.payable_price > 0, Order.payable_price),
@@ -353,7 +353,7 @@ def _resolve_operator_user_role(
     )[0]
 
 
-def _build_learner_user_bid_subquery():
+def _build_learner_user_bid_subquery() -> object:
     order_query = db.session.query(Order.user_bid.label("user_bid")).filter(
         Order.deleted == 0,
         Order.status == ORDER_STATUS_SUCCESS,
@@ -377,7 +377,7 @@ def _build_recent_learning_active_user_bid_subquery(
     *,
     since: datetime,
     until: datetime,
-):
+) -> object:
     activity_at = db.func.coalesce(
         LearnProgressRecord.updated_at,
         LearnProgressRecord.created_at,
@@ -400,7 +400,7 @@ def _build_recent_paid_user_bid_subquery(
     *,
     since: datetime,
     until: datetime,
-):
+) -> object:
     return (
         db.session.query(Order.user_bid.label("user_bid"))
         .filter(
@@ -415,7 +415,7 @@ def _build_recent_paid_user_bid_subquery(
     )
 
 
-def _build_registered_user_timestamp_subquery():
+def _build_registered_user_timestamp_subquery() -> object:
     registered_states = [USER_STATE_REGISTERED, USER_STATE_TRAIL, USER_STATE_PAID]
     credential_subquery = (
         db.session.query(

--- a/src/api/flaskr/service/shifu/repair.py
+++ b/src/api/flaskr/service/shifu/repair.py
@@ -19,6 +19,7 @@ from .shifu_outline_funcs import (
 
 if TYPE_CHECKING:
     from flask import Flask
+    from flask_sqlalchemy.query import Query
 
 
 @dataclass
@@ -104,7 +105,7 @@ class OutlineStructureRepairResult:
         }
 
 
-def _apply_shifu_scope(query: object, shifu_bids: list[str] | str | None) -> object:
+def _apply_shifu_scope(query: Query, shifu_bids: list[str] | str | None) -> Query:
     if shifu_bids is None:
         return query
     if isinstance(shifu_bids, str):

--- a/src/api/flaskr/service/shifu/repair.py
+++ b/src/api/flaskr/service/shifu/repair.py
@@ -104,7 +104,7 @@ class OutlineStructureRepairResult:
         }
 
 
-def _apply_shifu_scope(query: object, shifu_bids: list[str] | str | None):
+def _apply_shifu_scope(query: object, shifu_bids: list[str] | str | None) -> object:
     if shifu_bids is None:
         return query
     if isinstance(shifu_bids, str):

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -2365,7 +2365,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
             )
 
             def _chat_llm_stream(
-                stream_messages: list[dict[str, str]]
+                stream_messages: list[dict[str, str]],
             ) -> Generator[Any, None, None]:
                 return chat_llm(
                     app,

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -430,7 +430,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/shifus", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def get_shifu_list_api() -> object:
+    def get_shifu_list_api() -> str:
         """Get shifu list.
 
         ---
@@ -500,21 +500,21 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/shifus/<shifu_id>/archive", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def archive_shifu_api(shifu_id: str) -> object:
+    def archive_shifu_api(shifu_id: str) -> str:
         user_id = request.user.user_id
         archive_shifu(app, user_id, shifu_id)
         return make_common_response({"archived": True})
 
     @app.route(path_prefix + "/shifus/<shifu_id>/unarchive", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def unarchive_shifu_api(shifu_id: str) -> object:
+    def unarchive_shifu_api(shifu_id: str) -> str:
         user_id = request.user.user_id
         unarchive_shifu(app, user_id, shifu_id)
         return make_common_response({"archived": False})
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/permissions", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def list_shifu_permissions_api(shifu_bid: str) -> object:
+    def list_shifu_permissions_api(shifu_bid: str) -> str:
         """List shared permissions for a shifu."""
         owner_id = _require_shifu_owner(shifu_bid)
         contact_type = _normalize_contact_type(request.args.get("contact_type", ""))
@@ -572,7 +572,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         methods=["POST"],
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def grant_shifu_permissions_api(shifu_bid: str) -> object:
+    def grant_shifu_permissions_api(shifu_bid: str) -> str:
         """Grant shared permissions for a shifu."""
         owner_id = _require_shifu_owner(shifu_bid)
         payload = request.get_json() or {}
@@ -728,7 +728,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         methods=["POST"],
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def remove_shifu_permissions_api(shifu_bid: str) -> object:
+    def remove_shifu_permissions_api(shifu_bid: str) -> str:
         """Remove a shared permission from a shifu."""
         owner_id = _require_shifu_owner(shifu_bid)
         payload = request.get_json() or {}
@@ -750,7 +750,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/shifus", methods=["PUT"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def create_shifu_api() -> object:
+    def create_shifu_api() -> str:
         """Create shifu.
 
         ---
@@ -804,7 +804,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/detail", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_shifu_detail_api(shifu_bid: str) -> object:
+    def get_shifu_detail_api(shifu_bid: str) -> str:
         """Get shifu detail.
 
         ---
@@ -843,7 +843,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/detail", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def save_shifu_detail_api(shifu_bid: str) -> object:
+    def save_shifu_detail_api(shifu_bid: str) -> str:
         """Save shifu detail.
 
         ---
@@ -1034,7 +1034,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/favorite", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
     @with_shifu_context()
-    def mark_favorite_shifu_api() -> object:
+    def mark_favorite_shifu_api() -> str:
         """Mark favorite shifu.
 
         ---
@@ -1084,7 +1084,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/publish", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.PUBLISH)
     @with_shifu_context()
-    def publish_shifu_api(shifu_bid: str) -> object:
+    def publish_shifu_api(shifu_bid: str) -> str:
         """Publish shifu.
 
         ---
@@ -1120,7 +1120,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/preview", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def preview_shifu_api(shifu_bid: str) -> object:
+    def preview_shifu_api(shifu_bid: str) -> str:
         """Preview shifu.
 
         ---
@@ -1167,7 +1167,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/outlines/reorder", methods=["PATCH"])
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def update_chapter_order_api(shifu_bid: str) -> object:
+    def update_chapter_order_api(shifu_bid: str) -> str:
         """Update chapter order.
 
         Reset the chapter order to the order of the chapter IDs.
@@ -1224,7 +1224,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/outlines", methods=["PUT"])
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def create_outline_api(shifu_bid: str) -> object:
+    def create_outline_api(shifu_bid: str) -> str:
         """Create unit.
 
         ---
@@ -1307,7 +1307,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/outlines/batch", methods=["PUT"])
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def create_outlines_batch_api(shifu_bid: str) -> object:
+    def create_outlines_batch_api(shifu_bid: str) -> str:
         """Create multiple outlines atomically.
 
         ---
@@ -1374,7 +1374,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         path_prefix + "/shifus/<shifu_bid>/outlines/<outline_bid>", methods=["POST"]
     )
     @ShifuTokenValidation(ShifuPermission.EDIT)
-    def modify_outline_api(shifu_bid: str, outline_bid: str) -> object:
+    def modify_outline_api(shifu_bid: str, outline_bid: str) -> str:
         """Modify outline.
 
         ---
@@ -1451,7 +1451,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_unit_info_api(shifu_bid: str, outline_bid: str) -> object:
+    def get_unit_info_api(shifu_bid: str, outline_bid: str) -> str:
         """Get unit info.
 
         ---
@@ -1488,7 +1488,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def delete_unit_api(shifu_bid: str, outline_bid: str) -> object:
+    def delete_unit_api(shifu_bid: str, outline_bid: str) -> str:
         """Delete unit.
 
         ---
@@ -1528,7 +1528,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_mdflow_api(shifu_bid: str, outline_bid: str) -> object:
+    def get_mdflow_api(shifu_bid: str, outline_bid: str) -> str:
         """Get mdflow.
 
         ---
@@ -1565,7 +1565,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         methods=["GET"],
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def get_draft_meta_api(shifu_bid: str) -> object:
+    def get_draft_meta_api(shifu_bid: str) -> str:
         """Get draft meta.
 
         ---
@@ -1620,7 +1620,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def save_mdflow_api(shifu_bid: str, outline_bid: str) -> object:
+    def save_mdflow_api(shifu_bid: str, outline_bid: str) -> str | Response:
         """Save mdflow.
 
         ---
@@ -1698,7 +1698,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def parse_mdflow_api(shifu_bid: str, outline_bid: str) -> object:
+    def parse_mdflow_api(shifu_bid: str, outline_bid: str) -> str:
         """Parse mdflow.
 
         ---
@@ -1745,7 +1745,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_mdflow_history_api(shifu_bid: str, outline_bid: str) -> object:
+    def get_mdflow_history_api(shifu_bid: str, outline_bid: str) -> str:
         """Get mdflow history.
 
         ---
@@ -1822,7 +1822,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @with_shifu_context()
     def get_mdflow_history_version_detail_api(
         shifu_bid: str, outline_bid: str, version_id: str
-    ) -> object:
+    ) -> str:
         """Get mdflow history version detail.
 
         ---
@@ -1870,7 +1870,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def restore_mdflow_history_api(shifu_bid: str, outline_bid: str) -> object:
+    def restore_mdflow_history_api(shifu_bid: str, outline_bid: str) -> str | Response:
         """Restore mdflow history version.
 
         ---
@@ -1970,7 +1970,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/outlines", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_outline_tree_api(shifu_bid: str) -> object:
+    def get_outline_tree_api(shifu_bid: str) -> str:
         """Get outline tree.
 
         ---
@@ -2002,7 +2002,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         return make_common_response(get_outline_tree(app, user_id, shifu_bid))
 
     @app.route(path_prefix + "/upfile", methods=["POST"])
-    def upfile_api() -> object:
+    def upfile_api() -> str:
         """Upfile to oss.
 
         ---
@@ -2041,7 +2041,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         return make_common_response(upload_file(app, user_id, resource_id, file))
 
     @app.route(path_prefix + "/url-upfile", methods=["POST"])
-    def upload_url_api() -> object:
+    def upload_url_api() -> str:
         """Upload url to oss.
 
         ---
@@ -2081,7 +2081,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         return make_common_response(upload_url(app, user_id, url))
 
     @app.route(path_prefix + "/get-video-info", methods=["POST"])
-    def get_video_info_api() -> object:
+    def get_video_info_api() -> str:
         """Get video info.
 
         ---
@@ -2122,7 +2122,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/export", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def export_shifu_api(shifu_bid: str) -> object:
+    def export_shifu_api(shifu_bid: str) -> Response:
         """Export shifu.
 
         ---
@@ -2165,7 +2165,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/ask/config", methods=["GET"])
     @bypass_token_validation
-    def ask_config_api() -> object:
+    def ask_config_api() -> str:
         """Get ask provider configuration metadata.
 
         ---
@@ -2207,7 +2207,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
             set_language(original_language)
 
     @app.route(path_prefix + "/ask/preview", methods=["POST"])
-    def ask_preview_api() -> object:
+    def ask_preview_api() -> str:
         """Preview ask provider output with current settings.
 
         ---
@@ -2490,7 +2490,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def list_minimax_tts_voices_api() -> object:
+    def list_minimax_tts_voices_api() -> str:
         from flaskr.service.tts.api import list_minimax_cloned_voices
 
         user_id = request.user.user_id
@@ -2512,7 +2512,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/clone-cost", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def minimax_tts_clone_cost_api() -> object:
+    def minimax_tts_clone_cost_api() -> str:
         from flaskr.service.tts.api import build_minimax_clone_cost
 
         user_id = request.user.user_id
@@ -2523,7 +2523,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/validate-id", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def validate_minimax_tts_voice_id_api() -> object:
+    def validate_minimax_tts_voice_id_api() -> str:
         from flaskr.service.tts.api import (
             is_valid_minimax_custom_voice_id,
         )
@@ -2539,7 +2539,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/clone", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.EDIT, is_creator=True)
-    def clone_minimax_tts_voice_api() -> object:
+    def clone_minimax_tts_voice_api() -> Response:
         from flaskr.service.tts.api import (
             serialize_minimax_cloned_voice,
             submit_minimax_voice_clone,
@@ -2575,7 +2575,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/<voice_bid>", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def get_minimax_tts_voice_api(voice_bid: object) -> object:
+    def get_minimax_tts_voice_api(voice_bid: object) -> str:
         from flaskr.service.tts.api import get_minimax_cloned_voice
 
         return make_common_response(
@@ -2591,7 +2591,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         methods=["POST"],
     )
     @ShifuTokenValidation(ShifuPermission.EDIT, is_creator=True)
-    def retry_minimax_tts_voice_api(voice_bid: object) -> object:
+    def retry_minimax_tts_voice_api(voice_bid: object) -> str:
         from flaskr.service.tts.api import retry_minimax_voice_clone
 
         return make_common_response(
@@ -2604,7 +2604,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/<voice_bid>", methods=["DELETE"])
     @ShifuTokenValidation(ShifuPermission.EDIT, is_creator=True)
-    def delete_minimax_tts_voice_api(voice_bid: object) -> object:
+    def delete_minimax_tts_voice_api(voice_bid: object) -> str:
         from flaskr.service.tts.api import delete_minimax_cloned_voice
 
         return make_common_response(
@@ -2617,7 +2617,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/config", methods=["GET"])
     @bypass_token_validation
-    def tts_config_api() -> object:
+    def tts_config_api() -> str:
         """Get TTS provider configuration.
 
         ---
@@ -2641,7 +2641,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         return make_common_response(config)
 
     @app.route(path_prefix + "/tts/preview", methods=["POST"])
-    def tts_preview_api() -> object:
+    def tts_preview_api() -> Response:
         """Preview TTS with specified settings.
 
         ---

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -33,10 +33,11 @@ import json
 import re
 import tempfile
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from enum import Enum
 from functools import wraps
 from pathlib import Path
+from typing import Any
 
 from flask import (
     Flask,
@@ -179,7 +180,7 @@ class ShifuTokenValidation:
         """Validate token permissions and optional creator status before invoking the route."""
 
         @wraps(f)
-        def decorated_function(*args: object, **kwargs: object):
+        def decorated_function(*args: object, **kwargs: object) -> object:
             token = request.cookies.get("token", None)
             if not token:
                 token = request.args.get("token", None)
@@ -429,7 +430,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/shifus", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def get_shifu_list_api():
+    def get_shifu_list_api() -> object:
         """Get shifu list.
 
         ---
@@ -499,21 +500,21 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/shifus/<shifu_id>/archive", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def archive_shifu_api(shifu_id: str):
+    def archive_shifu_api(shifu_id: str) -> object:
         user_id = request.user.user_id
         archive_shifu(app, user_id, shifu_id)
         return make_common_response({"archived": True})
 
     @app.route(path_prefix + "/shifus/<shifu_id>/unarchive", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def unarchive_shifu_api(shifu_id: str):
+    def unarchive_shifu_api(shifu_id: str) -> object:
         user_id = request.user.user_id
         unarchive_shifu(app, user_id, shifu_id)
         return make_common_response({"archived": False})
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/permissions", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def list_shifu_permissions_api(shifu_bid: str):
+    def list_shifu_permissions_api(shifu_bid: str) -> object:
         """List shared permissions for a shifu."""
         owner_id = _require_shifu_owner(shifu_bid)
         contact_type = _normalize_contact_type(request.args.get("contact_type", ""))
@@ -571,7 +572,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         methods=["POST"],
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def grant_shifu_permissions_api(shifu_bid: str):
+    def grant_shifu_permissions_api(shifu_bid: str) -> object:
         """Grant shared permissions for a shifu."""
         owner_id = _require_shifu_owner(shifu_bid)
         payload = request.get_json() or {}
@@ -727,7 +728,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         methods=["POST"],
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def remove_shifu_permissions_api(shifu_bid: str):
+    def remove_shifu_permissions_api(shifu_bid: str) -> object:
         """Remove a shared permission from a shifu."""
         owner_id = _require_shifu_owner(shifu_bid)
         payload = request.get_json() or {}
@@ -749,7 +750,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/shifus", methods=["PUT"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def create_shifu_api():
+    def create_shifu_api() -> object:
         """Create shifu.
 
         ---
@@ -803,7 +804,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/detail", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_shifu_detail_api(shifu_bid: str):
+    def get_shifu_detail_api(shifu_bid: str) -> object:
         """Get shifu detail.
 
         ---
@@ -842,7 +843,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/detail", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def save_shifu_detail_api(shifu_bid: str):
+    def save_shifu_detail_api(shifu_bid: str) -> object:
         """Save shifu detail.
 
         ---
@@ -1033,7 +1034,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/favorite", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
     @with_shifu_context()
-    def mark_favorite_shifu_api():
+    def mark_favorite_shifu_api() -> object:
         """Mark favorite shifu.
 
         ---
@@ -1083,7 +1084,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/publish", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.PUBLISH)
     @with_shifu_context()
-    def publish_shifu_api(shifu_bid: str):
+    def publish_shifu_api(shifu_bid: str) -> object:
         """Publish shifu.
 
         ---
@@ -1119,7 +1120,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/preview", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def preview_shifu_api(shifu_bid: str):
+    def preview_shifu_api(shifu_bid: str) -> object:
         """Preview shifu.
 
         ---
@@ -1166,7 +1167,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/outlines/reorder", methods=["PATCH"])
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def update_chapter_order_api(shifu_bid: str):
+    def update_chapter_order_api(shifu_bid: str) -> object:
         """Update chapter order.
 
         Reset the chapter order to the order of the chapter IDs.
@@ -1223,7 +1224,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/outlines", methods=["PUT"])
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def create_outline_api(shifu_bid: str):
+    def create_outline_api(shifu_bid: str) -> object:
         """Create unit.
 
         ---
@@ -1306,7 +1307,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/outlines/batch", methods=["PUT"])
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def create_outlines_batch_api(shifu_bid: str):
+    def create_outlines_batch_api(shifu_bid: str) -> object:
         """Create multiple outlines atomically.
 
         ---
@@ -1373,7 +1374,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         path_prefix + "/shifus/<shifu_bid>/outlines/<outline_bid>", methods=["POST"]
     )
     @ShifuTokenValidation(ShifuPermission.EDIT)
-    def modify_outline_api(shifu_bid: str, outline_bid: str):
+    def modify_outline_api(shifu_bid: str, outline_bid: str) -> object:
         """Modify outline.
 
         ---
@@ -1450,7 +1451,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_unit_info_api(shifu_bid: str, outline_bid: str):
+    def get_unit_info_api(shifu_bid: str, outline_bid: str) -> object:
         """Get unit info.
 
         ---
@@ -1487,7 +1488,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def delete_unit_api(shifu_bid: str, outline_bid: str):
+    def delete_unit_api(shifu_bid: str, outline_bid: str) -> object:
         """Delete unit.
 
         ---
@@ -1527,7 +1528,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_mdflow_api(shifu_bid: str, outline_bid: str):
+    def get_mdflow_api(shifu_bid: str, outline_bid: str) -> object:
         """Get mdflow.
 
         ---
@@ -1564,7 +1565,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         methods=["GET"],
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def get_draft_meta_api(shifu_bid: str):
+    def get_draft_meta_api(shifu_bid: str) -> object:
         """Get draft meta.
 
         ---
@@ -1619,7 +1620,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def save_mdflow_api(shifu_bid: str, outline_bid: str):
+    def save_mdflow_api(shifu_bid: str, outline_bid: str) -> object:
         """Save mdflow.
 
         ---
@@ -1697,7 +1698,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def parse_mdflow_api(shifu_bid: str, outline_bid: str):
+    def parse_mdflow_api(shifu_bid: str, outline_bid: str) -> object:
         """Parse mdflow.
 
         ---
@@ -1744,7 +1745,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_mdflow_history_api(shifu_bid: str, outline_bid: str):
+    def get_mdflow_history_api(shifu_bid: str, outline_bid: str) -> object:
         """Get mdflow history.
 
         ---
@@ -1821,7 +1822,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @with_shifu_context()
     def get_mdflow_history_version_detail_api(
         shifu_bid: str, outline_bid: str, version_id: str
-    ):
+    ) -> object:
         """Get mdflow history version detail.
 
         ---
@@ -1869,7 +1870,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     )
     @ShifuTokenValidation(ShifuPermission.EDIT)
     @with_shifu_context()
-    def restore_mdflow_history_api(shifu_bid: str, outline_bid: str):
+    def restore_mdflow_history_api(shifu_bid: str, outline_bid: str) -> object:
         """Restore mdflow history version.
 
         ---
@@ -1956,7 +1957,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         methods=["POST"],
     )
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def run_mdflow_api(shifu_bid: str, outline_bid: str):
+    def run_mdflow_api(shifu_bid: str, outline_bid: str) -> None:
         """Run mdflow.
 
         Raises:
@@ -1969,7 +1970,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
     @app.route(path_prefix + "/shifus/<shifu_bid>/outlines", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
     @with_shifu_context()
-    def get_outline_tree_api(shifu_bid: str):
+    def get_outline_tree_api(shifu_bid: str) -> object:
         """Get outline tree.
 
         ---
@@ -2001,7 +2002,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         return make_common_response(get_outline_tree(app, user_id, shifu_bid))
 
     @app.route(path_prefix + "/upfile", methods=["POST"])
-    def upfile_api():
+    def upfile_api() -> object:
         """Upfile to oss.
 
         ---
@@ -2040,7 +2041,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         return make_common_response(upload_file(app, user_id, resource_id, file))
 
     @app.route(path_prefix + "/url-upfile", methods=["POST"])
-    def upload_url_api():
+    def upload_url_api() -> object:
         """Upload url to oss.
 
         ---
@@ -2080,7 +2081,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         return make_common_response(upload_url(app, user_id, url))
 
     @app.route(path_prefix + "/get-video-info", methods=["POST"])
-    def get_video_info_api():
+    def get_video_info_api() -> object:
         """Get video info.
 
         ---
@@ -2121,7 +2122,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/shifus/<shifu_bid>/export", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW)
-    def export_shifu_api(shifu_bid: str):
+    def export_shifu_api(shifu_bid: str) -> object:
         """Export shifu.
 
         ---
@@ -2145,7 +2146,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         export_shifu(app, shifu_bid, str(file_path))
 
         @after_this_request
-        def cleanup(response: object):
+        def cleanup(response: object) -> object:
             try:
                 file_path.unlink()
                 Path(temp_dir).rmdir()
@@ -2164,7 +2165,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/ask/config", methods=["GET"])
     @bypass_token_validation
-    def ask_config_api():
+    def ask_config_api() -> object:
         """Get ask provider configuration metadata.
 
         ---
@@ -2206,7 +2207,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
             set_language(original_language)
 
     @app.route(path_prefix + "/ask/preview", methods=["POST"])
-    def ask_preview_api():
+    def ask_preview_api() -> object:
         """Preview ask provider output with current settings.
 
         ---
@@ -2363,7 +2364,9 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
                 else 0
             )
 
-            def _chat_llm_stream(stream_messages: list[dict[str, str]]):
+            def _chat_llm_stream(
+                stream_messages: list[dict[str, str]]
+            ) -> Generator[Any, None, None]:
                 return chat_llm(
                     app,
                     preview_user_id,
@@ -2487,7 +2490,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def list_minimax_tts_voices_api():
+    def list_minimax_tts_voices_api() -> object:
         from flaskr.service.tts.api import list_minimax_cloned_voices
 
         user_id = request.user.user_id
@@ -2509,7 +2512,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/clone-cost", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def minimax_tts_clone_cost_api():
+    def minimax_tts_clone_cost_api() -> object:
         from flaskr.service.tts.api import build_minimax_clone_cost
 
         user_id = request.user.user_id
@@ -2520,7 +2523,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/validate-id", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def validate_minimax_tts_voice_id_api():
+    def validate_minimax_tts_voice_id_api() -> object:
         from flaskr.service.tts.api import (
             is_valid_minimax_custom_voice_id,
         )
@@ -2536,7 +2539,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/clone", methods=["POST"])
     @ShifuTokenValidation(ShifuPermission.EDIT, is_creator=True)
-    def clone_minimax_tts_voice_api():
+    def clone_minimax_tts_voice_api() -> object:
         from flaskr.service.tts.api import (
             serialize_minimax_cloned_voice,
             submit_minimax_voice_clone,
@@ -2572,7 +2575,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/<voice_bid>", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def get_minimax_tts_voice_api(voice_bid: object):
+    def get_minimax_tts_voice_api(voice_bid: object) -> object:
         from flaskr.service.tts.api import get_minimax_cloned_voice
 
         return make_common_response(
@@ -2588,7 +2591,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         methods=["POST"],
     )
     @ShifuTokenValidation(ShifuPermission.EDIT, is_creator=True)
-    def retry_minimax_tts_voice_api(voice_bid: object):
+    def retry_minimax_tts_voice_api(voice_bid: object) -> object:
         from flaskr.service.tts.api import retry_minimax_voice_clone
 
         return make_common_response(
@@ -2601,7 +2604,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/<voice_bid>", methods=["DELETE"])
     @ShifuTokenValidation(ShifuPermission.EDIT, is_creator=True)
-    def delete_minimax_tts_voice_api(voice_bid: object):
+    def delete_minimax_tts_voice_api(voice_bid: object) -> object:
         from flaskr.service.tts.api import delete_minimax_cloned_voice
 
         return make_common_response(
@@ -2614,7 +2617,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/config", methods=["GET"])
     @bypass_token_validation
-    def tts_config_api():
+    def tts_config_api() -> object:
         """Get TTS provider configuration.
 
         ---
@@ -2638,7 +2641,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         return make_common_response(config)
 
     @app.route(path_prefix + "/tts/preview", methods=["POST"])
-    def tts_preview_api():
+    def tts_preview_api() -> object:
         """Preview TTS with specified settings.
 
         ---

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -2146,7 +2146,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         export_shifu(app, shifu_bid, str(file_path))
 
         @after_this_request
-        def cleanup(response: object) -> object:
+        def cleanup(response: Response) -> Response:
             try:
                 file_path.unlink()
                 Path(temp_dir).rmdir()
@@ -2575,7 +2575,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/<voice_bid>", methods=["GET"])
     @ShifuTokenValidation(ShifuPermission.VIEW, is_creator=True)
-    def get_minimax_tts_voice_api(voice_bid: object) -> str:
+    def get_minimax_tts_voice_api(voice_bid: str) -> str:
         from flaskr.service.tts.api import get_minimax_cloned_voice
 
         return make_common_response(
@@ -2591,7 +2591,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
         methods=["POST"],
     )
     @ShifuTokenValidation(ShifuPermission.EDIT, is_creator=True)
-    def retry_minimax_tts_voice_api(voice_bid: object) -> str:
+    def retry_minimax_tts_voice_api(voice_bid: str) -> str:
         from flaskr.service.tts.api import retry_minimax_voice_clone
 
         return make_common_response(
@@ -2604,7 +2604,7 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
 
     @app.route(path_prefix + "/tts/minimax/voices/<voice_bid>", methods=["DELETE"])
     @ShifuTokenValidation(ShifuPermission.EDIT, is_creator=True)
-    def delete_minimax_tts_voice_api(voice_bid: object) -> str:
+    def delete_minimax_tts_voice_api(voice_bid: str) -> str:
         from flaskr.service.tts.api import delete_minimax_cloned_voice
 
         return make_common_response(

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -956,7 +956,7 @@ def get_shifu_published_list(
         return PageNationDTO(safe_page_index, page_size, total, shifu_dtos)
 
 
-def _set_shifu_archive_state(app: object, user_id: str, shifu_id: str, archived: bool):
+def _set_shifu_archive_state(app: object, user_id: str, shifu_id: str, archived: bool) -> None:
     with app.app_context():
         shifu_draft = get_latest_shifu_draft(shifu_id)
         if not shifu_draft:

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -956,7 +956,9 @@ def get_shifu_published_list(
         return PageNationDTO(safe_page_index, page_size, total, shifu_dtos)
 
 
-def _set_shifu_archive_state(app: object, user_id: str, shifu_id: str, archived: bool) -> None:
+def _set_shifu_archive_state(
+    app: object, user_id: str, shifu_id: str, archived: bool
+) -> None:
     with app.app_context():
         shifu_draft = get_latest_shifu_draft(shifu_id)
         if not shifu_draft:

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -387,7 +387,9 @@ def __save_new_item_history(
     __save_shifu_history(app, user_id, shifu_bid, history)
 
 
-def __delete_item_history(app: Flask, user_id: str, shifu_bid: str, item_bid: str) -> None:
+def __delete_item_history(
+    app: Flask, user_id: str, shifu_bid: str, item_bid: str
+) -> None:
     """Delete item history internal function.
 
     Args:

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -127,7 +127,9 @@ def iter_outline_item_versions_desc(
         last_id = int(batch[-1].id)
 
 
-def _get_latest_outline_content_log(shifu_bid: str, outline_bid: str) -> object:
+def _get_latest_outline_content_log(
+    shifu_bid: str, outline_bid: str
+) -> DraftOutlineItem | None:
     latest_version = (
         DraftOutlineItem.query.filter(
             DraftOutlineItem.shifu_bid == shifu_bid,

--- a/src/api/flaskr/service/shifu/shifu_history_manager.py
+++ b/src/api/flaskr/service/shifu/shifu_history_manager.py
@@ -72,7 +72,9 @@ class HistoryItem(BaseModel, Generic[T]):
         return cls.model_validate_json(json)
 
 
-def _get_latest_draft_log(shifu_bid: str, for_update: bool = False):
+def _get_latest_draft_log(
+    shifu_bid: str, for_update: bool = False
+) -> LogDraftStruct | None:
     query = LogDraftStruct.query.filter_by(
         shifu_bid=shifu_bid,
         deleted=0,
@@ -125,7 +127,7 @@ def iter_outline_item_versions_desc(
         last_id = int(batch[-1].id)
 
 
-def _get_latest_outline_content_log(shifu_bid: str, outline_bid: str):
+def _get_latest_outline_content_log(shifu_bid: str, outline_bid: str) -> object:
     latest_version = (
         DraftOutlineItem.query.filter(
             DraftOutlineItem.shifu_bid == shifu_bid,
@@ -277,7 +279,7 @@ def get_shifu_history(app: object, shifu_bid: str) -> HistoryItem:
 
 def __save_shifu_history(
     app: Flask, user_id: str, shifu_bid: str, history: HistoryItem
-):
+) -> LogDraftStruct:
     """Save shifu history.
 
     Args:
@@ -330,7 +332,7 @@ def __save_new_item_history(
     parent_bid: str,
     item_type: str,
     index: int = 0,
-):
+) -> None:
     """Save new item history internal function.
 
     Args:
@@ -385,7 +387,7 @@ def __save_new_item_history(
     __save_shifu_history(app, user_id, shifu_bid, history)
 
 
-def __delete_item_history(app: Flask, user_id: str, shifu_bid: str, item_bid: str):
+def __delete_item_history(app: Flask, user_id: str, shifu_bid: str, item_bid: str) -> None:
     """Delete item history internal function.
 
     Args:

--- a/src/api/flaskr/service/shifu/shifu_outline_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_outline_funcs.py
@@ -692,7 +692,7 @@ def reorder_outline_tree(
             parent_position: object = "",
             parent_bid: object = "",
             history_infos: list[HistoryItem] | None = None,
-        ):
+        ) -> None:
             if history_infos is None:
                 history_infos = []
             for i, outline_dto in enumerate(outline_dtos):

--- a/src/api/flaskr/service/shifu/shifu_publish_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_publish_funcs.py
@@ -155,7 +155,7 @@ def publish_shifu_draft(
         assert_outline_items_publishable(app, shifu_id, outline_items)
         outline_tree = build_outline_tree_from_items(app, outline_items)
 
-        def publish_outline_item(node: ShifuOutlineTreeNode, history_item: HistoryItem):
+        def publish_outline_item(node: ShifuOutlineTreeNode, history_item: HistoryItem) -> None:
             outline_item = PublishedOutlineItem()
             draft_outline_item: DraftOutlineItem = node.outline
             outline_item.shifu_bid = shifu_id
@@ -228,7 +228,7 @@ def publish_shifu_draft(
 
 def _run_summary_with_error_handling(
     app: object, shifu_id: object, shifu_context_snapshot: object = None
-):
+) -> None:
     """Run shifu summary generation with error handling.
 
     Args:
@@ -312,7 +312,7 @@ def _generate_ask_prompts(
     outline_summary_map: dict[str, dict],
     outline_item_map: dict[str, PublishedOutlineItem],
     ask_prompt_template: str,
-):
+) -> None:
     """Generate ask_prompt for each section.
 
     Args:
@@ -513,7 +513,7 @@ def _get_summary(
     model_name: object,
     user_id: object = None,
     temperature: object = 0.8,
-):
+) -> str:
     """Call the AI model to generate summary.
 
     Args:

--- a/src/api/flaskr/service/shifu/shifu_publish_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_publish_funcs.py
@@ -155,7 +155,9 @@ def publish_shifu_draft(
         assert_outline_items_publishable(app, shifu_id, outline_items)
         outline_tree = build_outline_tree_from_items(app, outline_items)
 
-        def publish_outline_item(node: ShifuOutlineTreeNode, history_item: HistoryItem) -> None:
+        def publish_outline_item(
+            node: ShifuOutlineTreeNode, history_item: HistoryItem
+        ) -> None:
             outline_item = PublishedOutlineItem()
             draft_outline_item: DraftOutlineItem = node.outline
             outline_item.shifu_bid = shifu_id

--- a/src/api/flaskr/service/shifu/tts_preview.py
+++ b/src/api/flaskr/service/shifu/tts_preview.py
@@ -6,7 +6,7 @@ import base64
 import json
 import uuid
 from dataclasses import replace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from flask import Response, current_app, stream_with_context
 from flaskr.api.tts import (
@@ -28,6 +28,9 @@ from flaskr.service.tts.validation import (
     validate_tts_settings_strict,
 )
 from flaskr.util.uuid import generate_id
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 def _build_tts_preview_usage_metadata(
@@ -121,7 +124,7 @@ def build_tts_preview_response(
         audio_settings=safe_audio_settings,
     )
 
-    def event_stream():
+    def event_stream() -> Iterator[str]:
         total_duration_ms = 0
         total_word_count = 0
         total_output_chars = 0

--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -36,7 +36,7 @@ def _estimated_duration_ms(audio_data: bytes) -> int:
     return int(len(audio_data or b"") / 16000 * 1000)
 
 
-def _load_audio_segment(audio_data: bytes, *, input_format: str = "mp3"):
+def _load_audio_segment(audio_data: bytes, *, input_format: str = "mp3") -> AudioSegment:
     audio_io = io.BytesIO(audio_data)
     if input_format == "mp3" and hasattr(AudioSegment, "from_mp3"):
         return AudioSegment.from_mp3(audio_io)

--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -36,7 +36,9 @@ def _estimated_duration_ms(audio_data: bytes) -> int:
     return int(len(audio_data or b"") / 16000 * 1000)
 
 
-def _load_audio_segment(audio_data: bytes, *, input_format: str = "mp3") -> AudioSegment:
+def _load_audio_segment(
+    audio_data: bytes, *, input_format: str = "mp3"
+) -> AudioSegment:
     audio_io = io.BytesIO(audio_data)
     if input_format == "mp3" and hasattr(AudioSegment, "from_mp3"):
         return AudioSegment.from_mp3(audio_io)

--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -38,7 +38,7 @@ def _estimated_duration_ms(audio_data: bytes) -> int:
 
 def _load_audio_segment(
     audio_data: bytes, *, input_format: str = "mp3"
-) -> AudioSegment:
+) -> "AudioSegment":
     audio_io = io.BytesIO(audio_data)
     if input_format == "mp3" and hasattr(AudioSegment, "from_mp3"):
         return AudioSegment.from_mp3(audio_io)

--- a/src/api/flaskr/service/tts/minimax_voice_clone.py
+++ b/src/api/flaskr/service/tts/minimax_voice_clone.py
@@ -66,6 +66,8 @@ from flaskr.util.datetime import now_utc, to_utc_iso
 from flaskr.util.uuid import generate_id
 
 if TYPE_CHECKING:
+    from decimal import Decimal
+
     from flask import Flask
 
 MINIMAX_FILE_UPLOAD_URL = "https://api.minimaxi.com/v1/files/upload"
@@ -1116,7 +1118,7 @@ def _validate_audio_upload(data: bytes, *, filename: str, max_bytes: int) -> Non
         raise_param_error("unsupported audio file type")
 
 
-def _available_wallet_credits(app: Flask, creator_bid: str):
+def _available_wallet_credits(app: Flask, creator_bid: str) -> Decimal:
     from flaskr.service.billing.models import CreditWallet
 
     with app.app_context():

--- a/src/api/flaskr/service/tts/models.py
+++ b/src/api/flaskr/service/tts/models.py
@@ -340,7 +340,7 @@ class TTSMiniMaxClonedVoice(db.Model):
     ready_at = Column(DateTime, nullable=True)
     deleted_at = Column(DateTime, nullable=True)
 
-    def to_dict(self) -> object:
+    def to_dict(self) -> dict[str, object]:
         """Convert model to dictionary."""
         return {
             "audio_bid": self.audio_bid,

--- a/src/api/flaskr/service/tts/pipeline.py
+++ b/src/api/flaskr/service/tts/pipeline.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 
 from flaskr.api.tts import (
     AudioSettings,
+    TTSResult,
     VoiceSettings,
     get_default_audio_settings,
     get_default_voice_settings,
@@ -286,7 +287,7 @@ def _append_open_close_boundary_candidate(
     close_pattern: re.Pattern[str],
     rewind_start: bool = False,
     extend_end: bool = False,
-):
+) -> None:
     match = _find_first_match_outside_fence(raw, open_pattern, fence_ranges)
     if match is None:
         return
@@ -449,7 +450,7 @@ def build_av_segmentation_contract(raw: str, block_bid: str = "") -> dict:
         start_offset: int,
         end_offset: int,
         after_visual_kind: str,
-    ):
+    ) -> None:
         cleaned = (text or "").strip()
         if not cleaned:
             return
@@ -463,7 +464,7 @@ def build_av_segmentation_contract(raw: str, block_bid: str = "") -> dict:
             }
         )
 
-    def _split(text: str, base_offset: int, after_visual_kind: str):
+    def _split(text: str, base_offset: int, after_visual_kind: str) -> None:
         if not text or not text.strip():
             return
 
@@ -823,7 +824,7 @@ def synthesize_long_text_to_oss(
         audio_parts = [b""] * len(segments)
         segment_map = dict(enumerate(segments))
 
-        def _synthesize_in_app_context(segment_text: str):
+        def _synthesize_in_app_context(segment_text: str) -> TTSResult:
             with app.app_context():
                 return synthesize_text(
                     text=segment_text,

--- a/src/api/flaskr/service/tts/rpm_gate.py
+++ b/src/api/flaskr/service/tts/rpm_gate.py
@@ -16,6 +16,8 @@ from flaskr.util.deprecation import deprecated_alias_getattr
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from redis import Redis
+
 logger = AppLoggerProxy(logging.getLogger(__name__))
 
 _LOCAL_STATE: dict[str, float] = {}
@@ -161,7 +163,7 @@ def _acquire_local_slot(
         )
 
 
-def _get_redis_client():
+def _get_redis_client() -> Redis:
     from flaskr.dao import get_redis_client
 
     redis_client = get_redis_client()

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -20,6 +20,7 @@ from typing import Any
 from flask import Flask
 from flaskr.api.tts import (
     AudioSettings,
+    TTSResult,
     VoiceSettings,
     get_default_audio_settings,
     get_default_voice_settings,
@@ -392,7 +393,7 @@ class StreamingTTSProcessor:
         """Yield already-synthesized segments without submitting new text."""
         yield from self._yield_ready_segments()
 
-    def _try_submit_tts_task(self):
+    def _try_submit_tts_task(self) -> None:
         """Submit all complete sentences currently available in the stream buffer."""
         if not self._buffer:
             return
@@ -473,7 +474,7 @@ class StreamingTTSProcessor:
                 lo = mid + 1
         return best
 
-    def _submit_tts_task(self, text: str):
+    def _submit_tts_task(self, text: str) -> None:
         """Submit a TTS synthesis task to the background thread pool."""
         with self._lock:
             segment_index = self._segment_index
@@ -503,7 +504,7 @@ class StreamingTTSProcessor:
         remaining_text: str,
         *,
         include_trailing_fragment: bool = True,
-    ):
+    ) -> None:
         """Submit text sentence-by-sentence.
 
         When ``include_trailing_fragment`` is True, any trailing text without
@@ -552,7 +553,7 @@ class StreamingTTSProcessor:
         tts_provider: str = "",
         tts_model: str = "",
         segment_index: int | None = None,
-    ):
+    ) -> TTSResult:
         result = None
         max_attempts = 2
         attempt = 0
@@ -2156,7 +2157,7 @@ class AVStreamingTTSProcessor:
             # 'fence' | 'svg' | 'iframe' | 'video' | 'html_table' | 'md_table' | 'sandbox' | 'md_img'
         )
 
-    def _update_av_contract(self):
+    def _update_av_contract(self) -> None:
         try:
             self._av_contract = build_av_segmentation_contract(
                 self._raw_full_content, self.generated_block_bid
@@ -2205,7 +2206,7 @@ class AVStreamingTTSProcessor:
         """Return whether an unfinished visual boundary remains."""
         return bool(self._skip_mode)
 
-    def _refresh_next_element_index_from_contract(self):
+    def _refresh_next_element_index_from_contract(self) -> None:
         segments, _ = build_visual_segments_for_block(
             app=self.app,
             raw_content=self._raw_full_content,

--- a/src/api/flaskr/service/tts/tasks.py
+++ b/src/api/flaskr/service/tts/tasks.py
@@ -22,7 +22,7 @@ except ImportError:  # pragma: no cover - local fallback for non-Celery test env
         return decorator
 
 
-def _create_task_app():
+def _create_task_app() -> object:
     os.environ.setdefault("SKIP_APP_AUTOCREATE", "1")
     from app import create_app
 

--- a/src/api/flaskr/service/tts/tasks.py
+++ b/src/api/flaskr/service/tts/tasks.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from flask import Flask
+
 try:  # pragma: no cover - exercised indirectly when Celery is installed.
     from celery import shared_task
 except ImportError:  # pragma: no cover - local fallback for non-Celery test envs.
@@ -22,7 +24,7 @@ except ImportError:  # pragma: no cover - local fallback for non-Celery test env
         return decorator
 
 
-def _create_task_app() -> object:
+def _create_task_app() -> Flask:
     os.environ.setdefault("SKIP_APP_AUTOCREATE", "1")
     from app import create_app
 

--- a/src/api/migrations/env.py
+++ b/src/api/migrations/env.py
@@ -146,7 +146,7 @@ def run_migrations_online() -> None:
     # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
     def process_revision_directives(
         context: object, revision: object, directives: object
-    ):
+    ) -> None:
         _ = (context, revision)
         if getattr(config.cmd_opts, "autogenerate", False):
             script = directives[0]
@@ -188,7 +188,7 @@ def run_migrations_online() -> None:
                         # merge the related changes into the same migration
                         merge_related_changes(script)
 
-    def is_meaningful_operation(op: object):
+    def is_meaningful_operation(op: object) -> object:
         """Judge if an operation is meaningful (not meaningless type conversion)."""
         op_type = type(op).__name__
 
@@ -240,7 +240,7 @@ def run_migrations_online() -> None:
 
         return True
 
-    def filter_unnecessary_operations(script: object):
+    def filter_unnecessary_operations(script: object) -> None:
         """Filter out the unnecessary or duplicate operations."""
         if not hasattr(script, "upgrade_ops") or not script.upgrade_ops:
             return
@@ -278,7 +278,7 @@ def run_migrations_online() -> None:
                 len(filtered_ops),
             )
 
-    def get_operation_signature(op: object):
+    def get_operation_signature(op: object) -> object:
         """Generate the unique signature of the operation to detect duplication."""
         op_type = type(op).__name__
 
@@ -306,12 +306,12 @@ def run_migrations_online() -> None:
             return f"{op_type}:{table_name}"
         return f"{op_type}:unknown"
 
-    def should_skip_operation(op: object):
+    def should_skip_operation(op: object) -> object:
         """Judge if it should skip the operation."""
         op_type = type(op).__name__
 
         # dynamically get the application table prefixes, based on the actual defined models
-        def get_app_table_prefixes():
+        def get_app_table_prefixes() -> object:
             """Dynamically get the table prefixes from the actual models."""
             prefixes = set()
 
@@ -342,7 +342,7 @@ def run_migrations_online() -> None:
         app_table_prefixes = get_app_table_prefixes()
 
         # get all registered application table names
-        def get_app_table_names():
+        def get_app_table_names() -> object:
             """Get all registered application table names."""
             table_names = set()
             for mapper in db.Model.registry.mappers:
@@ -496,7 +496,7 @@ def run_migrations_online() -> None:
 
         return False
 
-    def merge_related_changes(script: object):
+    def merge_related_changes(script: object) -> None:
         """Merge the related changes into the same migration."""
         if not hasattr(script, "upgrade_ops") or not script.upgrade_ops:
             return
@@ -595,12 +595,12 @@ def run_migrations_online() -> None:
         inspected_default: object,
         metadata_default: object,
         rendered_metadata_default: object,
-    ):
+    ) -> object:
         """Compare server defaults leniently to reduce false positives."""
         # Normalize how a default value is spelled
         _ = (context, inspected_column, metadata_column, metadata_default)
 
-        def normalize_default(default: object):
+        def normalize_default(default: object) -> object:
             if default is None:
                 return None
             default_str = str(default).strip()
@@ -628,12 +628,12 @@ def run_migrations_online() -> None:
         metadata_column: object,
         inspected_comment: object,
         metadata_comment: object,
-    ):
+    ) -> object:
         """Compare comments leniently, still reporting real comment changes."""
         # Normalize how a comment is spelled
         _ = inspected_column
 
-        def normalize_comment(comment: object):
+        def normalize_comment(comment: object) -> object:
             if comment is None:
                 return None
             comment_str = str(comment).strip()
@@ -678,7 +678,7 @@ def run_migrations_online() -> None:
         metadata_column: object,
         inspected_type: object,
         metadata_type: object,
-    ):
+    ) -> object:
         """Compare column types leniently to reduce false positives."""
         # Treat small type differences as equal
         _ = (context, inspected_column, metadata_column)

--- a/src/api/scripts/check_mdflow_listen_adapter.py
+++ b/src/api/scripts/check_mdflow_listen_adapter.py
@@ -44,12 +44,12 @@ if TYPE_CHECKING:
 
 
 @compiles(LONGTEXT, "sqlite")
-def _compile_longtext_sqlite(_type: object, _compiler: object, **_kw: object):
+def _compile_longtext_sqlite(_type: object, _compiler: object, **_kw: object) -> object:
     return "TEXT"
 
 
 @compiles(BIGINT, "sqlite")
-def _compile_bigint_sqlite(_type: object, _compiler: object, **_kw: object):
+def _compile_bigint_sqlite(_type: object, _compiler: object, **_kw: object) -> object:
     return "INTEGER"
 
 
@@ -182,7 +182,7 @@ def _load_samples(path: Path, limit: int) -> list[BlockSample]:
     return samples
 
 
-def _bootstrap_mdflow(mdflow_root: str):
+def _bootstrap_mdflow(mdflow_root: str) -> object:
     root = Path(mdflow_root)
     init_file = root / "markdown_flow" / "__init__.py"
     if not init_file.exists():

--- a/src/api/scripts/check_sse_segmentation.py
+++ b/src/api/scripts/check_sse_segmentation.py
@@ -146,13 +146,13 @@ def _simulate_observed_segments(
             self.position = int(kwargs.get("position", 0) or 0)
             self._parts: list[str] = []
 
-        def process_chunk(self, chunk: object):
+        def process_chunk(self, chunk: object) -> object:
             if chunk:
                 self._parts.append(chunk)
             return
             yield
 
-        def finalize(self, commit: object = True):
+        def finalize(self, commit: object = True) -> object:
             _ = commit
             text = "".join(self._parts).strip()
             if text:

--- a/src/api/scripts/tts_test_report.py
+++ b/src/api/scripts/tts_test_report.py
@@ -114,7 +114,7 @@ def _build_cases(*, provider_name: str, matrix: str) -> list[dict[str, str]]:
 
     cases: list[dict[str, str]] = []
 
-    def add_case(model_value: str, voice_value: str):
+    def add_case(model_value: str, voice_value: str) -> None:
         cases.append(
             {
                 "provider": provider_name,

--- a/src/api/tests/api/doc/test_feishu_notify.py
+++ b/src/api/tests/api/doc/test_feishu_notify.py
@@ -10,15 +10,15 @@ class _Logger:
         self.warnings = []
         self.exceptions = []
 
-    def info(self, *args: object, **kwargs: object):
+    def info(self, *args: object, **kwargs: object) -> None:
         _ = kwargs
         self.infos.append(args)
 
-    def warning(self, *args: object, **kwargs: object):
+    def warning(self, *args: object, **kwargs: object) -> None:
         _ = kwargs
         self.warnings.append(args)
 
-    def exception(self, *args: object, **kwargs: object):
+    def exception(self, *args: object, **kwargs: object) -> None:
         _ = kwargs
         self.exceptions.append(args)
 
@@ -41,7 +41,7 @@ class _Response:
         self._json_value = json_value
         self._json_exc = json_exc
 
-    def json(self):
+    def json(self) -> object:
         if self._json_exc is not None:
             raise self._json_exc
         return self._json_value
@@ -97,7 +97,7 @@ def test_send_notify_returns_none_for_request_error(monkeypatch: object) -> None
         lambda key, default=None: "https://example.test/webhook",  # noqa: ARG005 -- preserve get_config keyword contract
     )
 
-    def _raise(*args: object, **kwargs: object):
+    def _raise(*args: object, **kwargs: object) -> None:
         _ = (args, kwargs)
         message = "network down"
         raise requests.RequestException(message)

--- a/src/api/tests/command/test_unified_migration_task.py
+++ b/src/api/tests/command/test_unified_migration_task.py
@@ -15,10 +15,10 @@ class _FakeResult:
     def __init__(self, value: object) -> None:
         self._value = value
 
-    def scalar(self):
+    def scalar(self) -> object:
         return self._value
 
-    def fetchone(self):
+    def fetchone(self) -> object:
         return self._value
 
 
@@ -29,15 +29,15 @@ class _FakeSession:
         self._value = value
         self.calls = []
 
-    def execute(self, statement: object, params: object = None):
+    def execute(self, statement: object, params: object = None) -> object:
         self.calls.append((str(statement), params))
         return _FakeResult(self._value)
 
-    def close(self):
+    def close(self) -> None:
         pass
 
 
-def _task_with_session(session: object):
+def _task_with_session(session: object) -> object:
     task = UnifiedMigrationTask.__new__(UnifiedMigrationTask)
     task.SessionClass = lambda: session
     return task
@@ -118,13 +118,13 @@ def test_migrate_table_logs_formatted_batch_progress(caplog: object) -> None:
     task = UnifiedMigrationTask.__new__(UnifiedMigrationTask)
     task.config = MigrationConfig(batch_size=10)
 
-    async def table_exists(_table_name: object):
+    async def table_exists(_table_name: object) -> object:
         return True
 
-    async def table_count(_table_name: object):
+    async def table_count(_table_name: object) -> object:
         return 20
 
-    async def process_batch(*_args: object):
+    async def process_batch(*_args: object) -> object:
         return {"synced": 5, "errors": 0, "error_messages": []}
 
     task._table_exists_async = table_exists

--- a/src/api/tests/common/fixtures/mock_validators.py
+++ b/src/api/tests/common/fixtures/mock_validators.py
@@ -36,7 +36,7 @@ def always_pass_validator(value: object) -> object:
 def range_validator(min_val: object, max_val: object) -> object:
     """Create a range validator for numeric values."""
 
-    def validator(value: object):
+    def validator(value: object) -> object:
         try:
             num = float(value)
         except (ValueError, TypeError):
@@ -50,7 +50,7 @@ def range_validator(min_val: object, max_val: object) -> object:
 def string_length_validator(min_len: object = 0, max_len: object = 100) -> object:
     """Create a string length validator."""
 
-    def validator(value: object):
+    def validator(value: object) -> object:
         if value is None:
             return False
         s = str(value)
@@ -65,7 +65,7 @@ def regex_validator(pattern: object) -> object:
 
     compiled = re.compile(pattern)
 
-    def validator(value: object):
+    def validator(value: object) -> object:
         if value is None:
             return False
         return bool(compiled.match(str(value)))
@@ -95,7 +95,7 @@ def dependency_validator(depends_on_key: object) -> object:
     """Create a validator that checks if another config key is set."""
     _ = depends_on_key
 
-    def validator(value: object):
+    def validator(value: object) -> object:
         # In real usage, this would check if depends_on_key is configured
         # For testing, we just check if value is not empty
         return bool(value)

--- a/src/api/tests/common/test_celery_fork_pool_dispose.py
+++ b/src/api/tests/common/test_celery_fork_pool_dispose.py
@@ -53,13 +53,13 @@ def test_one_failing_bind_does_not_block_the_rest(
     disposed = []
 
     class _BrokenEngine:
-        def dispose(self, close: object):
+        def dispose(self, close: object) -> None:
             _ = close
             message = "bind gone"
             raise RuntimeError(message)
 
     class _GoodEngine:
-        def dispose(self, close: object):
+        def dispose(self, close: object) -> None:
             disposed.append(close)
 
     class _FakeDB:

--- a/src/api/tests/common/test_common_route.py
+++ b/src/api/tests/common/test_common_route.py
@@ -20,7 +20,7 @@ def test_common_handler_returns_translated_unexpected_error_for_unhandled_except
     register_common_handler(app)
 
     @app.route("/boom")
-    def _boom():
+    def _boom() -> None:
         message = "unexpected failure"
         raise RuntimeError(message)
 
@@ -43,7 +43,7 @@ def test_common_handler_uses_request_language_for_unhandled_exceptions(
     register_common_handler(app)
 
     @app.route("/boom-zh")
-    def _boom_zh():
+    def _boom_zh() -> None:
         message = "unexpected failure"
         raise RuntimeError(message)
 
@@ -93,7 +93,7 @@ def test_common_handler_uses_json_language_for_patch_requests(
     register_common_handler(app)
 
     @app.route("/boom-patch", methods=["PATCH"])
-    def _boom_patch():
+    def _boom_patch() -> None:
         message = "unexpected failure"
         raise RuntimeError(message)
 

--- a/src/api/tests/common/test_dao_session_termination.py
+++ b/src/api/tests/common/test_dao_session_termination.py
@@ -91,7 +91,7 @@ def test_invalidate_session_uses_fake_sessions_directly() -> None:
     calls = []
 
     class _Fake:
-        def invalidate(self):
+        def invalidate(self) -> None:
             calls.append(1)
 
     assert invalidate_session(source="test fake", session=_Fake()) is True
@@ -102,10 +102,10 @@ def test_cleanup_rolls_back_on_server_delivered_errors() -> None:
     events = []
 
     class _Fake:
-        def invalidate(self):
+        def invalidate(self) -> None:
             events.append("invalidate")
 
-        def rollback(self):
+        def rollback(self) -> None:
             events.append("rollback")
 
     outcome = cleanup_session_after(ValueError("business"), source="t", session=_Fake())
@@ -117,10 +117,10 @@ def test_cleanup_invalidates_on_interrupting_terminations() -> None:
     events = []
 
     class _Fake:
-        def invalidate(self):
+        def invalidate(self) -> None:
             events.append("invalidate")
 
-        def rollback(self):
+        def rollback(self) -> None:
             events.append("rollback")
 
     outcome = cleanup_session_after(GeneratorExit(), source="t", session=_Fake())
@@ -132,10 +132,10 @@ def test_cleanup_escalates_to_invalidate_when_rollback_fails() -> None:
     events = []
 
     class _Fake:
-        def invalidate(self):
+        def invalidate(self) -> None:
             events.append("invalidate")
 
-        def rollback(self):
+        def rollback(self) -> None:
             events.append("rollback")
             message = "rollback broke"
             raise RuntimeError(message)
@@ -159,7 +159,7 @@ def test_teardown_hook_invalidates_before_session_removal(
     )
     original_remove = db.session.remove
 
-    def _tracking_remove():
+    def _tracking_remove() -> object:
         order.append("remove")
         return original_remove()
 

--- a/src/api/tests/common/test_gevent_hub_observer.py
+++ b/src/api/tests/common/test_gevent_hub_observer.py
@@ -15,14 +15,14 @@ class _StubHub:
     def __init__(self) -> None:
         self.calls = []
 
-        def _original(context: object, exc_type: object, value: object, tb: object):
+        def _original(context: object, exc_type: object, value: object, tb: object) -> object:
             self.calls.append((context, exc_type, value, tb))
             return "original-result"
 
         self.handle_error = _original
 
 
-def _fire(hub: object, context: object = None, exc: object = None):
+def _fire(hub: object, context: object = None, exc: object = None) -> object:
     exc = exc if exc is not None else AssertionError("(None, <callback>)")
     return hub.handle_error(context, type(exc), exc, None)
 
@@ -67,7 +67,7 @@ def test_logger_failure_never_blocks_the_original_handler() -> None:
     hub = _StubHub()
 
     class _BrokenLogger:
-        def error(self, *args: object, **kwargs: object):
+        def error(self, *args: object, **kwargs: object) -> None:
             _ = (args, kwargs)
             message = "logging backend down"
             raise RuntimeError(message)

--- a/src/api/tests/common/test_gevent_hub_observer.py
+++ b/src/api/tests/common/test_gevent_hub_observer.py
@@ -15,7 +15,9 @@ class _StubHub:
     def __init__(self) -> None:
         self.calls = []
 
-        def _original(context: object, exc_type: object, value: object, tb: object) -> object:
+        def _original(
+            context: object, exc_type: object, value: object, tb: object
+        ) -> object:
             self.calls.append((context, exc_type, value, tb))
             return "original-result"
 

--- a/src/api/tests/common/test_gunicorn_post_fork_langfuse.py
+++ b/src/api/tests/common/test_gunicorn_post_fork_langfuse.py
@@ -19,7 +19,7 @@ from opentelemetry import trace as otel_trace_api
 from opentelemetry.util._once import Once
 
 
-def _reset_langfuse_after_fork():
+def _reset_langfuse_after_fork() -> None:
     # Mirrors the sequence in src/api/gunicorn.conf.py post_fork. Kept in
     # sync manually; the assertions below are what the hook relies on.
     LangfuseResourceManager._instances.clear()
@@ -28,7 +28,7 @@ def _reset_langfuse_after_fork():
 
 
 @pytest.fixture(autouse=True)
-def _clean_singletons():
+def _clean_singletons() -> object:
     _reset_langfuse_after_fork()
     yield
     _reset_langfuse_after_fork()

--- a/src/api/tests/common/test_i18n_loader.py
+++ b/src/api/tests/common/test_i18n_loader.py
@@ -21,7 +21,7 @@ def _shared_i18n_root() -> Path:
 
 
 @pytest.fixture(autouse=True)
-def _isolate_i18n_state(monkeypatch: object):
+def _isolate_i18n_state(monkeypatch: object) -> object:
     # SHARED_I18N_ROOT is restored by monkeypatch; the thread-local language
     # set via set_language() must be cleared so later tests (e.g. ask provider
     # adapters asserting en-US messages) are not affected by test order.

--- a/src/api/tests/common/test_i18n_utils.py
+++ b/src/api/tests/common/test_i18n_utils.py
@@ -19,13 +19,13 @@ def test_french_native_name_reaches_content_and_interaction_prompts() -> None:
         def __init__(self) -> None:
             self.calls = []
 
-        def complete(self, messages: object, **_kwargs: object):
+        def complete(self, messages: object, **_kwargs: object) -> object:
             self.calls.append(messages)
             if "JSON Interaction Translation Task" in messages[0]["content"]:
                 return '{"buttons":["Continuer"]}'
             return "Réponse"
 
-        def stream(self, _messages: object, **_kwargs: object):
+        def stream(self, _messages: object, **_kwargs: object) -> object:
             return iter(())
 
     provider = CapturingProvider()

--- a/src/api/tests/common/test_log.py
+++ b/src/api/tests/common/test_log.py
@@ -7,7 +7,7 @@ from flaskr.common.log import FeishuLogHandler
 
 
 class _FailingResponse:
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         message = "400 Client Error"
         raise requests.exceptions.HTTPError(message)
 
@@ -17,7 +17,7 @@ def test_feishu_log_handler_does_not_reemit_webhook_failures(
 ) -> None:
     calls = []
 
-    def fake_post(*args: object, **kwargs: object):
+    def fake_post(*args: object, **kwargs: object) -> object:
         calls.append((args, kwargs))
         return _FailingResponse()
 
@@ -45,7 +45,7 @@ def test_feishu_log_handler_surfaces_delivery_failure_without_recursion(
 ) -> None:
     calls = []
 
-    def fake_post(*args: object, **kwargs: object):
+    def fake_post(*args: object, **kwargs: object) -> object:
         calls.append((args, kwargs))
         return _FailingResponse()
 
@@ -75,7 +75,7 @@ def test_feishu_log_handler_reentrancy_guard_blocks_nested_emit(
 ) -> None:
     calls = []
 
-    def fake_post(*args: object, **kwargs: object):
+    def fake_post(*args: object, **kwargs: object) -> object:
         calls.append((args, kwargs))
         return type("Response", (), {"raise_for_status": lambda _self: None})()
 
@@ -103,7 +103,7 @@ def test_feishu_log_handler_reentrancy_guard_blocks_nested_emit(
 def test_feishu_log_handler_truncates_oversized_payload(monkeypatch: object) -> None:
     captured = {}
 
-    def fake_post(_url: object, *, json: object, timeout: object):
+    def fake_post(_url: object, *, json: object, timeout: object) -> object:
         captured["payload"] = json
         captured["timeout"] = timeout
         return type("Response", (), {"raise_for_status": lambda _self: None})()

--- a/src/api/tests/common/test_module_state_owners.py
+++ b/src/api/tests/common/test_module_state_owners.py
@@ -31,7 +31,7 @@ def test_redis_initialization_updates_the_owned_client(monkeypatch: object) -> N
     sentinel = object()
     captured: dict[str, object] = {}
 
-    def fake_redis(**kwargs: object):
+    def fake_redis(**kwargs: object) -> object:
         captured.update(kwargs)
         return sentinel
 

--- a/src/api/tests/common/test_pool_desync_detection.py
+++ b/src/api/tests/common/test_pool_desync_detection.py
@@ -22,10 +22,10 @@ class _FakePyMySQLConnection:
         self.closed = False
 
     # QueuePool reset/close hooks
-    def rollback(self):
+    def rollback(self) -> None:
         pass
 
-    def close(self):
+    def close(self) -> None:
         self.closed = True
         self._sock.close()
 
@@ -73,7 +73,7 @@ def test_pool_discards_connection_desynced_during_use(sock_pair: object) -> None
     ]
     made = []
 
-    def _creator():
+    def _creator() -> object:
         conn = connections[len(made) % len(connections)]
         made.append(conn)
         return conn
@@ -108,7 +108,7 @@ def test_checkout_rejects_connection_that_became_dirty_in_pool(
     connections = [dirty_conn, _FakePyMySQLConnection(clean_sock_a)]
     made = []
 
-    def _creator():
+    def _creator() -> object:
         conn = connections[len(made) % len(connections)]
         made.append(conn)
         return conn
@@ -147,7 +147,7 @@ def test_probe_timeout_waits_for_in_flight_data(sock_pair: object) -> None:
     # Zero-timeout probe sees nothing yet.
     assert dao._socket_has_unread_data(conn) is False
 
-    def _late_send():
+    def _late_send() -> None:
         time_module.sleep(0.001)
         right.sendall(b"\x05late-owed-response")
 
@@ -178,7 +178,7 @@ class _FakePingablePyMySQLConnection(_FakePyMySQLConnection):
         super().__init__(sock)
         self.pings = 0
 
-    def ping(self, reconnect: object):
+    def ping(self, reconnect: object) -> None:
         _ = reconnect
         self.pings += 1
 

--- a/src/api/tests/common/test_pre_execute_desync_interception.py
+++ b/src/api/tests/common/test_pre_execute_desync_interception.py
@@ -45,7 +45,7 @@ def test_pre_execute_probe_blocks_desynced_connection() -> None:
             info: ClassVar[dict[str, object]] = {}
             invalidated_count = 0
 
-            def invalidate(self):
+            def invalidate(self) -> None:
                 type(self).invalidated_count += 1
 
         conn = _FakeConn()

--- a/src/api/tests/common/test_protected_checkout_ping.py
+++ b/src/api/tests/common/test_protected_checkout_ping.py
@@ -19,7 +19,7 @@ class _FakeRecord:
     def __init__(self) -> None:
         self.invalidated_with = []
 
-    def invalidate(self, e: object = None):
+    def invalidate(self, e: object = None) -> None:
         self.invalidated_with.append(e)
 
 
@@ -27,11 +27,11 @@ class _FakeGreenletExit(BaseException):
     pass
 
 
-def _make_conn(sock: object, ping_exc: object = None):
+def _make_conn(sock: object, ping_exc: object = None) -> object:
     class _Conn:
         _sock = sock
 
-        def ping(self, reconnect: object):
+        def ping(self, reconnect: object) -> None:
             assert reconnect is False
             if ping_exc is not None:
                 raise ping_exc

--- a/src/api/tests/common/test_swagger_docstrings.py
+++ b/src/api/tests/common/test_swagger_docstrings.py
@@ -16,7 +16,7 @@ KNOWN_UNPARSEABLE_SWAGGER_DOCSTRINGS = {
 }
 
 
-def _swagger_docstrings():
+def _swagger_docstrings() -> object:
     for path in (API_ROOT / "flaskr").rglob("*.py"):
         source = path.read_text(encoding="utf-8")
         tree = ast.parse(source)
@@ -48,7 +48,7 @@ def test_all_swagger_docstrings_keep_valid_yaml_after_summary() -> None:
         assert separator_index > 1, (path, function_name)
         assert lines[1].strip() == "", (path, function_name)
 
-        def view():
+        def view() -> None:
             pass
 
         view.__doc__ = docstring

--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -55,7 +55,7 @@ class _TestPluginManager:
         self.extensible_generic_functions = {}
         self.is_enabled = False
 
-    def register_extension(self, target_func_name: object, func: object):
+    def register_extension(self, target_func_name: object, func: object) -> None:
         self.extension_functions.setdefault(target_func_name, []).append(func)
 
     def execute_extensions(
@@ -64,16 +64,16 @@ class _TestPluginManager:
         result: object,
         *args: object,
         **kwargs: object,
-    ):
+    ) -> object:
         _ = (args, kwargs)
         return result
 
-    def register_extensible_generic(self, func_name: object, func: object):
+    def register_extensible_generic(self, func_name: object, func: object) -> None:
         self.extensible_generic_functions.setdefault(func_name, []).append(func)
 
     def execute_extensible_generic(
         self, _func_name: object, *args: object, **kwargs: object
-    ):
+    ) -> None:
         _ = (args, kwargs)
 
 
@@ -81,12 +81,12 @@ set_plugin_manager(_TestPluginManager())
 
 
 @compiles(LONGTEXT, "sqlite")
-def _compile_longtext_sqlite(_type: object, _compiler: object, **_kw: object):
+def _compile_longtext_sqlite(_type: object, _compiler: object, **_kw: object) -> object:
     return "TEXT"
 
 
 @compiles(BIGINT, "sqlite")
-def _compile_bigint_sqlite(_type: object, _compiler: object, **_kw: object):
+def _compile_bigint_sqlite(_type: object, _compiler: object, **_kw: object) -> object:
     return "INTEGER"
 
 

--- a/src/api/tests/contract/test_sms_contract.py
+++ b/src/api/tests/contract/test_sms_contract.py
@@ -16,7 +16,7 @@ def test_send_sms_ali_builds_request_for_generic_template(monkeypatch: object) -
         def __init__(self, config: object) -> None:
             captured["config"] = config
 
-        def send_sms_with_options(self, request: object, runtime: object):
+        def send_sms_with_options(self, request: object, runtime: object) -> object:
             captured["request"] = request
             captured["runtime"] = runtime
             return SimpleNamespace(body=SimpleNamespace(code="OK"))
@@ -59,7 +59,7 @@ def test_send_sms_code_ali_builds_request(monkeypatch: object) -> None:
         def __init__(self, config: object) -> None:
             captured["config"] = config
 
-        def send_sms_with_options(self, request: object, runtime: object):
+        def send_sms_with_options(self, request: object, runtime: object) -> object:
             captured["request"] = request
             captured["runtime"] = runtime
             return SimpleNamespace(body=SimpleNamespace(code="OK"))
@@ -90,7 +90,7 @@ def test_send_sms_code_ali_builds_request(monkeypatch: object) -> None:
 def test_send_sms_code_ali_returns_none_without_keys(monkeypatch: object) -> None:
     from flaskr.api.sms import aliyun as sms_aliyun
 
-    def fake_client(_config: object):
+    def fake_client(_config: object) -> None:
         message = "client should not be created"
         raise AssertionError(message)
 
@@ -124,11 +124,11 @@ def test_send_sms_code_ali_handles_client_error(monkeypatch: object) -> None:
         def __init__(self, config: object) -> None:
             captured["config"] = config
 
-        def send_sms_with_options(self, request: object, runtime: object):
+        def send_sms_with_options(self, request: object, runtime: object) -> None:
             _ = (request, runtime)
             raise DummyError
 
-    def fake_assert(message: object):
+    def fake_assert(message: object) -> None:
         captured["assert_message"] = message
 
     monkeypatch.setattr(sms_aliyun, "Dysmsapi20170525Client", FakeClient)
@@ -157,7 +157,7 @@ def test_send_sms_ali_returns_none_when_provider_response_is_not_ok(
         def __init__(self, _config: object) -> None:
             pass
 
-        def send_sms_with_options(self, request: object, runtime: object):
+        def send_sms_with_options(self, request: object, runtime: object) -> object:
             del request, runtime
             return SimpleNamespace(
                 body=SimpleNamespace(
@@ -203,7 +203,7 @@ def test_send_sms_ali_logs_recipient_throttle_as_warning(
         def __init__(self, _config: object) -> None:
             pass
 
-        def send_sms_with_options(self, request: object, runtime: object):
+        def send_sms_with_options(self, request: object, runtime: object) -> object:
             del request, runtime
             return SimpleNamespace(
                 body=SimpleNamespace(
@@ -250,7 +250,7 @@ def test_send_sms_ali_logs_illegal_recipient_number_as_warning(
         def __init__(self, _config: object) -> None:
             pass
 
-        def send_sms_with_options(self, request: object, runtime: object):
+        def send_sms_with_options(self, request: object, runtime: object) -> object:
             del request, runtime
             return SimpleNamespace(
                 body=SimpleNamespace(

--- a/src/api/tests/migrations/test_learner_profile_migration.py
+++ b/src/api/tests/migrations/test_learner_profile_migration.py
@@ -24,7 +24,7 @@ MERGE_MIGRATION_PATH = (
 )
 
 
-def _load_migration_module(path: object = MIGRATION_PATH):
+def _load_migration_module(path: object = MIGRATION_PATH) -> object:
     spec = importlib.util.spec_from_file_location(
         "test_learner_profile_migration_module",
         path,
@@ -45,18 +45,18 @@ def test_learner_profile_column_remains_nullable_for_rolling_writers() -> None:
     executed_statements = []
 
     class _BatchOperations:
-        def add_column(self, column: object):
+        def add_column(self, column: object) -> None:
             added_columns.append(column)
 
-        def alter_column(self, column_name: object, **kwargs: object):
+        def alter_column(self, column_name: object, **kwargs: object) -> None:
             altered_columns.append((column_name, kwargs))
 
     class _Operations:
         @contextmanager
-        def batch_alter_table(self, *_args: object, **_kwargs: object):
+        def batch_alter_table(self, *_args: object, **_kwargs: object) -> object:
             yield _BatchOperations()
 
-        def execute(self, statement: object):
+        def execute(self, statement: object) -> None:
             executed_statements.append(str(statement))
 
     migration.op = _Operations()

--- a/src/api/tests/route/test_user_language_context.py
+++ b/src/api/tests/route/test_user_language_context.py
@@ -21,7 +21,7 @@ def test_authenticated_request_prefers_accept_language_for_runtime_context(
     register_user_handler(app, "/api/user")
 
     @app.route("/runtime-language")
-    def runtime_language():
+    def runtime_language() -> object:
         return jsonify({"language": get_current_language()})
 
     try:
@@ -48,7 +48,7 @@ def test_authenticated_request_normalizes_accept_language_for_runtime_context(
     register_user_handler(app, "/api/user")
 
     @app.route("/runtime-language")
-    def runtime_language():
+    def runtime_language() -> object:
         return jsonify({"language": get_current_language()})
 
     try:
@@ -75,7 +75,7 @@ def test_authenticated_request_reads_json_payload_language_for_runtime_context(
     register_user_handler(app, "/api/user")
 
     @app.route("/runtime-language", methods=["POST"])
-    def runtime_language():
+    def runtime_language() -> object:
         return jsonify({"language": get_current_language()})
 
     try:

--- a/src/api/tests/scripts/test_observability_consistency_probes.py
+++ b/src/api/tests/scripts/test_observability_consistency_probes.py
@@ -16,7 +16,7 @@ class _Db:
         self.session = session
 
 
-def _build_db():
+def _build_db() -> object:
     engine = create_engine("sqlite:///:memory:")
     session = sessionmaker(bind=engine)()
     session.execute(
@@ -70,7 +70,7 @@ def _build_db():
     return SimpleNamespace(engine=engine, session=session, db=_Db(session))
 
 
-def _args():
+def _args() -> object:
     return argparse.Namespace(limit=20)
 
 
@@ -81,7 +81,7 @@ def _insert_wallet(
     creator_bid: str,
     available: str,
     reserved: str = "0",
-):
+) -> None:
     session.execute(
         text(
             """
@@ -110,7 +110,7 @@ def _insert_bucket(
     source_type: int = 7411,
     effective_from: datetime,
     effective_to: datetime | None = None,
-):
+) -> None:
     session.execute(
         text(
             """
@@ -152,7 +152,7 @@ def _insert_bucket(
     )
 
 
-def _insert_active_subscription(session: object, *, creator_bid: str, now: datetime):
+def _insert_active_subscription(session: object, *, creator_bid: str, now: datetime) -> None:
     session.execute(
         text(
             """
@@ -173,7 +173,7 @@ def _insert_active_subscription(session: object, *, creator_bid: str, now: datet
     )
 
 
-def _probe(env: object, *, now: datetime):
+def _probe(env: object, *, now: datetime) -> object:
     return probe_wallet_snapshot(
         env.db,
         inspect(env.engine),

--- a/src/api/tests/scripts/test_observability_consistency_probes.py
+++ b/src/api/tests/scripts/test_observability_consistency_probes.py
@@ -152,7 +152,9 @@ def _insert_bucket(
     )
 
 
-def _insert_active_subscription(session: object, *, creator_bid: str, now: datetime) -> None:
+def _insert_active_subscription(
+    session: object, *, creator_bid: str, now: datetime
+) -> None:
     session.execute(
         text(
             """

--- a/src/api/tests/service/billing/billing_write_routes_test_helpers.py
+++ b/src/api/tests/service/billing/billing_write_routes_test_helpers.py
@@ -392,7 +392,7 @@ def billing_write_client(monkeypatch: object) -> Iterator[dict[str, object]]:
     refund_requests: list[dict] = []
 
     class FakeStripeProvider:
-        def create_payment(self, *, request: object, app: object):
+        def create_payment(self, *, request: object, app: object) -> object:
             _ = app
             stripe_requests.append(
                 {
@@ -413,12 +413,12 @@ def billing_write_client(monkeypatch: object) -> Iterator[dict[str, object]]:
                 extra={"url": "https://stripe.test/checkout"},
             )
 
-        def create_subscription(self, *, request: object, app: object):
+        def create_subscription(self, *, request: object, app: object) -> object:
             return self.create_payment(request=request, app=app)
 
         def sync_reference(
             self, *, provider_reference: str, reference_type: str, app: object
-        ):
+        ) -> object:
             _ = app
             assert reference_type == "checkout_session"
             return PaymentNotificationResult(
@@ -447,7 +447,7 @@ def billing_write_client(monkeypatch: object) -> Iterator[dict[str, object]]:
             subscription_bid: str,
             provider_subscription_id: str,
             app: object,
-        ):
+        ) -> object:
             _ = app
             return SubscriptionUpdateResult(
                 provider_reference=provider_subscription_id,
@@ -467,7 +467,7 @@ def billing_write_client(monkeypatch: object) -> Iterator[dict[str, object]]:
             subscription_bid: str,
             provider_subscription_id: str,
             app: object,
-        ):
+        ) -> object:
             _ = app
             return SubscriptionUpdateResult(
                 provider_reference=provider_subscription_id,
@@ -481,7 +481,7 @@ def billing_write_client(monkeypatch: object) -> Iterator[dict[str, object]]:
                 extra={"cancel_at_period_end": False},
             )
 
-        def refund_payment(self, *, request: object, app: object):
+        def refund_payment(self, *, request: object, app: object) -> object:
             _ = app
             refund_requests.append(
                 {
@@ -498,7 +498,7 @@ def billing_write_client(monkeypatch: object) -> Iterator[dict[str, object]]:
             )
 
     class FakePingxxProvider:
-        def create_payment(self, *, request: object, app: object):
+        def create_payment(self, *, request: object, app: object) -> object:
             _ = app
             pingxx_requests.append(
                 {
@@ -517,7 +517,7 @@ def billing_write_client(monkeypatch: object) -> Iterator[dict[str, object]]:
 
         def sync_reference(
             self, *, provider_reference: str, reference_type: str, app: object
-        ):
+        ) -> object:
             _ = app
             assert reference_type == "charge"
             return PaymentNotificationResult(
@@ -527,7 +527,7 @@ def billing_write_client(monkeypatch: object) -> Iterator[dict[str, object]]:
                 charge_id=provider_reference,
             )
 
-    def _fake_get_payment_provider(channel: str):
+    def _fake_get_payment_provider(channel: str) -> object:
         if channel == "stripe":
             return FakeStripeProvider()
         if channel == "pingxx":
@@ -552,7 +552,7 @@ def billing_write_client(monkeypatch: object) -> Iterator[dict[str, object]]:
     )
 
     @app.errorhandler(AppError)
-    def _handle_app_exception(error: AppError):
+    def _handle_app_exception(error: AppError) -> object:
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response

--- a/src/api/tests/service/billing/test_admin_billing_routes.py
+++ b/src/api/tests/service/billing/test_admin_billing_routes.py
@@ -154,7 +154,7 @@ def admin_billing_client(monkeypatch: object) -> Iterator[dict[str, object]]:
     load_translations(app)
 
     @app.errorhandler(AppError)
-    def _handle_app_exception(error: AppError):
+    def _handle_app_exception(error: AppError) -> object:
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response
@@ -1293,7 +1293,7 @@ class TestAdminBillingRoutes:
 
         def _save_branding(
             _app: object, creator_bid: object, payload: object, **kwargs: object
-        ):
+        ) -> object:
             captured["creator_bid"] = creator_bid
             captured["payload"] = payload
             captured["kwargs"] = kwargs

--- a/src/api/tests/service/billing/test_admin_ops_state.py
+++ b/src/api/tests/service/billing/test_admin_ops_state.py
@@ -9,11 +9,11 @@ class _TrackingLock:
         self._events = events
         self._key = key
 
-    def acquire(self, **_kwargs: object):
+    def acquire(self, **_kwargs: object) -> object:
         self._events.append(("acquire", self._key))
         return True
 
-    def release(self):
+    def release(self) -> None:
         self._events.append(("release", self._key))
 
 
@@ -21,18 +21,18 @@ class _TrackingRedis:
     def __init__(self) -> None:
         self.events = []
 
-    def lock(self, key: object, **_kwargs: object):
+    def lock(self, key: object, **_kwargs: object) -> object:
         self.events.append(("lock", key))
         return _TrackingLock(self.events, key)
 
 
-def _patch_config_store(monkeypatch: object):
+def _patch_config_store(monkeypatch: object) -> object:
     store = {}
 
-    def fake_get_config(key: object, default: object = None):
+    def fake_get_config(key: object, default: object = None) -> object:
         return store.get(key, default)
 
-    def fake_update_config(_app: object, key: object, value: object, **kwargs: object):
+    def fake_update_config(_app: object, key: object, value: object, **kwargs: object) -> object:
         store[key] = value
         store[(key, "meta")] = kwargs
         return True

--- a/src/api/tests/service/billing/test_admin_ops_state.py
+++ b/src/api/tests/service/billing/test_admin_ops_state.py
@@ -32,7 +32,9 @@ def _patch_config_store(monkeypatch: object) -> object:
     def fake_get_config(key: object, default: object = None) -> object:
         return store.get(key, default)
 
-    def fake_update_config(_app: object, key: object, value: object, **kwargs: object) -> object:
+    def fake_update_config(
+        _app: object, key: object, value: object, **kwargs: object
+    ) -> object:
         store[key] = value
         store[(key, "meta")] = kwargs
         return True

--- a/src/api/tests/service/billing/test_billing_callbacks.py
+++ b/src/api/tests/service/billing/test_billing_callbacks.py
@@ -606,7 +606,7 @@ class TestBillingNativeCallbacks:
         self, billing_callback_app: object, monkeypatch: object
     ) -> None:
         class FakeAlipayProvider:
-            def handle_notification(self, *, payload: object, app: object):
+            def handle_notification(self, *, payload: object, app: object) -> object:
                 _ = (payload, app)
                 return _alipay_notification("bill-native-alipay-1", "TRADE_SUCCESS")
 
@@ -796,7 +796,7 @@ class TestBillingNativeCallbacks:
         self, billing_callback_app: object, monkeypatch: object
     ) -> None:
         class FakeAlipayProvider:
-            def handle_notification(self, *, payload: object, app: object):
+            def handle_notification(self, *, payload: object, app: object) -> object:
                 _ = (payload, app)
                 return _alipay_notification("missing-native-order", "TRADE_SUCCESS")
 
@@ -822,7 +822,7 @@ class TestBillingNativeCallbacks:
         self, billing_callback_app: object, monkeypatch: object
     ) -> None:
         class FakeWechatPayProvider:
-            def verify_webhook(self, *, headers: object, raw_body: object, app: object):
+            def verify_webhook(self, *, headers: object, raw_body: object, app: object) -> object:
                 _ = (headers, raw_body, app)
                 return _wechatpay_notification("legacy-wechatpay-attempt-1", "SUCCESS")
 
@@ -888,7 +888,7 @@ class TestBillingNativeCallbacks:
         self, billing_callback_app: object, monkeypatch: object
     ) -> None:
         class FakeWechatPayProvider:
-            def verify_webhook(self, *, headers: object, raw_body: object, app: object):
+            def verify_webhook(self, *, headers: object, raw_body: object, app: object) -> None:
                 _ = (headers, raw_body, app)
                 message = "secret verification detail"
                 raise RuntimeError(message)

--- a/src/api/tests/service/billing/test_billing_callbacks.py
+++ b/src/api/tests/service/billing/test_billing_callbacks.py
@@ -822,7 +822,9 @@ class TestBillingNativeCallbacks:
         self, billing_callback_app: object, monkeypatch: object
     ) -> None:
         class FakeWechatPayProvider:
-            def verify_webhook(self, *, headers: object, raw_body: object, app: object) -> object:
+            def verify_webhook(
+                self, *, headers: object, raw_body: object, app: object
+            ) -> object:
                 _ = (headers, raw_body, app)
                 return _wechatpay_notification("legacy-wechatpay-attempt-1", "SUCCESS")
 
@@ -888,7 +890,9 @@ class TestBillingNativeCallbacks:
         self, billing_callback_app: object, monkeypatch: object
     ) -> None:
         class FakeWechatPayProvider:
-            def verify_webhook(self, *, headers: object, raw_body: object, app: object) -> None:
+            def verify_webhook(
+                self, *, headers: object, raw_body: object, app: object
+            ) -> None:
                 _ = (headers, raw_body, app)
                 message = "secret verification detail"
                 raise RuntimeError(message)

--- a/src/api/tests/service/billing/test_billing_cli.py
+++ b/src/api/tests/service/billing/test_billing_cli.py
@@ -66,7 +66,7 @@ def billing_cli_runner() -> object:
     app.testing = True
 
     @app.cli.group()
-    def console():
+    def console() -> None:
         """Test console root."""
 
     register_billing_commands(console)
@@ -91,7 +91,7 @@ def billing_cli_db_app() -> Iterator[Flask]:
     dao.db.init_app(app)
 
     @app.cli.group()
-    def console():
+    def console() -> None:
         """Test console root."""
 
     register_billing_commands(console)

--- a/src/api/tests/service/billing/test_billing_credit_audit.py
+++ b/src/api/tests/service/billing/test_billing_credit_audit.py
@@ -49,7 +49,7 @@ def billing_credit_audit_app() -> Iterator[Flask]:
     dao.db.init_app(app)
 
     @app.cli.group()
-    def console():
+    def console() -> None:
         """Test console root."""
 
     register_billing_commands(console)

--- a/src/api/tests/service/billing/test_billing_cycle_transitions.py
+++ b/src/api/tests/service/billing/test_billing_cycle_transitions.py
@@ -20,7 +20,7 @@ from flaskr.service.billing.cycle_transitions import (
 )
 
 
-def _raise_unexpected_call(*_args: object, **_kwargs: object):
+def _raise_unexpected_call(*_args: object, **_kwargs: object) -> None:
     message = "unexpected callback call"
     raise AssertionError(message)
 

--- a/src/api/tests/service/billing/test_billing_domains.py
+++ b/src/api/tests/service/billing/test_billing_domains.py
@@ -56,7 +56,7 @@ def billing_domain_client(monkeypatch: object) -> Iterator[dict[str, object]]:
     dao.db.init_app(app)
 
     @app.errorhandler(AppError)
-    def _handle_app_exception(error: AppError):
+    def _handle_app_exception(error: AppError) -> object:
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response
@@ -72,7 +72,7 @@ def billing_domain_client(monkeypatch: object) -> Iterator[dict[str, object]]:
 
     @app.route("/_domain-context", methods=["GET"])
     @with_shifu_context()
-    def _domain_context():
+    def _domain_context() -> object:
         return jsonify({"creator_bid": get_shifu_creator_bid()})
 
     monkeypatch.setattr(
@@ -184,7 +184,7 @@ class TestBillingDomains:
             verification_token="verify-token",
         )
 
-        def fake_resolve(name: object, record_type: object, lifetime: object):
+        def fake_resolve(name: object, record_type: object, lifetime: object) -> object:
             assert lifetime == 5
             if record_type == "TXT":
                 assert name == "_ai-shifu-verification.learn.example.com"

--- a/src/api/tests/service/billing/test_billing_entitlements.py
+++ b/src/api/tests/service/billing/test_billing_entitlements.py
@@ -55,7 +55,7 @@ def billing_entitlement_app() -> Flask:
         dao.db.drop_all()
 
 
-def _seed_products_with_yearly_entitlements():
+def _seed_products_with_yearly_entitlements() -> object:
     return build_bill_products(
         overrides_by_bid={
             "bill-product-plan-yearly": {

--- a/src/api/tests/service/billing/test_billing_error_specificity.py
+++ b/src/api/tests/service/billing/test_billing_error_specificity.py
@@ -31,7 +31,7 @@ class _UnavailableLock:
 
 
 class _LockFactory:
-    def lock(self, *_args: object, **_kwargs: object):
+    def lock(self, *_args: object, **_kwargs: object) -> object:
         return _UnavailableLock()
 
 

--- a/src/api/tests/service/billing/test_billing_renewal_compensation.py
+++ b/src/api/tests/service/billing/test_billing_renewal_compensation.py
@@ -60,7 +60,7 @@ def billing_renewal_compensation_env(
     class FakeStripeProvider:
         def sync_reference(
             self, *, provider_reference: str, reference_type: str, app: object
-        ):
+        ) -> object:
             _ = app
             assert reference_type == "subscription"
             assert provider_reference == sync_state["subscription"]["id"]

--- a/src/api/tests/service/billing/test_billing_routes.py
+++ b/src/api/tests/service/billing/test_billing_routes.py
@@ -119,7 +119,7 @@ def _freeze_billing_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(billing_serializers_module, "now_utc", lambda: _frozen_now)
 
 
-def _seed_products_with_yearly_entitlements():
+def _seed_products_with_yearly_entitlements() -> object:
     return build_bill_products(
         overrides_by_bid={
             "bill-product-plan-yearly": {
@@ -156,7 +156,7 @@ def billing_test_client(monkeypatch: object) -> Iterator[FlaskClient]:
     dao.db.init_app(app)
 
     @app.errorhandler(AppError)
-    def _handle_app_exception(error: AppError):
+    def _handle_app_exception(error: AppError) -> object:
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response
@@ -1228,7 +1228,7 @@ class TestBillingRoutes:
 
             def _count_order_selects(
                 _conn: object, _cursor: object, statement: object, *_args: object
-            ):
+            ) -> None:
                 nonlocal order_select_count
                 if "bill_orders" in statement.lower():
                     order_select_count += 1
@@ -1699,7 +1699,7 @@ class TestBillingRoutes:
 
         def _count_order_selects(
             _conn: object, _cursor: object, statement: object, *_args: object
-        ):
+        ) -> None:
             nonlocal order_select_count
             if "bill_orders" in statement.lower():
                 order_select_count += 1

--- a/src/api/tests/service/billing/test_billing_subscription_sms.py
+++ b/src/api/tests/service/billing/test_billing_subscription_sms.py
@@ -145,7 +145,7 @@ def _billing_paid_feishu_payload(
     }
 
 
-def _raise_if_send_notify_called(*args: object, **kwargs: object):
+def _raise_if_send_notify_called(*args: object, **kwargs: object) -> None:
     _ = (args, kwargs)
     message = "billing paid Feishu delivery should run in a Celery task"
     raise AssertionError(message)
@@ -267,7 +267,7 @@ def test_sync_billing_order_enqueues_subscription_purchase_sms_once(
     class FakeStripeProvider:
         def sync_reference(
             self, *, provider_reference: str, reference_type: str, app: object
-        ):
+        ) -> object:
             _ = app
             assert reference_type == "subscription"
             return PaymentNotificationResult(
@@ -422,7 +422,7 @@ def test_sync_billing_order_enqueues_subscription_paid_feishu_once(
     class FakeStripeProvider:
         def sync_reference(
             self, *, provider_reference: str, reference_type: str, app: object
-        ):
+        ) -> object:
             _ = app
             assert reference_type == "subscription"
             return PaymentNotificationResult(
@@ -594,7 +594,7 @@ def test_sync_billing_topup_enqueues_billing_paid_feishu_once(
     class FakePingxxProvider:
         def sync_reference(
             self, *, provider_reference: str, reference_type: str, app: object
-        ):
+        ) -> object:
             _ = app
             assert provider_reference == "ch_billing_feishu_topup_sync_1"
             assert reference_type == "charge"
@@ -681,7 +681,7 @@ def test_sync_pingxx_order_syncs_manual_trial_subscription_provider(
     class FakePingxxProvider:
         def sync_reference(
             self, *, provider_reference: str, reference_type: str, app: object
-        ):
+        ) -> object:
             _ = app
             assert provider_reference == "ch_trial_upgrade_sync_pingxx_1"
             assert reference_type == "charge"
@@ -1172,7 +1172,7 @@ def test_requeue_subscription_purchase_sms_enqueues_failed_provider_order(
     captured_kwargs: list[dict[str, str]] = []
 
     class FakeTask:
-        def apply_async(self, kwargs: object):
+        def apply_async(self, kwargs: object) -> None:
             captured_kwargs.append(dict(kwargs))
 
     fake_celery = SimpleNamespace(tasks={SUBSCRIPTION_SMS_TASK_NAME: FakeTask()})

--- a/src/api/tests/service/billing/test_billing_tasks.py
+++ b/src/api/tests/service/billing/test_billing_tasks.py
@@ -111,7 +111,7 @@ def test_settle_usage_task_calls_settlement_engine(
 
     captured: dict[str, object] = {}
 
-    def _fake_settle_bill_usage(app: object, *, usage_bid: str = ""):
+    def _fake_settle_bill_usage(app: object, *, usage_bid: str = "") -> object:
         captured["app"] = app
         captured["usage_bid"] = usage_bid
         return {
@@ -170,7 +170,7 @@ def test_aggregate_daily_usage_metrics_task_calls_helper(
         stat_date: str = "",
         creator_bid: str = "",
         finalize: bool = False,
-    ):
+    ) -> object:
         captured["app"] = app
         captured["stat_date"] = stat_date
         captured["creator_bid"] = creator_bid
@@ -217,7 +217,7 @@ def test_aggregate_daily_ledger_summary_task_calls_helper(
         stat_date: str = "",
         creator_bid: str = "",
         finalize: bool = False,
-    ):
+    ) -> object:
         captured["app"] = app
         captured["stat_date"] = stat_date
         captured["creator_bid"] = creator_bid
@@ -266,7 +266,7 @@ def test_finalize_daily_ledger_summary_task_defaults_to_previous_day(
         *,
         stat_date: str = "",
         creator_bid: str = "",
-    ):
+    ) -> object:
         captured["app"] = app
         captured["stat_date"] = stat_date
         captured["creator_bid"] = creator_bid
@@ -307,7 +307,7 @@ def test_finalize_daily_ledger_summary_task_accepts_explicit_stat_date(
         *,
         stat_date: str = "",
         creator_bid: str = "",
-    ):
+    ) -> object:
         captured["app"] = app
         captured["stat_date"] = stat_date
         captured["creator_bid"] = creator_bid
@@ -352,7 +352,7 @@ def test_rebuild_daily_aggregates_task_calls_helper(
         shifu_bid: str = "",
         date_from: str = "",
         date_to: str = "",
-    ):
+    ) -> object:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["shifu_bid"] = shifu_bid
@@ -404,7 +404,7 @@ def test_verify_domain_binding_task_calls_helper(
         domain_binding_bid: str = "",
         host: str = "",
         verification_token: str = "",
-    ):
+    ) -> object:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["domain_binding_bid"] = domain_binding_bid
@@ -460,7 +460,7 @@ def test_settle_usage_task_serializes_same_creator_concurrent_usage(
             self._events = events
             self._second_attempted = second_attempted
 
-        def acquire(self, blocking: bool = True, blocking_timeout: object = None):
+        def acquire(self, blocking: bool = True, blocking_timeout: object = None) -> object:
             self._events.append(
                 {
                     "type": "attempt",
@@ -515,7 +515,7 @@ def test_settle_usage_task_serializes_same_creator_concurrent_usage(
             key: str,
             timeout: object = None,
             blocking_timeout: object = None,
-        ):
+        ) -> object:
             del timeout, blocking_timeout
             with self._guard:
                 raw_lock = self._locks.setdefault(key, threading.Lock())
@@ -541,7 +541,7 @@ def test_settle_usage_task_serializes_same_creator_concurrent_usage(
 
     original_build_usage_metric_charges = settlement_module.build_usage_metric_charges
 
-    def _blocking_build_usage_metric_charges(*args: object, **kwargs: object):
+    def _blocking_build_usage_metric_charges(*args: object, **kwargs: object) -> object:
         usage = args[0]
         if usage.usage_bid == "usage-concurrent-1":
             entered_first_charge.set()
@@ -765,7 +765,7 @@ def test_replay_usage_settlement_task_calls_replay_helper(
         creator_bid: str = "",
         usage_bid: str = "",
         usage_id: object = None,
-    ):
+    ) -> object:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["usage_bid"] = usage_bid
@@ -808,7 +808,7 @@ def test_expire_wallet_buckets_task_calls_wallet_helper(
 
     def _fake_expire_credit_wallet_buckets(
         app: object, *, creator_bid: object = "", expire_before: object = None
-    ):
+    ) -> object:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["expire_before"] = expire_before
@@ -865,7 +865,7 @@ def test_expire_pending_orders_task_delegates_to_sync_flow(
 
     def _fake_sync_billing_order(
         app: object, creator_bid: str, bill_order_bid: str, payload: object
-    ):
+    ) -> object:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["bill_order_bid"] = bill_order_bid
@@ -936,7 +936,7 @@ def test_expire_pending_orders_task_includes_legacy_orders_without_expires_at(
 
     def _fake_sync_billing_order(
         app: object, creator_bid: str, bill_order_bid: str, payload: object
-    ):
+    ) -> object:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["bill_order_bid"] = bill_order_bid
@@ -1067,7 +1067,7 @@ def test_sync_billing_order_runs_under_per_creator_credit_ledger_lock(
             key: object,
             timeout: object = None,
             blocking_timeout: object = None,
-        ):
+        ) -> object:
             _ = (timeout, blocking_timeout)
             return _RecordingLock(key)
 
@@ -1127,7 +1127,7 @@ def test_reconcile_provider_reference_task_delegates_to_reconcile_helper(
         provider_reference_id: object = "",
         bill_order_bid: object = "",
         session_id: object = "",
-    ):
+    ) -> object:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["payment_provider"] = payment_provider
@@ -1210,7 +1210,7 @@ def test_dispatch_due_renewal_events_task_noops_when_disabled(
 
     called = {"apply_async": 0}
 
-    def _fake_apply_async(*, kwargs: object = None, **options: object):
+    def _fake_apply_async(*, kwargs: object = None, **options: object) -> None:
         del kwargs, options
         called["apply_async"] += 1
 
@@ -1352,7 +1352,7 @@ def test_dispatch_due_renewal_events_task_enqueues_due_pending_events_only(
 
     captured_calls: list[dict[str, object]] = []
 
-    def _fake_apply_async(*, kwargs: object = None, **options: object):
+    def _fake_apply_async(*, kwargs: object = None, **options: object) -> None:
         captured_calls.append(
             {
                 "kwargs": dict(kwargs or {}),
@@ -1443,7 +1443,7 @@ def test_dispatch_due_renewal_events_recovers_stale_processing_events(
 
     captured_calls: list[dict[str, object]] = []
 
-    def _fake_apply_async(*, kwargs: object = None, **options: object):
+    def _fake_apply_async(*, kwargs: object = None, **options: object) -> None:
         captured_calls.append(
             {
                 "kwargs": dict(kwargs or {}),
@@ -1521,7 +1521,7 @@ def test_dispatch_due_renewal_events_uses_dedicated_queue_when_enabled(
 
     captured_calls: list[dict[str, object]] = []
 
-    def _fake_apply_async(*, kwargs: object = None, **options: object):
+    def _fake_apply_async(*, kwargs: object = None, **options: object) -> None:
         captured_calls.append(
             {
                 "kwargs": dict(kwargs or {}),
@@ -1637,7 +1637,7 @@ def test_retry_failed_renewal_task_reuses_reconcile_helper_when_reference_exists
         provider_reference_id: object = "",
         bill_order_bid: object = "",
         session_id: object = "",
-    ):
+    ) -> object:
         captured["app"] = app
         captured["creator_bid"] = creator_bid
         captured["payment_provider"] = payment_provider

--- a/src/api/tests/service/billing/test_billing_tasks.py
+++ b/src/api/tests/service/billing/test_billing_tasks.py
@@ -460,7 +460,9 @@ def test_settle_usage_task_serializes_same_creator_concurrent_usage(
             self._events = events
             self._second_attempted = second_attempted
 
-        def acquire(self, blocking: bool = True, blocking_timeout: object = None) -> object:
+        def acquire(
+            self, blocking: bool = True, blocking_timeout: object = None
+        ) -> object:
             self._events.append(
                 {
                     "type": "attempt",

--- a/src/api/tests/service/billing/test_billing_trial_credits.py
+++ b/src/api/tests/service/billing/test_billing_trial_credits.py
@@ -76,7 +76,7 @@ def trial_billing_client(monkeypatch: object) -> object:
     dao.db.init_app(app)
 
     @app.errorhandler(AppError)
-    def _handle_app_exception(error: AppError):
+    def _handle_app_exception(error: AppError) -> object:
         response = jsonify({"code": error.code, "message": error.message})
         response.status_code = 200
         return response

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
@@ -777,7 +777,9 @@ def test_expire_credit_wallet_buckets_skips_empty_bucket_released_before_status_
         real_sync = wallets_mod._sync_empty_available_bucket_status_if_unchanged
         changed = {"done": False}
 
-        def _release_before_status_sync(target_bucket: object, **kwargs: object) -> object:
+        def _release_before_status_sync(
+            target_bucket: object, **kwargs: object
+        ) -> object:
             if not changed["done"]:
                 changed["done"] = True
                 CreditWalletBucket.query.filter(

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_expiration.py
@@ -464,7 +464,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_realigned_during_refresh(
 
         real_refresh = wallets_mod.db.session.refresh
 
-        def _refresh_with_realign(target_bucket: object):
+        def _refresh_with_realign(target_bucket: object) -> object:
             if (
                 isinstance(target_bucket, CreditWalletBucket)
                 and target_bucket.wallet_bucket_bid == "bucket-expire-realigned"
@@ -565,7 +565,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_consumed_before_write(
         real_expire = wallets_mod._expire_bucket_available_credits_if_unchanged
         changed = {"done": False}
 
-        def _consume_before_expire(target_bucket: object, **kwargs: object):
+        def _consume_before_expire(target_bucket: object, **kwargs: object) -> object:
             if (
                 not changed["done"]
                 and target_bucket.wallet_bucket_bid
@@ -687,7 +687,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_extended_before_write(
         real_expire = wallets_mod._expire_bucket_available_credits_if_unchanged
         changed = {"done": False}
 
-        def _extend_before_expire(target_bucket: object, **kwargs: object):
+        def _extend_before_expire(target_bucket: object, **kwargs: object) -> object:
             if (
                 not changed["done"]
                 and target_bucket.wallet_bucket_bid
@@ -777,7 +777,7 @@ def test_expire_credit_wallet_buckets_skips_empty_bucket_released_before_status_
         real_sync = wallets_mod._sync_empty_available_bucket_status_if_unchanged
         changed = {"done": False}
 
-        def _release_before_status_sync(target_bucket: object, **kwargs: object):
+        def _release_before_status_sync(target_bucket: object, **kwargs: object) -> object:
             if not changed["done"]:
                 changed["done"] = True
                 CreditWalletBucket.query.filter(
@@ -885,7 +885,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_deleted_during_refresh(
 
         real_refresh = wallets_mod.db.session.refresh
 
-        def _refresh_with_deleted_bucket(target_bucket: object):
+        def _refresh_with_deleted_bucket(target_bucket: object) -> object:
             if (
                 isinstance(target_bucket, CreditWalletBucket)
                 and target_bucket.wallet_bucket_bid == "bucket-expire-refresh-skip"
@@ -977,7 +977,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_when_refresh_raises_deleted(
 
         real_refresh = wallets_mod.db.session.refresh
 
-        def _refresh_with_deleted_error(target_bucket: object):
+        def _refresh_with_deleted_error(target_bucket: object) -> object:
             if (
                 isinstance(target_bucket, CreditWalletBucket)
                 and target_bucket.wallet_bucket_bid == "bucket-expire-refresh-error"
@@ -1063,7 +1063,7 @@ def test_expire_credit_wallet_buckets_skips_bucket_on_wallet_version_conflict(
         real_persist = wallets_mod.persist_credit_wallet_snapshot
         state = {"calls": 0}
 
-        def _persist_conflict_once(target_wallet: object, **kwargs: object):
+        def _persist_conflict_once(target_wallet: object, **kwargs: object) -> object:
             state["calls"] += 1
             if state["calls"] == 1:
                 message = "credit_wallet_version_conflict"

--- a/src/api/tests/service/billing/test_billing_wallet_lifecycle_grants.py
+++ b/src/api/tests/service/billing/test_billing_wallet_lifecycle_grants.py
@@ -165,7 +165,7 @@ def test_grant_manual_credit_wallet_balance_returns_noop_existing_after_integrit
     original_commit = dao.db.session.commit
     state = {"raised": False}
 
-    def _commit_once_with_duplicate():
+    def _commit_once_with_duplicate() -> object:
         if not state["raised"]:
             state["raised"] = True
             dao.db.session.rollback()

--- a/src/api/tests/service/billing/test_billing_write_routes_checkout.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_checkout.py
@@ -76,7 +76,7 @@ class TestBillingWriteRoutesCheckout:
     ) -> None:
         client = billing_write_client["client"]
 
-        def fake_get_config(key: object, default: object = None):
+        def fake_get_config(key: object, default: object = None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "stripe"
             return default

--- a/src/api/tests/service/billing/test_billing_write_routes_subscription_lifecycle.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_subscription_lifecycle.py
@@ -457,7 +457,7 @@ class TestBillingWriteRoutesSubscriptionLifecycle:
     ) -> None:
         client = billing_write_client["client"]
 
-        def fake_get_config(key: object, default: object = None):
+        def fake_get_config(key: object, default: object = None) -> object:
             if key == "PINGXX_APP_ID":
                 return "app_billing_test"
             return default

--- a/src/api/tests/service/billing/test_billing_write_routes_topup.py
+++ b/src/api/tests/service/billing/test_billing_write_routes_topup.py
@@ -600,7 +600,7 @@ class TestBillingWriteRoutesTopup:
         app = billing_write_client["app"]
         add_active_subscription(app, subscription_bid="sub-topup-default-provider-1")
 
-        def fake_get_config(key: object, default: object = None):
+        def fake_get_config(key: object, default: object = None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "pingxx"
             return default

--- a/src/api/tests/service/billing/test_creator_customization.py
+++ b/src/api/tests/service/billing/test_creator_customization.py
@@ -627,7 +627,7 @@ def test_creator_brand_logo_upload_uses_courses_oss_and_can_be_saved(
     _require_saas_config_plugin()
     monkeypatch.setattr(customization, "is_creator_customization_enabled", lambda: True)
 
-    def fake_get_config(key: object, default: object = None):
+    def fake_get_config(key: object, default: object = None) -> object:
         if key == "ALIBABA_CLOUD_OSS_COURSES_URL":
             return "https://courses-oss.example.com"
         if key == "ALIBABA_CLOUD_OSS_BASE_URL":
@@ -636,7 +636,7 @@ def test_creator_brand_logo_upload_uses_courses_oss_and_can_be_saved(
 
     uploaded = {}
 
-    def fake_upload_to_storage(_app: object, **kwargs: object):
+    def fake_upload_to_storage(_app: object, **kwargs: object) -> object:
         uploaded.update(kwargs)
         return SimpleNamespace(
             url=f"https://courses-oss.example.com/{kwargs['object_key']}",
@@ -681,7 +681,7 @@ def test_creator_brand_logo_upload_uses_courses_oss_and_can_be_saved(
 def test_unavailable_saas_plugin_keeps_optional_customization_reads_empty(
     app: object, monkeypatch: object
 ) -> None:
-    def missing_plugin(name: object):
+    def missing_plugin(name: object) -> object:
         if name.startswith("flaskr.plugins.ai_shifu_saas_plugin"):
             raise ModuleNotFoundError(name=name)
         return import_module(name)
@@ -714,7 +714,7 @@ def test_installed_but_disabled_saas_plugin_falls_back(
             message = "SaaS plugin must not be used while SAAS_PLUGIN_ENABLED is false"
             raise AssertionError(message)
 
-    def fake_import(name: object):
+    def fake_import(name: object) -> object:
         if name.startswith("flaskr.plugins.ai_shifu_saas_plugin"):
             return _ExplodingModule()
         return import_module(name)
@@ -748,7 +748,7 @@ def test_creator_brand_favicon_upload_converts_png_to_ico(
 
     uploaded = {}
 
-    def fake_upload_to_storage(_app: object, **kwargs: object):
+    def fake_upload_to_storage(_app: object, **kwargs: object) -> object:
         uploaded.update(kwargs)
         return SimpleNamespace(
             url=f"https://courses-oss.example.com/{kwargs['object_key']}",
@@ -844,7 +844,7 @@ def test_runtime_branding_falls_back_to_square_logo_for_favicon(app: object) -> 
 def test_creator_branding_home_url_roundtrip(app: object, monkeypatch: object) -> None:
     monkeypatch.setattr(customization, "is_creator_customization_enabled", lambda: True)
 
-    def missing_plugin(name: object):
+    def missing_plugin(name: object) -> object:
         if name.startswith("flaskr.plugins.ai_shifu_saas_plugin"):
             raise ModuleNotFoundError(name=name)
         return import_module(name)
@@ -945,7 +945,7 @@ def test_creator_brand_logo_upload_normalizes_square_variant(
 ) -> None:
     uploaded = {}
 
-    def fake_upload_to_storage(_app: object, **kwargs: object):
+    def fake_upload_to_storage(_app: object, **kwargs: object) -> object:
         content = kwargs["file_content"].read()
         uploaded["content"] = content
         return type("UploadResult", (), {"url": "https://cdn.example.com/logo.png"})()
@@ -984,7 +984,7 @@ def test_creator_brand_logo_upload_preserves_wide_retina_variant(
 ) -> None:
     uploaded = {}
 
-    def fake_upload_to_storage(_app: object, **kwargs: object):
+    def fake_upload_to_storage(_app: object, **kwargs: object) -> object:
         content = kwargs["file_content"].read()
         uploaded["content"] = content
         return type("UploadResult", (), {"url": "https://cdn.example.com/logo.png"})()

--- a/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_credit_notification_uow_failure_paths.py
@@ -91,7 +91,7 @@ def credit_notification_uow_app(tmp_path: object) -> Flask:
 
 
 @pytest.fixture(autouse=True)
-def _neutralize_savepoints_on_sqlite(monkeypatch: object):
+def _neutralize_savepoints_on_sqlite(monkeypatch: object) -> None:
     """Make begin_nested a no-op under the SQLite test engine.
 
     ``_stage_notification_record`` wraps its INSERT in
@@ -249,7 +249,7 @@ def _seed_credit_ledger(*, ledger_bid: str, creator_bid: str) -> None:
     dao.db.session.commit()
 
 
-def _stub_send_sms(monkeypatch: pytest.MonkeyPatch, sends: list[dict]):
+def _stub_send_sms(monkeypatch: pytest.MonkeyPatch, sends: list[dict]) -> None:
     def fake_send(
         app: object,
         mobile: object,
@@ -257,7 +257,7 @@ def _stub_send_sms(monkeypatch: pytest.MonkeyPatch, sends: list[dict]):
         template_code: object,
         template_params: object,
         sign_name: object = None,
-    ):
+    ) -> object:
         _ = (app, sign_name)
         sends.append(
             {
@@ -300,7 +300,7 @@ def test_scan_item_failure_is_isolated_from_neighbor_items(
 
     original_stage = credit_notifications._stage_notification_record
 
-    def staging_then_boom(app_arg: object, **kwargs: object):
+    def staging_then_boom(app_arg: object, **kwargs: object) -> object:
         result = original_stage(app_arg, **kwargs)
         if kwargs.get("creator_bid") == "creator-uow-2":
             message = "boom in creator-uow-2"
@@ -408,7 +408,7 @@ def test_failed_provider_marker_persists_and_stays_retryable(
     )
     notification_bid = str(staged["notification_bid"])
 
-    def crashing_send(*_args: object, **_kwargs: object):
+    def crashing_send(*_args: object, **_kwargs: object) -> None:
         message = "provider connection dropped"
         raise RuntimeError(message)
 

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -2226,7 +2226,7 @@ def test_failed_provider_notification_can_be_requeued(
     captured_kwargs: list[dict[str, str]] = []
 
     class FakeTask:
-        def apply_async(self, kwargs: object):
+        def apply_async(self, kwargs: object) -> None:
             captured_kwargs.append(dict(kwargs))
 
     def get_celery_app(flask_app: object | None = None) -> object:
@@ -2240,7 +2240,7 @@ def test_failed_provider_notification_can_be_requeued(
         template_code: object,
         template_params: object,
         sign_name: object = None,
-    ):
+    ) -> None:
         del app, mobile, template_code, template_params, sign_name
 
     monkeypatch.setattr(
@@ -2295,7 +2295,7 @@ def test_requeue_keeps_failed_status_when_enqueue_fails(
         template_code: object,
         template_params: object,
         sign_name: object = None,
-    ):
+    ) -> None:
         del app, mobile, template_code, template_params, sign_name
 
     monkeypatch.setattr(
@@ -2349,7 +2349,7 @@ def test_requeue_records_operator_audit_metadata(
         template_code: object,
         template_params: object,
         sign_name: object = None,
-    ):
+    ) -> None:
         del app, mobile, template_code, template_params, sign_name
 
     monkeypatch.setattr(

--- a/src/api/tests/service/billing/test_operation_credit_reservations.py
+++ b/src/api/tests/service/billing/test_operation_credit_reservations.py
@@ -508,17 +508,17 @@ def test_operation_credit_mutations_request_wallet_and_bucket_locks(
     real_load_active_buckets = operation_credits._load_active_buckets
     real_iter_hold_buckets = operation_credits._iter_hold_buckets
 
-    def spy_load_wallet(creator_bid: str, *, lock: bool = False):
+    def spy_load_wallet(creator_bid: str, *, lock: bool = False) -> object:
         wallet_lock_calls.append(lock)
         return real_load_wallet(creator_bid, lock=lock)
 
     def spy_load_active_buckets(
         wallet: object, operation_at: object, *, lock: bool = False
-    ):
+    ) -> object:
         active_bucket_lock_calls.append(lock)
         return real_load_active_buckets(wallet, operation_at, lock=lock)
 
-    def spy_iter_hold_buckets(hold: object, *, lock: bool = False):
+    def spy_iter_hold_buckets(hold: object, *, lock: bool = False) -> object:
         hold_bucket_lock_calls.append(lock)
         return real_iter_hold_buckets(hold, lock=lock)
 

--- a/src/api/tests/service/billing/test_provider_catalog.py
+++ b/src/api/tests/service/billing/test_provider_catalog.py
@@ -29,7 +29,7 @@ class _StripeObject:
     def __init__(self, payload: object) -> None:
         self._payload = payload
 
-    def to_dict(self):
+    def to_dict(self) -> object:
         return dict(self._payload)
 
 
@@ -38,7 +38,7 @@ class _FakeStripeResource:
         self.payload = payload
         self.calls = []
 
-    def retrieve(self, *args: object, **kwargs: object):
+    def retrieve(self, *args: object, **kwargs: object) -> object:
         self.calls.append({"args": args, "kwargs": kwargs})
         return _StripeObject(self.payload)
 
@@ -86,7 +86,7 @@ class _FakeStripe:
 
 
 class _FailingStripeResource:
-    def retrieve(self, *args: object, **kwargs: object):
+    def retrieve(self, *args: object, **kwargs: object) -> None:
         _ = (args, kwargs)
         message = "secret sk_test_should_not_leak"
         raise RuntimeError(message)
@@ -102,7 +102,7 @@ class _FakeStripeAdapter(StripeCatalogReadAdapter):
     def __init__(self, stripe: object) -> None:
         self.stripe = stripe
 
-    def _client_options(self, app: object):
+    def _client_options(self, app: object) -> object:
         _ = app
         return self.stripe, build_stripe_request_options()
 
@@ -205,7 +205,7 @@ def _snapshot(
         )
 
 
-def _validate(product: BillingProduct, snapshot: ProviderCatalogSnapshot):
+def _validate(product: BillingProduct, snapshot: ProviderCatalogSnapshot) -> object:
     return validate_provider_price_mapping(
         product,
         snapshot,

--- a/src/api/tests/service/billing/test_referral_plan_rewards.py
+++ b/src/api/tests/service/billing/test_referral_plan_rewards.py
@@ -964,7 +964,7 @@ def test_pingxx_renewal_event_preserves_paid_referral_reward_order(
     boundary_at = normalize_mysql_datetime(now_utc() - timedelta(minutes=1))
     current_cycle_start = boundary_at - timedelta(days=30)
 
-    def _fail_provider_sync(*_args: object, **_kwargs: object):
+    def _fail_provider_sync(*_args: object, **_kwargs: object) -> None:
         message = "paid referral reward orders must not sync providers"
         raise AssertionError(message)
 

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -159,14 +159,14 @@ def _seed_event(
     return event
 
 
-def _failing_lifecycle_sync(monkeypatch: pytest.MonkeyPatch, *, failing_bids: set):
+def _failing_lifecycle_sync(monkeypatch: pytest.MonkeyPatch, *, failing_bids: set) -> None:
     """Fail the cancel-effective handler mid-flow for selected subscriptions.
 
     The failure point sits after the subscription mutation and before the
     event completion, simulating any late in-transaction error.
     """
 
-    def fake_sync(_app: object, subscription: object):
+    def fake_sync(_app: object, subscription: object) -> None:
         if subscription.subscription_bid in failing_bids:
             message = f"boom in {subscription.subscription_bid}"
             raise RuntimeError(message)
@@ -316,7 +316,7 @@ def test_renewal_order_persists_before_provider_sync_crash(
     )
     dao.db.session.commit()
 
-    def crashing_sync(*_args: object, **_kwargs: object):
+    def crashing_sync(*_args: object, **_kwargs: object) -> None:
         message = "provider sync crash"
         raise RuntimeError(message)
 
@@ -952,7 +952,7 @@ def test_provider_guard_renews_lease_before_cross_transaction_sync(
 
     recovery_counts: list[int] = []
 
-    def fake_sync(*_args: object, **_kwargs: object):
+    def fake_sync(*_args: object, **_kwargs: object) -> object:
         recovery_counts.append(
             billing_tasks._recover_stale_processing_renewal_events(
                 stale_before=now_utc() - timedelta(minutes=30),
@@ -1067,7 +1067,7 @@ def test_upsert_recovers_when_concurrent_insert_wins(
         event_type: int,
         scheduled_at: object,
         for_update: bool = False,
-    ):
+    ) -> object:
         nonlocal calls
         calls += 1
         if calls == 1:
@@ -1140,7 +1140,7 @@ def test_upsert_recovers_when_cross_session_insert_wins(
         event_type: int,
         scheduled_at: object,
         for_update: bool = False,
-    ):
+    ) -> object:
         calls.append(for_update)
         if len(calls) == 1:
             session_factory = sessionmaker(bind=dao.db.engine)

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -159,7 +159,9 @@ def _seed_event(
     return event
 
 
-def _failing_lifecycle_sync(monkeypatch: pytest.MonkeyPatch, *, failing_bids: set) -> None:
+def _failing_lifecycle_sync(
+    monkeypatch: pytest.MonkeyPatch, *, failing_bids: set
+) -> None:
     """Fail the cancel-effective handler mid-flow for selected subscriptions.
 
     The failure point sits after the subscription mutation and before the

--- a/src/api/tests/service/billing/test_runtime_config_billing.py
+++ b/src/api/tests/service/billing/test_runtime_config_billing.py
@@ -263,7 +263,7 @@ def test_runtime_config_uses_origin_header_for_google_redirect_when_host_url_mis
 ) -> None:
     original_route_get_config = config_route.get_config
 
-    def get_config_override(key: object, default: object = ""):
+    def get_config_override(key: object, default: object = "") -> object:
         if key == "HOST_URL":
             return ""
         return original_route_get_config(key, default)
@@ -293,7 +293,7 @@ def test_runtime_config_returns_empty_official_site_url_when_unconfigured(
 ) -> None:
     original_route_get_config = config_route.get_config
 
-    def get_config_override(key: object, default: object = ""):
+    def get_config_override(key: object, default: object = "") -> object:
         if key == "OFFICIAL_SITE_URL":
             return ""
         return original_route_get_config(key, default)
@@ -313,7 +313,7 @@ def test_runtime_config_uses_registered_home_url_default_on_config_lock_miss(
 ) -> None:
     original_route_get_config = config_route.get_config
 
-    def get_config_override(key: object, default: object = None):
+    def get_config_override(key: object, default: object = None) -> object:
         if key == "HOME_URL":
             return default
         return original_route_get_config(key, default)

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -1123,7 +1123,7 @@ def test_settle_usage_acquires_creator_scoped_lock(
             self.acquire_calls: list[bool] = []
             self.release_calls = 0
 
-        def acquire(self, blocking: bool = True, blocking_timeout: object = None):
+        def acquire(self, blocking: bool = True, blocking_timeout: object = None) -> object:
             _ = blocking_timeout
             self.acquire_calls.append(bool(blocking))
             return True
@@ -1141,7 +1141,7 @@ def test_settle_usage_acquires_creator_scoped_lock(
             key: str,
             timeout: object = None,
             blocking_timeout: object = None,
-        ):
+        ) -> object:
             self.calls.append(
                 {
                     "key": key,
@@ -1215,7 +1215,7 @@ def test_settle_usage_releases_creator_lock_on_error(
         def __init__(self) -> None:
             self.release_calls = 0
 
-        def acquire(self, blocking: bool = True, blocking_timeout: object = None):
+        def acquire(self, blocking: bool = True, blocking_timeout: object = None) -> object:
             _ = (blocking, blocking_timeout)
             return True
 
@@ -1641,7 +1641,7 @@ def test_resolve_credit_multiplier_label_uses_utc_default_settlement(
 
     def fake_load_usage_rate(
         *, usage: object, billing_metric: object, settlement_at: object
-    ):
+    ) -> None:
         _ = (usage, billing_metric)
         captured.append(settlement_at)
 

--- a/src/api/tests/service/billing/test_usage_settlement.py
+++ b/src/api/tests/service/billing/test_usage_settlement.py
@@ -1123,7 +1123,9 @@ def test_settle_usage_acquires_creator_scoped_lock(
             self.acquire_calls: list[bool] = []
             self.release_calls = 0
 
-        def acquire(self, blocking: bool = True, blocking_timeout: object = None) -> object:
+        def acquire(
+            self, blocking: bool = True, blocking_timeout: object = None
+        ) -> object:
             _ = blocking_timeout
             self.acquire_calls.append(bool(blocking))
             return True
@@ -1215,7 +1217,9 @@ def test_settle_usage_releases_creator_lock_on_error(
         def __init__(self) -> None:
             self.release_calls = 0
 
-        def acquire(self, blocking: bool = True, blocking_timeout: object = None) -> object:
+        def acquire(
+            self, blocking: bool = True, blocking_timeout: object = None
+        ) -> object:
             _ = (blocking, blocking_timeout)
             return True
 

--- a/src/api/tests/service/common/test_storage.py
+++ b/src/api/tests/service/common/test_storage.py
@@ -125,15 +125,15 @@ def test_read_storage_bytes_fetches_from_oss_when_local_file_is_missing(
     )
 
     class FakeObject:
-        def read(self):
+        def read(self) -> object:
             return b"remote-audio"
 
     class FakeBucket:
-        def get_object(self, object_key: str):
+        def get_object(self, object_key: str) -> object:
             assert object_key == "tts/minimax/source.webm"
             return FakeObject()
 
-    def fake_create_oss_bucket(config: object):
+    def fake_create_oss_bucket(config: object) -> object:
         assert config.bucket == "resource-bucket"
         return FakeBucket()
 

--- a/src/api/tests/service/common/test_umami_client.py
+++ b/src/api/tests/service/common/test_umami_client.py
@@ -316,7 +316,9 @@ def test_get_course_visit_count_30d_waits_for_cache_on_lock_contention(
     )
 
     class BusyLock:
-        def acquire(self, blocking: object = True, blocking_timeout: object = None) -> object:
+        def acquire(
+            self, blocking: object = True, blocking_timeout: object = None
+        ) -> object:
             _ = (blocking, blocking_timeout)
             return False
 
@@ -372,7 +374,9 @@ def test_login_for_access_token_rechecks_cache_when_lock_is_busy(
     )
 
     class BusyLock:
-        def acquire(self, blocking: object = True, blocking_timeout: object = None) -> object:
+        def acquire(
+            self, blocking: object = True, blocking_timeout: object = None
+        ) -> object:
             _ = (blocking, blocking_timeout)
             return False
 

--- a/src/api/tests/service/common/test_umami_client.py
+++ b/src/api/tests/service/common/test_umami_client.py
@@ -40,7 +40,7 @@ def test_get_course_visit_count_30d_counts_all_metric_pages(
         params: object = None,
         headers: object = None,
         timeout: object = None,
-    ):
+    ) -> object:
         calls.append(
             {
                 "url": url,
@@ -93,7 +93,7 @@ def test_get_course_visit_count_30d_uses_cached_value(
         params: object = None,
         headers: object = None,
         timeout: object = None,
-    ):
+    ) -> object:
         _ = (url, params, headers, timeout)
         request_count["value"] += 1
         return SimpleNamespace(
@@ -157,7 +157,7 @@ def test_get_course_visit_count_30d_caches_failures_briefly(
         params: object = None,
         headers: object = None,
         timeout: object = None,
-    ):
+    ) -> None:
         _ = (url, params, headers, timeout)
         request_count["value"] += 1
         message = "umami unavailable"
@@ -215,13 +215,13 @@ def test_get_course_visit_count_30d_returns_fetched_value_when_cache_write_fails
         def __init__(self) -> None:
             self._cache = InMemoryCacheProvider()
 
-        def get(self, key: object):
+        def get(self, key: object) -> object:
             return self._cache.get(key)
 
-        def delete(self, *keys: str):
+        def delete(self, *keys: str) -> object:
             return self._cache.delete(*keys)
 
-        def setex(self, key: object, ttl: object, value: object):
+        def setex(self, key: object, ttl: object, value: object) -> None:
             _ = (key, ttl, value)
             message = "cache unavailable"
             raise RuntimeError(message)
@@ -231,7 +231,7 @@ def test_get_course_visit_count_30d_returns_fetched_value_when_cache_write_fails
             key: object,
             timeout: object = None,
             blocking_timeout: object = None,
-        ):
+        ) -> object:
             return self._cache.lock(
                 key, timeout=timeout, blocking_timeout=blocking_timeout
             )
@@ -266,13 +266,13 @@ def test_get_course_visit_count_30d_returns_zero_when_failure_cache_write_fails(
         def __init__(self) -> None:
             self._cache = InMemoryCacheProvider()
 
-        def get(self, key: object):
+        def get(self, key: object) -> object:
             return self._cache.get(key)
 
-        def delete(self, *keys: str):
+        def delete(self, *keys: str) -> object:
             return self._cache.delete(*keys)
 
-        def setex(self, key: object, ttl: object, value: object):
+        def setex(self, key: object, ttl: object, value: object) -> None:
             _ = (key, ttl, value)
             message = "cache unavailable"
             raise RuntimeError(message)
@@ -282,7 +282,7 @@ def test_get_course_visit_count_30d_returns_zero_when_failure_cache_write_fails(
             key: object,
             timeout: object = None,
             blocking_timeout: object = None,
-        ):
+        ) -> object:
             return self._cache.lock(
                 key, timeout=timeout, blocking_timeout=blocking_timeout
             )
@@ -316,22 +316,22 @@ def test_get_course_visit_count_30d_waits_for_cache_on_lock_contention(
     )
 
     class BusyLock:
-        def acquire(self, blocking: object = True, blocking_timeout: object = None):
+        def acquire(self, blocking: object = True, blocking_timeout: object = None) -> object:
             _ = (blocking, blocking_timeout)
             return False
 
-        def release(self):
+        def release(self) -> None:
             return None
 
     class CacheWrapper:
-        def get(self, key: object):
+        def get(self, key: object) -> None:
             _ = key
 
-        def delete(self, *keys: str):
+        def delete(self, *keys: str) -> object:
             _ = keys
             return 0
 
-        def setex(self, key: object, ttl: object, value: object):
+        def setex(self, key: object, ttl: object, value: object) -> None:
             _ = (key, ttl, value)
 
         def lock(
@@ -339,7 +339,7 @@ def test_get_course_visit_count_30d_waits_for_cache_on_lock_contention(
             key: object,
             timeout: object = None,
             blocking_timeout: object = None,
-        ):
+        ) -> object:
             _ = (key, timeout, blocking_timeout)
             return BusyLock()
 
@@ -372,21 +372,21 @@ def test_login_for_access_token_rechecks_cache_when_lock_is_busy(
     )
 
     class BusyLock:
-        def acquire(self, blocking: object = True, blocking_timeout: object = None):
+        def acquire(self, blocking: object = True, blocking_timeout: object = None) -> object:
             _ = (blocking, blocking_timeout)
             return False
 
-        def release(self):
+        def release(self) -> None:
             return None
 
     cache_provider = InMemoryCacheProvider()
     cache_provider.setex("test:analytics:umami:access-token", 60, "fresh-token")
 
     class CacheWrapper:
-        def get(self, key: object):
+        def get(self, key: object) -> object:
             return cache_provider.get(key)
 
-        def setex(self, key: object, ttl: object, value: object):
+        def setex(self, key: object, ttl: object, value: object) -> object:
             return cache_provider.setex(key, ttl, value)
 
         def lock(
@@ -394,7 +394,7 @@ def test_login_for_access_token_rechecks_cache_when_lock_is_busy(
             key: object,
             timeout: object = None,
             blocking_timeout: object = None,
-        ):
+        ) -> object:
             _ = (key, timeout, blocking_timeout)
             return BusyLock()
 
@@ -422,10 +422,10 @@ def test_login_for_access_token_returns_token_when_cache_write_fails(
         def __init__(self) -> None:
             self._cache = InMemoryCacheProvider()
 
-        def get(self, key: object):
+        def get(self, key: object) -> object:
             return self._cache.get(key)
 
-        def setex(self, key: object, ttl: object, value: object):
+        def setex(self, key: object, ttl: object, value: object) -> None:
             _ = (key, ttl, value)
             message = "cache unavailable"
             raise RuntimeError(message)
@@ -435,7 +435,7 @@ def test_login_for_access_token_returns_token_when_cache_write_fails(
             key: object,
             timeout: object = None,
             blocking_timeout: object = None,
-        ):
+        ) -> object:
             return self._cache.lock(
                 key, timeout=timeout, blocking_timeout=blocking_timeout
             )

--- a/src/api/tests/service/common/test_uow.py
+++ b/src/api/tests/service/common/test_uow.py
@@ -32,7 +32,7 @@ def test_outermost_commits_on_clean_exit(app: object) -> None:
 def test_outermost_rolls_back_on_exception(app: object) -> None:
     with app.app_context():
 
-        def write_then_fail():
+        def write_then_fail() -> None:
             with uow.unit_of_work():
                 dao.db.session.add(_make_shifu("uow-rollback-1"))
                 dao.db.session.flush()
@@ -47,11 +47,11 @@ def test_outermost_rolls_back_on_exception(app: object) -> None:
 def test_nested_block_joins_outer_transaction(app: object) -> None:
     with app.app_context():
 
-        def helper():
+        def helper() -> None:
             with uow.unit_of_work():
                 dao.db.session.add(_make_shifu("uow-nested-inner-1"))
 
-        def outer_fails_after_helper():
+        def outer_fails_after_helper() -> None:
             with uow.unit_of_work():
                 helper()
                 dao.db.session.add(_make_shifu("uow-nested-outer-1"))
@@ -89,7 +89,7 @@ def test_depth_is_isolated_per_thread(app: object) -> None:
     """The /run producer runs in its own thread; depth must not leak across."""
     seen = {}
 
-    def worker():
+    def worker() -> None:
         seen["inside_thread"] = uow.in_unit_of_work()
 
     with app.app_context(), uow.unit_of_work():
@@ -129,7 +129,7 @@ def test_on_commit_dropped_on_rollback(app: object) -> None:
     calls = []
     with app.app_context():
 
-        def schedule_then_fail():
+        def schedule_then_fail() -> None:
             with uow.unit_of_work():
                 uow.on_commit(lambda: calls.append("never"))
                 message = "boom"
@@ -143,7 +143,7 @@ def test_on_commit_dropped_on_rollback(app: object) -> None:
 def test_on_commit_callback_exception_does_not_propagate(app: object) -> None:
     calls = []
 
-    def boom():
+    def boom() -> None:
         message = "callback boom"
         raise RuntimeError(message)
 

--- a/src/api/tests/service/creator_analytics/conftest.py
+++ b/src/api/tests/service/creator_analytics/conftest.py
@@ -55,7 +55,7 @@ def _clear_tables() -> None:
 
 
 @pytest.fixture(autouse=True)
-def _isolate_creator_analytics_tables(app: object):
+def _isolate_creator_analytics_tables(app: object) -> object:
     if app is None:
         yield
         return

--- a/src/api/tests/service/creator_analytics/test_credit_detail.py
+++ b/src/api/tests/service/creator_analytics/test_credit_detail.py
@@ -30,13 +30,13 @@ ENDPOINT = "/api/creator-analytics/credit-detail"
 
 
 @pytest.fixture(autouse=True)
-def _reset_analytics_engine_singleton():
+def _reset_analytics_engine_singleton() -> object:
     analytics_engine.reset_for_tests()
     yield
     analytics_engine.reset_for_tests()
 
 
-def _post(test_client: object, body: object):
+def _post(test_client: object, body: object) -> object:
     return test_client.post(ENDPOINT, json=body)
 
 

--- a/src/api/tests/service/creator_analytics/test_dsl.py
+++ b/src/api/tests/service/creator_analytics/test_dsl.py
@@ -20,7 +20,7 @@ from flaskr.service.creator_analytics.dsl import (
 DEFAULT_LIMIT_MAX = 1000
 
 
-def _payload(**overrides: object):
+def _payload(**overrides: object) -> object:
     base = {
         "shifu_bid": "shifu-abc",
         "table": "learn_progress_records",
@@ -31,7 +31,7 @@ def _payload(**overrides: object):
     return base
 
 
-def _parse(payload: object):
+def _parse(payload: object) -> object:
     return parse_dsl(payload, limit_max=DEFAULT_LIMIT_MAX)
 
 
@@ -372,7 +372,7 @@ def test_select_user_bid_with_group_by_other_dimension_is_rejected() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _content_payload(**overrides: object):
+def _content_payload(**overrides: object) -> object:
     base = {
         "shifu_bid": "shifu-abc",
         "table": "learn_generated_blocks",
@@ -436,7 +436,7 @@ def test_generated_content_limit_at_100_is_allowed() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _user_users_payload(**overrides: object):
+def _user_users_payload(**overrides: object) -> object:
     base = {
         "shifu_bid": "shifu-abc",
         "table": "user_users",
@@ -504,7 +504,7 @@ def test_user_users_select_disallowed_column_rejected() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _user_users_identify_payload(**overrides: object):
+def _user_users_identify_payload(**overrides: object) -> object:
     base = {
         "shifu_bid": "shifu-abc",
         "table": "user_users",
@@ -579,7 +579,7 @@ def test_user_users_user_identify_not_groupable() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _daily_metric_payload(**overrides: object):
+def _daily_metric_payload(**overrides: object) -> object:
     base = {
         "shifu_bid": "shifu-abc",
         "table": "bill_daily_usage_metrics",
@@ -651,7 +651,7 @@ def test_bill_usage_table_rejected() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _generated_blocks_payload(**overrides: object):
+def _generated_blocks_payload(**overrides: object) -> object:
     """Build a baseline DSL payload for learn_generated_blocks tests."""
     base = {
         "shifu_bid": "shifu-abc",
@@ -765,7 +765,7 @@ def test_bill_daily_creator_bid_filter_rejected() -> None:
 
 def _shifu_meta_payload(
     table_key: object = "shifu_published_shifus", **overrides: object
-):
+) -> object:
     """Build a baseline DSL payload for shifu metadata-table tests."""
     base = {
         "shifu_bid": "shifu-abc",

--- a/src/api/tests/service/creator_analytics/test_query.py
+++ b/src/api/tests/service/creator_analytics/test_query.py
@@ -24,14 +24,14 @@ ENDPOINT = "/api/creator-analytics/query"
 
 
 @pytest.fixture(autouse=True)
-def _reset_analytics_engine_singleton():
+def _reset_analytics_engine_singleton() -> object:
     """Ensure each test starts with the cached fallback engine cleared."""
     analytics_engine.reset_for_tests()
     yield
     analytics_engine.reset_for_tests()
 
 
-def _post(test_client: object, body: object):
+def _post(test_client: object, body: object) -> object:
     return test_client.post(ENDPOINT, json=body)
 
 
@@ -707,7 +707,7 @@ def test_dedicated_engine_replacement_disposes_previous_owner(
 
     created: list[_FakeEngine] = []
 
-    def fake_create_engine(uri: object, **_kwargs: object):
+    def fake_create_engine(uri: object, **_kwargs: object) -> object:
         engine = _FakeEngine(uri)
         created.append(engine)
         return engine

--- a/src/api/tests/service/creator_analytics/test_sql_builder.py
+++ b/src/api/tests/service/creator_analytics/test_sql_builder.py
@@ -292,7 +292,9 @@ def test_generated_blocks_status_explicit_filter_does_not_override_auto() -> Non
 # ---------------------------------------------------------------------------
 
 
-def _meta_payload(table_key: object = "shifu_published_shifus", **overrides: object) -> object:
+def _meta_payload(
+    table_key: object = "shifu_published_shifus", **overrides: object
+) -> object:
     """Build a baseline DSL payload for shifu metadata-table compile tests."""
     base = {
         "shifu_bid": "shifu-abc",

--- a/src/api/tests/service/creator_analytics/test_sql_builder.py
+++ b/src/api/tests/service/creator_analytics/test_sql_builder.py
@@ -16,7 +16,7 @@ LIMIT_MAX = 1000
 
 def _compile_for(
     dialect: object, payload: object, dialect_name: object, user_id: object = ""
-):
+) -> object:
     dsl = parse_dsl(payload, limit_max=LIMIT_MAX, user_id=user_id)
     stmt = build_statement(dsl, dialect_name=dialect_name)
     return str(
@@ -27,11 +27,11 @@ def _compile_for(
     )
 
 
-def _compile_mysql(payload: object, user_id: object = ""):
+def _compile_mysql(payload: object, user_id: object = "") -> object:
     return _compile_for(mysql.dialect(), payload, "mysql", user_id=user_id)
 
 
-def _compile_sqlite(payload: object, user_id: object = ""):
+def _compile_sqlite(payload: object, user_id: object = "") -> object:
     return _compile_for(sqlite.dialect(), payload, "sqlite", user_id=user_id)
 
 
@@ -292,7 +292,7 @@ def test_generated_blocks_status_explicit_filter_does_not_override_auto() -> Non
 # ---------------------------------------------------------------------------
 
 
-def _meta_payload(table_key: object = "shifu_published_shifus", **overrides: object):
+def _meta_payload(table_key: object = "shifu_published_shifus", **overrides: object) -> object:
     """Build a baseline DSL payload for shifu metadata-table compile tests."""
     base = {
         "shifu_bid": "shifu-abc",

--- a/src/api/tests/service/dashboard/test_dashboard_routes.py
+++ b/src/api/tests/service/dashboard/test_dashboard_routes.py
@@ -74,7 +74,9 @@ def _isolate_dashboard_tables(app: object) -> object:
 class TestDashboardRoutes:
     """Verify dashboard routes behavior."""
 
-    def _mock_request_user(self, monkeypatch: object, *, user_id: str = "teacher-1") -> None:
+    def _mock_request_user(
+        self, monkeypatch: object, *, user_id: str = "teacher-1"
+    ) -> None:
         dummy_user = SimpleNamespace(
             user_id=user_id,
             language="en-US",

--- a/src/api/tests/service/dashboard/test_dashboard_routes.py
+++ b/src/api/tests/service/dashboard/test_dashboard_routes.py
@@ -56,7 +56,7 @@ def _clear_dashboard_tables() -> None:
 
 
 @pytest.fixture(autouse=True)
-def _isolate_dashboard_tables(app: object):
+def _isolate_dashboard_tables(app: object) -> object:
     if app is None:
         yield
         return
@@ -74,7 +74,7 @@ def _isolate_dashboard_tables(app: object):
 class TestDashboardRoutes:
     """Verify dashboard routes behavior."""
 
-    def _mock_request_user(self, monkeypatch: object, *, user_id: str = "teacher-1"):
+    def _mock_request_user(self, monkeypatch: object, *, user_id: str = "teacher-1") -> None:
         dummy_user = SimpleNamespace(
             user_id=user_id,
             language="en-US",

--- a/src/api/tests/service/learn/run/test_run_disconnect_e2e.py
+++ b/src/api/tests/service/learn/run/test_run_disconnect_e2e.py
@@ -44,7 +44,7 @@ STREAMED_MARKER = "Hello "
 STREAMED_FULL_TEXT = "Hello golden learner."
 
 
-def _open_run_generator(app: object, user_bid: str, shifu: object, *, input_type: str):
+def _open_run_generator(app: object, user_bid: str, shifu: object, *, input_type: str) -> object:
     from flaskr.service.learn.runscript_v2 import run_script_inner
 
     return run_script_inner(
@@ -73,7 +73,7 @@ def _consume_until_streaming(generator: object) -> list:
     raise AssertionError(message)
 
 
-def _load_rows(app: object, user_bid: str):
+def _load_rows(app: object, user_bid: str) -> object:
     from flaskr.service.learn.models import LearnGeneratedBlock, LearnProgressRecord
 
     with app.app_context():

--- a/src/api/tests/service/learn/run/test_run_disconnect_e2e.py
+++ b/src/api/tests/service/learn/run/test_run_disconnect_e2e.py
@@ -44,7 +44,9 @@ STREAMED_MARKER = "Hello "
 STREAMED_FULL_TEXT = "Hello golden learner."
 
 
-def _open_run_generator(app: object, user_bid: str, shifu: object, *, input_type: str) -> object:
+def _open_run_generator(
+    app: object, user_bid: str, shifu: object, *, input_type: str
+) -> object:
     from flaskr.service.learn.runscript_v2 import run_script_inner
 
     return run_script_inner(

--- a/src/api/tests/service/learn/run/test_run_emitter.py
+++ b/src/api/tests/service/learn/run/test_run_emitter.py
@@ -32,19 +32,19 @@ class _RecordingEmitter:
 
     def render_outline_updates(
         self, outline_updates: object, new_chapter: object = False
-    ):
+    ) -> object:
         self.calls.append(("render_outline_updates", outline_updates, new_chapter))
         yield "outline-event"
 
-    def emit_next_chapter_interaction(self, progress_record: object):
+    def emit_next_chapter_interaction(self, progress_record: object) -> object:
         self.calls.append(("emit_next_chapter_interaction", progress_record))
         yield "next-event"
 
-    def emit_lesson_feedback_interaction(self, progress_record: object):
+    def emit_lesson_feedback_interaction(self, progress_record: object) -> object:
         self.calls.append(("emit_lesson_feedback_interaction", progress_record))
         yield "feedback-event"
 
-    def is_access_gate_blocking_interaction(self, parsed_interaction: object):
+    def is_access_gate_blocking_interaction(self, parsed_interaction: object) -> object:
         self.calls.append(("is_access_gate_blocking_interaction", parsed_interaction))
         return True
 
@@ -54,7 +54,7 @@ class _RecordingEmitter:
         parsed_interaction: object,
         progress_record: object,
         is_tail_gate: object,
-    ):
+    ) -> object:
         self.calls.append(
             (
                 "maybe_emit_feedback_after_access_gate",
@@ -65,15 +65,15 @@ class _RecordingEmitter:
         )
         yield "gate-feedback-event"
 
-    def emit_feedback_after_exception_gate(self):
+    def emit_feedback_after_exception_gate(self) -> object:
         self.calls.append(("emit_feedback_after_exception_gate",))
         yield "exception-feedback-event"
 
-    def ensure_current_attend_for_gate_interaction(self):
+    def ensure_current_attend_for_gate_interaction(self) -> object:
         self.calls.append(("ensure_current_attend_for_gate_interaction",))
         return "attend"
 
-    def emit_current_progress_gate_interaction(self, content: object):
+    def emit_current_progress_gate_interaction(self, content: object) -> object:
         self.calls.append(("emit_current_progress_gate_interaction", content))
         yield "gate-interaction-event"
 
@@ -83,7 +83,7 @@ class _RecordingEmitter:
         progress_record: object,
         current_outline_completed: object,
         has_next_outline_item: object,
-    ):
+    ) -> object:
         self.calls.append(
             (
                 "emit_completion_tail_interactions",
@@ -192,11 +192,11 @@ class EmitterContextSeamTests(unittest.TestCase):
         ctx = _make_context()
         calls: list[str] = []
 
-        def _emit_feedback(_progress: object):
+        def _emit_feedback(_progress: object) -> object:
             calls.append("feedback")
             yield "feedback-event"
 
-        def _emit_next(_progress: object):
+        def _emit_next(_progress: object) -> object:
             calls.append("next")
             yield "next-event"
 
@@ -218,7 +218,7 @@ class EmitterContextSeamTests(unittest.TestCase):
         ctx = _make_context()
         calls: list[str] = []
 
-        def _emit_feedback(_progress: object):
+        def _emit_feedback(_progress: object) -> object:
             calls.append("feedback")
             yield "feedback-event"
 

--- a/src/api/tests/service/learn/run/test_run_recorder.py
+++ b/src/api/tests/service/learn/run/test_run_recorder.py
@@ -49,7 +49,7 @@ def recorder_app() -> Flask:
         dao.db.drop_all()
 
 
-def _seed_attend(progress_record_bid: str = "progress-recorder-0001"):
+def _seed_attend(progress_record_bid: str = "progress-recorder-0001") -> object:
     attend = LearnProgressRecord(
         progress_record_bid=progress_record_bid,
         shifu_bid=SHIFU_BID,
@@ -82,7 +82,7 @@ def _fail_next_flush(monkeypatch: object, exc: Exception) -> None:
     real_flush = dao.db.session.flush
     state = {"fired": False}
 
-    def _boom(*args: object, **kwargs: object):
+    def _boom(*args: object, **kwargs: object) -> object:
         if not state["fired"]:
             state["fired"] = True
             raise exc

--- a/src/api/tests/service/learn/test_ask_provider_adapters.py
+++ b/src/api/tests/service/learn/test_ask_provider_adapters.py
@@ -32,15 +32,15 @@ class _FakeResponse:
         self._json_data = json_data
         self._json_error = json_error
 
-    def iter_lines(self, decode_unicode: object = True):
+    def iter_lines(self, decode_unicode: object = True) -> object:
         _ = decode_unicode
         yield from self._lines
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         if self._http_error is not None:
             raise self._http_error
 
-    def json(self):
+    def json(self) -> object:
         if self._json_error is not None:
             raise self._json_error
         return self._json_data
@@ -58,7 +58,7 @@ def test_dify_adapter_streams_success_content(app: object, monkeypatch: object) 
         }.get,
     )
 
-    def _fake_post(*_args: object, **kwargs: object):
+    def _fake_post(*_args: object, **kwargs: object) -> object:
         request_state["json"] = kwargs.get("json")
         return _FakeResponse(
             lines=[
@@ -116,7 +116,7 @@ def test_coze_adapter_timeout_raises_timeout_error(
         }.get,
     )
 
-    def _raise_timeout(*_args: object, **_kwargs: object):
+    def _raise_timeout(*_args: object, **_kwargs: object) -> None:
         message = "timeout"
         raise requests.Timeout(message)
 
@@ -212,7 +212,7 @@ def test_coze_workflow_adapter_streams_success_content(
         }.get,
     )
 
-    def _fake_post(url: object, **kwargs: object):
+    def _fake_post(url: object, **kwargs: object) -> object:
         request_state["url"] = url
         request_state["json"] = kwargs.get("json")
         request_state["headers"] = kwargs.get("headers") or {}
@@ -372,7 +372,7 @@ def test_coze_adapter_uses_default_base_url_when_missing(
         }.get,
     )
 
-    def _fake_post(url: object, **kwargs: object):
+    def _fake_post(url: object, **kwargs: object) -> object:
         request_state["url"] = url
         request_state["json"] = kwargs["json"]
         return _FakeResponse(
@@ -419,7 +419,7 @@ def test_volc_knowledge_adapter_streams_success_content(
 
     request_state = {}
 
-    def _fake_request(*_args: object, **kwargs: object):
+    def _fake_request(*_args: object, **kwargs: object) -> object:
         request_state["method"] = kwargs.get("method")
         request_state["headers"] = kwargs.get("headers") or {}
         request_state["url"] = kwargs.get("url")
@@ -503,7 +503,7 @@ def test_get_biji_knowledge_adapter_synthesizes_with_llm_context(
 
     request_state = {}
 
-    def _fake_post(url: object, **kwargs: object):
+    def _fake_post(url: object, **kwargs: object) -> object:
         request_state["url"] = url
         request_state["headers"] = kwargs.get("headers") or {}
         request_state["json"] = kwargs.get("json")
@@ -539,7 +539,7 @@ def test_get_biji_knowledge_adapter_synthesizes_with_llm_context(
 
     captured_context = {}
 
-    def _context_stream_factory(knowledge_context: object):
+    def _context_stream_factory(knowledge_context: object) -> object:
         captured_context["value"] = knowledge_context
         return iter(
             [
@@ -620,7 +620,7 @@ def test_get_biji_knowledge_adapter_skips_results_without_title_or_content(
 
     captured_context = {}
 
-    def _context_stream_factory(knowledge_context: object):
+    def _context_stream_factory(knowledge_context: object) -> object:
         captured_context["value"] = knowledge_context
         return iter([types.SimpleNamespace(result="answer")])
 
@@ -664,7 +664,7 @@ def test_get_biji_knowledge_adapter_empty_results_synthesizes_with_empty_context
 
     captured_context = {}
 
-    def _context_stream_factory(knowledge_context: object):
+    def _context_stream_factory(knowledge_context: object) -> object:
         captured_context["value"] = knowledge_context
         return iter([types.SimpleNamespace(result="fallback answer")])
 
@@ -772,7 +772,7 @@ def test_get_biji_knowledge_adapter_timeout_raises_timeout_error(
 ) -> None:
     adapter = module.GetBijiKnowledgeAskProviderAdapter()
 
-    def _raise_timeout(*_args: object, **_kwargs: object):
+    def _raise_timeout(*_args: object, **_kwargs: object) -> None:
         message = "timeout"
         raise requests.Timeout(message)
 

--- a/src/api/tests/service/learn/test_ask_provider_langfuse.py
+++ b/src/api/tests/service/learn/test_ask_provider_langfuse.py
@@ -12,7 +12,7 @@ class _DummyGeneration:
         self.kwargs = kwargs
         self.end_kwargs = {}
 
-    def end(self, **kwargs: object):
+    def end(self, **kwargs: object) -> None:
         self.end_kwargs = kwargs
 
 
@@ -24,7 +24,7 @@ class _DummySpan:
         self.id = span_id
         self.generations = []
 
-    def generation(self, **kwargs: object):
+    def generation(self, **kwargs: object) -> object:
         generation = _DummyGeneration(**kwargs)
         self.generations.append(generation)
         return generation

--- a/src/api/tests/service/learn/test_context_v2.py
+++ b/src/api/tests/service/learn/test_context_v2.py
@@ -19,7 +19,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> None:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -149,10 +149,10 @@ class _FakeLangfuseSpan:
         self.updated = {}
         self.end_kwargs = {}
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updated = kwargs
 
-    def end(self, **kwargs: object):
+    def end(self, **kwargs: object) -> None:
         self.end_kwargs = kwargs
 
 
@@ -160,7 +160,7 @@ class _FakeLangfuseTrace:
     def __init__(self) -> None:
         self.updated = {}
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updated = kwargs
 
 
@@ -232,7 +232,7 @@ class CollectAsyncGeneratorTests(unittest.TestCase):
     def test_without_running_loop(self) -> None:
         ctx = _make_context()
 
-        async def sample():
+        async def sample() -> object:
             yield "one"
             yield "two"
 
@@ -243,10 +243,10 @@ class CollectAsyncGeneratorTests(unittest.TestCase):
     def test_inside_running_loop(self) -> None:
         ctx = _make_context()
 
-        async def sample():
+        async def sample() -> object:
             yield "alpha"
 
-        async def runner():
+        async def runner() -> None:
             result = ctx._collect_async_generator(sample)
             assert result == ["alpha"]
 
@@ -263,7 +263,7 @@ class RunAsyncInSafeContextTests(unittest.TestCase):
     def test_without_running_loop(self) -> None:
         ctx = _make_context()
 
-        async def sample():
+        async def sample() -> object:
             return "result"
 
         assert ctx._run_async_in_safe_context(sample) == "result"
@@ -271,10 +271,10 @@ class RunAsyncInSafeContextTests(unittest.TestCase):
     def test_inside_running_loop(self) -> None:
         ctx = _make_context()
 
-        async def sample():
+        async def sample() -> object:
             return "loop"
 
-        async def runner():
+        async def runner() -> None:
             assert ctx._run_async_in_safe_context(sample) == "loop"
 
         asyncio.run(runner())
@@ -372,11 +372,11 @@ class CompletionTailInteractionTests(unittest.TestCase):
         ctx = _make_context()
         calls: list[str] = []
 
-        def _emit_feedback(_progress: object):
+        def _emit_feedback(_progress: object) -> object:
             calls.append("feedback")
             yield "feedback-event"
 
-        def _emit_next(_progress: object):
+        def _emit_next(_progress: object) -> object:
             calls.append("next")
             yield "next-event"
 
@@ -398,11 +398,11 @@ class CompletionTailInteractionTests(unittest.TestCase):
         ctx = _make_context()
         calls: list[str] = []
 
-        def _emit_feedback(_progress: object):
+        def _emit_feedback(_progress: object) -> object:
             calls.append("feedback")
             yield "feedback-event"
 
-        def _emit_next(_progress: object):
+        def _emit_next(_progress: object) -> object:
             calls.append("next")
             yield "next-event"
 
@@ -424,11 +424,11 @@ class CompletionTailInteractionTests(unittest.TestCase):
         ctx = _make_context()
         calls: list[str] = []
 
-        def _emit_feedback(_progress: object):
+        def _emit_feedback(_progress: object) -> object:
             calls.append("feedback")
             yield "feedback-event"
 
-        def _emit_next(_progress: object):
+        def _emit_next(_progress: object) -> object:
             calls.append("next")
             yield "next-event"
 
@@ -460,7 +460,7 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
         class _Column:
             __hash__ = None
 
-            def in_(self, _values: object):
+            def in_(self, _values: object) -> object:
                 return self
 
             def __eq__(self, _other: object) -> "_Column":
@@ -473,17 +473,17 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
             deleted = _Column()
 
         class _FakeQuery:
-            def filter(self, *_args: object, **_kwargs: object):
+            def filter(self, *_args: object, **_kwargs: object) -> object:
                 return self
 
-            def all(self):
+            def all(self) -> object:
                 return [("outline-1", False, "Outline 1")]
 
         class _FakeMarkdownFlow:
             def __init__(self, *args: object, **kwargs: object) -> None:
                 pass
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> object:
                 return [object(), object()]
 
         outline_item = HistoryItem(
@@ -545,7 +545,7 @@ class RuntimeOutlineBlockCountTests(unittest.TestCase):
             def __init__(self, *args: object, **kwargs: object) -> None:
                 pass
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> object:
                 return [object(), object()]
 
         with (
@@ -732,11 +732,11 @@ class StreamTtsGateTests(unittest.TestCase):
 
         idle_ticks: list[int] = []
 
-        def delayed_stream():
+        def delayed_stream() -> object:
             time.sleep(0.05)
             yield "chunk-1"
 
-        def on_idle():
+        def on_idle() -> object:
             idle_ticks.append(len(idle_ticks))
             yield f"idle-{len(idle_ticks)}"
 
@@ -780,7 +780,7 @@ class StreamTtsGateTests(unittest.TestCase):
                     raise StopIteration
                 return "chunk-2"
 
-            def close(self):
+            def close(self) -> None:
                 self.close_calls += 1
 
         stream = ClosableStream()
@@ -1072,14 +1072,14 @@ class StreamTtsTeardownTests(unittest.TestCase):
             def __init__(self) -> None:
                 self.finalize_calls = []
 
-            def finalize(self, *, commit: object = True):
+            def finalize(self, *, commit: object = True) -> object:
                 self.finalize_calls.append(commit)
                 yield "audio-complete"
 
         flush_calls: list[str] = []
         processor = _FakeProcessor()
 
-        def _flush_content_cache():
+        def _flush_content_cache() -> object:
             flush_calls.append("flush")
             yield "content-flush"
 
@@ -1109,7 +1109,7 @@ class StreamTtsTeardownTests(unittest.TestCase):
             def __init__(self) -> None:
                 self.finalize_calls = 0
 
-            def finalize(self, *, commit: object = True):
+            def finalize(self, *, commit: object = True) -> object:
                 _ = commit
                 self.finalize_calls += 1
                 yield "audio-complete"
@@ -1117,7 +1117,7 @@ class StreamTtsTeardownTests(unittest.TestCase):
         flush_calls: list[str] = []
         processor = _FakeProcessor()
 
-        def _flush_content_cache():
+        def _flush_content_cache() -> object:
             flush_calls.append("flush")
             yield "content-flush"
 
@@ -1146,7 +1146,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
                 self.args = args
                 self.kwargs = kwargs
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(self, *_args: object, **_kwargs: object) -> object:
                 return self
 
         with patch("flaskr.service.learn.context_v2.MarkdownFlow", FakeMarkdownFlow):
@@ -1160,10 +1160,10 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
                 _ = (args, kwargs)
                 self.visual_mode = None
 
-            def set_visual_mode(self, visual_mode: object):
+            def set_visual_mode(self, visual_mode: object) -> None:
                 self.visual_mode = visual_mode
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(self, *_args: object, **_kwargs: object) -> object:
                 return self
 
         with patch("flaskr.service.learn.context_v2.MarkdownFlow", FakeMarkdownFlow):
@@ -1177,7 +1177,7 @@ class MdflowContextCompatibilityTests(unittest.TestCase):
                 _ = (args, kwargs)
                 self.output_language = None
 
-            def set_output_language(self, language: object):
+            def set_output_language(self, language: object) -> object:
                 self.output_language = language
                 return self
 
@@ -1732,7 +1732,7 @@ class LangfuseTraceFinalizationTests(unittest.TestCase):
 
         def _fake_create_trace_with_root_span(
             *, client: object, trace_payload: object, root_span_payload: object
-        ):
+        ) -> object:
             captured["client"] = client
             captured["trace_payload"] = trace_payload
             captured["root_span_payload"] = root_span_payload
@@ -1848,10 +1848,10 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
             def __init__(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def get_context(self, *_args: object, **_kwargs: object):
+            def get_context(self, *_args: object, **_kwargs: object) -> object:
                 return []
 
-            def replace_context(self, *_args: object, **_kwargs: object):
+            def replace_context(self, *_args: object, **_kwargs: object) -> None:
                 return None
 
         class _FakePreviewMdflowContext:
@@ -1868,12 +1868,12 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
             ) -> object:
                 return context
 
-            def get_block(self, _block_index: object):
+            def get_block(self, _block_index: object) -> object:
                 return types.SimpleNamespace(
                     block_type=PreviewBlockType.CONTENT, content="Prompt block"
                 )
 
-            def process(self, **_kwargs: object):
+            def process(self, **_kwargs: object) -> object:
                 return (
                     item
                     for item in [
@@ -1889,12 +1889,12 @@ class PreviewLangfuseTraceTests(unittest.TestCase):
             def __init__(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def process(self, events: object):
+            def process(self, events: object) -> object:
                 return events
 
         def _fake_create_trace_with_root_span(
             *, client: object, trace_payload: object, root_span_payload: object
-        ):
+        ) -> object:
             _ = client, root_span_payload
             captured["trace_payload"] = trace_payload
             trace = _FakeLangfuseTrace()
@@ -2195,10 +2195,10 @@ class _InMemoryCache:
     def __init__(self) -> None:
         self.store: dict[str, str] = {}
 
-    def get(self, key: str):
+    def get(self, key: str) -> object:
         return self.store.get(key)
 
-    def setex(self, key: str, _ttl: int, value: object):
+    def setex(self, key: str, _ttl: int, value: object) -> None:
         self.store[key] = value
 
     def delete(self, *keys: str) -> int:
@@ -2286,7 +2286,7 @@ class PreviewSentPromptCaptureTests(unittest.TestCase):
 class PreviewContextStoreTruncationTests(unittest.TestCase):
     """Verify preview context store truncation behavior."""
 
-    def _populate(self, store: object, doc: object, indices: object):
+    def _populate(self, store: object, doc: object, indices: object) -> None:
         for idx in indices:
             store.append_context(doc, idx, f"u{idx}", f"a{idx}")
 
@@ -2433,7 +2433,7 @@ class RuntimeExceptionLangfuseTests(unittest.TestCase):
         app = Flask("runtime-langfuse-paid")
         ctx = _make_context()
 
-        def _raise_paid(_app: object):
+        def _raise_paid(_app: object) -> None:
             raise PaidError
 
         ctx.run_inner = _raise_paid
@@ -2457,7 +2457,7 @@ class BuildContextFromBlocksTests(unittest.TestCase):
         "Second content {{nickname}}."
     )
 
-    def _blocks(self):
+    def _blocks(self) -> object:
         return [
             types.SimpleNamespace(
                 type=BLOCK_TYPE_MDCONTENT_VALUE,
@@ -2597,7 +2597,7 @@ class StreamContentBlockPromptCaptureTests(unittest.TestCase):
         with cls.app.app_context():
             dao.db.create_all()
 
-    def _run_stream_phase(self, stream_items: object):
+    def _run_stream_phase(self, stream_items: object) -> object:
         ctx = _make_context()
         ctx.app = self.app
         ctx._input_type = "normal"
@@ -2610,7 +2610,7 @@ class StreamContentBlockPromptCaptureTests(unittest.TestCase):
         # _recorder is a lazy read-only property backed by __dict__.
         ctx.__dict__["_run_recorder"] = MagicMock()
 
-        def fake_stream():
+        def fake_stream() -> object:
             yield from stream_items
 
         mdflow_context = types.SimpleNamespace(process=lambda **_kwargs: fake_stream())
@@ -2686,7 +2686,7 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
     )
     INTERACTION = "?[网络招聘网站 | 猎头公司 | 人才测评 | 培训业务]"
 
-    def _blocks(self, selection: object):
+    def _blocks(self, selection: object) -> object:
         return [
             types.SimpleNamespace(
                 type=BLOCK_TYPE_MDCONTENT_VALUE,
@@ -2783,7 +2783,7 @@ class BuildContextNoVariableInteractionTests(unittest.TestCase):
 class TraceSessionBindingTests(unittest.TestCase):
     """Cover the langfuse session id binding of a runtime step."""
 
-    def _context(self, trace: object):
+    def _context(self, trace: object) -> object:
         ctx = _make_context()
         ctx.app = MagicMock()
         ctx._trace = trace

--- a/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
+++ b/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
@@ -9,7 +9,7 @@ from flaskr.service.learn.context_v2 import RunScriptContextV2
 _PRODUCER_THREAD_NAME = "mdflow_stream_result_producer"
 
 
-def _make_context_stub(app: object):
+def _make_context_stub(app: object) -> object:
     stub = types.SimpleNamespace(app=app)
     stub._stop_requested = lambda: False
     stub._stop_if_requested = lambda: None
@@ -19,7 +19,7 @@ def _make_context_stub(app: object):
 def test_stream_producer_stops_when_consumer_exits_early(app: object) -> None:
     stop_streaming = threading.Event()
 
-    def endless_stream():
+    def endless_stream() -> object:
         index = 0
         while not stop_streaming.is_set():
             yield index
@@ -61,7 +61,7 @@ def test_early_consumer_exit_invalidates_producer_session(
 
     stop_streaming = threading.Event()
 
-    def endless_stream():
+    def endless_stream() -> object:
         index = 0
         while not stop_streaming.is_set():
             yield index
@@ -95,7 +95,7 @@ def test_natural_exhaustion_does_not_invalidate_producer_session(
         lambda *, source, _session=None: invalidations.append(source) or True,
     )
 
-    def short_stream():
+    def short_stream() -> object:
         yield "a"
         yield "b"
 
@@ -125,7 +125,7 @@ def test_tts_finalize_failure_runs_classified_cleanup(
 
     outcomes = []
 
-    def cleanup_session_after(exc: object, *, source: object, session: object = None):
+    def cleanup_session_after(exc: object, *, source: object, session: object = None) -> object:
         del session
         outcomes.append((type(exc).__name__, source))
         return "invalidated"
@@ -139,7 +139,7 @@ def test_tts_finalize_failure_runs_classified_cleanup(
     class _FailingProcessor:
         next_element_index = 0
 
-        def finalize(self, *, commit: object):
+        def finalize(self, *, commit: object) -> object:
             _ = commit
             message = "desynced during finalize"
             raise ResourceClosedError(message)

--- a/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
+++ b/src/api/tests/service/learn/test_context_v2_stream_producer_stop.py
@@ -125,7 +125,9 @@ def test_tts_finalize_failure_runs_classified_cleanup(
 
     outcomes = []
 
-    def cleanup_session_after(exc: object, *, source: object, session: object = None) -> object:
+    def cleanup_session_after(
+        exc: object, *, source: object, session: object = None
+    ) -> object:
         del session
         outcomes.append((type(exc).__name__, source))
         return "invalidated"

--- a/src/api/tests/service/learn/test_element_protocol.py
+++ b/src/api/tests/service/learn/test_element_protocol.py
@@ -50,7 +50,7 @@ class _FollowUpDummyGeneration:
         self.kwargs = kwargs
         self.end_kwargs = {}
 
-    def end(self, **kwargs: object):
+    def end(self, **kwargs: object) -> None:
         self.end_kwargs = kwargs
 
 
@@ -60,21 +60,21 @@ class _FollowUpDummySpan:
         self.updated = {}
         self.output = ""
 
-    def generation(self, **kwargs: object):
+    def generation(self, **kwargs: object) -> object:
         generation = _FollowUpDummyGeneration(**kwargs)
         self.generations.append(generation)
         return generation
 
-    def span(self, **_kwargs: object):
+    def span(self, **_kwargs: object) -> object:
         return _FollowUpDummySpan()
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updated = kwargs
 
-    def event(self, **_kwargs: object):
+    def event(self, **_kwargs: object) -> None:
         return None
 
-    def end(self, output: object = None, **kwargs: object):
+    def end(self, output: object = None, **kwargs: object) -> None:
         self.output = output or ""
         self.end_kwargs = {"output": output, **kwargs}
 
@@ -83,10 +83,10 @@ class _FollowUpDummyTrace:
     def __init__(self) -> None:
         self.updated = {}
 
-    def span(self, **_kwargs: object):
+    def span(self, **_kwargs: object) -> object:
         return _FollowUpDummySpan()
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updated = kwargs
 
 
@@ -95,10 +95,10 @@ class _FollowUpContext:
         self._shifu_info = types.SimpleNamespace(use_learner_language=0)
         self.langfuse_outputs = []
 
-    def get_system_prompt(self, _outline_bid: str):
+    def get_system_prompt(self, _outline_bid: str) -> object:
         return "COURSE_PROMPT"
 
-    def append_langfuse_output(self, value: str):
+    def append_langfuse_output(self, value: str) -> None:
         self.langfuse_outputs.append(value)
 
 
@@ -122,7 +122,7 @@ def _setup_handle_input_ask_test_doubles(
     ask_provider_config: object,
     *,
     patch_generated_blocks: bool = True,
-):
+) -> None:
     from flaskr.service.learn.ask_provider_adapters import AskProviderError
 
     class _DummyLLMSettings:
@@ -186,7 +186,7 @@ def _setup_handle_input_ask_test_doubles(
 
         call_counter = {"index": 0}
 
-        def _fake_init_generated_block(*_args: object, **_kwargs: object):
+        def _fake_init_generated_block(*_args: object, **_kwargs: object) -> object:
             call_counter["index"] += 1
             return types.SimpleNamespace(
                 generated_block_bid=f"gb-{call_counter['index']}",
@@ -269,7 +269,7 @@ class TestElementType:
 class TestElementDTONewFields:
     """Verify element DTO new fields behavior."""
 
-    def _make_dto(self, **overrides: object):
+    def _make_dto(self, **overrides: object) -> object:
         from flaskr.service.learn.learn_dtos import ElementDTO, ElementType
 
         defaults = {
@@ -590,7 +590,7 @@ class TestVisualKindMapping:
 # ---------------------------------------------------------------------------
 
 
-def _require_app(app: object):
+def _require_app(app: object) -> None:
     if app is None:
         pytest.skip("App fixture disabled")
 
@@ -2499,7 +2499,7 @@ class TestHandleAskAdapter:
                 patch_generated_blocks=False,
             )
 
-            def _raise_provider_error(**_kwargs: object):
+            def _raise_provider_error(**_kwargs: object) -> object:
                 if False:
                     yield None
                 message = "provider failed"

--- a/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
+++ b/src/api/tests/service/learn/test_generated_block_tts_av_mode.py
@@ -28,7 +28,7 @@ def _patch_run_tts_processor(
     *,
     voice_settings: _FakeVoiceSettings | None = None,
     tts_model: str = "test-model",
-):
+) -> object:
     synthesized_texts = []
     resolved_voice_settings = voice_settings or _FakeVoiceSettings()
 
@@ -54,7 +54,7 @@ def _patch_run_tts_processor(
         lambda _provider: False,
     )
 
-    def _fake_synthesize_text(**kwargs: object):
+    def _fake_synthesize_text(**kwargs: object) -> object:
         synthesized_texts.append(kwargs["text"])
         return SimpleNamespace(
             audio_data=f"fake-audio:{kwargs['text']}".encode(),
@@ -935,7 +935,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
         synthesized_texts = _patch_run_tts_processor(monkeypatch)
 
-        def _fail_sem_acquire(*_args: object, **_kwargs: object):
+        def _fail_sem_acquire(*_args: object, **_kwargs: object) -> None:
             message = "cache fast-path should not acquire the synthesis semaphore"
             raise AssertionError(message)
 
@@ -1159,7 +1159,7 @@ class TestGeneratedBlockListenTtsElementFirst:
 
         synthesized_texts = _patch_run_tts_processor(monkeypatch)
 
-        def _fail_sem_acquire(*_args: object, **_kwargs: object):
+        def _fail_sem_acquire(*_args: object, **_kwargs: object) -> None:
             message = "markup-only blocks should not acquire the synthesis semaphore"
             raise AssertionError(message)
 

--- a/src/api/tests/service/learn/test_handle_input_ask_provider.py
+++ b/src/api/tests/service/learn/test_handle_input_ask_provider.py
@@ -11,7 +11,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> None:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -90,21 +90,21 @@ class _DummyColumn:
 
 
 class _DummyOrderColumn(_DummyColumn):
-    def desc(self):
+    def desc(self) -> object:
         return self
 
 
 class _DummyQuery:
-    def filter(self, *_args: object, **_kwargs: object):
+    def filter(self, *_args: object, **_kwargs: object) -> object:
         return self
 
-    def order_by(self, *_args: object, **_kwargs: object):
+    def order_by(self, *_args: object, **_kwargs: object) -> object:
         return self
 
-    def limit(self, *_args: object, **_kwargs: object):
+    def limit(self, *_args: object, **_kwargs: object) -> object:
         return self
 
-    def all(self):
+    def all(self) -> object:
         return []
 
 
@@ -118,10 +118,10 @@ class _DummyLearnGeneratedBlockModel:
 class _DummyNoneQuery:
     """Query that always returns None for .first()."""
 
-    def filter(self, *_args: object, **_kwargs: object):
+    def filter(self, *_args: object, **_kwargs: object) -> object:
         return self
 
-    def first(self):
+    def first(self) -> None:
         return None
 
 
@@ -150,7 +150,7 @@ class _DummyGeneration:
         self.kwargs = kwargs
         self.end_kwargs = {}
 
-    def end(self, **kwargs: object):
+    def end(self, **kwargs: object) -> None:
         self.end_kwargs = kwargs
 
 
@@ -164,23 +164,23 @@ class _DummySpan:
         self.end_kwargs = {}
         self.events = []
 
-    def generation(self, **kwargs: object):
+    def generation(self, **kwargs: object) -> object:
         generation = _DummyGeneration(**kwargs)
         self.generations.append(generation)
         return generation
 
-    def span(self, **kwargs: object):
+    def span(self, **kwargs: object) -> object:
         self.span_calls.append(kwargs)
         self.last_span = _DummySpan()
         return self.last_span
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updated = kwargs
 
-    def event(self, **kwargs: object):
+    def event(self, **kwargs: object) -> None:
         self.events.append(kwargs)
 
-    def end(self, output: object = None, **kwargs: object):
+    def end(self, output: object = None, **kwargs: object) -> None:
         self.output = output or ""
         self.end_kwargs = {"output": output, **kwargs}
 
@@ -191,11 +191,11 @@ class _DummyTrace:
         self.updated = {}
         self.last_span = None
 
-    def span(self, **_kwargs: object):
+    def span(self, **_kwargs: object) -> object:
         self.last_span = _DummySpan()
         return self.last_span
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updated = kwargs
 
 
@@ -209,16 +209,16 @@ class _Context:
         self._shifu_info = types.SimpleNamespace(use_learner_language=0)
         self.langfuse_outputs = []
 
-    def get_system_prompt(self, _outline_bid: str):
+    def get_system_prompt(self, _outline_bid: str) -> object:
         return "COURSE_PROMPT"
 
-    def append_langfuse_output(self, value: str):
+    def append_langfuse_output(self, value: str) -> None:
         self.langfuse_outputs.append(value)
 
 
 def _setup_handle_input_ask_patches(
     monkeypatch: object, module: object, ask_provider_config: object
-):
+) -> None:
     class _DummyLLMSettings:
         def __init__(self, model: object, temperature: object) -> None:
             self.model = model
@@ -281,7 +281,7 @@ def _setup_handle_input_ask_patches(
 
     call_counter = {"index": 0}
 
-    def _fake_init_generated_block(*_args: object, **_kwargs: object):
+    def _fake_init_generated_block(*_args: object, **_kwargs: object) -> object:
         call_counter["index"] += 1
         return types.SimpleNamespace(
             generated_block_bid=f"gb-{call_counter['index']}",
@@ -294,7 +294,7 @@ def _setup_handle_input_ask_patches(
     monkeypatch.setattr(module, "init_generated_block", _fake_init_generated_block)
 
 
-def _collect_content_chunks(events: object):
+def _collect_content_chunks(events: object) -> object:
     return [event.content for event in events if event.type == GeneratedType.CONTENT]
 
 
@@ -315,13 +315,13 @@ def test_handle_input_ask_provider_only_returns_provider_error_without_llm(
 
     llm_call_counter = {"count": 0}
 
-    def _fake_chat_llm(*_args: object, **_kwargs: object):
+    def _fake_chat_llm(*_args: object, **_kwargs: object) -> object:
         llm_call_counter["count"] += 1
         yield _LLMChunk("should-not-run")
 
     monkeypatch.setattr(module, "chat_llm", _fake_chat_llm)
 
-    def _raise_provider_error(**_kwargs: object):
+    def _raise_provider_error(**_kwargs: object) -> object:
         if False:
             yield None
         message = "provider failed"
@@ -383,13 +383,13 @@ def test_handle_input_ask_provider_then_llm_falls_back_to_llm(
 
     llm_call_counter = {"count": 0}
 
-    def _fake_chat_llm(*_args: object, **_kwargs: object):
+    def _fake_chat_llm(*_args: object, **_kwargs: object) -> object:
         llm_call_counter["count"] += 1
         yield _LLMChunk("llm-fallback-answer")
 
     monkeypatch.setattr(module, "chat_llm", _fake_chat_llm)
 
-    def _provider_then_llm_stream(**kwargs: object):
+    def _provider_then_llm_stream(**kwargs: object) -> object:
         if kwargs.get("provider") == "llm":
             runtime = kwargs.get("runtime")
             if runtime is None or runtime.llm_stream_factory is None:
@@ -457,13 +457,13 @@ def test_handle_input_ask_get_biji_synthesizes_via_context_factory(
 
     llm_calls = []
 
-    def _fake_chat_llm(*_args: object, **kwargs: object):
+    def _fake_chat_llm(*_args: object, **kwargs: object) -> object:
         llm_calls.append(kwargs)
         yield _LLMChunk("synthesized-answer")
 
     monkeypatch.setattr(module, "chat_llm", _fake_chat_llm)
 
-    def _retrieval_provider_stream(**kwargs: object):
+    def _retrieval_provider_stream(**kwargs: object) -> object:
         # Mimic a retrieval adapter: synthesize through the runtime factory.
         runtime = kwargs.get("runtime")
         assert runtime is not None
@@ -530,7 +530,7 @@ def test_handle_input_ask_provider_response_skips_llm(
 
     llm_call_counter = {"count": 0}
 
-    def _fake_chat_llm(*_args: object, **_kwargs: object):
+    def _fake_chat_llm(*_args: object, **_kwargs: object) -> object:
         llm_call_counter["count"] += 1
         yield _LLMChunk("should-not-run")
 
@@ -600,7 +600,7 @@ def test_handle_input_ask_dify_uses_context_without_follow_up_prompt(
 
     captured = {"messages": None}
 
-    def _fake_stream_ask_provider_response(**kwargs: object):
+    def _fake_stream_ask_provider_response(**kwargs: object) -> object:
         if kwargs.get("provider") == "dify":
             captured["messages"] = kwargs.get("messages")
             return iter([types.SimpleNamespace(content="provider-answer")])
@@ -702,7 +702,7 @@ def test_handle_input_ask_formats_provider_prompt_with_request_language(
         template: object,
         *,
         profile_overrides: object = None,
-    ):
+    ) -> object:
         captured["profile_overrides"] = profile_overrides
         profiles = {
             "language": "zh-CN",
@@ -711,7 +711,7 @@ def test_handle_input_ask_formats_provider_prompt_with_request_language(
         }
         return template.format(**profiles)
 
-    def _fake_stream_ask_provider_response(**kwargs: object):
+    def _fake_stream_ask_provider_response(**kwargs: object) -> object:
         captured["messages"] = kwargs.get("messages")
         return iter([types.SimpleNamespace(content="provider-answer")])
 
@@ -761,11 +761,11 @@ def test_handle_input_ask_formats_provider_prompt_with_request_language(
 # ---------------------------------------------------------------------------
 
 
-def _setup_llm_only_patches(monkeypatch: object, module: object, llm_chunks: object):
+def _setup_llm_only_patches(monkeypatch: object, module: object, llm_chunks: object) -> None:
     ask_provider_config = {"provider": "llm", "mode": "provider_then_llm", "config": {}}
     _setup_handle_input_ask_patches(monkeypatch, module, ask_provider_config)
 
-    def _fake_stream(**_kwargs: object):
+    def _fake_stream(**_kwargs: object) -> object:
         for chunk in llm_chunks:
             yield types.SimpleNamespace(content=chunk)
 

--- a/src/api/tests/service/learn/test_handle_input_ask_provider.py
+++ b/src/api/tests/service/learn/test_handle_input_ask_provider.py
@@ -761,7 +761,9 @@ def test_handle_input_ask_formats_provider_prompt_with_request_language(
 # ---------------------------------------------------------------------------
 
 
-def _setup_llm_only_patches(monkeypatch: object, module: object, llm_chunks: object) -> None:
+def _setup_llm_only_patches(
+    monkeypatch: object, module: object, llm_chunks: object
+) -> None:
     ask_provider_config = {"provider": "llm", "mode": "provider_then_llm", "config": {}}
     _setup_handle_input_ask_patches(monkeypatch, module, ask_provider_config)
 

--- a/src/api/tests/service/learn/test_learn_funcs.py
+++ b/src/api/tests/service/learn/test_learn_funcs.py
@@ -228,7 +228,7 @@ class LearnRecordLoadTests(unittest.TestCase):
 
         def get_run_script_info(
             self: object, attend: object, *, is_ask: object = False
-        ):
+        ) -> object:
             del self, is_ask
             return RunScriptInfo(
                 attend=attend,
@@ -258,16 +258,16 @@ class LearnRecordLoadTests(unittest.TestCase):
                 _ = (args, kwargs)
                 self.blocks = [DummyBlock(BlockType.CONTENT, "md content", 0)]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(self, *_args: object, **_kwargs: object) -> object:
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> object:
                 return self.blocks
 
-            def get_block(self, block_index: object):
+            def get_block(self, block_index: object) -> object:
                 return self.blocks[block_index]
 
             def process(
@@ -277,11 +277,11 @@ class LearnRecordLoadTests(unittest.TestCase):
                 variables: object = None,
                 context: object = None,
                 user_input: object = None,
-            ):
+            ) -> object:
                 _ = (block_index, mode, variables, user_input)
                 FakeMarkdownFlow.last_context = context
 
-                def _gen():
+                def _gen() -> object:
                     yield DummyLLMResult("chunk")
 
                 return _gen()
@@ -393,16 +393,16 @@ class LearnRecordLoadTests(unittest.TestCase):
                     ),
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(self, *_args: object, **_kwargs: object) -> object:
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> object:
                 return self.blocks
 
-            def get_block(self, block_index: object):
+            def get_block(self, block_index: object) -> object:
                 return self.blocks[block_index]
 
             def process(
@@ -412,13 +412,13 @@ class LearnRecordLoadTests(unittest.TestCase):
                 variables: object = None,
                 context: object = None,
                 user_input: object = None,
-            ):
+            ) -> object:
                 _ = (mode, variables, context, user_input)
                 block = self.blocks[block_index]
                 if block.block_type == MarkdownFlowBlockType.INTERACTION:
                     return types.SimpleNamespace(content=block.content)
 
-                def _gen():
+                def _gen() -> object:
                     yield DummyLLMResult(block.content)
 
                 return _gen()
@@ -542,16 +542,16 @@ class LearnRecordLoadTests(unittest.TestCase):
                 _ = (args, kwargs)
                 self.blocks = [DummyBlock(BlockType.CONTENT, "===fixed output===", 0)]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(self, *_args: object, **_kwargs: object) -> object:
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> object:
                 return self.blocks
 
-            def get_block(self, block_index: object):
+            def get_block(self, block_index: object) -> object:
                 return self.blocks[block_index]
 
             def process(
@@ -561,7 +561,7 @@ class LearnRecordLoadTests(unittest.TestCase):
                 variables: object = None,
                 context: object = None,
                 user_input: object = None,
-            ):
+            ) -> object:
                 _ = (block_index, mode, variables, context, user_input)
                 FakeMarkdownFlow.process_called = True
                 return types.SimpleNamespace(content="should-not-be-emitted")
@@ -679,16 +679,16 @@ class LearnRecordLoadTests(unittest.TestCase):
                     DummyBlock(BlockType.INTERACTION, "?[%{{v}} A|B]", 1),
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(self, *_args: object, **_kwargs: object) -> object:
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> object:
                 return self.blocks
 
-            def get_block(self, block_index: object):
+            def get_block(self, block_index: object) -> object:
                 return self.blocks[block_index]
 
             def process(
@@ -698,7 +698,7 @@ class LearnRecordLoadTests(unittest.TestCase):
                 variables: object = None,
                 context: object = None,
                 user_input: object = None,
-            ):
+            ) -> object:
                 _ = (block_index, mode, variables, context, user_input)
                 FakeMarkdownFlow.process_called = True
                 return types.SimpleNamespace(content="should-not-be-called")
@@ -809,16 +809,16 @@ class LearnRecordLoadTests(unittest.TestCase):
                     DummyBlock(BlockType.INTERACTION, "?[%{{v}} A|B]", 1),
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(self, *_args: object, **_kwargs: object) -> object:
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> object:
                 return self.blocks
 
-            def get_block(self, block_index: object):
+            def get_block(self, block_index: object) -> object:
                 return self.blocks[block_index]
 
             def process(
@@ -828,7 +828,7 @@ class LearnRecordLoadTests(unittest.TestCase):
                 variables: object = None,
                 context: object = None,
                 user_input: object = None,
-            ):
+            ) -> object:
                 _ = (block_index, mode, variables, context, user_input)
                 FakeMarkdownFlow.process_called = True
                 return types.SimpleNamespace(content="should-not-be-called")

--- a/src/api/tests/service/learn/test_learn_record.py
+++ b/src/api/tests/service/learn/test_learn_record.py
@@ -70,10 +70,10 @@ class LearnRecordFallbackTests(unittest.TestCase):
         dao.db.session.commit()
         return progress
 
-    def _set_request_user(self, mobile: str = ""):
+    def _set_request_user(self, mobile: str = "") -> None:
         request.user = types.SimpleNamespace(mobile=mobile, user_id="user-1")
 
-    def _seed_struct(self, outline_bids: list[str]):
+    def _seed_struct(self, outline_bids: list[str]) -> None:
         struct = HistoryItem(
             bid="shifu-1",
             id=1,

--- a/src/api/tests/service/learn/test_learn_record_slides.py
+++ b/src/api/tests/service/learn/test_learn_record_slides.py
@@ -6,7 +6,7 @@ import pytest
 from flask import request
 
 
-def _require_app(app: object):
+def _require_app(app: object) -> None:
     if app is None:
         pytest.skip("App fixture disabled")
 

--- a/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
+++ b/src/api/tests/service/learn/test_learn_stream_response_cleanup.py
@@ -28,7 +28,7 @@ def invalidations(monkeypatch: object) -> object:
     return calls
 
 
-def _iter_stream(app: object, helper: object, iter_factory: object):
+def _iter_stream(app: object, helper: object, iter_factory: object) -> object:
     with app.test_request_context("/"):
         response = helper(
             app,
@@ -40,7 +40,7 @@ def _iter_stream(app: object, helper: object, iter_factory: object):
 
 
 def test_sse_close_invalidates_session(app: object, invalidations: object) -> None:
-    def factory():
+    def factory() -> object:
         yield {"type": "chunk"}
         yield {"type": "chunk2"}
 
@@ -61,7 +61,7 @@ def test_sse_close_invalidates_session(app: object, invalidations: object) -> No
 def test_sse_protocol_error_invalidates_session(
     app: object, invalidations: object
 ) -> None:
-    def factory():
+    def factory() -> object:
         yield {"type": "chunk"}
         message = "desynced"
         raise ResourceClosedError(message)
@@ -84,7 +84,7 @@ def test_sse_protocol_error_invalidates_session(
 def test_sse_business_error_does_not_invalidate(
     app: object, invalidations: object
 ) -> None:
-    def factory():
+    def factory() -> object:
         yield {"type": "chunk"}
         message = "business"
         raise ValueError(message)
@@ -107,7 +107,7 @@ def test_sse_business_error_does_not_invalidate(
 def test_passthrough_close_invalidates_session(
     app: object, invalidations: object
 ) -> None:
-    def factory():
+    def factory() -> object:
         yield "data: 1\n\n"
         yield "data: 2\n\n"
 
@@ -128,7 +128,7 @@ def test_passthrough_close_invalidates_session(
 def test_passthrough_close_disguised_as_runtime_error(
     app: object, invalidations: object
 ) -> None:
-    def factory():
+    def factory() -> object:
         yield "data: 1\n\n"
         message = "generator ignored GeneratorExit"
         raise RuntimeError(message)
@@ -151,7 +151,7 @@ def test_passthrough_close_disguised_as_runtime_error(
 def test_passthrough_normal_exhaustion_does_not_invalidate(
     app: object, invalidations: object
 ) -> None:
-    def factory():
+    def factory() -> object:
         yield "data: 1\n\n"
 
     with app.test_request_context("/"):

--- a/src/api/tests/service/learn/test_listen_element_history_subtitles.py
+++ b/src/api/tests/service/learn/test_listen_element_history_subtitles.py
@@ -129,7 +129,7 @@ class TestListenElementHistorySubtitles:
             element_type: str,
             content_text: str,
             is_speakable: int,
-        ):
+        ) -> None:
             db.session.add(
                 self.LearnGeneratedElement(
                     element_bid=element_bid,
@@ -163,7 +163,7 @@ class TestListenElementHistorySubtitles:
                 )
             )
 
-        def add_audio(*, position: int):
+        def add_audio(*, position: int) -> None:
             db.session.add(
                 self.LearnGeneratedAudio(
                     audio_bid=f"audio-history-multi-{position}",
@@ -259,7 +259,7 @@ class TestListenElementHistorySubtitles:
             element_bid: str,
             element_index: int,
             content_text: str,
-        ):
+        ) -> None:
             db.session.add(
                 self.LearnGeneratedElement(
                     element_bid=element_bid,

--- a/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
+++ b/src/api/tests/service/learn/test_listen_element_mdflow_backfill.py
@@ -13,7 +13,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> None:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)

--- a/src/api/tests/service/learn/test_listen_element_run_persistence.py
+++ b/src/api/tests/service/learn/test_listen_element_run_persistence.py
@@ -14,7 +14,7 @@ def _make_row(
     target_element_bid: str = "",
     run_event_seq: int,
     status: int = 1,
-):
+) -> object:
     return LearnGeneratedElement(
         element_bid=element_bid,
         target_element_bid=target_element_bid,
@@ -109,31 +109,31 @@ def test_find_active_element_row_ids_invalidates_desynced_connection(
     app: object, monkeypatch: object
 ) -> None:
     class _DesyncedResult:
-        def fetchall(self):
+        def fetchall(self) -> None:
             message = (
                 "This result object does not return rows. "
                 "It has been closed automatically."
             )
             raise ResourceClosedError(message)
 
-        def close(self):
+        def close(self) -> None:
             pass
 
     class _FakeConnection:
         def __init__(self) -> None:
             self.invalidated = 0
 
-        def execute(self, *_args: object, **_kwargs: object):
+        def execute(self, *_args: object, **_kwargs: object) -> object:
             return _DesyncedResult()
 
-        def invalidate(self):
+        def invalidate(self) -> None:
             self.invalidated += 1
 
     class _FakeSession:
         def __init__(self, connection: object) -> None:
             self._connection = connection
 
-        def connection(self):
+        def connection(self) -> object:
             return self._connection
 
     fake_connection = _FakeConnection()
@@ -238,7 +238,7 @@ def test_desync_forensics_capture_fingerprints_the_stale_response() -> None:
         _result = _FakePrevResult()
         _sock = None
 
-        def thread_id(self):
+        def thread_id(self) -> object:
             return 555001
 
     class _FakeConnection:
@@ -287,7 +287,7 @@ def test_desync_forensics_logs_only_packet_header_not_payload() -> None:
             _result = None
             _sock = left
 
-            def thread_id(self):
+            def thread_id(self) -> object:
                 return 1
 
         class _FakeConnection:

--- a/src/api/tests/service/learn/test_listen_elements.py
+++ b/src/api/tests/service/learn/test_listen_elements.py
@@ -7,7 +7,7 @@ import types
 import pytest
 
 
-def _require_app(app: object):
+def _require_app(app: object) -> None:
     if app is None:
         pytest.skip("App fixture disabled")
 
@@ -1430,16 +1430,16 @@ def test_listen_run_persists_content_block_before_element_rows(app: object) -> N
                     )
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(self, *_args: object, **_kwargs: object) -> object:
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> object:
                 return self.blocks
 
-            def get_block(self, block_index: object):
+            def get_block(self, block_index: object) -> object:
                 return self.blocks[block_index]
 
             def process(
@@ -1449,11 +1449,11 @@ def test_listen_run_persists_content_block_before_element_rows(app: object) -> N
                 variables: object = None,
                 context: object = None,
                 user_input: object = None,
-            ):
+            ) -> object:
                 _ = (mode, variables, context, user_input)
                 block = self.blocks[block_index]
 
-                def _gen():
+                def _gen() -> object:
                     yield DummyLLMResult(block.content)
 
                 return _gen()
@@ -1632,16 +1632,16 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app: object) -> No
                     )
                 ]
 
-            def set_visual_mode(self, *_args: object, **_kwargs: object):
+            def set_visual_mode(self, *_args: object, **_kwargs: object) -> None:
                 pass
 
-            def set_output_language(self, *_args: object, **_kwargs: object):
+            def set_output_language(self, *_args: object, **_kwargs: object) -> object:
                 return self
 
-            def get_all_blocks(self):
+            def get_all_blocks(self) -> object:
                 return self.blocks
 
-            def get_block(self, block_index: object):
+            def get_block(self, block_index: object) -> object:
                 return self.blocks[block_index]
 
             def process(
@@ -1651,10 +1651,10 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app: object) -> No
                 variables: object = None,
                 context: object = None,
                 user_input: object = None,
-            ):
+            ) -> object:
                 _ = (block_index, mode, variables, context, user_input)
 
-                def _gen():
+                def _gen() -> object:
                     yield DummyLLMResult(
                         [DummyFormattedElement("Intro narration.\n", "text", 0)]
                     )
@@ -1686,15 +1686,15 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app: object) -> No
                 self.stream_element_number = stream_element_number
                 self.stream_element_type = stream_element_type
 
-            def process_chunk(self, chunk_content: object):
+            def process_chunk(self, chunk_content: object) -> object:
                 if False:
                     yield chunk_content
 
-            def drain_ready_segments(self):
+            def drain_ready_segments(self) -> object:
                 if False:
                     yield None
 
-            def finalize(self, *, commit: object = True):
+            def finalize(self, *, commit: object = True) -> object:
                 _ = commit
                 if self.stream_element_number == 0:
                     time.sleep(0.02)
@@ -1723,7 +1723,7 @@ def test_listen_run_emits_visual_before_blocking_tts_finalize(app: object) -> No
             stream_element_number: object,
             stream_element_type: object,
             **_kwargs: object,
-        ):
+        ) -> object:
             _ = self
             return FakeTTSProcessor(
                 generated_block_bid,
@@ -1881,7 +1881,7 @@ def test_listen_run_persists_exception_gate_block_before_element_rows(
             ctx,
         )
 
-        def _raise_paid(self: object, current_app: object):
+        def _raise_paid(self: object, current_app: object) -> object:
             _ = (self, current_app)
             raise PaidError
             yield  # pragma: no cover

--- a/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
+++ b/src/api/tests/service/learn/test_runscript_v2_connection_probe.py
@@ -10,7 +10,7 @@ class _EchoResult:
     def __init__(self, value: object) -> None:
         self._value = value
 
-    def scalar(self):
+    def scalar(self) -> object:
         return self._value
 
 
@@ -18,7 +18,7 @@ class _FakeConnection:
     def __init__(self) -> None:
         self.invalidated = 0
 
-    def invalidate(self):
+    def invalidate(self) -> None:
         self.invalidated += 1
 
 
@@ -33,10 +33,10 @@ class _FakeSession:
         self.invalidations = 0
         self._connection = _FakeConnection()
 
-    def invalidate(self):
+    def invalidate(self) -> None:
         self.invalidations += 1
 
-    def execute(self, _statement: object, params: object):
+    def execute(self, _statement: object, params: object) -> object:
         self.executed += 1
         behaviour = self._behaviours.pop(0)
         if behaviour == "ok":
@@ -50,14 +50,14 @@ class _FakeSession:
             )
         return _EchoResult(behaviour)
 
-    def connection(self):
+    def connection(self) -> object:
         return self._connection
 
-    def rollback(self):
+    def rollback(self) -> None:
         self.rollbacks += 1
 
 
-def _patch_session(monkeypatch: object, behaviours: object):
+def _patch_session(monkeypatch: object, behaviours: object) -> object:
     session = _FakeSession(behaviours)
 
     class _FakeDb:

--- a/src/api/tests/service/learn/test_runscript_v2_lock.py
+++ b/src/api/tests/service/learn/test_runscript_v2_lock.py
@@ -19,7 +19,7 @@ from flaskr.service.learn.learn_dtos import (
 
 
 @pytest.fixture(autouse=True)
-def _skip_connection_probe(monkeypatch: object):
+def _skip_connection_probe(monkeypatch: object) -> None:
     # These tests exercise run-script locking and orchestration with minimal
     # fake sessions; the connection health probe has its own dedicated tests
     # in test_runscript_v2_connection_probe.py.
@@ -153,7 +153,7 @@ def test_sse_chunk_serializes_datetime_as_utc_iso_z() -> None:
     assert events == [{"created_at": "2026-06-30T11:57:03Z"}]
 
 
-def _patch_fake_element_adapter(monkeypatch: object):
+def _patch_fake_element_adapter(monkeypatch: object) -> None:
     monkeypatch.setattr(
         runscript_v2, "ListenElementRunAdapter", FakeListenElementAdapter
     )
@@ -168,7 +168,7 @@ def test_run_script_retries_lock_then_streams(monkeypatch: object) -> None:
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         monkeypatch.setattr(runscript_v2.time, "sleep", lambda *_args, **_kwargs: None)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             with app.app_context():
                 yield from [
                     RunMarkdownFlowDTO(
@@ -216,7 +216,7 @@ def test_run_script_producer_owns_app_context(monkeypatch: object) -> None:
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         observed = {"has_app_context": None, "manage_app_context": None}
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             observed["has_app_context"] = has_app_context()
             observed["manage_app_context"] = _kwargs.get("manage_app_context")
             yield RunMarkdownFlowDTO(
@@ -263,7 +263,7 @@ def test_run_script_removes_producer_db_session(monkeypatch: object) -> None:
             ),
         )
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
                 generated_block_bid="generated-1",
@@ -299,7 +299,7 @@ def test_run_script_producer_done_survives_db_session_remove_failure(
         remove_calls = []
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def _remove():
+        def _remove() -> None:
             remove_calls.append("remove")
             message = "remove failed"
             raise RuntimeError(message)
@@ -310,7 +310,7 @@ def test_run_script_producer_done_survives_db_session_remove_failure(
             SimpleNamespace(session=SimpleNamespace(remove=_remove)),
         )
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
                 generated_block_bid="generated-1",
@@ -346,7 +346,7 @@ def test_run_script_read_mode_keeps_interaction_after_block_break(
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             with app.app_context():
                 yield from [
                     RunMarkdownFlowDTO(
@@ -400,7 +400,7 @@ def test_run_script_ask_mode_uses_element_protocol(monkeypatch: object) -> None:
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             with app.app_context():
                 element_adapter = _kwargs["element_adapter"]
                 yield from element_adapter.process(
@@ -455,7 +455,7 @@ def test_run_script_ask_mode_ignores_listen_flag(monkeypatch: object) -> None:
         observed: dict[str, object] = {}
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             observed["listen"] = _kwargs["listen"]
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
@@ -538,19 +538,19 @@ def test_run_script_inner_ask_mode_routes_events_through_element_adapter(
         def __init__(self, **_kwargs: object) -> None:
             self._has_next = True
 
-        def set_input(self, *_args: object, **_kwargs: object):
+        def set_input(self, *_args: object, **_kwargs: object) -> None:
             return None
 
-        def reload(self, *_args: object, **_kwargs: object):
+        def reload(self, *_args: object, **_kwargs: object) -> object:
             return []
 
-        def has_next(self):
+        def has_next(self) -> object:
             if self._has_next:
                 self._has_next = False
                 return True
             return False
 
-        def run(self, _app: object):
+        def run(self, _app: object) -> object:
             return [
                 RunMarkdownFlowDTO(
                     outline_bid="outline-1",
@@ -579,7 +579,7 @@ def test_run_script_inner_ask_mode_routes_events_through_element_adapter(
         def __init__(self) -> None:
             self.calls = []
 
-        def process(self, events: object):
+        def process(self, events: object) -> object:
             captured = list(events)
             self.calls.append(captured)
             return iter([f"converted:{event.type.value}" for event in captured])
@@ -696,13 +696,13 @@ def test_run_script_inner_rolls_back_on_unexpected_exception(
     commit_calls = []
     remove_calls = []
 
-    def _commit():
+    def _commit() -> None:
         commit_calls.append("commit")
 
-    def _rollback():
+    def _rollback() -> None:
         rollback_calls.append("rollback")
 
-    def _remove():
+    def _remove() -> None:
         remove_calls.append("remove")
         message = "remove failed"
         raise RuntimeError(message)
@@ -744,19 +744,19 @@ def test_run_script_inner_rolls_back_on_unexpected_exception(
         def __init__(self, **_kwargs: object) -> None:
             self._has_next = True
 
-        def set_input(self, *_args: object, **_kwargs: object):
+        def set_input(self, *_args: object, **_kwargs: object) -> None:
             return None
 
-        def reload(self, *_args: object, **_kwargs: object):
+        def reload(self, *_args: object, **_kwargs: object) -> object:
             return []
 
-        def has_next(self):
+        def has_next(self) -> object:
             if self._has_next:
                 self._has_next = False
                 return True
             return False
 
-        def run(self, _app: object):
+        def run(self, _app: object) -> None:
             message = "boom"
             raise RuntimeError(message)
 
@@ -832,19 +832,19 @@ def test_run_script_inner_finalizes_langfuse_after_loop(monkeypatch: object) -> 
             self.finalize_calls = 0
             FakeRunScriptContext.last_instance = self
 
-        def set_input(self, *_args: object, **_kwargs: object):
+        def set_input(self, *_args: object, **_kwargs: object) -> None:
             return None
 
-        def reload(self, *_args: object, **_kwargs: object):
+        def reload(self, *_args: object, **_kwargs: object) -> object:
             return []
 
-        def has_next(self):
+        def has_next(self) -> object:
             if self._has_next:
                 self._has_next = False
                 return True
             return False
 
-        def run(self, _app: object):
+        def run(self, _app: object) -> object:
             return [
                 RunMarkdownFlowDTO(
                     outline_bid="outline-1",
@@ -860,7 +860,7 @@ def test_run_script_inner_finalizes_langfuse_after_loop(monkeypatch: object) -> 
                 ),
             ]
 
-        def _finalize_langfuse_trace(self):
+        def _finalize_langfuse_trace(self) -> None:
             self.finalize_calls += 1
 
     monkeypatch.setattr(runscript_v2, "RunScriptContextV2", FakeRunScriptContext)
@@ -934,19 +934,19 @@ def test_run_script_inner_emits_audio_backfill_ready_after_final_commit(
         def __init__(self, **_kwargs: object) -> None:
             self._has_next = True
 
-        def set_input(self, *_args: object, **_kwargs: object):
+        def set_input(self, *_args: object, **_kwargs: object) -> None:
             return None
 
-        def reload(self, *_args: object, **_kwargs: object):
+        def reload(self, *_args: object, **_kwargs: object) -> object:
             return []
 
-        def has_next(self):
+        def has_next(self) -> object:
             if self._has_next:
                 self._has_next = False
                 return True
             return False
 
-        def run(self, _app: object):
+        def run(self, _app: object) -> object:
             return [
                 RunMarkdownFlowDTO(
                     outline_bid="outline-1",
@@ -965,7 +965,7 @@ def test_run_script_inner_emits_audio_backfill_ready_after_final_commit(
     monkeypatch.setattr(runscript_v2, "RunScriptContextV2", FakeRunScriptContext)
 
     class ElementAdapter:
-        def process(self, events: object):
+        def process(self, events: object) -> object:
             for event in events:
                 if event.type == GeneratedType.CONTENT:
                     yield RunElementSSEMessageDTO(
@@ -1065,19 +1065,19 @@ def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(
         def __init__(self, **_kwargs: object) -> None:
             self._has_next = True
 
-        def set_input(self, *_args: object, **_kwargs: object):
+        def set_input(self, *_args: object, **_kwargs: object) -> None:
             return None
 
-        def reload(self, *_args: object, **_kwargs: object):
+        def reload(self, *_args: object, **_kwargs: object) -> object:
             return []
 
-        def has_next(self):
+        def has_next(self) -> object:
             if self._has_next:
                 self._has_next = False
                 return True
             return False
 
-        def run(self, _app: object):
+        def run(self, _app: object) -> object:
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
                 generated_block_bid="generated-1",
@@ -1089,7 +1089,7 @@ def test_run_script_inner_emits_audio_backfill_ready_after_break_commit(
     monkeypatch.setattr(runscript_v2, "RunScriptContextV2", FakeRunScriptContext)
 
     class ElementAdapter:
-        def process(self, events: object):
+        def process(self, events: object) -> object:
             for event in events:
                 if event.type == GeneratedType.CONTENT:
                     yield RunElementSSEMessageDTO(
@@ -1143,7 +1143,7 @@ def test_run_script_listen_keeps_interaction_after_block_done(
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             with app.app_context():
                 element_adapter = _kwargs["element_adapter"]
                 yield from element_adapter.process(
@@ -1265,7 +1265,7 @@ def test_run_script_maps_llm_stream_connection_error_to_retryable_message(
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         monkeypatch.setattr(runscript_v2, "_", lambda key: f"translated:{key}")
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             message = "litellm.APIConnectionError: APIConnectionError: OpenAIException - [SSL] record layer failure (_ssl.c:2590)"
             raise RuntimeError(message)
             yield  # pragma: no cover
@@ -1301,7 +1301,7 @@ def test_run_script_maps_standard_timeout_error_to_retryable_message(
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         monkeypatch.setattr(runscript_v2, "_", lambda key: f"translated:{key}")
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             message = "stream failed"
             raise RuntimeError(message) from TimeoutError(
                 "The read operation timed out"
@@ -1336,7 +1336,7 @@ def test_run_script_listen_done_uses_element_protocol(monkeypatch: object) -> No
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             if False:
                 yield None
 
@@ -1396,7 +1396,7 @@ def test_get_run_status_reports_true_while_stream_is_open(monkeypatch: object) -
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
         monkeypatch.setattr(runscript_v2.time, "time", lambda: 120.0)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             with app.app_context():
                 yield RunMarkdownFlowDTO(
                     outline_bid="outline-1",
@@ -1449,7 +1449,7 @@ def test_run_script_close_during_data_yield_does_not_raise_runtime_error(
         cache = FakeCacheProvider(lock)
         monkeypatch.setattr(runscript_v2, "cache_provider", cache)
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             yield RunMarkdownFlowDTO(
                 outline_bid="outline-1",
                 generated_block_bid="generated-1",
@@ -1497,7 +1497,7 @@ def test_run_script_propagates_explicit_language_to_producer(
 
         seen_languages: list[str] = []
 
-        def fake_run_script_inner(**_kwargs: object):
+        def fake_run_script_inner(**_kwargs: object) -> object:
             with app.app_context():
                 seen_languages.append(get_current_language())
                 yield RunMarkdownFlowDTO(

--- a/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
+++ b/src/api/tests/service/learn/test_runscript_v2_stream_abort_invalidate.py
@@ -30,16 +30,16 @@ class _FakeSession:
         self.invalidations = 0
         self.removed = 0
 
-    def rollback(self):
+    def rollback(self) -> None:
         self.rollbacks += 1
 
-    def commit(self):
+    def commit(self) -> None:
         self.commits += 1
 
-    def invalidate(self):
+    def invalidate(self) -> None:
         self.invalidations += 1
 
-    def remove(self):
+    def remove(self) -> None:
         self.removed += 1
 
 
@@ -51,20 +51,20 @@ class _StubRunContext:
     def __init__(self, **_kwargs: object) -> None:
         self._steps = iter([True, False])
 
-    def set_input(self, *_args: object, **_kwargs: object):
+    def set_input(self, *_args: object, **_kwargs: object) -> None:
         pass
 
-    def has_next(self):
+    def has_next(self) -> object:
         return next(self._steps, False)
 
-    def run(self, _app: object):
+    def run(self, _app: object) -> object:
         for item in type(self).script:
             if isinstance(item, BaseException):
                 raise item
             yield item
 
 
-def _patch_run_dependencies(monkeypatch: object, script: object):
+def _patch_run_dependencies(monkeypatch: object, script: object) -> object:
     session = _FakeSession()
 
     class _FakeDb:
@@ -102,7 +102,7 @@ def _patch_run_dependencies(monkeypatch: object, script: object):
     return session
 
 
-def _start_stream(app: object):
+def _start_stream(app: object) -> object:
     generator = run_script_inner(
         app=app,
         user_bid="user-1",

--- a/src/api/tests/service/learn/test_runtime_tts_admission.py
+++ b/src/api/tests/service/learn/test_runtime_tts_admission.py
@@ -19,7 +19,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> None:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -128,7 +128,7 @@ def _find_call_by_name(node: ast.AST, name: str) -> ast.Call:
     raise AssertionError(message)
 
 
-def _mock_user(monkeypatch: object, user_id: str, *, is_creator: bool = False):
+def _mock_user(monkeypatch: object, user_id: str, *, is_creator: bool = False) -> object:
     dummy_user = SimpleNamespace(
         user_id=user_id,
         is_creator=is_creator,
@@ -153,7 +153,7 @@ def test_stream_passthrough_releases_request_db_session(monkeypatch: object) -> 
         SimpleNamespace(session=SimpleNamespace(remove=lambda: calls.append("remove"))),
     )
 
-    def _messages():
+    def _messages() -> object:
         calls.append("iterate")
         yield 'data: {"type":"done"}\n\n'
 
@@ -179,7 +179,7 @@ def test_stream_passthrough_ignores_request_db_session_remove_failure(
     app = Flask(__name__)
     calls = []
 
-    def _remove():
+    def _remove() -> None:
         calls.append("remove")
         message = "remove failed"
         raise RuntimeError(message)
@@ -190,7 +190,7 @@ def test_stream_passthrough_ignores_request_db_session_remove_failure(
         SimpleNamespace(session=SimpleNamespace(remove=_remove)),
     )
 
-    def _messages():
+    def _messages() -> object:
         calls.append("iterate")
         yield 'data: {"type":"done"}\n\n'
 
@@ -221,7 +221,7 @@ def test_stream_sse_logs_business_errors_as_warning(
         SimpleNamespace(session=SimpleNamespace(remove=lambda: None)),
     )
 
-    def _messages():
+    def _messages() -> object:
         message = "TTS provider quota exceeded"
         raise AppError(message, 45000292)
         yield  # pragma: no cover
@@ -255,7 +255,7 @@ def test_stream_sse_keeps_unexpected_errors_at_error_level(
         SimpleNamespace(session=SimpleNamespace(remove=lambda: None)),
     )
 
-    def _messages():
+    def _messages() -> object:
         message = "tts worker crashed"
         raise RuntimeError(message)
         yield  # pragma: no cover
@@ -287,7 +287,7 @@ def test_stream_sse_emits_error_event_for_business_error_with_factory(
         SimpleNamespace(session=SimpleNamespace(remove=lambda: None)),
     )
 
-    def _messages():
+    def _messages() -> object:
         message = "TTS provider quota exceeded"
         raise AppError(message, 45000292)
         yield  # pragma: no cover
@@ -418,7 +418,7 @@ def test_run_route_skips_runtime_admission_payload_for_builtin_demo(
         ),
     )
 
-    def _fake_run_script(*_args: object, **kwargs: object):
+    def _fake_run_script(*_args: object, **kwargs: object) -> object:
         assert "runtime_admission_payload" not in kwargs
         yield 'data: {"type":"done","event_type":"done","content":""}\n\n'
 
@@ -450,7 +450,7 @@ def test_run_route_uses_payload_language_as_generation_snapshot(
         lambda _app, shifu_bid: shifu_bid == "builtin-demo-1",
     )
 
-    def _fake_run_script(*_args: object, **kwargs: object):
+    def _fake_run_script(*_args: object, **kwargs: object) -> object:
         captured.update(kwargs)
         yield 'data: {"type":"done","event_type":"done","content":""}\n\n'
 

--- a/src/api/tests/service/learn/test_runtime_tts_admission.py
+++ b/src/api/tests/service/learn/test_runtime_tts_admission.py
@@ -128,7 +128,9 @@ def _find_call_by_name(node: ast.AST, name: str) -> ast.Call:
     raise AssertionError(message)
 
 
-def _mock_user(monkeypatch: object, user_id: str, *, is_creator: bool = False) -> object:
+def _mock_user(
+    monkeypatch: object, user_id: str, *, is_creator: bool = False
+) -> object:
     dummy_user = SimpleNamespace(
         user_id=user_id,
         is_creator=is_creator,

--- a/src/api/tests/service/learn/test_runtime_tts_voice_id.py
+++ b/src/api/tests/service/learn/test_runtime_tts_voice_id.py
@@ -37,7 +37,7 @@ def _patch_provider(
     monkeypatch: object,
     built_in: object = ("builtin-1",),
     default_voice_id: object = "default-voice",
-):
+) -> None:
     provider_config = SimpleNamespace(voices=[{"value": value} for value in built_in])
     monkeypatch.setattr(
         "flaskr.service.learn.learn_funcs.get_tts_provider",
@@ -55,7 +55,7 @@ def _add_clone(
     status: object,
     voice_bid: object,
     provider: object = "minimax",
-):
+) -> None:
     dao.db.session.add(
         TTSMiniMaxClonedVoice(
             voice_bid=voice_bid,

--- a/src/api/tests/service/learn/test_sse_element_split_from_db.py
+++ b/src/api/tests/service/learn/test_sse_element_split_from_db.py
@@ -53,7 +53,7 @@ VALID_TYPE_CODES = set(range(201, 214))
 # ---------------------------------------------------------------------------
 
 
-def _fetch_blocks_raw(app: object, limit: object = 100):
+def _fetch_blocks_raw(app: object, limit: object = 100) -> object:
     """Fetch latest generated blocks with content directly via SQLAlchemy."""
     from flaskr.service.learn.models import LearnGeneratedBlock
 
@@ -86,7 +86,7 @@ def _fetch_blocks_raw(app: object, limit: object = 100):
         ]
 
 
-def _role_str(role_int: object):
+def _role_str(role_int: object) -> object:
     if role_int == ROLE_STUDENT:
         return "student"
     return "teacher"
@@ -94,7 +94,7 @@ def _role_str(role_int: object):
 
 def _try_simulate_sse_for_block(
     app: object, block: object, *, with_av_contract: object = True
-):
+) -> object:
     """Simulate SSE for a block, returning None when the simulation fails.
 
     Callers scan a sample of production-shaped rows and skip the ones the
@@ -108,7 +108,7 @@ def _try_simulate_sse_for_block(
 
 def _simulate_sse_for_block(
     app: object, block: object, *, with_av_contract: object = True
-):
+) -> object:
     """Simulate SSE stream for a single block via ListenElementRunAdapter.
 
     When with_av_contract=True (default), builds an AV segmentation contract

--- a/src/api/tests/service/learn/test_tts_error_mapping.py
+++ b/src/api/tests/service/learn/test_tts_error_mapping.py
@@ -11,7 +11,7 @@ from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeoutError
 def test_rpm_queue_timeout_maps_to_rate_limited_not_unknown(
     app: object, caplog: object
 ) -> None:
-    def _body():
+    def _body() -> object:
         message = "TTS RPM queue wait exceeded 10.00s"
         raise TTSRpmQueueTimeoutError(message)
         yield  # pragma: no cover
@@ -39,7 +39,7 @@ def test_rpm_queue_timeout_maps_to_rate_limited_not_unknown(
 def test_unexpected_error_still_maps_to_unknown_error(
     app: object, caplog: object
 ) -> None:
-    def _body():
+    def _body() -> object:
         message = "tts worker crashed"
         raise RuntimeError(message)
         yield  # pragma: no cover

--- a/src/api/tests/service/learn/test_tts_synth_concurrency.py
+++ b/src/api/tests/service/learn/test_tts_synth_concurrency.py
@@ -124,7 +124,7 @@ def test_yield_tts_synthesis_sheds_request_when_full(
 
     body_calls = {"n": 0}
 
-    def _body():
+    def _body() -> object:
         body_calls["n"] += 1
         yield "chunk"
 
@@ -155,7 +155,7 @@ def test_yield_tts_synthesis_runs_and_releases_slot(
     monkeypatch.setattr(dao._redis_state, "client", fake)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
 
-    def _body():
+    def _body() -> object:
         yield "a"
         yield "b"
 
@@ -186,7 +186,7 @@ def test_yield_tts_synthesis_bypass_does_not_release(
     monkeypatch.setattr(dao._redis_state, "client", boom)
     app.config["MAX_PARALLEL_TTS_SYNTH_COUNT"] = 1
 
-    def _body():
+    def _body() -> object:
         yield "a"
 
     with app.app_context():

--- a/src/api/tests/service/metering/test_recording.py
+++ b/src/api/tests/service/metering/test_recording.py
@@ -351,7 +351,7 @@ def test_persist_cleanup_targets_failed_session_inside_context(
 
     events = []
 
-    def _fake_cleanup(exc: object, *, source: object, session: object = None):
+    def _fake_cleanup(exc: object, *, source: object, session: object = None) -> object:
         # Must be called while the pushed app context is active.
         _ = (source, session)
         events.append((type(exc).__name__, current_app._get_current_object() is app))
@@ -360,10 +360,10 @@ def test_persist_cleanup_targets_failed_session_inside_context(
     monkeypatch.setattr(recorder_module, "cleanup_session_after", _fake_cleanup)
 
     class _FailingSession:
-        def add(self, _record: object):
+        def add(self, _record: object) -> None:
             pass
 
-        def commit(self):
+        def commit(self) -> None:
             message = "desynced"
             raise ResourceClosedError(message)
 
@@ -393,10 +393,10 @@ def test_persist_invalidates_on_base_exception_interrupt(
         pass
 
     class _InterruptedSession:
-        def add(self, _record: object):
+        def add(self, _record: object) -> None:
             pass
 
-        def commit(self):
+        def commit(self) -> None:
             raise _Interrupt
 
     monkeypatch.setattr(

--- a/src/api/tests/service/metering/test_tts_usage_recorder.py
+++ b/src/api/tests/service/metering/test_tts_usage_recorder.py
@@ -12,7 +12,7 @@ from flaskr.service.tts.tts_usage_recorder import (
 )
 
 
-def _voice_settings():
+def _voice_settings() -> object:
     return SimpleNamespace(
         voice_id="voice-1",
         speed=1.0,
@@ -22,7 +22,7 @@ def _voice_settings():
     )
 
 
-def _audio_settings():
+def _audio_settings() -> object:
     return SimpleNamespace(format="mp3", sample_rate=32000)
 
 

--- a/src/api/tests/service/order/test_import_activation_parse.py
+++ b/src/api/tests/service/order/test_import_activation_parse.py
@@ -237,7 +237,7 @@ def test_import_activation_does_not_consult_profile_state_for_nickname_defaults(
         read_order: list[tuple[str, str, bool, bool]] = []
         reads_before_ensure: list[tuple[str, str, bool, bool]] = []
 
-        def track_first(query: object):
+        def track_first(query: object) -> object:
             statement = str(query.statement)
             parameters = query.statement.compile().params
             lookup_value = str(
@@ -262,7 +262,7 @@ def test_import_activation_does_not_consult_profile_state_for_nickname_defaults(
 
         original_ensure_user = order_admin.ensure_user_for_identifier
 
-        def track_ensure_user(*args: object, **kwargs: object):
+        def track_ensure_user(*args: object, **kwargs: object) -> object:
             reads_before_ensure.extend(read_order)
             return original_ensure_user(*args, **kwargs)
 

--- a/src/api/tests/service/order/test_import_activation_permissions.py
+++ b/src/api/tests/service/order/test_import_activation_permissions.py
@@ -48,7 +48,7 @@ def _add_shared_permission(app: object, shifu_bid: str, user_id: str) -> None:
         dao.db.session.commit()
 
 
-def _mock_user(monkeypatch: object, user_id: str, *, is_creator: bool = True):
+def _mock_user(monkeypatch: object, user_id: str, *, is_creator: bool = True) -> object:
     dummy_user = SimpleNamespace(
         user_id=user_id,
         is_creator=is_creator,

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -95,7 +95,7 @@ def test_legacy_order_purchase_flow_stays_on_order_tables(
         lambda *_args, **_kwargs: None,
     )
 
-    def _fake_pingxx_charge(**kwargs: object):
+    def _fake_pingxx_charge(**kwargs: object) -> object:
         buy_record = kwargs["buy_record"]
         buy_record.status = ORDER_STATUS_TO_BE_PAID
         dao.db.session.add(buy_record)
@@ -200,7 +200,7 @@ class _FakeSaasConfigFuncs:
     def get_sass_config(self, user_bid: str, key: str, default: str = "") -> str:
         return self._by_user_key.get((user_bid, key), default)
 
-    def get_saas_user_config_value_by_bid(self, app: object, config_bid: str):
+    def get_saas_user_config_value_by_bid(self, app: object, config_bid: str) -> object:
         del app
         record = self._by_bid.get(config_bid)
         return None if record is None else record["value"]
@@ -251,7 +251,7 @@ class _FakeSaasQuery:
     def order_by(self, *_args: object) -> _FakeSaasQuery:
         return self
 
-    def first(self):
+    def first(self) -> object:
         rows = sorted(
             self._fake_saas._by_bid.values(),
             key=lambda row: int(row["id"]),
@@ -263,7 +263,7 @@ class _FakeSaasQuery:
         return None
 
 
-def _make_fake_saas_model(fake_saas: _FakeSaasConfigFuncs):
+def _make_fake_saas_model(fake_saas: _FakeSaasConfigFuncs) -> object:
     class FakeSaasUserConfig:
         id = _FakeSaasColumn("id")
         user_bid = _FakeSaasColumn("user_bid")
@@ -290,7 +290,7 @@ def test_creator_payment_config_smoke_supports_alipay_and_wechatpay_checkout(
         def __init__(self, provider_name: str) -> None:
             self.provider_name = provider_name
 
-        def create_payment(self, *, request: object, app: object):
+        def create_payment(self, *, request: object, app: object) -> object:
             del app
             if self.provider_name == "alipay":
                 assert request.channel == "alipay_qr"
@@ -501,7 +501,7 @@ def test_legacy_stripe_checkout_urls_are_derived_from_host_url(
     stripe_requests: list[dict] = []
 
     class FakeStripeProvider:
-        def create_payment(self, *, request: object, app: object):
+        def create_payment(self, *, request: object, app: object) -> object:
             _ = app
             stripe_requests.append(
                 {

--- a/src/api/tests/service/order/test_native_payment_split_tables.py
+++ b/src/api/tests/service/order/test_native_payment_split_tables.py
@@ -237,7 +237,7 @@ def test_learner_sync_and_admin_payment_detail_read_alipay_table(
             provider_reference: object,
             reference_type: object,
             app: object,
-        ):
+        ) -> object:
             _ = app
             assert reference_type == "payment"
             return PaymentNotificationResult(
@@ -324,7 +324,7 @@ def test_learner_sync_does_not_mark_paid_when_native_amount_mismatches(
             provider_reference: object,
             reference_type: object,
             app: object,
-        ):
+        ) -> object:
             _ = app
             assert reference_type == "payment"
             return PaymentNotificationResult(

--- a/src/api/tests/service/order/test_order_import_error_specificity.py
+++ b/src/api/tests/service/order/test_order_import_error_specificity.py
@@ -9,7 +9,7 @@ from flaskr.i18n import _
 def test_import_activation_orders_unexpected_failure_returns_specific_message(
     app: object, monkeypatch: object
 ) -> None:
-    def raise_unexpected(*_args: object, **_kwargs: object):
+    def raise_unexpected(*_args: object, **_kwargs: object) -> None:
         message = "boom"
         raise RuntimeError(message)
 
@@ -35,7 +35,7 @@ def test_import_activation_orders_unexpected_failure_returns_specific_message(
 def test_import_activation_orders_from_entries_unexpected_failure_returns_specific_message(
     app: object, monkeypatch: object
 ) -> None:
-    def raise_unexpected(*_args: object, **_kwargs: object):
+    def raise_unexpected(*_args: object, **_kwargs: object) -> None:
         message = "boom"
         raise RuntimeError(message)
 

--- a/src/api/tests/service/order/test_order_init_lock.py
+++ b/src/api/tests/service/order/test_order_init_lock.py
@@ -67,7 +67,7 @@ def test_order_init_lock_uses_prefixed_key(monkeypatch: object) -> None:
 
 def test_order_init_lock_skips_when_cache_provider_errors(monkeypatch: object) -> None:
     class _BrokenCacheProvider:
-        def lock(self, *args: object, **kwargs: object):
+        def lock(self, *args: object, **kwargs: object) -> None:
             _ = (args, kwargs)
             message = "lock unavailable"
             raise RuntimeError(message)

--- a/src/api/tests/service/order/test_payment_channel_resolution.py
+++ b/src/api/tests/service/order/test_payment_channel_resolution.py
@@ -55,7 +55,7 @@ class TestResolvePaymentChannel:
     def test_stripe_only_configuration_overrides_pingxx_default(
         self, monkeypatch: object
     ) -> None:
-        def fake_get_config(key: object, default: object = None):
+        def fake_get_config(key: object, default: object = None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "stripe"
             return default
@@ -77,7 +77,7 @@ class TestResolvePaymentChannel:
     def test_disabled_payment_channel_raises_for_explicit_request(
         self, monkeypatch: object
     ) -> None:
-        def fake_get_config(key: object, default: object = None):
+        def fake_get_config(key: object, default: object = None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "stripe"
             return default
@@ -95,7 +95,7 @@ class TestResolvePaymentChannel:
             )
 
     def test_alipay_qr_prefers_native_when_enabled(self, monkeypatch: object) -> None:
-        def fake_get_config(key: object, default: object = None):
+        def fake_get_config(key: object, default: object = None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "alipay,pingxx"
             return default
@@ -116,7 +116,7 @@ class TestResolvePaymentChannel:
     def test_alipay_qr_falls_back_to_pingxx_when_native_disabled(
         self, monkeypatch: object
     ) -> None:
-        def fake_get_config(key: object, default: object = None):
+        def fake_get_config(key: object, default: object = None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "pingxx"
             return default
@@ -137,7 +137,7 @@ class TestResolvePaymentChannel:
     def test_wechat_jsapi_prefers_native_when_enabled(
         self, monkeypatch: object
     ) -> None:
-        def fake_get_config(key: object, default: object = None):
+        def fake_get_config(key: object, default: object = None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "wechatpay,pingxx"
             return default
@@ -158,7 +158,7 @@ class TestResolvePaymentChannel:
     def test_explicit_wechatpay_defaults_to_qr_channel(
         self, monkeypatch: object
     ) -> None:
-        def fake_get_config(key: object, default: object = None):
+        def fake_get_config(key: object, default: object = None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "wechatpay"
             return default
@@ -191,7 +191,7 @@ class TestResolvePaymentChannel:
     def test_explicit_native_provider_rejects_unsupported_channel(
         self, monkeypatch: object
     ) -> None:
-        def fake_get_config(key: object, default: object = None):
+        def fake_get_config(key: object, default: object = None) -> object:
             if key == "PAYMENT_CHANNELS_ENABLED":
                 return "alipay"
             return default

--- a/src/api/tests/service/order/test_provider_public_urls.py
+++ b/src/api/tests/service/order/test_provider_public_urls.py
@@ -108,7 +108,9 @@ def test_wechatpay_native_uses_host_url_notify_url(monkeypatch: object) -> None:
 
     provider = WechatPayProvider()
 
-    def fake_request(*, method: object, path: object, body: object, app: object) -> object:
+    def fake_request(
+        *, method: object, path: object, body: object, app: object
+    ) -> object:
         del method, path, app
         captured.update(json.loads(body))
         return {"code_url": "https://wechatpay.test/qr"}

--- a/src/api/tests/service/order/test_provider_public_urls.py
+++ b/src/api/tests/service/order/test_provider_public_urls.py
@@ -50,7 +50,7 @@ def test_alipay_precreate_uses_host_url_notify_url(monkeypatch: object) -> None:
             self.biz_model = biz_model
 
     class FakeClient:
-        def execute(self, precreate_request: object):
+        def execute(self, precreate_request: object) -> object:
             captured["notify_url"] = precreate_request.notify_url
             return {
                 "alipay_trade_precreate_response": {
@@ -108,7 +108,7 @@ def test_wechatpay_native_uses_host_url_notify_url(monkeypatch: object) -> None:
 
     provider = WechatPayProvider()
 
-    def fake_request(*, method: object, path: object, body: object, app: object):
+    def fake_request(*, method: object, path: object, body: object, app: object) -> object:
         del method, path, app
         captured.update(json.loads(body))
         return {"code_url": "https://wechatpay.test/qr"}

--- a/src/api/tests/service/order/test_stripe_refund.py
+++ b/src/api/tests/service/order/test_stripe_refund.py
@@ -44,7 +44,7 @@ def app() -> Iterator[Flask]:
         dao.db.drop_all()
 
 
-def _ensure_order(status: object, order_bid: object):
+def _ensure_order(status: object, order_bid: object) -> object:
     order = Order.query.filter(Order.order_bid == order_bid).first()
     if not order:
         order = Order(order_bid=order_bid, shifu_bid="shifu-1", user_bid="user-1")

--- a/src/api/tests/service/order/test_stripe_webhook.py
+++ b/src/api/tests/service/order/test_stripe_webhook.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
-def _load_route_module(module_name: str):
+def _load_route_module(module_name: str) -> object:
     return importlib.import_module(f"flaskr.route.{module_name}")
 
 
@@ -76,7 +76,7 @@ def stripe_webhook_app() -> Iterator[Flask]:
         dao.db.drop_all()
 
 
-def _ensure_order(status: object, order_bid: object):
+def _ensure_order(status: object, order_bid: object) -> object:
     order = Order.query.filter(Order.order_bid == order_bid).first()
     if not order:
         order = Order(order_bid=order_bid, shifu_bid="shifu-1", user_bid="user-1")
@@ -88,7 +88,7 @@ def _ensure_order(status: object, order_bid: object):
     return order
 
 
-def _ensure_billing_subscription(status: object, subscription_bid: object):
+def _ensure_billing_subscription(status: object, subscription_bid: object) -> object:
     subscription = BillingSubscription.query.filter(
         BillingSubscription.subscription_bid == subscription_bid
     ).first()
@@ -114,7 +114,7 @@ def _ensure_billing_subscription(status: object, subscription_bid: object):
 
 def _ensure_billing_order(
     status: object, bill_order_bid: object, subscription_bid: object
-):
+) -> object:
     order = BillingOrder.query.filter(
         BillingOrder.bill_order_bid == bill_order_bid
     ).first()
@@ -145,7 +145,7 @@ def _ensure_billing_order(
     return order
 
 
-def _ensure_billing_stripe_raw_snapshot(bill_order_bid: object):
+def _ensure_billing_stripe_raw_snapshot(bill_order_bid: object) -> object:
     raw_order = StripeOrder.query.filter(
         StripeOrder.bill_order_bid == bill_order_bid,
         StripeOrder.biz_domain == "billing",

--- a/src/api/tests/service/order/test_uow_failure_paths.py
+++ b/src/api/tests/service/order/test_uow_failure_paths.py
@@ -108,7 +108,7 @@ def _fail_after_pricing_sync(monkeypatch: pytest.MonkeyPatch) -> None:
     """Run the real pricing sync, then fail — simulating any late step error."""
     real_sync = order_funs._sync_order_campaign_pricing
 
-    def failing_sync(*args: object, **kwargs: object):
+    def failing_sync(*args: object, **kwargs: object) -> None:
         real_sync(*args, **kwargs)
         message = "boom after pricing sync"
         raise RuntimeError(message)
@@ -143,7 +143,7 @@ def test_init_buy_record_late_failure_persists_nothing(
     """
     _ = stub_shifu
 
-    def fake_apply_promo(_app: object, **kwargs: object):
+    def fake_apply_promo(_app: object, **kwargs: object) -> object:
         application = PromoRedemption(
             redemption_bid="uow-redemption-1",
             promo_bid="uow-promo-1",

--- a/src/api/tests/service/profile/test_profile.py
+++ b/src/api/tests/service/profile/test_profile.py
@@ -26,11 +26,11 @@ def test_add_profile_item_quick_creates_definition(app: object) -> None:
 def test_hide_unused_profile_items_no_unused(monkeypatch: object) -> None:
     calls = []
 
-    def fake_get_unused(_app: object, parent_id: object):
+    def fake_get_unused(_app: object, parent_id: object) -> object:
         calls.append(("unused", parent_id))
         return []
 
-    def fake_get_defs(_app: object, parent_id: object = None):
+    def fake_get_defs(_app: object, parent_id: object = None) -> object:
         calls.append(("defs", parent_id))
         return ["defs"]
 
@@ -51,7 +51,7 @@ def test_hide_unused_profile_items_no_unused(monkeypatch: object) -> None:
 def test_hide_unused_profile_items_updates_hidden(monkeypatch: object) -> None:
     calls = []
 
-    def fake_get_unused(_app: object, parent_id: object):
+    def fake_get_unused(_app: object, parent_id: object) -> object:
         calls.append(("unused", parent_id))
         return ["v1", "v2"]
 
@@ -61,7 +61,7 @@ def test_hide_unused_profile_items_updates_hidden(monkeypatch: object) -> None:
         profile_keys: object,
         hidden: object,
         user_id: object,
-    ):
+    ) -> object:
         calls.append(("update", parent_id, tuple(profile_keys), hidden, user_id))
         return ["updated"]
 
@@ -80,7 +80,7 @@ def test_hide_unused_profile_items_updates_hidden(monkeypatch: object) -> None:
 def test_get_profile_variable_usage_groups_keys(monkeypatch: object) -> None:
     calls = []
 
-    def fake_get_defs(_app: object, parent_id: object = None, _type: object = "all"):
+    def fake_get_defs(_app: object, parent_id: object = None, _type: object = "all") -> object:
         calls.append(("defs", parent_id))
         return [
             # system key should be ignored
@@ -91,7 +91,7 @@ def test_get_profile_variable_usage_groups_keys(monkeypatch: object) -> None:
             object.__class__("obj", (), {"profile_scope": "user", "profile_key": "k2"}),
         ]
 
-    def fake_collect(_app: object, parent_id: object):
+    def fake_collect(_app: object, parent_id: object) -> object:
         calls.append(("collect", parent_id))
         return {"k2"}
 

--- a/src/api/tests/service/profile/test_profile.py
+++ b/src/api/tests/service/profile/test_profile.py
@@ -80,7 +80,9 @@ def test_hide_unused_profile_items_updates_hidden(monkeypatch: object) -> None:
 def test_get_profile_variable_usage_groups_keys(monkeypatch: object) -> None:
     calls = []
 
-    def fake_get_defs(_app: object, parent_id: object = None, _type: object = "all") -> object:
+    def fake_get_defs(
+        _app: object, parent_id: object = None, _type: object = "all"
+    ) -> object:
         calls.append(("defs", parent_id))
         return [
             # system key should be ignored

--- a/src/api/tests/service/profile/test_profile_routes.py
+++ b/src/api/tests/service/profile/test_profile_routes.py
@@ -12,7 +12,7 @@ _dummy_lock = SimpleNamespace(
 
 
 @pytest.fixture(autouse=True)
-def _stub_profile_config_cache(monkeypatch: object):
+def _stub_profile_config_cache(monkeypatch: object) -> None:
     monkeypatch.setattr(
         config_funcs,
         "redis",
@@ -28,7 +28,7 @@ def _stub_profile_config_cache(monkeypatch: object):
 class TestProfileRoutes:
     """Verify profile routes behavior."""
 
-    def _mock_request_user(self, monkeypatch: object):
+    def _mock_request_user(self, monkeypatch: object) -> None:
         dummy_user = SimpleNamespace(user_id="test-user", language="en-US")
         monkeypatch.setattr(
             "flaskr.route.user.validate_user",
@@ -43,7 +43,7 @@ class TestProfileRoutes:
 
         def fake_get_definitions(
             _app_ctx: object, parent_id: object, definition_type: object
-        ):
+        ) -> object:
             called["parent_id"] = parent_id
             called["definition_type"] = definition_type
             return []
@@ -77,7 +77,7 @@ class TestProfileRoutes:
     ) -> None:
         called = {}
 
-        def fake_hide(_app_ctx: object, parent_id: object, user_id: object):
+        def fake_hide(_app_ctx: object, parent_id: object, user_id: object) -> object:
             called["parent_id"] = parent_id
             called["user_id"] = user_id
             return [
@@ -127,7 +127,7 @@ class TestProfileRoutes:
             profile_keys: object,
             hidden: object,
             user_id: object,
-        ):
+        ) -> object:
             called["parent_id"] = parent_id
             called["profile_keys"] = profile_keys
             called["hidden"] = hidden
@@ -189,7 +189,7 @@ class TestProfileRoutes:
             parent_id: object,
             user_id: object,
             key: object,
-        ):
+        ) -> object:
             called["profile_id"] = profile_id
             called["parent_id"] = parent_id
             called["user_id"] = user_id

--- a/src/api/tests/service/promo/test_admin_promotions.py
+++ b/src/api/tests/service/promo/test_admin_promotions.py
@@ -180,7 +180,9 @@ def _seed_user(
     return user
 
 
-def _seed_course(shifu_bid: str, title: str, *, creator_user_bid: str = "operator-1") -> object:
+def _seed_course(
+    shifu_bid: str, title: str, *, creator_user_bid: str = "operator-1"
+) -> object:
     course = PublishedShifu()
     course.shifu_bid = shifu_bid
     course.title = title

--- a/src/api/tests/service/promo/test_admin_promotions.py
+++ b/src/api/tests/service/promo/test_admin_promotions.py
@@ -43,7 +43,7 @@ from flaskr.util.datetime import now_utc, parse_naive_utc
 
 
 @pytest.fixture(autouse=True)
-def _isolate_tables(app: object):
+def _isolate_tables(app: object) -> object:
     with app.app_context():
         db.session.query(PromoRedemption).delete()
         db.session.query(PromoCampaign).delete()
@@ -161,7 +161,7 @@ def _mock_creator(monkeypatch: object, user_id: str = "creator-1") -> None:
 
 def _seed_user(
     user_bid: str, identifier: str, nickname: str, *, is_operator: bool = False
-):
+) -> object:
     user = UserEntity()
     user.user_bid = user_bid
     user.user_identify = identifier
@@ -180,7 +180,7 @@ def _seed_user(
     return user
 
 
-def _seed_course(shifu_bid: str, title: str, *, creator_user_bid: str = "operator-1"):
+def _seed_course(shifu_bid: str, title: str, *, creator_user_bid: str = "operator-1") -> object:
     course = PublishedShifu()
     course.shifu_bid = shifu_bid
     course.title = title
@@ -198,7 +198,7 @@ def _seed_order(
     *,
     payable: str = "99.00",
     paid: str = "79.00",
-):
+) -> object:
     order = Order()
     order.order_bid = order_bid
     order.shifu_bid = shifu_bid
@@ -718,7 +718,7 @@ def test_creator_redemption_code_list_accepts_utc_date_filter_bounds(
         page_index: object,
         page_size: object,
         filters: object,
-    ):
+    ) -> object:
         captured_filters.update(filters)
         assert creator_user_bid == "creator-1"
         assert page_index == 1

--- a/src/api/tests/service/promo/test_promo_error_specificity.py
+++ b/src/api/tests/service/promo/test_promo_error_specificity.py
@@ -13,7 +13,7 @@ from flaskr.service.promo.models import Coupon, CouponUsage
 
 
 @pytest.fixture(autouse=True)
-def _isolate_coupon_tables(app: object):
+def _isolate_coupon_tables(app: object) -> object:
     with app.app_context():
         CouponUsage.query.delete()
         Coupon.query.delete()

--- a/src/api/tests/service/referral/test_referral_campaign_admin.py
+++ b/src/api/tests/service/referral/test_referral_campaign_admin.py
@@ -61,7 +61,7 @@ def _seed_plan_product(product_code: str = "creator-plan-monthly-pro") -> None:
     db.session.commit()
 
 
-def _payload(**overrides: object):
+def _payload(**overrides: object) -> object:
     payload = {
         "campaign_code": "domestic_creator_invite_202606",
         "campaign_name": "Domestic creator invite",

--- a/src/api/tests/service/referral/test_referral_campaign_admin_routes.py
+++ b/src/api/tests/service/referral/test_referral_campaign_admin_routes.py
@@ -28,7 +28,7 @@ from flaskr.service.referral.models import (
 
 
 @pytest.fixture(autouse=True)
-def _isolate_referral_campaign_tables(app: object):
+def _isolate_referral_campaign_tables(app: object) -> object:
     with app.app_context():
         db.session.query(ReferralInviteEvent).delete()
         db.session.query(ReferralInviteReward).delete()
@@ -83,7 +83,7 @@ def _seed_plan_product() -> None:
     db.session.commit()
 
 
-def _payload():
+def _payload() -> object:
     return {
         "campaign_code": "domestic_creator_invite_202606",
         "campaign_name": "Domestic creator invite",

--- a/src/api/tests/service/referral/test_referral_service.py
+++ b/src/api/tests/service/referral/test_referral_service.py
@@ -450,7 +450,7 @@ def test_post_auth_binding_is_idempotent_and_creates_reward(
         )
         db.session.commit()
 
-        def fake_grant(_app: Flask, *, reward: ReferralInviteReward):
+        def fake_grant(_app: Flask, *, reward: ReferralInviteReward) -> object:
             grant_calls.append(reward.reward_bid)
             reward.reward_status = REFERRAL_REWARD_STATUS_GENERATED
             reward.billing_artifacts = {

--- a/src/api/tests/service/shifu/test_admin_config_rates.py
+++ b/src/api/tests/service/shifu/test_admin_config_rates.py
@@ -89,7 +89,7 @@ def _seed_default_llm_rates() -> None:
 def test_update_llm_rate_uses_rate_model_and_keeps_metric_ratios(
     monkeypatch: object, app: object
 ) -> None:
-    def config_getter(key: object, default: object = None):
+    def config_getter(key: object, default: object = None) -> object:
         return {
             "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
             "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS": "3000",
@@ -322,14 +322,14 @@ def test_update_db_only_llm_alias_only_supersedes_explicit_alias(
 def test_update_new_llm_rate_uses_default_metric_ratios(
     monkeypatch: object, app: object
 ) -> None:
-    def config_getter(key: object, default: object = None):
+    def config_getter(key: object, default: object = None) -> object:
         return {
             "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
             "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS": "3000",
             "TTS_CHARS_PER_LLM_TOKEN": "1",
         }.get(key, default)
 
-    def resolve_identity(model: str):
+    def resolve_identity(model: str) -> object:
         provider, actual_model = model.split("/", 1)
         return provider, [actual_model, model]
 
@@ -395,7 +395,7 @@ def test_update_new_llm_rate_uses_default_metric_ratios(
 def test_operator_rate_config_exposes_fixed_credit_1x_baseline(
     monkeypatch: object, app: object
 ) -> None:
-    def config_getter(key: object, default: object = None):
+    def config_getter(key: object, default: object = None) -> object:
         return {
             "DEFAULT_LLM_MODEL": "ark/doubao-seed-2-0-lite-260428",
             "LLM_CREDIT_1X_PER_1000_OUTPUT_TOKENS": "0.066667",
@@ -442,7 +442,7 @@ def test_operator_rate_config_exposes_fixed_credit_1x_baseline(
 def test_update_rate_rejects_missing_credit_1x_anchor(
     monkeypatch: object, app: object
 ) -> None:
-    def config_getter(key: object, default: object = None):
+    def config_getter(key: object, default: object = None) -> object:
         return {
             "DEFAULT_LLM_MODEL": "qwen/deepseek-v4-flash",
             "TTS_CHARS_PER_LLM_TOKEN": "1",
@@ -632,7 +632,7 @@ def test_operator_rate_config_appends_only_current_exact_db_identities(
             _parameters: object,
             _context: object,
             _executemany: object,
-        ):
+        ) -> None:
             nonlocal active_rate_selects
             if "credit_usage_rates" in statement.lower():
                 active_rate_selects += 1

--- a/src/api/tests/service/shifu/test_admin_course_detail.py
+++ b/src/api/tests/service/shifu/test_admin_course_detail.py
@@ -105,7 +105,7 @@ def _clear_tables() -> None:
 
 
 @pytest.fixture(autouse=True)
-def _pin_app_timezone_to_utc(app: object):
+def _pin_app_timezone_to_utc(app: object) -> object:
     original_tz = app.config.get("TZ")
     app.config["TZ"] = "UTC"
     try:
@@ -118,8 +118,8 @@ def _pin_app_timezone_to_utc(app: object):
 
 
 @pytest.fixture(autouse=True)
-def _mock_bcrypt_module(monkeypatch: object):
-    def gensalt(rounds: object = 12):
+def _mock_bcrypt_module(monkeypatch: object) -> None:
+    def gensalt(rounds: object = 12) -> object:
         del rounds
         return b"salt"
 
@@ -135,7 +135,7 @@ def _mock_bcrypt_module(monkeypatch: object):
 
 
 @pytest.fixture(autouse=True)
-def _isolate_tables(app: object):
+def _isolate_tables(app: object) -> object:
     with app.app_context():
         _clear_tables()
     yield
@@ -2483,14 +2483,14 @@ def test_admin_operation_course_credit_usage_model_labels_are_cached_per_request
     created_at = datetime(2026, 4, 1, 9, 0, 0)
     load_counts = {"llm": 0, "tts": 0}
 
-    def fake_get_current_models(_app: object):
+    def fake_get_current_models(_app: object) -> object:
         load_counts["llm"] += 1
         return [
             {"model": "gpt-known", "display_name": "GPT Known"},
             {"model": "shared-model", "display_name": "Shared Model"},
         ]
 
-    def fake_get_all_provider_configs():
+    def fake_get_all_provider_configs() -> object:
         load_counts["tts"] += 1
         return {
             "providers": [],

--- a/src/api/tests/service/shifu/test_admin_courses.py
+++ b/src/api/tests/service/shifu/test_admin_courses.py
@@ -243,7 +243,7 @@ def test_list_operator_courses_attaches_prompt_flags_for_lightweight_page_items(
         updated_at=datetime(2025, 4, 3, 10, 0, 0),
     )
 
-    def attach_prompt_flags(model: object, rows: object):
+    def attach_prompt_flags(model: object, rows: object) -> None:
         for row in rows:
             row.has_course_prompt = model is PublishedShifu
 

--- a/src/api/tests/service/shifu/test_admin_users.py
+++ b/src/api/tests/service/shifu/test_admin_users.py
@@ -107,7 +107,7 @@ from tests.common.fixtures.billing_products import build_bill_products
 
 
 @pytest.fixture(autouse=True)
-def _mock_bcrypt_module(monkeypatch: object):
+def _mock_bcrypt_module(monkeypatch: object) -> None:
     monkeypatch.setitem(
         sys.modules,
         "bcrypt",
@@ -120,7 +120,7 @@ def _mock_bcrypt_module(monkeypatch: object):
 
 
 @pytest.fixture(autouse=True)
-def _isolate_tables(app: object):
+def _isolate_tables(app: object) -> object:
     with app.app_context():
         db.session.query(CreditLedgerEntry).delete()
         db.session.query(BillUsageRecord).delete()
@@ -185,7 +185,7 @@ def _mock_operator(
     )
 
 
-def _z(value: object):
+def _z(value: object) -> object:
     """Serialize a datetime the way flaskr.route.common.fmt does (UTC ISO 'Z')."""
     if value.tzinfo is None:
         value = value.replace(tzinfo=UTC)
@@ -215,7 +215,7 @@ def _seed_user(
     updated_at: datetime,
     providers: list[tuple[str, str]] | None = None,
     credential_created_at: datetime | None = None,
-):
+) -> None:
     entity = create_user_entity(
         user_bid=user_bid,
         identify=identify,
@@ -255,7 +255,7 @@ def _seed_course(
     creator_user_bid: str,
     created_at: datetime,
     updated_at: datetime,
-):
+) -> object:
     course = model(
         shifu_bid=shifu_bid,
         title=title,
@@ -278,7 +278,7 @@ def _seed_success_order(
     created_at: datetime,
     paid_price: str = "0.00",
     payable_price: str = "0.00",
-):
+) -> object:
     order = Order(
         order_bid=order_bid,
         shifu_bid=shifu_bid,
@@ -303,7 +303,7 @@ def _seed_published_outline_item(
     parent_bid: str,
     position: str,
     hidden: int = 0,
-):
+) -> object:
     outline_item = PublishedOutlineItem(
         shifu_bid=shifu_bid,
         outline_item_bid=outline_item_bid,
@@ -323,7 +323,7 @@ def _seed_credit_wallet(
     creator_bid: str,
     wallet_bid: str,
     available_credits: str,
-):
+) -> object:
     wallet = CreditWallet(
         wallet_bid=wallet_bid,
         creator_bid=creator_bid,
@@ -340,7 +340,7 @@ def _seed_billing_order(
     creator_bid: str,
     bill_order_bid: str,
     metadata_json: dict | None = None,
-):
+) -> object:
     order = BillingOrder(
         bill_order_bid=bill_order_bid,
         creator_bid=creator_bid,
@@ -373,7 +373,7 @@ def _seed_billing_subscription(
     billing_provider: str = "manual",
     provider_subscription_id: str = "",
     provider_customer_id: str = "",
-):
+) -> object:
     subscription = BillingSubscription(
         subscription_bid=subscription_bid,
         creator_bid=creator_bid,
@@ -404,7 +404,7 @@ def _seed_credit_wallet_bucket(
     source_type: int,
     effective_from: datetime,
     effective_to: datetime | None = None,
-):
+) -> object:
     bucket = CreditWalletBucket(
         wallet_bucket_bid=bucket_bid,
         wallet_bid=wallet_bid,
@@ -443,7 +443,7 @@ def _seed_credit_ledger_entry(
     expires_at: datetime | None = None,
     consumable_from: datetime | None = None,
     metadata_json: dict | None = None,
-):
+) -> object:
     entry = CreditLedgerEntry(
         ledger_bid=ledger_bid,
         creator_bid=creator_bid,
@@ -488,7 +488,7 @@ def _seed_bill_usage_record(
     duration_ms: int = 0,
     segment_index: int = 0,
     segment_count: int = 0,
-):
+) -> object:
     usage = BillUsageRecord(
         usage_bid=usage_bid,
         parent_usage_bid=parent_usage_bid,
@@ -533,7 +533,7 @@ def _seed_generated_block(
     outline_item_bid: str,
     generated_content: str,
     created_at: datetime,
-):
+) -> object:
     block = LearnGeneratedBlock(
         generated_block_bid=generated_block_bid,
         progress_record_bid=progress_record_bid,
@@ -563,7 +563,7 @@ def _seed_generated_element(
     audio_segments: str,
     sequence_number: int,
     created_at: datetime,
-):
+) -> object:
     element = LearnGeneratedElement(
         element_bid=element_bid,
         generated_block_bid=generated_block_bid,
@@ -594,7 +594,7 @@ def _seed_learn_progress(
     user_bid: str,
     status: int,
     created_at: datetime,
-):
+) -> object:
     progress_record = LearnProgressRecord(
         progress_record_bid=f"progress-{user_bid}-{outline_item_bid}-{status}",
         shifu_bid=shifu_bid,
@@ -616,7 +616,7 @@ def _seed_course_auth(
     user_id: str,
     created_at: datetime,
     status: int = 1,
-):
+) -> object:
     course_auth = AiCourseAuth(
         course_auth_id=f"course-auth-{user_id}-{course_id}",
         course_id=course_id,
@@ -632,7 +632,7 @@ def _seed_course_auth(
     return course_auth
 
 
-def _seed_user_token(*, user_bid: str, token: str, created_at: datetime):
+def _seed_user_token(*, user_bid: str, token: str, created_at: datetime) -> object:
     user_token = UserToken(
         user_id=user_bid,
         token=token,
@@ -1253,7 +1253,7 @@ def test_user_course_count_maps_use_lightweight_course_rows(
 ) -> None:
     load_calls = []
 
-    def fake_load_latest_shifus(model: object, **kwargs: object):
+    def fake_load_latest_shifus(model: object, **kwargs: object) -> object:
         load_calls.append(("latest", model.__name__, kwargs.get("lightweight")))
         return []
 
@@ -1262,7 +1262,7 @@ def test_user_course_count_maps_use_lightweight_course_rows(
         shifu_bids: object,
         *,
         lightweight: object = False,
-    ):
+    ) -> object:
         load_calls.append(("by_bids", model.__name__, tuple(shifu_bids), lightweight))
         return []
 
@@ -1959,7 +1959,7 @@ def test_get_operator_user_credits_loads_order_metadata_only_for_order_sources(
     captured_source_bids: list[str] = []
     original_load_billing_order_map = user_credits_module._load_billing_order_map
 
-    def capture_order_source_bids(source_bids: object):
+    def capture_order_source_bids(source_bids: object) -> object:
         captured_source_bids.extend(list(source_bids))
         return original_load_billing_order_map(source_bids)
 
@@ -4878,7 +4878,7 @@ def test_registration_source_map_skips_user_query_when_users_argument_is_empty(
     app: object, monkeypatch: object
 ) -> None:
     class ForbiddenUserQuery:
-        def filter(self, *_args: object, **_kwargs: object):
+        def filter(self, *_args: object, **_kwargs: object) -> None:
             message = "expected no user query when users=[] is provided"
             raise AssertionError(message)
 
@@ -4936,7 +4936,7 @@ def test_contact_map_skips_user_query_when_users_argument_is_empty(
     app: object, monkeypatch: object
 ) -> None:
     class ForbiddenUserQuery:
-        def filter(self, *_args: object, **_kwargs: object):
+        def filter(self, *_args: object, **_kwargs: object) -> None:
             message = "expected no user query when users=[] is provided"
             raise AssertionError(message)
 

--- a/src/api/tests/service/shifu/test_archive.py
+++ b/src/api/tests/service/shifu/test_archive.py
@@ -8,7 +8,7 @@ from flaskr import dao
 from flaskr.service.common.models import AppError
 
 
-def _get_models():
+def _get_models() -> object:
     from flaskr.service.shifu.models import (
         DraftOutlineItem,
         DraftShifu,
@@ -19,19 +19,19 @@ def _get_models():
     return DraftOutlineItem, DraftShifu, LogDraftStruct, ShifuUserArchive
 
 
-def _get_archive_funcs():
+def _get_archive_funcs() -> object:
     from flaskr.service.shifu import shifu_draft_funcs
 
     return shifu_draft_funcs.archive_shifu, shifu_draft_funcs.unarchive_shifu
 
 
-def _get_draft_module():
+def _get_draft_module() -> object:
     from flaskr.service.shifu import shifu_draft_funcs
 
     return shifu_draft_funcs
 
 
-def _seed_shifu(app: object, shifu_bid: str, owner_bid: str):
+def _seed_shifu(app: object, shifu_bid: str, owner_bid: str) -> None:
     """Create draft shifu row and clear archive state for testing."""
     with app.app_context():
         _, draft_shifu_model, _, shifu_user_archive_model = _get_models()
@@ -323,7 +323,7 @@ def test_create_shifu_draft_skips_risk_check_for_default_outline_content(
 
     monkeypatch.setattr(draft_module, "generate_id", lambda _app: "shifu-risk-skip")
 
-    def fake_draft_risk(*args: object, **kwargs: object):
+    def fake_draft_risk(*args: object, **kwargs: object) -> None:
         draft_risk_calls.append((args, kwargs))
 
     monkeypatch.setattr(
@@ -334,7 +334,7 @@ def test_create_shifu_draft_skips_risk_check_for_default_outline_content(
 
     from flaskr.service.shifu import shifu_outline_funcs
 
-    def fail_outline_risk(*_args: object, **_kwargs: object):
+    def fail_outline_risk(*_args: object, **_kwargs: object) -> None:
         message = "default outline content should not trigger risk check"
         raise AssertionError(message)
 
@@ -373,7 +373,7 @@ def test_create_shifu_draft_raises_when_default_outline_init_fails(
         lambda *_args, **_kwargs: None,
     )
 
-    def fail_default_outlines(*_args: object, **_kwargs: object):
+    def fail_default_outlines(*_args: object, **_kwargs: object) -> None:
         message = "outline init failed"
         raise AppError(message)
 

--- a/src/api/tests/service/shifu/test_ask_preview_route.py
+++ b/src/api/tests/service/shifu/test_ask_preview_route.py
@@ -24,7 +24,7 @@ class _FakeObservation:
         self.span_calls = []
         self.last_span = None
 
-    def start_observation(self, as_type: object = "span", **kwargs: object):
+    def start_observation(self, as_type: object = "span", **kwargs: object) -> object:
         child = _FakeObservation(as_type, **kwargs)
         if as_type == "generation":
             self.generations.append(child)
@@ -33,17 +33,17 @@ class _FakeObservation:
             self.last_span = child
         return child
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updates.append(kwargs)
 
-    def set_trace_as_public(self):
+    def set_trace_as_public(self) -> None:
         self.public = True
 
-    def end(self):
+    def end(self) -> None:
         self.ended = True
 
     @property
-    def end_kwargs(self):
+    def end_kwargs(self) -> object:
         merged = {}
         for item in self.updates:
             merged.update(item)
@@ -59,7 +59,7 @@ class _FakeLangfuseClient:
         as_type: object = "span",
         trace_context: object = None,
         **kwargs: object,
-    ):
+    ) -> object:
         root = _FakeObservation(as_type, **kwargs)
         root.trace_context = trace_context or {}
         self.traces.append(root)
@@ -96,7 +96,7 @@ def test_ask_preview_route_success_with_provider(
     _mock_authenticated_user(monkeypatch)
     fake_langfuse = _FakeLangfuseClient()
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object) -> object:
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "dify"
@@ -157,7 +157,7 @@ def test_ask_preview_route_fallbacks_to_llm(
 ) -> None:
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object) -> object:
         _ = args
         provider = kwargs.get("provider", "")
         if provider == "dify":
@@ -232,7 +232,7 @@ def test_ask_preview_route_provider_only_does_not_require_ask_model(
 ) -> None:
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object) -> object:
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "coze"
@@ -275,7 +275,7 @@ def test_ask_preview_route_provider_only_accepts_coze_workflow(
 ) -> None:
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object) -> object:
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "coze_workflow"
@@ -319,7 +319,7 @@ def test_ask_preview_route_provider_only_accepts_get_biji_knowledge(
     _mock_authenticated_user(monkeypatch)
     captured: dict[str, object] = {}
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object) -> object:
         _ = args
         provider = kwargs.get("provider", "")
         assert provider == "get_biji_knowledge"
@@ -369,7 +369,7 @@ def test_ask_preview_route_surfaces_friendly_provider_error(
 ) -> None:
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object) -> object:
         _ = (args, kwargs)
         message = (
             "get_biji_knowledge request failed: 401 Client Error for url: "
@@ -417,7 +417,7 @@ def test_ask_preview_route_falls_back_to_generic_provider_error(
 ) -> None:
     _mock_authenticated_user(monkeypatch)
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object) -> object:
         _ = (args, kwargs)
         message = "dify request failed: 500 | {raw body}"
         raise AskProviderError(message)
@@ -477,12 +477,12 @@ def test_ask_preview_route_uses_authenticated_creator_for_debug_billing(
         raising=False,
     )
 
-    def fake_chat_llm(*args: object, **kwargs: object):
+    def fake_chat_llm(*args: object, **kwargs: object) -> object:
         _ = args
         captured["chat_llm"] = kwargs
         yield SimpleNamespace(content="debug answer")
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object) -> object:
         _ = args
         runtime = kwargs.get("runtime")
         assert runtime is not None
@@ -534,12 +534,12 @@ def test_ask_preview_route_passes_debug_usage_context_for_creator(
     fake_langfuse = _FakeLangfuseClient()
     captured: dict[str, object] = {}
 
-    def fake_chat_llm(*args: object, **kwargs: object):
+    def fake_chat_llm(*args: object, **kwargs: object) -> object:
         _ = args
         captured.update(kwargs)
         yield SimpleNamespace(content="debug answer")
 
-    def fake_stream_ask_provider_response(*args: object, **kwargs: object):
+    def fake_stream_ask_provider_response(*args: object, **kwargs: object) -> object:
         _ = args
         runtime = kwargs.get("runtime")
         assert runtime is not None

--- a/src/api/tests/service/shifu/test_billing_debug_admission_contracts.py
+++ b/src/api/tests/service/shifu/test_billing_debug_admission_contracts.py
@@ -20,8 +20,8 @@ def test_shifu_preview_routes_gate_creator_debug_usage_with_billing_admission() 
     )
     assert source.count("_admit_creator_debug_usage()") >= 3
     assert "_admit_creator_preview_usage_for_shifu(shifu_bid)" in source
-    assert "def ask_preview_api():" in source
-    assert "def tts_preview_api():" in source
+    assert "def ask_preview_api() -> object:" in source
+    assert "def tts_preview_api() -> object:" in source
     assert "@bypass_token_validation\n    def ask_preview_api():" not in source
     assert "@bypass_token_validation\n    def tts_preview_api():" not in source
 

--- a/src/api/tests/service/shifu/test_billing_debug_admission_contracts.py
+++ b/src/api/tests/service/shifu/test_billing_debug_admission_contracts.py
@@ -20,8 +20,8 @@ def test_shifu_preview_routes_gate_creator_debug_usage_with_billing_admission() 
     )
     assert source.count("_admit_creator_debug_usage()") >= 3
     assert "_admit_creator_preview_usage_for_shifu(shifu_bid)" in source
-    assert "def ask_preview_api() -> object:" in source
-    assert "def tts_preview_api() -> object:" in source
+    assert "def ask_preview_api() -> str:" in source
+    assert "def tts_preview_api() -> Response:" in source
     assert "@bypass_token_validation\n    def ask_preview_api():" not in source
     assert "@bypass_token_validation\n    def tts_preview_api():" not in source
 

--- a/src/api/tests/service/shifu/test_course_copy.py
+++ b/src/api/tests/service/shifu/test_course_copy.py
@@ -33,7 +33,7 @@ def _unique_email(label: str) -> str:
 
 
 @pytest.fixture(autouse=True)
-def _stub_copy_course_risk_control(monkeypatch: object):
+def _stub_copy_course_risk_control(monkeypatch: object) -> None:
     monkeypatch.setattr(
         "flaskr.service.shifu.admin.check_text_with_risk_control",
         lambda *_args, **_kwargs: None,
@@ -202,7 +202,7 @@ def _seed_course_with_outlines(
     }
 
 
-def _mock_operator(monkeypatch: object, user_id: str = SOURCE_OPERATOR_BID):
+def _mock_operator(monkeypatch: object, user_id: str = SOURCE_OPERATOR_BID) -> object:
     dummy_user = SimpleNamespace(
         user_id=user_id,
         is_operator=True,
@@ -747,7 +747,7 @@ def test_copy_course_risk_rejection_does_not_create_target_user(
         )
         db.session.commit()
 
-    def _reject_risk(*args: object, **kwargs: object):
+    def _reject_risk(*args: object, **kwargs: object) -> None:
         _ = (args, kwargs)
         raise_error("server.check.checkRiskControlReject")
 

--- a/src/api/tests/service/shifu/test_create_outlines_batch.py
+++ b/src/api/tests/service/shifu/test_create_outlines_batch.py
@@ -26,7 +26,7 @@ from flaskr.service.shifu.shifu_outline_funcs import (
 
 
 @pytest.fixture(autouse=True)
-def _isolate_side_effects(monkeypatch: object):
+def _isolate_side_effects(monkeypatch: object) -> None:
     """Drop the external risk check and history machinery: these tests only exercise position allocation and publishability."""
     monkeypatch.setattr(
         shifu_outline_funcs,

--- a/src/api/tests/service/shifu/test_mdflow_history_routes.py
+++ b/src/api/tests/service/shifu/test_mdflow_history_routes.py
@@ -7,13 +7,13 @@ from flaskr import dao
 from flaskr.service.common.models import ERROR_CODE
 
 
-def _get_models():
+def _get_models() -> object:
     from flaskr.service.shifu.models import DraftOutlineItem, DraftShifu
 
     return DraftShifu, DraftOutlineItem
 
 
-def _mock_user(monkeypatch: object, user_id: str, is_creator: bool = True):
+def _mock_user(monkeypatch: object, user_id: str, is_creator: bool = True) -> object:
     dummy_user = SimpleNamespace(
         user_id=user_id,
         is_creator=is_creator,

--- a/src/api/tests/service/shifu/test_operator_voice_clone_register.py
+++ b/src/api/tests/service/shifu/test_operator_voice_clone_register.py
@@ -185,7 +185,7 @@ def _mock_volcengine_status(monkeypatch: object, status: int) -> None:
 
 
 def _forbid_minimax_synthesis(monkeypatch: object) -> None:
-    def _fail(*_args: object, **_kwargs: object):
+    def _fail(*_args: object, **_kwargs: object) -> None:
         message = "synthesize_text must not be called for volcengine"
         raise AssertionError(message)
 

--- a/src/api/tests/service/shifu/test_outline_history_buffered_pagination.py
+++ b/src/api/tests/service/shifu/test_outline_history_buffered_pagination.py
@@ -33,7 +33,7 @@ def _seed_versions(count: int) -> list[int]:
     return sorted((int(row.id) for row in rows), reverse=True)
 
 
-def _cleanup():
+def _cleanup() -> None:
     DraftOutlineItem.query.filter(DraftOutlineItem.shifu_bid == SHIFU).delete()
     db.session.commit()
 

--- a/src/api/tests/service/shifu/test_permissions.py
+++ b/src/api/tests/service/shifu/test_permissions.py
@@ -17,13 +17,13 @@ from flaskr.service.user.repository import create_user_entity, upsert_credential
 from tests.common.fixtures.bill_products import build_bill_products
 
 
-def _get_models():
+def _get_models() -> object:
     from flaskr.service.shifu.models import AiCourseAuth, DraftShifu
 
     return DraftShifu, AiCourseAuth
 
 
-def _seed_shifu(app: object, shifu_bid: str, owner_bid: str):
+def _seed_shifu(app: object, shifu_bid: str, owner_bid: str) -> None:
     with app.app_context():
         draft_shifu_model, course_auth_model = _get_models()
         draft_shifu_model.query.filter_by(shifu_bid=shifu_bid).delete()
@@ -46,7 +46,7 @@ def _seed_shifu(app: object, shifu_bid: str, owner_bid: str):
         dao.db.session.commit()
 
 
-def _mock_user(monkeypatch: object, user_id: str, is_creator: bool = True):
+def _mock_user(monkeypatch: object, user_id: str, is_creator: bool = True) -> object:
     dummy_user = SimpleNamespace(
         user_id=user_id,
         is_creator=is_creator,
@@ -73,7 +73,7 @@ def _allow_email_login(monkeypatch: object) -> None:
     _clear_config_caches()
 
 
-def _add_auth(app: object, shifu_bid: str, user_id: str, status: int):
+def _add_auth(app: object, shifu_bid: str, user_id: str, status: int) -> None:
     with app.app_context():
         _, course_auth_model = _get_models()
         dao.db.session.add(
@@ -88,7 +88,7 @@ def _add_auth(app: object, shifu_bid: str, user_id: str, status: int):
         dao.db.session.commit()
 
 
-def _seed_user(app: object, *, user_bid: str, email: str):
+def _seed_user(app: object, *, user_bid: str, email: str) -> None:
     with app.app_context():
         entity = create_user_entity(
             user_bid=user_bid,
@@ -111,7 +111,7 @@ def _seed_user(app: object, *, user_bid: str, email: str):
         dao.db.session.commit()
 
 
-def _ensure_trial_billing_enabled(monkeypatch: object):
+def _ensure_trial_billing_enabled(monkeypatch: object) -> None:
     import flaskr.service.billing.auth_hooks  # noqa: F401
 
     monkeypatch.setattr(
@@ -144,7 +144,7 @@ class TestShifuPermissions:
         _add_auth(app, shifu_bid, active_user, status=1)
         _add_auth(app, shifu_bid, inactive_user, status=0)
 
-        def fake_load_user_aggregate(user_id: str):
+        def fake_load_user_aggregate(user_id: str) -> object:
             return SimpleNamespace(
                 user_bid=user_id,
                 mobile="13800000000",

--- a/src/api/tests/service/shifu/test_reorder_outline_tree.py
+++ b/src/api/tests/service/shifu/test_reorder_outline_tree.py
@@ -15,7 +15,7 @@ from flaskr.service.shifu.shifu_outline_funcs import (
 
 
 @pytest.fixture(autouse=True)
-def _stub_reorder_side_effects(monkeypatch: object):
+def _stub_reorder_side_effects(monkeypatch: object) -> None:
     monkeypatch.setattr(
         shifu_outline_funcs,
         "cleanup_outline_history_versions",

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -76,7 +76,9 @@ def _mock_route_user(monkeypatch: object, user_id: str) -> object:
     return dummy_user
 
 
-def _mock_route_permission(monkeypatch: object, permission_map: dict[str, bool]) -> None:
+def _mock_route_permission(
+    monkeypatch: object, permission_map: dict[str, bool]
+) -> None:
     from flaskr.service.shifu import route
 
     def _has_permission(

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -15,7 +15,7 @@ def _seed_shifu(
     owner_bid: str,
     price: Decimal,
     ask_provider_config: str = "{}",
-):
+) -> None:
     from flaskr.service.shifu.models import DraftShifu
 
     with app.app_context():
@@ -43,7 +43,7 @@ def _seed_shifu(
         dao.db.session.commit()
 
 
-def _mock_shifu_permissions(monkeypatch: object):
+def _mock_shifu_permissions(monkeypatch: object) -> None:
     from flaskr.service.shifu import shifu_draft_funcs
 
     monkeypatch.setattr(
@@ -60,7 +60,7 @@ def _mock_shifu_permissions(monkeypatch: object):
     )
 
 
-def _mock_route_user(monkeypatch: object, user_id: str):
+def _mock_route_user(monkeypatch: object, user_id: str) -> object:
     from types import SimpleNamespace
 
     dummy_user = SimpleNamespace(
@@ -76,12 +76,12 @@ def _mock_route_user(monkeypatch: object, user_id: str):
     return dummy_user
 
 
-def _mock_route_permission(monkeypatch: object, permission_map: dict[str, bool]):
+def _mock_route_permission(monkeypatch: object, permission_map: dict[str, bool]) -> None:
     from flaskr.service.shifu import route
 
     def _has_permission(
         _app: object, _user_id: object, _shifu_bid: object, permission: str
-    ):
+    ) -> object:
         return permission_map.get(permission, False)
 
     monkeypatch.setattr(
@@ -218,7 +218,7 @@ def test_save_shifu_draft_info_normalizes_removed_tts_fields(
 
     captured: dict[str, object] = {}
 
-    def _fake_validate_tts_settings_strict(**kwargs: object):
+    def _fake_validate_tts_settings_strict(**kwargs: object) -> object:
         captured.update(kwargs)
         return SimpleNamespace(
             provider="minimax",
@@ -299,7 +299,7 @@ def test_save_shifu_draft_info_normalizes_legacy_tts_fields_when_omitted(
         legacy.tts_emotion = "happy"
         dao.db.session.commit()
 
-    def _fake_validate_tts_settings_strict(**kwargs: object):
+    def _fake_validate_tts_settings_strict(**kwargs: object) -> object:
         return SimpleNamespace(
             provider=kwargs["provider"],
             model=kwargs["model"],

--- a/src/api/tests/service/shifu/test_shifu_outline_tree.py
+++ b/src/api/tests/service/shifu/test_shifu_outline_tree.py
@@ -18,7 +18,7 @@ from flaskr.service.shifu.shifu_outline_funcs import (
 from sqlalchemy import inspect as sa_inspect
 
 
-def _mk_item(shifu_bid: object, bid: object, position: object, parent_bid: object = ""):
+def _mk_item(shifu_bid: object, bid: object, position: object, parent_bid: object = "") -> object:
     item = DraftOutlineItem()
     item.outline_item_bid = bid
     item.shifu_bid = shifu_bid

--- a/src/api/tests/service/shifu/test_shifu_outline_tree.py
+++ b/src/api/tests/service/shifu/test_shifu_outline_tree.py
@@ -18,7 +18,9 @@ from flaskr.service.shifu.shifu_outline_funcs import (
 from sqlalchemy import inspect as sa_inspect
 
 
-def _mk_item(shifu_bid: object, bid: object, position: object, parent_bid: object = "") -> object:
+def _mk_item(
+    shifu_bid: object, bid: object, position: object, parent_bid: object = ""
+) -> object:
     item = DraftOutlineItem()
     item.outline_item_bid = bid
     item.shifu_bid = shifu_bid

--- a/src/api/tests/service/shifu/test_shifu_public_urls.py
+++ b/src/api/tests/service/shifu/test_shifu_public_urls.py
@@ -97,7 +97,7 @@ def _seed_preview_route_course(
         dao.db.session.commit()
 
 
-def _build_detail_for_base_url(monkeypatch: object, base_url: str):
+def _build_detail_for_base_url(monkeypatch: object, base_url: str) -> object:
     from flaskr.service.shifu import shifu_draft_funcs
 
     monkeypatch.setattr(

--- a/src/api/tests/service/shifu/test_shifu_publish_funcs.py
+++ b/src/api/tests/service/shifu/test_shifu_publish_funcs.py
@@ -20,7 +20,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> None:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -99,23 +99,23 @@ class _FakeObservation:
         self.id = f"fake-{kind}-id"
         self.generations = []
 
-    def start_observation(self, as_type: object = "span", **kwargs: object):
+    def start_observation(self, as_type: object = "span", **kwargs: object) -> object:
         child = _FakeObservation(as_type, **kwargs)
         if as_type == "generation":
             self.generations.append(child)
         return child
 
-    def update(self, **kwargs: object):
+    def update(self, **kwargs: object) -> None:
         self.updates.append(kwargs)
 
-    def set_trace_as_public(self):
+    def set_trace_as_public(self) -> None:
         self.public = True
 
-    def end(self):
+    def end(self) -> None:
         self.ended = True
 
     @property
-    def end_kwargs(self):
+    def end_kwargs(self) -> object:
         merged = {}
         for item in self.updates:
             merged.update(item)
@@ -131,7 +131,7 @@ class _FakeLangfuseClient:
         as_type: object = "span",
         trace_context: object = None,
         **kwargs: object,
-    ):
+    ) -> object:
         root = _FakeObservation(as_type, **kwargs)
         root.trace_context = trace_context or {}
         self.traces.append(root)
@@ -168,7 +168,7 @@ def test_get_summary_updates_trace_and_span_output(monkeypatch: object) -> None:
 
     fake_langfuse = _FakeLangfuseClient()
 
-    def create_trace_id(seed: object = None):
+    def create_trace_id(seed: object = None) -> object:
         del seed
         return "a" * 32
 
@@ -221,7 +221,7 @@ def test_run_summary_downgrades_shutdown_race_to_warning(monkeypatch: object) ->
 
     monkeypatch.setattr(module, "apply_shifu_context_snapshot", lambda *_a, **_k: None)
 
-    def _raise_shutdown(*_a: object, **_k: object):
+    def _raise_shutdown(*_a: object, **_k: object) -> None:
         message = (
             "litellm.MidStreamFallbackError: APIConnectionError: OpenAIException - "
             "cannot schedule new futures after shutdown"
@@ -249,7 +249,7 @@ def test_run_summary_logs_error_for_other_failures(monkeypatch: object) -> None:
 
     monkeypatch.setattr(module, "apply_shifu_context_snapshot", lambda *_a, **_k: None)
 
-    def _raise_other(*_a: object, **_k: object):
+    def _raise_other(*_a: object, **_k: object) -> None:
         message = "boom"
         raise ValueError(message)
 
@@ -276,7 +276,7 @@ def test_publish_shifu_draft_preserves_outline_updated_at(
     original_load_existing_outline_items = module.load_existing_outline_items
     outline_load_calls = []
 
-    def _record_outline_load(*args: object, **kwargs: object):
+    def _record_outline_load(*args: object, **kwargs: object) -> object:
         outline_load_calls.append((args, kwargs))
         return original_load_existing_outline_items(*args, **kwargs)
 

--- a/src/api/tests/service/shifu/test_transfer_creator.py
+++ b/src/api/tests/service/shifu/test_transfer_creator.py
@@ -113,7 +113,7 @@ def _seed_published_course(shifu_bid: str, creator_user_bid: str) -> None:
     db.session.flush()
 
 
-def _mock_operator(monkeypatch: object, user_id: str = "operator-1"):
+def _mock_operator(monkeypatch: object, user_id: str = "operator-1") -> object:
     dummy_user = SimpleNamespace(
         user_id=user_id,
         is_operator=True,

--- a/src/api/tests/service/shifu/test_tts_preview_helper.py
+++ b/src/api/tests/service/shifu/test_tts_preview_helper.py
@@ -93,7 +93,7 @@ def test_build_tts_preview_response_records_debug_usage_and_summary(
         raising=False,
     )
 
-    def _fake_record_tts_usage(app: object, context: object, **kwargs: object):
+    def _fake_record_tts_usage(app: object, context: object, **kwargs: object) -> object:
         captured.append(
             {
                 "app": app,
@@ -155,7 +155,7 @@ def test_build_tts_preview_response_normalizes_removed_fields(
     app = Flask(__name__)
     captured: dict[str, object] = {}
 
-    def _fake_validate_tts_settings_strict(**kwargs: object):
+    def _fake_validate_tts_settings_strict(**kwargs: object) -> object:
         captured.update(kwargs)
         return SimpleNamespace(
             provider="fake",
@@ -253,7 +253,7 @@ def test_build_tts_preview_response_guards_minimax_custom_voice(
 
     def _fake_guard(
         _app: object, *, provider: object, voice_id: object, owner_user_bid: object
-    ):
+    ) -> None:
         guard_calls.append(
             {
                 "provider": provider,
@@ -297,7 +297,7 @@ def test_build_tts_preview_response_guards_minimax_custom_voice(
     ]
 
 
-def _stub_preview_pipeline(monkeypatch: object):
+def _stub_preview_pipeline(monkeypatch: object) -> None:
     monkeypatch.setattr(
         "flaskr.service.shifu.tts_preview.validate_tts_settings_strict",
         lambda **_kwargs: SimpleNamespace(

--- a/src/api/tests/service/shifu/test_tts_preview_helper.py
+++ b/src/api/tests/service/shifu/test_tts_preview_helper.py
@@ -93,7 +93,9 @@ def test_build_tts_preview_response_records_debug_usage_and_summary(
         raising=False,
     )
 
-    def _fake_record_tts_usage(app: object, context: object, **kwargs: object) -> object:
+    def _fake_record_tts_usage(
+        app: object, context: object, **kwargs: object
+    ) -> object:
         captured.append(
             {
                 "app": app,

--- a/src/api/tests/service/tts/test_aliyun_nls_token.py
+++ b/src/api/tests/service/tts/test_aliyun_nls_token.py
@@ -15,7 +15,7 @@ def test_get_aliyun_nls_token_uses_override_when_configured(
 ) -> None:
     monkeypatch.setenv("ALIYUN_TTS_TOKEN", "override-token")
 
-    def fake_get(*args: object, **kwargs: object):
+    def fake_get(*args: object, **kwargs: object) -> None:
         _ = (args, kwargs)
         message = "requests.get should not be called when override token exists"
         raise AssertionError(message)
@@ -46,10 +46,10 @@ def test_get_aliyun_nls_token_fetches_and_caches(monkeypatch: object) -> None:
         status_code = 200
         text = ""
 
-        def json(self):
+        def json(self) -> object:
             return {"Token": {"Id": "tok-1", "ExpireTime": int(time.time()) + 3600}}
 
-    def fake_get(url: object, headers: object = None, timeout: object = None):
+    def fake_get(url: object, headers: object = None, timeout: object = None) -> object:
         captured["calls"] += 1
         captured["url"] = url
         captured["headers"] = headers
@@ -100,7 +100,7 @@ def test_get_aliyun_nls_token_refresh_falls_back_to_cached_token(
 
     captured = {"calls": 0}
 
-    def fake_get(*args: object, **kwargs: object):
+    def fake_get(*args: object, **kwargs: object) -> None:
         _ = (args, kwargs)
         captured["calls"] += 1
         message = "network down"
@@ -140,7 +140,7 @@ def test_aliyun_provider_synthesize_uses_dynamic_token(monkeypatch: object) -> N
 
     def fake_post(
         url: object, json: object = None, headers: object = None, timeout: object = None
-    ):
+    ) -> object:
         captured["url"] = url
         captured["json"] = json
         captured["headers"] = headers

--- a/src/api/tests/service/tts/test_audio_utils.py
+++ b/src/api/tests/service/tts/test_audio_utils.py
@@ -16,7 +16,7 @@ class _FakeSegment:
     def __len__(self) -> int:
         return self.duration_ms
 
-    def append(self, other: object, crossfade: object = 100):
+    def append(self, other: object, crossfade: object = 100) -> object:
         _FakeSegment.append_crossfades.append(crossfade)
         if crossfade > len(self):
             message = (
@@ -44,7 +44,7 @@ class _FakeSegment:
         output_io: object,
         format: object = "mp3",  # noqa: A002 - mirrors the pydub API
         bitrate: object = "128k",
-    ):
+    ) -> None:
         _ = (format, bitrate)
         output_io.write(f"duration={self.duration_ms}".encode())
 

--- a/src/api/tests/service/tts/test_av_speakable_segmentation.py
+++ b/src/api/tests/service/tts/test_av_speakable_segmentation.py
@@ -3,7 +3,7 @@
 import pytest
 
 
-def _require_app(app: object):
+def _require_app(app: object) -> None:
     if app is None:
         pytest.skip("App fixture disabled")
 

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -513,7 +513,9 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
                 word_count=12,
             )
 
-    def _fake_try_get_duration(audio_data: object, audio_format: object = "mp3") -> object:
+    def _fake_try_get_duration(
+        audio_data: object, audio_format: object = "mp3"
+    ) -> object:
         _ = audio_format
         if audio_data == b"broken-stream-mp3":
             return None

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -19,19 +19,19 @@ class _FakeResponse:
         self._json_payload = json_payload or {}
         self.headers = {"content-type": "text/event-stream"}
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         if self._status_error:
             raise self._status_error
 
-    def iter_lines(self, decode_unicode: object = True):
+    def iter_lines(self, decode_unicode: object = True) -> object:
         _ = decode_unicode
         yield from self._lines
 
-    def json(self):
+    def json(self) -> object:
         return self._json_payload
 
 
-def _sse_line(payload: object):
+def _sse_line(payload: object) -> object:
     return f"data: {json.dumps(payload)}"
 
 
@@ -63,7 +63,7 @@ def test_minimax_http_streaming_parses_audio_and_final_subtitles(
         lambda **kwargs: gate_calls.append(kwargs),
     )
 
-    def _fake_post(url: object, **kwargs: object):
+    def _fake_post(url: object, **kwargs: object) -> object:
         post_calls.append((url, kwargs))
         return _FakeResponse(
             [
@@ -159,7 +159,7 @@ def test_minimax_synthesize_splits_word_count_and_usage_characters(
         lambda key: config.get(key, ""),
     )
 
-    def _fake_post(url: object, **kwargs: object):
+    def _fake_post(url: object, **kwargs: object) -> object:
         post_calls.append((url, kwargs))
         return _FakeResponse(
             json_payload={
@@ -236,7 +236,7 @@ def test_streaming_tts_minimax_http_stream_sends_one_request_on_finalize(
     aggregate_usage_calls = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **kwargs: object):
+        def stream_synthesize(self, **kwargs: object) -> object:
             calls.append(kwargs["text"])
             yield SimpleNamespace(
                 audio_data=b"fake-mp3",
@@ -371,7 +371,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_for_partial_subtitles(
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs: object):
+        def stream_synthesize(self, **_kwargs: object) -> object:
             yield SimpleNamespace(
                 audio_data=b"fake-mp3",
                 is_final=False,
@@ -492,7 +492,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
     synthesize_calls = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **kwargs: object):
+        def stream_synthesize(self, **kwargs: object) -> object:
             stream_calls.append(kwargs["text"])
             yield SimpleNamespace(
                 audio_data=b"broken-stream-mp3",
@@ -504,7 +504,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
                 trace_id="trace-invalid-audio",
             )
 
-        def synthesize(self, **kwargs: object):
+        def synthesize(self, **kwargs: object) -> object:
             synthesize_calls.append(kwargs["text"])
             return SimpleNamespace(
                 audio_data=b"complete-mp3",
@@ -513,7 +513,7 @@ def test_streaming_tts_minimax_http_stream_falls_back_when_stream_audio_invalid(
                 word_count=12,
             )
 
-    def _fake_try_get_duration(audio_data: object, audio_format: object = "mp3"):
+    def _fake_try_get_duration(audio_data: object, audio_format: object = "mp3") -> object:
         _ = audio_format
         if audio_data == b"broken-stream-mp3":
             return None
@@ -613,7 +613,7 @@ def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitle
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs: object):
+        def stream_synthesize(self, **_kwargs: object) -> object:
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -640,7 +640,7 @@ def test_streaming_tts_minimax_http_stream_buffers_audio_until_provider_subtitle
 
     export_calls = []
 
-    def _fake_export(_audio_data: object, **kwargs: object):
+    def _fake_export(_audio_data: object, **kwargs: object) -> object:
         export_calls.append(kwargs)
         end_ms = kwargs.get("end_ms")
         start_ms = int(kwargs.get("start_ms") or 0)
@@ -739,7 +739,7 @@ def test_streaming_tts_minimax_http_stream_does_not_emit_audio_past_subtitles(
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs: object):
+        def stream_synthesize(self, **_kwargs: object) -> object:
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -788,7 +788,7 @@ def test_streaming_tts_minimax_http_stream_does_not_emit_audio_past_subtitles(
 
     export_calls = []
 
-    def _fake_export(_audio_data: object, **kwargs: object):
+    def _fake_export(_audio_data: object, **kwargs: object) -> object:
         export_calls.append(kwargs)
         end_ms = int(kwargs.get("end_ms") or 0)
         start_ms = int(kwargs.get("start_ms") or 0)
@@ -880,7 +880,7 @@ def test_streaming_tts_minimax_http_stream_offsets_live_cues_by_emitted_audio(
     saved_records = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **kwargs: object):
+        def stream_synthesize(self, **kwargs: object) -> object:
             calls.append(kwargs["text"])
             if kwargs["text"] == "First sentence.":
                 yield SimpleNamespace(
@@ -913,12 +913,12 @@ def test_streaming_tts_minimax_http_stream_offsets_live_cues_by_emitted_audio(
                 ],
             )
 
-    def _fake_export(audio_data: object, **_kwargs: object):
+    def _fake_export(audio_data: object, **_kwargs: object) -> object:
         if audio_data == b"first-mp3":
             return audio_data, 1000
         return audio_data, 1200
 
-    def _fake_build_completed_audio_record(**kwargs: object):
+    def _fake_build_completed_audio_record(**kwargs: object) -> object:
         saved_records.append(kwargs)
         return SimpleNamespace(**kwargs)
 
@@ -1035,7 +1035,7 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
     from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs: object):
+        def stream_synthesize(self, **_kwargs: object) -> object:
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -1062,7 +1062,7 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
                 ],
             )
 
-    def _fake_export(_audio_data: object, **kwargs: object):
+    def _fake_export(_audio_data: object, **kwargs: object) -> object:
         end_ms = kwargs.get("end_ms")
         start_ms = int(kwargs.get("start_ms") or 0)
         if end_ms is None:
@@ -1093,7 +1093,7 @@ def test_streaming_tts_minimax_http_stream_uses_provider_progress_cues_without_s
     )
     saved_records = []
 
-    def _fake_build_completed_audio_record(**kwargs: object):
+    def _fake_build_completed_audio_record(**kwargs: object) -> object:
         saved_records.append(kwargs)
         return SimpleNamespace(**kwargs)
 
@@ -1174,7 +1174,7 @@ def test_streaming_tts_minimax_http_stream_keeps_provider_middle_cue_timing(
     saved_records = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs: object):
+        def stream_synthesize(self, **_kwargs: object) -> object:
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -1211,14 +1211,14 @@ def test_streaming_tts_minimax_http_stream_keeps_provider_middle_cue_timing(
                 ],
             )
 
-    def _fake_export(_audio_data: object, **kwargs: object):
+    def _fake_export(_audio_data: object, **kwargs: object) -> object:
         end_ms = kwargs.get("end_ms")
         start_ms = int(kwargs.get("start_ms") or 0)
         if end_ms is None:
             return b"early-piece", 1900
         return b"final-piece", int(end_ms or 0) - start_ms
 
-    def _fake_build_completed_audio_record(**kwargs: object):
+    def _fake_build_completed_audio_record(**kwargs: object) -> object:
         saved_records.append(kwargs)
         return SimpleNamespace(**kwargs)
 
@@ -1335,7 +1335,7 @@ def test_streaming_tts_minimax_http_stream_freezes_emitted_prefix_for_same_count
     saved_records = []
 
     class _FakeMinimaxProvider:
-        def stream_synthesize(self, **_kwargs: object):
+        def stream_synthesize(self, **_kwargs: object) -> object:
             yield SimpleNamespace(
                 audio_data=b"fake-mp3-part-1",
                 is_final=False,
@@ -1365,14 +1365,14 @@ def test_streaming_tts_minimax_http_stream_freezes_emitted_prefix_for_same_count
                 ],
             )
 
-    def _fake_export(_audio_data: object, **kwargs: object):
+    def _fake_export(_audio_data: object, **kwargs: object) -> object:
         end_ms = kwargs.get("end_ms")
         start_ms = int(kwargs.get("start_ms") or 0)
         if end_ms is None:
             return b"early-piece", 1946
         return b"final-piece", int(end_ms or 0) - start_ms
 
-    def _fake_build_completed_audio_record(**kwargs: object):
+    def _fake_build_completed_audio_record(**kwargs: object) -> object:
         saved_records.append(kwargs)
         return SimpleNamespace(**kwargs)
 

--- a/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
+++ b/src/api/tests/service/tts/test_minimax_preview_voice_guard.py
@@ -20,7 +20,7 @@ _BUILT_IN_VOICE_ID = "female-shaonv"
 
 
 @pytest.fixture(autouse=True)
-def _fake_minimax_provider(monkeypatch: object):
+def _fake_minimax_provider(monkeypatch: object) -> None:
     """Isolate the guard from real provider config/credentials."""
     provider = SimpleNamespace(
         get_provider_config=lambda: SimpleNamespace(
@@ -47,7 +47,7 @@ def _seed_clone(
     status: str,
     deleted: int = 0,
     provider: str = "minimax",
-):
+) -> None:
     with app.app_context():
         db.session.add(
             TTSMiniMaxClonedVoice(

--- a/src/api/tests/service/tts/test_minimax_rpm_limit.py
+++ b/src/api/tests/service/tts/test_minimax_rpm_limit.py
@@ -3,7 +3,7 @@
 from flaskr.api.tts import minimax_provider
 
 
-def _set_config(monkeypatch: object, mapping: object):
+def _set_config(monkeypatch: object, mapping: object) -> None:
     monkeypatch.setattr(
         minimax_provider,
         "get_config",

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -271,7 +271,9 @@ def test_minimax_clone_voice_sends_numeric_file_id(monkeypatch: object) -> None:
                 "base_resp": {"status_code": 0, "status_msg": "success"},
             }
 
-    def fake_post(url: object, headers: object, json: object, timeout: object) -> object:
+    def fake_post(
+        url: object, headers: object, json: object, timeout: object
+    ) -> object:
         assert url.endswith("/v1/voice_clone?GroupId=test-group")
         assert headers["Authorization"] == "Bearer test-api-key"
         assert headers["Content-Type"] == "application/json"

--- a/src/api/tests/service/tts/test_minimax_voice_clone.py
+++ b/src/api/tests/service/tts/test_minimax_voice_clone.py
@@ -171,7 +171,7 @@ def test_normalize_audio_blob_validates_duration_and_exports_wav(
         def __len__(self) -> int:
             return 12_000
 
-        def export(self, out: object, format: object = "wav"):  # noqa: A002 - mirrors the pydub API
+        def export(self, out: object, format: object = "wav") -> None:  # noqa: A002 - mirrors the pydub API
             assert format == "wav"
             out.write(b"WAV-BYTES")
 
@@ -210,10 +210,10 @@ def test_minimax_upload_file_accepts_official_file_response(
     )
 
     class FakeResponse:
-        def raise_for_status(self):
+        def raise_for_status(self) -> None:
             return None
 
-        def json(self):
+        def json(self) -> object:
             return {
                 "file": {
                     "file_id": 123456789012345680,
@@ -226,7 +226,7 @@ def test_minimax_upload_file_accepts_official_file_response(
 
     def fake_post(
         url: object, headers: object, data: object, files: object, timeout: object
-    ):
+    ) -> object:
         assert url.endswith("/v1/files/upload?GroupId=test-group")
         assert headers["Authorization"] == "Bearer test-api-key"
         assert data == {"purpose": "voice_clone"}
@@ -260,10 +260,10 @@ def test_minimax_clone_voice_sends_numeric_file_id(monkeypatch: object) -> None:
     )
 
     class FakeResponse:
-        def raise_for_status(self):
+        def raise_for_status(self) -> None:
             return None
 
-        def json(self):
+        def json(self) -> object:
             return {
                 "input_sensitive": False,
                 "demo_audio": "https://example.test/demo.mp3",
@@ -271,7 +271,7 @@ def test_minimax_clone_voice_sends_numeric_file_id(monkeypatch: object) -> None:
                 "base_resp": {"status_code": 0, "status_msg": "success"},
             }
 
-    def fake_post(url: object, headers: object, json: object, timeout: object):
+    def fake_post(url: object, headers: object, json: object, timeout: object) -> object:
         assert url.endswith("/v1/voice_clone?GroupId=test-group")
         assert headers["Authorization"] == "Bearer test-api-key"
         assert headers["Content-Type"] == "application/json"
@@ -329,7 +329,7 @@ def test_run_minimax_voice_clone_success_captures_credit_once(
     class FakeClient:
         def upload_clone_audio(
             self, audio_bytes: object, filename: object, content_type: object
-        ):
+        ) -> object:
             assert audio_bytes == b"WAV"
             assert filename.endswith(".wav")
             assert content_type == "audio/wav"
@@ -337,12 +337,12 @@ def test_run_minimax_voice_clone_success_captures_credit_once(
 
         def upload_prompt_audio(
             self, audio_bytes: object, filename: object, content_type: object
-        ):
+        ) -> None:
             _ = (audio_bytes, filename, content_type)
             message = "prompt upload should not be called"
             raise AssertionError(message)
 
-        def clone_voice(self, **kwargs: object):
+        def clone_voice(self, **kwargs: object) -> object:
             assert kwargs["file_id"] == "file-source"
             return SimpleNamespace(
                 voice_id=kwargs["voice_id"],
@@ -415,7 +415,7 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
 
     def fake_upload_to_storage(
         _app: object, *, file_content: object, object_key: object, **_kwargs: object
-    ):
+    ) -> object:
         if hasattr(file_content, "seek"):
             file_content.seek(0)
         stored_objects[object_key] = file_content.read()
@@ -427,7 +427,7 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
 
     def fake_read_storage_bytes(
         *, object_key: object, profile: object, bucket_name: object
-    ):
+    ) -> object:
         _ = profile
         read_calls.append((object_key, bucket_name))
         return stored_objects[object_key]
@@ -455,19 +455,19 @@ def test_run_minimax_voice_clone_reads_persisted_storage_when_worker_cache_misse
     class FakeClient:
         def upload_clone_audio(
             self, audio_bytes: object, filename: object, content_type: object
-        ):
+        ) -> object:
             _ = (filename, content_type)
             assert audio_bytes == b"WAV"
             return SimpleNamespace(file_id="file-source")
 
         def upload_prompt_audio(
             self, audio_bytes: object, filename: object, content_type: object
-        ):
+        ) -> None:
             _ = (audio_bytes, filename, content_type)
             message = "prompt upload should not be called"
             raise AssertionError(message)
 
-        def clone_voice(self, **kwargs: object):
+        def clone_voice(self, **kwargs: object) -> object:
             return SimpleNamespace(
                 voice_id=kwargs["voice_id"],
                 demo_audio="https://example.test/demo.mp3",
@@ -529,7 +529,7 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(
     stored_calls: list[dict[str, str]] = []
 
     class FakeApp:
-        def app_context(self):
+        def app_context(self) -> object:
             class Context:
                 def __enter__(self) -> Self:
                     nonlocal in_context
@@ -589,7 +589,7 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(
         _normalize_audio,
     )
 
-    def fake_store_resource_bytes(_app: object, **kwargs: object):
+    def fake_store_resource_bytes(_app: object, **kwargs: object) -> object:
         stored_calls.append(
             {
                 "owner_user_bid": kwargs["owner_user_bid"],
@@ -627,18 +627,18 @@ def test_execute_clone_processing_uses_row_values_inside_app_context(
     class FakeClient:
         def upload_clone_audio(
             self, audio_bytes: object, filename: object, content_type: object
-        ):
+        ) -> object:
             _ = (audio_bytes, filename, content_type)
             return SimpleNamespace(file_id="file-source")
 
         def upload_prompt_audio(
             self, audio_bytes: object, filename: object, content_type: object
-        ):
+        ) -> None:
             _ = (audio_bytes, filename, content_type)
             message = "prompt upload should not be called"
             raise AssertionError(message)
 
-        def clone_voice(self, **kwargs: object):
+        def clone_voice(self, **kwargs: object) -> object:
             return SimpleNamespace(
                 voice_id=kwargs["voice_id"],
                 demo_audio="https://example.test/demo.mp3",

--- a/src/api/tests/service/tts/test_provider_error_responses.py
+++ b/src/api/tests/service/tts/test_provider_error_responses.py
@@ -15,7 +15,7 @@ class _Response:
         self._payload = payload
         self.text = text
 
-    def json(self):
+    def json(self) -> object:
         if self._payload is None:
             message = "no json"
             raise ValueError(message)

--- a/src/api/tests/service/tts/test_streaming_tts_av_contract.py
+++ b/src/api/tests/service/tts/test_streaming_tts_av_contract.py
@@ -3,7 +3,7 @@
 import pytest
 
 
-def _require_app(app: object):
+def _require_app(app: object) -> None:
     if app is None:
         pytest.skip("App fixture disabled")
 
@@ -28,7 +28,7 @@ def test_av_streaming_tts_processor_emits_av_contract_in_events(
             self.position = int(kwargs.get("position", 0) or 0)
             self.av_contract = kwargs.get("av_contract")
 
-        def process_chunk(self, chunk: object):
+        def process_chunk(self, chunk: object) -> object:
             if not (chunk or "").strip():
                 return
             yield RunMarkdownFlowDTO(
@@ -45,7 +45,7 @@ def test_av_streaming_tts_processor_emits_av_contract_in_events(
                 ),
             )
 
-        def finalize(self, commit: object = True):
+        def finalize(self, commit: object = True) -> object:
             _ = commit
             yield RunMarkdownFlowDTO(
                 outline_bid=self.outline_bid,
@@ -105,13 +105,13 @@ def test_av_streaming_tts_processor_skips_chunked_markdown_image(
         def __init__(self, **kwargs: object) -> None:
             _ = kwargs
 
-        def process_chunk(self, chunk: object):
+        def process_chunk(self, chunk: object) -> object:
             if (chunk or "").strip():
                 captured_chunks.append(chunk)
             return
             yield
 
-        def finalize(self, commit: object = True):
+        def finalize(self, commit: object = True) -> object:
             _ = commit
             return
             yield
@@ -163,13 +163,13 @@ def test_av_streaming_tts_processor_skips_chunked_html_img_tag(
         def __init__(self, **kwargs: object) -> None:
             _ = kwargs
 
-        def process_chunk(self, chunk: object):
+        def process_chunk(self, chunk: object) -> object:
             if (chunk or "").strip():
                 captured_chunks.append(chunk)
             return
             yield
 
-        def finalize(self, commit: object = True):
+        def finalize(self, commit: object = True) -> object:
             _ = commit
             return
             yield
@@ -221,13 +221,13 @@ def test_av_streaming_tts_processor_does_not_split_markdown_h2_after_svg(
             self.position = int(kwargs.get("position", 0) or 0)
             self._parts: list[str] = []
 
-        def process_chunk(self, chunk: object):
+        def process_chunk(self, chunk: object) -> object:
             if chunk:
                 self._parts.append(chunk)
             return
             yield
 
-        def finalize(self, commit: object = True):
+        def finalize(self, commit: object = True) -> object:
             _ = commit
             text = "".join(self._parts).strip()
             if text:
@@ -292,12 +292,12 @@ def test_av_streaming_tts_processor_advances_position_when_segment_has_no_audio(
             self.position = int(kwargs.get("position", 0) or 0)
             self._buffer = ""
 
-        def process_chunk(self, chunk: object):
+        def process_chunk(self, chunk: object) -> object:
             self._buffer += chunk or ""
             return
             yield
 
-        def finalize(self, commit: object = True):
+        def finalize(self, commit: object = True) -> object:
             _ = commit
             # Simulate provider behavior: very short text produces no audio completion.
             if len((self._buffer or "").strip()) < 2:
@@ -360,7 +360,7 @@ def test_av_streaming_tts_processor_never_emits_new_slide_event(
             self.outline_bid = kwargs.get("outline_bid", "")
             self.position = int(kwargs.get("position", 0) or 0)
 
-        def process_chunk(self, chunk: object):
+        def process_chunk(self, chunk: object) -> object:
             if not (chunk or "").strip():
                 return
             yield RunMarkdownFlowDTO(
@@ -376,7 +376,7 @@ def test_av_streaming_tts_processor_never_emits_new_slide_event(
                 ),
             )
 
-        def finalize(self, commit: object = True):
+        def finalize(self, commit: object = True) -> object:
             _ = commit
             return
             yield
@@ -419,17 +419,17 @@ def test_av_streaming_tts_processor_updates_next_element_index_from_contract(
         def __init__(self, **kwargs: object) -> None:
             _ = kwargs
 
-        def process_chunk(self, chunk: object):
+        def process_chunk(self, chunk: object) -> object:
             _ = chunk
             return
             yield
 
-        def finalize(self, commit: object = True):
+        def finalize(self, commit: object = True) -> object:
             _ = commit
             return
             yield
 
-    def _fake_build_visual_segments(**kwargs: object):
+    def _fake_build_visual_segments(**kwargs: object) -> object:
         _ = kwargs
         seg = VisualSegment(
             segment_id="seg-1",
@@ -477,13 +477,13 @@ def test_av_streaming_tts_processor_releases_sentence_before_long_list_tail(
         def __init__(self, **kwargs: object) -> None:
             _ = kwargs
 
-        def process_chunk(self, chunk: object):
+        def process_chunk(self, chunk: object) -> object:
             if chunk:
                 captured_chunks.append(chunk)
             return
             yield
 
-        def finalize(self, commit: object = True):
+        def finalize(self, commit: object = True) -> object:
             _ = commit
             return
             yield

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -53,7 +53,7 @@ class TestFinalizeSegmentation:
         processor = create_test_processor(mock_app)
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> object:
             _ = kwargs
             if len(args) > 1:
                 segment = args[1]
@@ -97,7 +97,7 @@ class TestFinalizeSegmentation:
         # Track submitted tasks
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> object:
             # Positional args are the thread target followed by segment,
             # voice settings, audio settings, provider and model.
             # Capture the segment text from args[1]
@@ -142,7 +142,7 @@ class TestFinalizeSegmentation:
 
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> object:
             # Positional args are the thread target followed by segment,
             # voice settings, audio settings, provider and model.
             _ = kwargs
@@ -178,7 +178,7 @@ class TestFinalizeSegmentation:
 
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> object:
             # Positional args are the thread target followed by segment,
             # voice settings, audio settings, provider and model.
             _ = kwargs
@@ -252,7 +252,7 @@ class TestFinalizeSegmentation:
 
         remaining_text = "First sentence. Second sentence."
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> object:
             _ = (args, kwargs)
             future = MagicMock()
             future.result.return_value = None
@@ -678,7 +678,7 @@ class TestOffsetDriftRegression:
         processor = create_test_processor(mock_app)
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> object:
             _ = kwargs
             if len(args) > 1:
                 segment = args[1]
@@ -723,7 +723,7 @@ class TestOffsetDriftRegression:
         processor = create_test_processor(mock_app)
         submitted_texts = []
 
-        def mock_submit(*args: object, **kwargs: object):
+        def mock_submit(*args: object, **kwargs: object) -> object:
             _ = kwargs
             if len(args) > 1:
                 segment = args[1]

--- a/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
+++ b/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
@@ -34,7 +34,9 @@ def test_rate_limit_detector(message: object, expected: object) -> None:
     assert _is_retryable_rate_limit_error(ValueError(message)) is expected
 
 
-def _run_retry(monkeypatch: object, outcomes: object, segment_index: object = 0) -> object:
+def _run_retry(
+    monkeypatch: object, outcomes: object, segment_index: object = 0
+) -> object:
     calls = []
     sleeps = []
 

--- a/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
+++ b/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
@@ -34,11 +34,11 @@ def test_rate_limit_detector(message: object, expected: object) -> None:
     assert _is_retryable_rate_limit_error(ValueError(message)) is expected
 
 
-def _run_retry(monkeypatch: object, outcomes: object, segment_index: object = 0):
+def _run_retry(monkeypatch: object, outcomes: object, segment_index: object = 0) -> object:
     calls = []
     sleeps = []
 
-    def _fake_synthesize_text(**kwargs: object):
+    def _fake_synthesize_text(**kwargs: object) -> object:
         calls.append(kwargs)
         outcome = outcomes[min(len(calls) - 1, len(outcomes) - 1)]
         if isinstance(outcome, Exception):

--- a/src/api/tests/service/tts/test_tencent_provider.py
+++ b/src/api/tests/service/tts/test_tencent_provider.py
@@ -16,14 +16,14 @@ class _FakeSSEStreamingResponse:
         self.headers = headers or {"content-type": "text/event-stream"}
         self.closed = False
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         return None
 
-    def iter_lines(self, decode_unicode: object = True):
+    def iter_lines(self, decode_unicode: object = True) -> object:
         _ = decode_unicode
         yield from self._lines
 
-    def close(self):
+    def close(self) -> None:
         self.closed = True
 
 
@@ -52,7 +52,7 @@ def _expected_tc3_authorization(*, payload_json: str, timestamp: int) -> str:
         ]
     )
 
-    def sign(key: object, msg: object):
+    def sign(key: object, msg: object) -> object:
         return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
 
     secret_date = sign(("TC3" + secret_key).encode("utf-8"), date)
@@ -69,7 +69,7 @@ def _expected_tc3_authorization(*, payload_json: str, timestamp: int) -> str:
     )
 
 
-def _patch_tencent_config(monkeypatch: object, tencent_provider: object):
+def _patch_tencent_config(monkeypatch: object, tencent_provider: object) -> None:
     config = {
         "TENCENT_TTS_APP_ID": "1400000000",
         "TENCENT_TTS_SECRET_ID": "secret-id",
@@ -197,7 +197,7 @@ def test_tencent_provider_stream_synthesize_parses_sse_audio_and_alignments(
 
     def fake_post(
         url: object, data: object, headers: object, stream: object, timeout: object
-    ):
+    ) -> object:
         post_calls.append(
             {
                 "url": url,
@@ -282,7 +282,7 @@ def test_tencent_provider_synthesize_collects_audio_and_sentence_subtitles(
 
     def fake_post(
         url: object, data: object, headers: object, stream: object, timeout: object
-    ):
+    ) -> object:
         _ = url, data, headers, stream, timeout
         return _FakeSSEStreamingResponse(
             [
@@ -380,7 +380,7 @@ def test_tencent_provider_raises_sanitized_error_on_sse_error(
 
     def fake_post(
         url: object, data: object, headers: object, stream: object, timeout: object
-    ):
+    ) -> object:
         _ = url, data, headers, stream, timeout
         return _FakeSSEStreamingResponse(
             [

--- a/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
+++ b/src/api/tests/service/tts/test_tencent_texttovoice_provider.py
@@ -33,7 +33,7 @@ def _expected_tc3_authorization(*, payload_json: str, timestamp: int) -> str:
         ]
     )
 
-    def sign(key: object, msg: object):
+    def sign(key: object, msg: object) -> object:
         return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
 
     secret_date = sign(("TC3" + secret_key).encode("utf-8"), date)
@@ -50,7 +50,7 @@ def _expected_tc3_authorization(*, payload_json: str, timestamp: int) -> str:
     )
 
 
-def _patch_credentials(monkeypatch: object):
+def _patch_credentials(monkeypatch: object) -> None:
     from flaskr.api.tts import tencent_texttovoice_provider as module
 
     config = {
@@ -68,7 +68,7 @@ class _FakeResponse:
     def __init__(self, body: object) -> None:
         self._body = body
 
-    def json(self):
+    def json(self) -> object:
         return self._body
 
 
@@ -179,7 +179,7 @@ def test_synthesize_builds_payload_and_concatenates_segments(
 
     def _fake_post(
         url: object, data: object = None, headers: object = None, timeout: object = None
-    ):
+    ) -> object:
         _ = (url, headers, timeout)
         captured_payloads.append(json.loads(data.decode("utf-8")))
         return _FakeResponse(

--- a/src/api/tests/service/tts/test_tts_config_options.py
+++ b/src/api/tests/service/tts/test_tts_config_options.py
@@ -8,7 +8,7 @@ from flaskr.api.tts import base
 
 
 class _FakeMinimaxProvider:
-    def get_provider_config(self):
+    def get_provider_config(self) -> object:
         return base.ProviderConfig(
             name="MiniMax",
             label="MiniMax",
@@ -25,7 +25,7 @@ class _FakeMinimaxProvider:
 
 
 class _FakeBaiduProvider:
-    def get_provider_config(self):
+    def get_provider_config(self) -> object:
         return base.ProviderConfig(
             name="baidu",
             label="Baidu",
@@ -116,8 +116,8 @@ class _FakeRate:
         self.model = model
 
 
-def _chars_per_token_config(value: str):
-    def _get_config(key: object, default: object = None):
+def _chars_per_token_config(value: str) -> object:
+    def _get_config(key: object, default: object = None) -> object:
         if key == "TTS_CHARS_PER_LLM_TOKEN":
             return value
         return default
@@ -134,7 +134,7 @@ def test_tts_credit_multiplier_uses_shared_llm_anchor(monkeypatch: object) -> No
 
     def fake_load_usage_rate(
         *, usage: object, billing_metric: object, settlement_at: object
-    ):
+    ) -> object:
         _ = settlement_at
         captured.append((usage.usage_type, usage.provider, usage.model, billing_metric))
         if (
@@ -173,7 +173,7 @@ def test_tts_credit_multiplier_scales_with_chars_per_token(monkeypatch: object) 
 
     def fake_load_usage_rate(
         *, usage: object, billing_metric: object, settlement_at: object
-    ):
+    ) -> object:
         _ = settlement_at
         if (
             usage.usage_type == BILL_USAGE_TYPE_TTS
@@ -207,7 +207,7 @@ def test_tts_credit_multiplier_none_when_tts_rate_missing(monkeypatch: object) -
 
     def fake_load_usage_rate(
         *, usage: object, billing_metric: object, settlement_at: object
-    ):
+    ) -> None:
         _ = (usage, billing_metric, settlement_at)  # no curated TTS rate
 
     monkeypatch.setattr(tts_api, "get_config", _chars_per_token_config("0.216"))
@@ -228,7 +228,7 @@ def test_tts_credit_multiplier_none_when_conversion_unset(monkeypatch: object) -
 
     def fake_load_usage_rate(
         *, usage: object, billing_metric: object, settlement_at: object
-    ):
+    ) -> object:
         _ = (usage, billing_metric, settlement_at)
         return _FakeRate("8", 10000, "tencent", "")
 
@@ -346,7 +346,7 @@ def test_usage_rate_unit_cost_uses_utc_settlement(monkeypatch: object) -> None:
 
     def fake_load_usage_rate(
         *, usage: object, billing_metric: object, settlement_at: object
-    ):
+    ) -> None:
         _ = (usage, billing_metric)
         captured["settlement_at"] = settlement_at
 
@@ -381,7 +381,7 @@ def test_tts_config_three_tier_allowlist_orders_and_localizes(
     from flaskr.i18n import clear_language, set_language
 
     class _FakeVolcengineProvider:
-        def get_provider_config(self):
+        def get_provider_config(self) -> object:
             return base.ProviderConfig(
                 name="volcengine",
                 label="火山引擎",
@@ -445,7 +445,7 @@ def test_tts_config_three_tier_allowlist_orders_and_localizes(
     ]
 
 
-def _patch_two_provider_registry(monkeypatch: object, tts_api: object):
+def _patch_two_provider_registry(monkeypatch: object, tts_api: object) -> None:
     monkeypatch.setattr(
         tts_api,
         "_PROVIDER_REGISTRY",

--- a/src/api/tests/service/tts/test_tts_rpm_gate.py
+++ b/src/api/tests/service/tts/test_tts_rpm_gate.py
@@ -8,7 +8,9 @@ class _FakeRedisLock:
     def __init__(self) -> None:
         self.released = False
 
-    def acquire(self, blocking: object = True, blocking_timeout: object = None) -> object:
+    def acquire(
+        self, blocking: object = True, blocking_timeout: object = None
+    ) -> object:
         _ = blocking, blocking_timeout
         return True
 

--- a/src/api/tests/service/tts/test_tts_rpm_gate.py
+++ b/src/api/tests/service/tts/test_tts_rpm_gate.py
@@ -8,11 +8,11 @@ class _FakeRedisLock:
     def __init__(self) -> None:
         self.released = False
 
-    def acquire(self, blocking: object = True, blocking_timeout: object = None):
+    def acquire(self, blocking: object = True, blocking_timeout: object = None) -> object:
         _ = blocking, blocking_timeout
         return True
 
-    def release(self):
+    def release(self) -> None:
         self.released = True
 
 
@@ -21,10 +21,10 @@ class _FakeRedis:
         self.values = {}
         self.locks = []
 
-    def get(self, key: object):
+    def get(self, key: object) -> object:
         return self.values.get(key)
 
-    def set(self, key: object, value: object, ex: object = None):
+    def set(self, key: object, value: object, ex: object = None) -> object:
         _ = ex
         self.values[key] = str(value).encode("utf-8")
         return True
@@ -34,27 +34,27 @@ class _FakeRedis:
         key: object,
         timeout: object = None,
         blocking_timeout: object = None,
-    ):
+    ) -> object:
         _ = key, timeout, blocking_timeout
         lock = _FakeRedisLock()
         self.locks.append(lock)
         return lock
 
 
-def _clock(start: object = 1000.0):
+def _clock(start: object = 1000.0) -> object:
     now = {"value": float(start)}
 
-    def now_fn():
+    def now_fn() -> object:
         return now["value"]
 
-    def sleep_fn(seconds: object):
+    def sleep_fn(seconds: object) -> None:
         now["value"] += seconds
 
     return now_fn, sleep_fn
 
 
 @pytest.fixture(autouse=True)
-def _reset_gate_state():
+def _reset_gate_state() -> object:
     rpm_gate._LOCAL_STATE.clear()
     rpm_gate._FALLBACK_WARNING_KEYS.clear()
     yield

--- a/src/api/tests/service/tts/test_tts_text_preprocess.py
+++ b/src/api/tests/service/tts/test_tts_text_preprocess.py
@@ -3,7 +3,7 @@
 import pytest
 
 
-def _require_app(app: object):
+def _require_app(app: object) -> None:
     if app is None:
         pytest.skip("App fixture disabled")
 
@@ -138,7 +138,7 @@ def test_streaming_tts_processor_skips_svg_and_keeps_following_text(
 
     captured: list[str] = []
 
-    def _capture_submit(self: object, text: str):
+    def _capture_submit(self: object, text: str) -> None:
         _ = self
         captured.append(text)
 
@@ -187,7 +187,7 @@ def test_streaming_tts_processor_skips_chunked_markdown_image(
 
     captured: list[str] = []
 
-    def _capture_submit(self: object, text: str):
+    def _capture_submit(self: object, text: str) -> None:
         _ = self
         captured.append(text)
 

--- a/src/api/tests/service/tts/test_tts_validation_cloned_voice.py
+++ b/src/api/tests/service/tts/test_tts_validation_cloned_voice.py
@@ -16,10 +16,10 @@ from flaskr.service.tts.validation import validate_tts_settings_strict
 
 
 @pytest.fixture(autouse=True)
-def _fake_providers(monkeypatch: object):
+def _fake_providers(monkeypatch: object) -> None:
     """Serve static voice/model lists without real provider credentials."""
 
-    def _fake_get_tts_provider(name: object):
+    def _fake_get_tts_provider(name: object) -> object:
         if name == "volcengine":
             cfg = SimpleNamespace(
                 voices=[{"value": "zh_female_vv_uranus_bigtts"}],
@@ -67,7 +67,7 @@ def _seed_ready_clone(app: object, *, provider: str, voice_id: str) -> None:
         db.session.commit()
 
 
-def _validate(provider: str, model: str, voice_id: str):
+def _validate(provider: str, model: str, voice_id: str) -> object:
     return validate_tts_settings_strict(
         provider=provider,
         model=model,

--- a/src/api/tests/service/tts/test_volcengine_http_provider.py
+++ b/src/api/tests/service/tts/test_volcengine_http_provider.py
@@ -28,10 +28,10 @@ def test_volcengine_http_synthesize_success(monkeypatch: object) -> None:
         headers: ClassVar[dict[str, str]] = {"Content-Type": "application/json"}
         text = ""
 
-        def raise_for_status(self):
+        def raise_for_status(self) -> None:
             return None
 
-        def json(self):
+        def json(self) -> object:
             return {
                 "reqid": "reqid",
                 "code": 3000,
@@ -43,7 +43,7 @@ def test_volcengine_http_synthesize_success(monkeypatch: object) -> None:
 
     def fake_post(
         url: object, json: object = None, headers: object = None, timeout: object = None
-    ):
+    ) -> object:
         captured["url"] = url
         captured["json"] = json
         captured["headers"] = headers
@@ -97,10 +97,10 @@ def test_volcengine_http_legacy_resource_id_overrides_default_cluster(
         headers: ClassVar[dict[str, str]] = {"Content-Type": "application/json"}
         text = ""
 
-        def raise_for_status(self):
+        def raise_for_status(self) -> None:
             return None
 
-        def json(self):
+        def json(self) -> object:
             return {
                 "reqid": "reqid",
                 "code": 3000,
@@ -112,7 +112,7 @@ def test_volcengine_http_legacy_resource_id_overrides_default_cluster(
 
     def fake_post(
         url: object, json: object = None, headers: object = None, timeout: object = None
-    ):
+    ) -> object:
         captured["url"] = url
         captured["json"] = json
         captured["headers"] = headers

--- a/src/api/tests/service/tts/test_volcengine_voice_clone.py
+++ b/src/api/tests/service/tts/test_volcengine_voice_clone.py
@@ -61,7 +61,9 @@ def test_is_valid_volcengine_custom_voice_id(value: object, expected: object) ->
 def test_query_status_sends_expected_request(monkeypatch: object) -> None:
     _patch_config(monkeypatch)
 
-    def fake_post(url: object, headers: object, json: object, timeout: object) -> object:
+    def fake_post(
+        url: object, headers: object, json: object, timeout: object
+    ) -> object:
         assert url == VOLCENGINE_MEGA_TTS_STATUS_URL
         assert headers["Authorization"] == "Bearer;test-token"
         assert headers["Resource-Id"] == VOLCENGINE_ICL_RESOURCE_ID

--- a/src/api/tests/service/tts/test_volcengine_voice_clone.py
+++ b/src/api/tests/service/tts/test_volcengine_voice_clone.py
@@ -19,7 +19,7 @@ _TEST_CONFIG = {
 }
 
 
-def _patch_config(monkeypatch: object, config: object = None):
+def _patch_config(monkeypatch: object, config: object = None) -> None:
     values = _TEST_CONFIG if config is None else config
     monkeypatch.setattr(
         volcengine_voice_clone,
@@ -34,7 +34,7 @@ class _FakeResponse:
         self.status_code = status_code
         self.text = ""
 
-    def json(self):
+    def json(self) -> object:
         return self._payload
 
 
@@ -61,7 +61,7 @@ def test_is_valid_volcengine_custom_voice_id(value: object, expected: object) ->
 def test_query_status_sends_expected_request(monkeypatch: object) -> None:
     _patch_config(monkeypatch)
 
-    def fake_post(url: object, headers: object, json: object, timeout: object):
+    def fake_post(url: object, headers: object, json: object, timeout: object) -> object:
         assert url == VOLCENGINE_MEGA_TTS_STATUS_URL
         assert headers["Authorization"] == "Bearer;test-token"
         assert headers["Resource-Id"] == VOLCENGINE_ICL_RESOURCE_ID
@@ -102,7 +102,7 @@ def test_query_status_converts_transport_error_to_param_error(
 
     _patch_config(monkeypatch)
 
-    def _raise_transport_error(*args: object, **kwargs: object):
+    def _raise_transport_error(*args: object, **kwargs: object) -> None:
         _ = (args, kwargs)
         message = "connect timeout"
         raise requests_lib.exceptions.ConnectTimeout(message)
@@ -119,7 +119,7 @@ def test_query_status_converts_invalid_json_to_param_error(monkeypatch: object) 
         status_code = 200
         text = "<html>gateway error</html>"
 
-        def json(self):
+        def json(self) -> None:
             message = "no json"
             raise ValueError(message)
 

--- a/src/api/tests/service/tts/test_volcengine_ws_provider.py
+++ b/src/api/tests/service/tts/test_volcengine_ws_provider.py
@@ -61,25 +61,25 @@ def test_volcengine_ws_waits_for_session_started_before_task_request(
     captured = {}
 
     class FakeProtocol:
-        def encode_start_connection(self):
+        def encode_start_connection(self) -> object:
             return b"start_connection"
 
-        def encode_start_session(self, **kwargs: object):
+        def encode_start_session(self, **kwargs: object) -> object:
             captured["start_session_kwargs"] = kwargs
             return b"start_session"
 
-        def encode_task_request(self, session_id: object, text: object):
+        def encode_task_request(self, session_id: object, text: object) -> object:
             _ = (session_id, text)
             return b"task_request"
 
-        def encode_finish_session(self, session_id: object):
+        def encode_finish_session(self, session_id: object) -> object:
             _ = session_id
             return b"finish_session"
 
-        def encode_finish_connection(self):
+        def encode_finish_connection(self) -> object:
             return b"finish_connection"
 
-        def decode_frame(self, message: object):
+        def decode_frame(self, message: object) -> object:
             if message == b"connection_started":
                 return SimpleNamespace(
                     event=volcengine_provider.Event.CONNECTION_STARTED,
@@ -161,11 +161,11 @@ def test_volcengine_ws_waits_for_session_started_before_task_request(
             self.session_started_sent = False
             captured["ws"] = self
 
-        def run_forever(self, **kwargs: object):
+        def run_forever(self, **kwargs: object) -> None:
             _ = kwargs
             self.on_open(self)
 
-        def send(self, frame: object, opcode: object = None):
+        def send(self, frame: object, opcode: object = None) -> None:
             _ = opcode
             self.sent.append(frame)
             if frame == b"start_connection":
@@ -185,11 +185,11 @@ def test_volcengine_ws_waits_for_session_started_before_task_request(
                 self.on_message(self, b"subtitle")
                 self.on_message(self, b"session_finished")
 
-        def _emit_session_started(self):
+        def _emit_session_started(self) -> None:
             self.session_started_sent = True
             self.on_message(self, b"session_started")
 
-        def close(self):
+        def close(self) -> None:
             self.on_close(self, None, None)
 
     fake_websocket = SimpleNamespace(

--- a/src/api/tests/service/user/test_captcha_routes.py
+++ b/src/api/tests/service/user/test_captcha_routes.py
@@ -8,7 +8,7 @@ from flasgger.utils import parse_docstring
 from PIL import Image
 
 
-def _post_json(client: object, path: str, payload: dict):
+def _post_json(client: object, path: str, payload: dict) -> object:
     resp = client.post(
         path,
         data=json.dumps(payload),
@@ -17,7 +17,7 @@ def _post_json(client: object, path: str, payload: dict):
     return resp, resp.get_json(force=True)
 
 
-def _get_captcha(client: object, app: object):
+def _get_captcha(client: object, app: object) -> object:
     app.config["ENV"] = "development"
     app.config["CAPTCHA_CODE_OVERRIDE"] = "0000"
     response = client.get("/api/user/captcha")
@@ -27,7 +27,7 @@ def _get_captcha(client: object, app: object):
     return body["data"]
 
 
-def _get_ticket(client: object, app: object):
+def _get_ticket(client: object, app: object) -> object:
     captcha = _get_captcha(client, app)
     response, body = _post_json(
         client,

--- a/src/api/tests/service/user/test_google_auth.py
+++ b/src/api/tests/service/user/test_google_auth.py
@@ -40,10 +40,10 @@ class _FakeGoogleResponse:
     def __init__(self, payload: object) -> None:
         self._payload = payload
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         return None
 
-    def json(self):
+    def json(self) -> object:
         return self._payload
 
 
@@ -52,16 +52,16 @@ class _FakeGoogleSession:
         self._profile = profile
         self._fetch_token_error = fetch_token_error
 
-    def fetch_token(self, *_args: object, **_kwargs: object):
+    def fetch_token(self, *_args: object, **_kwargs: object) -> object:
         if self._fetch_token_error is not None:
             raise self._fetch_token_error
         return {"access_token": "fake-access-token"}
 
-    def get(self, *_args: object, **_kwargs: object):
+    def get(self, *_args: object, **_kwargs: object) -> object:
         return _FakeGoogleResponse(self._profile)
 
 
-def _reset_user_auth_tables():
+def _reset_user_auth_tables() -> None:
     UserTokenModel.query.delete()
     AuthCredential.query.delete()
     UserEntity.query.delete()
@@ -74,7 +74,7 @@ def _run_google_callback(
     profile: object,
     *,
     fetch_token_error: object = None,
-):
+) -> object:
     monkeypatch.setenv("HOST_URL", "http://localhost")
     _reset_config_cache("HOST_URL")
     provider = GoogleAuthProvider()
@@ -216,7 +216,7 @@ def test_google_existing_account_keeps_pre_profile_display_name_behavior(
             original_first = query_type.first
             reads: list[tuple[str, str, bool, bool]] = []
 
-            def track_first(query: object):
+            def track_first(query: object) -> object:
                 statement = str(query.statement)
                 parameters = query.statement.compile().params
                 table = (

--- a/src/api/tests/service/user/test_import_user_command.py
+++ b/src/api/tests/service/user/test_import_user_command.py
@@ -141,7 +141,7 @@ def test_import_user_does_not_consult_profile_state_before_nickname_defaults(
         read_order: list[tuple[str, str, bool, bool]] = []
         reads_before_ensure: list[tuple[str, str, bool, bool]] = []
 
-        def track_first(query: object):
+        def track_first(query: object) -> object:
             statement = str(query.statement)
             parameters = query.statement.compile().params
             lookup_value = str(
@@ -166,7 +166,7 @@ def test_import_user_does_not_consult_profile_state_before_nickname_defaults(
 
         original_ensure_user = import_user_module.ensure_user_for_identifier
 
-        def track_ensure_user(*args: object, **kwargs: object):
+        def track_ensure_user(*args: object, **kwargs: object) -> object:
             reads_before_ensure.extend(read_order)
             return original_ensure_user(*args, **kwargs)
 

--- a/src/api/tests/service/user/test_learner_profile_optimizer.py
+++ b/src/api/tests/service/user/test_learner_profile_optimizer.py
@@ -59,8 +59,8 @@ def _snapshot_profile_state(user_bid: str) -> tuple:
     )
 
 
-def _successful_llm(raw_output: str, captured: dict):
-    def invoke(*args: object, **kwargs: object):
+def _successful_llm(raw_output: str, captured: dict) -> object:
+    def invoke(*args: object, **kwargs: object) -> object:
         captured["call_count"] = captured.get("call_count", 0) + 1
         captured["args"] = args
         captured["kwargs"] = kwargs
@@ -73,11 +73,11 @@ def _install_trace_spies(monkeypatch: object, captured: dict) -> None:
     trace = object()
     root_span = object()
 
-    def create_trace(**kwargs: object):
+    def create_trace(**kwargs: object) -> object:
         captured["trace_create"] = kwargs
         return trace, root_span
 
-    def finalize_trace(**kwargs: object):
+    def finalize_trace(**kwargs: object) -> None:
         captured["trace_finalize"] = kwargs
 
     monkeypatch.setattr(optimizer, "create_trace_with_root_span", create_trace)
@@ -313,7 +313,7 @@ def test_optimize_rejects_moderation_without_calling_llm_or_changing_state(
     invoked = False
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: False)
 
-    def unexpected_invoke(*_args: object, **_kwargs: object):
+    def unexpected_invoke(*_args: object, **_kwargs: object) -> object:
         nonlocal invoked
         invoked = True
         yield SimpleNamespace(result="unexpected")
@@ -389,7 +389,7 @@ def test_optimize_missing_default_model_does_not_call_llm_or_change_state(
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
     monkeypatch.setitem(app.config, "DEFAULT_LLM_MODEL", "")
 
-    def unexpected_invoke(*_args: object, **_kwargs: object):
+    def unexpected_invoke(*_args: object, **_kwargs: object) -> object:
         nonlocal invoked
         invoked = True
         yield SimpleNamespace(result="unexpected")
@@ -456,7 +456,7 @@ def test_optimize_timeout_finalizes_trace_without_changing_state(
     captured: dict = {}
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
-    def timeout_invoke(*_args: object, **_kwargs: object):
+    def timeout_invoke(*_args: object, **_kwargs: object) -> object:
         message = "provider timeout"
         raise TimeoutError(message)
         yield  # pragma: no cover
@@ -488,7 +488,7 @@ def test_optimize_reports_a_wrapped_timeout_as_timeout(
     user_bid = "profile-optimize-wrapped-timeout"
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
-    def timeout_invoke(*_args: object, **_kwargs: object):
+    def timeout_invoke(*_args: object, **_kwargs: object) -> object:
         try:
             # The wrapped-timeout shape is exactly what this test asserts.
             message = "provider timeout"
@@ -533,7 +533,7 @@ def test_optimize_reports_runtime_failure_reason_without_changing_state(
     captured: dict = {}
     monkeypatch.setattr(optimizer, "check_text_content", lambda *_args: True)
 
-    def failed_invoke(*_args: object, **_kwargs: object):
+    def failed_invoke(*_args: object, **_kwargs: object) -> object:
         raise provider_error
         yield  # pragma: no cover
 
@@ -562,11 +562,11 @@ def test_optimize_reports_moderation_failure_reason_without_calling_llm(
 ) -> None:
     invoked = False
 
-    def failed_moderation(*_args: object):
+    def failed_moderation(*_args: object) -> None:
         message = "moderation unavailable"
         raise RuntimeError(message)
 
-    def unexpected_invoke(*_args: object, **_kwargs: object):
+    def unexpected_invoke(*_args: object, **_kwargs: object) -> object:
         nonlocal invoked
         invoked = True
         yield SimpleNamespace(result="unexpected")
@@ -592,7 +592,7 @@ def test_optimize_rejects_invalid_input_before_moderation(
 ) -> None:
     moderated = False
 
-    def unexpected_moderation(*_args: object):
+    def unexpected_moderation(*_args: object) -> object:
         nonlocal moderated
         moderated = True
         return True

--- a/src/api/tests/service/user/test_learner_profile_service.py
+++ b/src/api/tests/service/user/test_learner_profile_service.py
@@ -83,7 +83,7 @@ def _track_profile_lock_reads(monkeypatch: object) -> list[tuple[str, str, bool,
     original_first = query_type.first
     read_order: list[tuple[str, str, bool, bool]] = []
 
-    def track_first(query: object):
+    def track_first(query: object) -> object:
         statement = str(query.statement)
         parameters = query.statement.compile().params
         table = (
@@ -718,7 +718,7 @@ def test_nickname_rejection_rolls_back_profile_nickname_and_state(
 
     checked: list[str] = []
 
-    def reject_nickname(_app: object, _user_id: object, text: object):
+    def reject_nickname(_app: object, _user_id: object, text: object) -> object:
         checked.append(text)
         return text != "Rejected nickname"
 
@@ -786,7 +786,7 @@ def test_profile_safety_audit_records_text_and_provider_response(
     profile = "称呼：小明\n职业背景：医疗产品经理"
     checked: dict[str, str] = {}
 
-    def fake_check_text(_app: object, check_id: object, text: object, user_id: object):
+    def fake_check_text(_app: object, check_id: object, text: object, user_id: object) -> object:
         checked.update(check_id=check_id, text=text, user_id=user_id)
         return CheckResultDTO(
             check_result=CHECK_RESULT_PASS,
@@ -967,7 +967,7 @@ def test_save_locks_user_then_state_before_writing_profile(
         read_order = _track_profile_lock_reads(monkeypatch)
         reads_when_moderated: list[tuple[str, str, bool, bool]] = []
 
-        def allow_after_user_lock(_app: object, _user_id: object, _text: object):
+        def allow_after_user_lock(_app: object, _user_id: object, _text: object) -> object:
             reads_when_moderated.extend(read_order)
             return True
 
@@ -1008,11 +1008,11 @@ def test_save_moderates_once_when_state_creation_retries(
     moderation_calls: list[str] = []
     operation_calls = 0
 
-    def allow_once(_app: object, _user_id: object, text: object):
+    def allow_once(_app: object, _user_id: object, text: object) -> object:
         moderation_calls.append(text)
         return True
 
-    def run_twice(operation: object, *, user_id: object):
+    def run_twice(operation: object, *, user_id: object) -> object:
         nonlocal operation_calls
         assert user_id == "profile-save-moderation-retry"
         operation()
@@ -1299,7 +1299,7 @@ def test_complete_rolls_back_profile_and_state_together(
         db.session.commit()
         original_commit = db.session.commit
 
-        def fail_commit():
+        def fail_commit() -> None:
             message = "database unavailable"
             raise RuntimeError(message)
 
@@ -1346,7 +1346,7 @@ def test_clear_rolls_back_profile_and_state_together(
         db.session.commit()
         original_commit = db.session.commit
 
-        def fail_commit():
+        def fail_commit() -> None:
             message = "database unavailable"
             raise RuntimeError(message)
 

--- a/src/api/tests/service/user/test_learner_profile_service.py
+++ b/src/api/tests/service/user/test_learner_profile_service.py
@@ -786,7 +786,9 @@ def test_profile_safety_audit_records_text_and_provider_response(
     profile = "称呼：小明\n职业背景：医疗产品经理"
     checked: dict[str, str] = {}
 
-    def fake_check_text(_app: object, check_id: object, text: object, user_id: object) -> object:
+    def fake_check_text(
+        _app: object, check_id: object, text: object, user_id: object
+    ) -> object:
         checked.update(check_id=check_id, text=text, user_id=user_id)
         return CheckResultDTO(
             check_result=CHECK_RESULT_PASS,
@@ -967,7 +969,9 @@ def test_save_locks_user_then_state_before_writing_profile(
         read_order = _track_profile_lock_reads(monkeypatch)
         reads_when_moderated: list[tuple[str, str, bool, bool]] = []
 
-        def allow_after_user_lock(_app: object, _user_id: object, _text: object) -> object:
+        def allow_after_user_lock(
+            _app: object, _user_id: object, _text: object
+        ) -> object:
             reads_when_moderated.extend(read_order)
             return True
 

--- a/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
+++ b/src/api/tests/service/user/test_learner_profile_sign_in_merge.py
@@ -44,10 +44,10 @@ def _assert_orm_utc(value: datetime | None, expected: datetime) -> None:
 
 
 class _FakeRedis:
-    def get(self, _key: object):
+    def get(self, _key: object) -> None:
         return None
 
-    def delete(self, *_keys: str):
+    def delete(self, *_keys: str) -> None:
         return None
 
 
@@ -55,10 +55,10 @@ class _FakeGoogleResponse:
     def __init__(self, payload: object) -> None:
         self._payload = payload
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         return None
 
-    def json(self):
+    def json(self) -> object:
         return self._payload
 
 
@@ -66,10 +66,10 @@ class _FakeGoogleSession:
     def __init__(self, profile: object) -> None:
         self._profile = profile
 
-    def fetch_token(self, *_args: object, **_kwargs: object):
+    def fetch_token(self, *_args: object, **_kwargs: object) -> object:
         return {"access_token": "fake-access-token"}
 
-    def get(self, *_args: object, **_kwargs: object):
+    def get(self, *_args: object, **_kwargs: object) -> object:
         return _FakeGoogleResponse(self._profile)
 
 
@@ -584,7 +584,7 @@ def test_merge_helper_rolls_back_with_sign_in_transaction(app: object) -> None:
         _add_state(source.user_bid, status="completed")
         db.session.commit()
 
-        def merge_then_fail():
+        def merge_then_fail() -> None:
             with transactional_session():
                 merge_learner_profile_for_sign_in(
                     source_user_id=source.user_bid,
@@ -622,7 +622,7 @@ def test_merge_helper_locks_target_then_source_profile_snapshots(
         original_first = query_type.first
         read_order: list[tuple[str, str, bool, bool]] = []
 
-        def track_first(query: object):
+        def track_first(query: object) -> object:
             statement = str(query.statement)
             parameters = query.statement.compile().params
             user_bid = str(parameters.get("user_bid_1", ""))

--- a/src/api/tests/service/user/test_legacy_learner_profile_compatibility.py
+++ b/src/api/tests/service/user/test_legacy_learner_profile_compatibility.py
@@ -96,7 +96,7 @@ def test_legacy_nickname_writers_keep_pre_profile_mapping_behavior(
         original_first = query_type.first
         reads: list[tuple[str, str, bool, bool]] = []
 
-        def track_first(query: object):
+        def track_first(query: object) -> object:
             statement = str(query.statement)
             parameters = query.statement.compile().params
             table = (

--- a/src/api/tests/service/user/test_oauth_origins.py
+++ b/src/api/tests/service/user/test_oauth_origins.py
@@ -30,7 +30,7 @@ def _reset_config_cache(*keys: str) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _shared_callback(monkeypatch: object):
+def _shared_callback(monkeypatch: object) -> object:
     """Pin the deployment to one shared callback URL."""
     _reset_config_cache("HOST_URL", "GOOGLE_OAUTH_REDIRECT_URI")
     monkeypatch.setattr(
@@ -44,7 +44,7 @@ def _shared_callback(monkeypatch: object):
 
 
 @pytest.fixture
-def _verified_custom_domain(monkeypatch: object):
+def _verified_custom_domain(monkeypatch: object) -> None:
     """Treat exactly one host as a verified, TLS-active custom domain."""
     monkeypatch.setattr(
         oauth_origins,
@@ -90,7 +90,7 @@ class TestIsAllowedOAuthOrigin:
     def test_lookup_failure_refuses_rather_than_allows(
         self, app: object, monkeypatch: object
     ) -> None:
-        def _boom(app: object, host: object):
+        def _boom(app: object, host: object) -> None:
             _ = (app, host)
             message = "database is down"
             raise RuntimeError(message)

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -615,7 +615,7 @@ def test_complete_onboarding_scene_handles_integrity_error(
     original_commit = db.session.commit
     state = {"raised": False}
 
-    def flaky_commit():
+    def flaky_commit() -> object:
         if not state["raised"]:
             state["raised"] = True
             message = "duplicate"

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 import jwt
 
 
-def _post_json(client: object, path: str, payload: dict, headers: dict | None = None):
+def _post_json(client: object, path: str, payload: dict, headers: dict | None = None) -> object:
     resp = client.post(
         path,
         data=json.dumps(payload),

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -7,7 +7,9 @@ from datetime import UTC, datetime
 import jwt
 
 
-def _post_json(client: object, path: str, payload: dict, headers: dict | None = None) -> object:
+def _post_json(
+    client: object, path: str, payload: dict, headers: dict | None = None
+) -> object:
     resp = client.post(
         path,
         data=json.dumps(payload),

--- a/src/api/tests/service/user/test_profile_onboarding.py
+++ b/src/api/tests/service/user/test_profile_onboarding.py
@@ -42,7 +42,7 @@ def test_profile_onboarding_config_roundtrip(app: object, monkeypatch: object) -
         module, "load_profile_onboarding_config_payload", lambda: current_config
     )
 
-    def fake_save_config(_app: object, payload: object, *, updated_by: object):
+    def fake_save_config(_app: object, payload: object, *, updated_by: object) -> None:
         saved_payloads.append((payload, updated_by))
         current_config.update(payload)
 

--- a/src/api/tests/service/user/test_require_tmp_route.py
+++ b/src/api/tests/service/user/test_require_tmp_route.py
@@ -18,7 +18,7 @@ def test_require_tmp_passes_payload_source_to_temp_user(
         source: object,
         wx_code: object = None,
         language: object = "en-US",
-    ):
+    ) -> object:
         _ = app
         calls.append(
             {

--- a/src/api/tests/service/user/test_trial_credit_bootstrap.py
+++ b/src/api/tests/service/user/test_trial_credit_bootstrap.py
@@ -48,7 +48,9 @@ def _load_user_route_handlers() -> object:
 register_user_handler, register_common_handler = _load_user_route_handlers()
 
 
-def _post_json(client: object, path: str, payload: dict, headers: dict | None = None) -> object:
+def _post_json(
+    client: object, path: str, payload: dict, headers: dict | None = None
+) -> object:
     return client.post(
         path,
         data=json.dumps(payload),

--- a/src/api/tests/service/user/test_trial_credit_bootstrap.py
+++ b/src/api/tests/service/user/test_trial_credit_bootstrap.py
@@ -39,7 +39,7 @@ from tests.common.fixtures.bill_products import build_bill_products
 from tests.common.fixtures.fake_redis import FakeRedis
 
 
-def _load_user_route_handlers():
+def _load_user_route_handlers() -> object:
     common_module = importlib.import_module("flaskr.route.common")
     user_module = importlib.import_module("flaskr.route.user")
     return user_module.register_user_handler, common_module.register_common_handler
@@ -48,7 +48,7 @@ def _load_user_route_handlers():
 register_user_handler, register_common_handler = _load_user_route_handlers()
 
 
-def _post_json(client: object, path: str, payload: dict, headers: dict | None = None):
+def _post_json(client: object, path: str, payload: dict, headers: dict | None = None) -> object:
     return client.post(
         path,
         data=json.dumps(payload),
@@ -367,7 +367,7 @@ def test_post_auth_extension_failures_do_not_block_trial_bootstrap(
         token = generate_token(app, user_bid)
         dao.db.session.commit()
 
-    def _failing_post_auth_handler(_context: object, *, app: object):
+    def _failing_post_auth_handler(_context: object, *, app: object) -> None:
         _ = app
         message = "boom"
         raise RuntimeError(message)

--- a/src/api/tests/service/user/test_user_identify.py
+++ b/src/api/tests/service/user/test_user_identify.py
@@ -8,15 +8,15 @@ class _FakeRedis:
         self.values = dict(values or {})
         self.deleted = []
 
-    def get(self, key: object):
+    def get(self, key: object) -> object:
         return self.values.get(key)
 
-    def delete(self, *keys: str):
+    def delete(self, *keys: str) -> object:
         self.deleted.extend(keys)
         return len(keys)
 
 
-def _reset_user_auth_tables():
+def _reset_user_auth_tables() -> None:
     from flaskr.dao import db
     from flaskr.service.user.models import (
         AuthCredential,
@@ -198,17 +198,17 @@ def test_send_email_code_stores_lowercase_identifier(
         def __init__(self, *_args: object, **_kwargs: object) -> None:
             pass
 
-        def starttls(self):
+        def starttls(self) -> None:
             return None
 
-        def login(self, *_args: object):
+        def login(self, *_args: object) -> None:
             return None
 
-        def sendmail(self, _sender: object, recipient: object, message: object):
+        def sendmail(self, _sender: object, recipient: object, message: object) -> None:
             type(self).sent_to = recipient
             type(self).sent_message = message
 
-        def quit(self):
+        def quit(self) -> None:
             return None
 
     fake_redis = FakeRedis()
@@ -289,16 +289,16 @@ def test_send_email_code_uses_requested_language_and_singular_expiry(
         def __init__(self, *_args: object, **_kwargs: object) -> None:
             pass
 
-        def starttls(self):
+        def starttls(self) -> None:
             return None
 
-        def login(self, *_args: object):
+        def login(self, *_args: object) -> None:
             return None
 
-        def sendmail(self, _sender: object, _recipient: object, message: object):
+        def sendmail(self, _sender: object, _recipient: object, message: object) -> None:
             type(self).sent_message = message
 
-        def quit(self):
+        def quit(self) -> None:
             return None
 
     fake_redis = FakeRedis()

--- a/src/api/tests/service/user/test_user_identify.py
+++ b/src/api/tests/service/user/test_user_identify.py
@@ -295,7 +295,9 @@ def test_send_email_code_uses_requested_language_and_singular_expiry(
         def login(self, *_args: object) -> None:
             return None
 
-        def sendmail(self, _sender: object, _recipient: object, message: object) -> None:
+        def sendmail(
+            self, _sender: object, _recipient: object, message: object
+        ) -> None:
             type(self).sent_message = message
 
         def quit(self) -> None:

--- a/src/api/tests/service/user/test_user_repository.py
+++ b/src/api/tests/service/user/test_user_repository.py
@@ -11,12 +11,12 @@ def test_transactional_session_classifies_before_savepoint_rollback(
 
     events = []
 
-    def invalidate(*, source: object, session: object = None):
+    def invalidate(*, source: object, session: object = None) -> object:
         del session
         events.append(("invalidate", source))
         return True
 
-    def cleanup(exc: object, *, source: object, session: object = None):
+    def cleanup(exc: object, *, source: object, session: object = None) -> object:
         del exc, session
         events.append(("cleanup", source))
         return "rolled_back"
@@ -37,10 +37,10 @@ def test_transactional_session_classifies_before_savepoint_rollback(
             self.rollbacks = 0
             self.commits = 0
 
-        def rollback(self):
+        def rollback(self) -> None:
             self.rollbacks += 1
 
-        def commit(self):
+        def commit(self) -> None:
             self.commits += 1
 
     nested = _Nested()

--- a/src/api/tests/service/user/test_validate_user.py
+++ b/src/api/tests/service/user/test_validate_user.py
@@ -14,7 +14,7 @@ def test_validate_user_maps_invalid_algorithm_token_to_user_not_found(
     app.config["SECRET_KEY"] = "test-secret"
     app.config["ENVERIMENT"] = "prod"
 
-    def _raise_invalid_algorithm(*_args: object, **_kwargs: object):
+    def _raise_invalid_algorithm(*_args: object, **_kwargs: object) -> None:
         message = "The specified alg value is not allowed"
         raise jwt.exceptions.InvalidAlgorithmError(message)
 

--- a/src/api/tests/test_edun.py
+++ b/src/api/tests/test_edun.py
@@ -22,7 +22,7 @@ def test_yidun_check_uses_configured_timeout(app: object, monkeypatch: object) -
     captured = {}
 
     class _Resp:
-        def json(self):
+        def json(self) -> object:
             return {
                 "code": 200,
                 "result": {"antispam": {"suggestion": 0, "label": 100}},
@@ -30,7 +30,7 @@ def test_yidun_check_uses_configured_timeout(app: object, monkeypatch: object) -
 
     def fake_post(
         url: object, data: object = None, headers: object = None, timeout: object = None
-    ):
+    ) -> object:
         _ = (data, headers)
         captured["url"] = url
         captured["timeout"] = timeout
@@ -55,7 +55,7 @@ def test_ilivedata_send_wraps_oserror_as_urlerror(monkeypatch: object) -> None:
 
     from flaskr.api.check import ilivedata as ilivedata_module
 
-    def fake_urlopen(*_args: object, **_kwargs: object):
+    def fake_urlopen(*_args: object, **_kwargs: object) -> None:
         message = "timed out"
         raise TimeoutError(message)
 
@@ -80,10 +80,10 @@ def test_ilivedata_check_uses_configured_timeout(
         def __exit__(self, exc_type: object, exc: object, tb: object) -> bool | None:
             captured["closed"] = True
 
-        def read(self):
+        def read(self) -> object:
             return b'{"errorCode":0,"textSpam":{"result":0,"tags":[]}}'
 
-    def fake_urlopen(req: object, timeout: object = None):
+    def fake_urlopen(req: object, timeout: object = None) -> object:
         captured["host"] = req.full_url
         captured["timeout"] = timeout
         return _Resp()

--- a/src/api/tests/test_feishu.py
+++ b/src/api/tests/test_feishu.py
@@ -41,13 +41,13 @@ def test_send_order_feishu_formats_notification(
             self._first_value = first_value
             self._count_value = count_value
 
-        def filter(self, *_args: object, **_kwargs: object):
+        def filter(self, *_args: object, **_kwargs: object) -> object:
             return self
 
-        def first(self):
+        def first(self) -> object:
             return self._first_value
 
-        def count(self):
+        def count(self) -> object:
             return self._count_value
 
     class FakeColumn:
@@ -73,7 +73,7 @@ def test_send_order_feishu_formats_notification(
 
     captured = {}
 
-    def fake_send_notify(_app: object, title: object, msgs: object):
+    def fake_send_notify(_app: object, title: object, msgs: object) -> None:
         captured["title"] = title
         captured["msgs"] = msgs
 

--- a/src/api/tests/test_fix_discount.py
+++ b/src/api/tests/test_fix_discount.py
@@ -55,7 +55,7 @@ def test_use_coupon_code_applies_discount(app: object, monkeypatch: object) -> N
 
     def fake_send_feishu_coupon_code(
         _app: object, user_id: object, code: object, _name: object, _value: object
-    ):
+    ) -> None:
         sent["user_id"] = user_id
         sent["code"] = code
 

--- a/src/api/tests/test_gunicorn_worker_patch_guard.py
+++ b/src/api/tests/test_gunicorn_worker_patch_guard.py
@@ -10,7 +10,7 @@ actually selects the gevent worker.
 import pathlib
 
 
-def _load_detector():
+def _load_detector() -> object:
     conf_path = pathlib.Path(__file__).resolve().parents[1] / "gunicorn.conf.py"
     source = conf_path.read_text()
     # Execute only the detector function, not the module (which would
@@ -64,7 +64,7 @@ def test_observer_skips_unpatched_processes(monkeypatch: object) -> None:
     monkeypatch.setattr(monkey, "is_module_patched", lambda _name: False)
 
     class _Logger:
-        def error(self, *args: object, **kwargs: object):
+        def error(self, *args: object, **kwargs: object) -> None:
             _ = (args, kwargs)
             message = "must not log during a skipped install"
             raise AssertionError(message)

--- a/src/api/tests/test_langfuse_preload_deferral.py
+++ b/src/api/tests/test_langfuse_preload_deferral.py
@@ -20,7 +20,7 @@ class _RecordingLangfuse:
         _RecordingLangfuse.instances.append(kwargs)
 
 
-def _configure(app: object, monkeypatch: object):
+def _configure(app: object, monkeypatch: object) -> None:
     app.config["LANGFUSE_PUBLIC_KEY"] = "pk"
     app.config["LANGFUSE_SECRET_KEY"] = "sk"
     app.config["LANGFUSE_HOST"] = "https://langfuse.example"

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -22,10 +22,10 @@ def _install_litellm_stub() -> None:
     litellm_stub = types.ModuleType("litellm")
     litellm_stub.model_cost = {}
 
-    def register_model(model_map: object):
+    def register_model(model_map: object) -> None:
         litellm_stub.model_cost.update(model_map)
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> None:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -197,7 +197,7 @@ def _create_credit_rate(
     )
 
 
-def _configure_model_list(monkeypatch: object):
+def _configure_model_list(monkeypatch: object) -> None:
     available_models = [
         "qwen/deepseek-v4-flash",
         "ark/doubao-seed-2-0-lite-260428",
@@ -425,7 +425,7 @@ def test_get_current_models_keeps_list_when_credit_rate_lookup_fails(
 ) -> None:
     _configure_model_list(monkeypatch)
 
-    def raise_lookup(_app: object):
+    def raise_lookup(_app: object) -> None:
         message = "db unavailable"
         raise RuntimeError(message)
 
@@ -444,7 +444,7 @@ def test_get_current_models_keeps_list_when_credit_rate_lookup_fails(
 def test_deepseek_model_loader_lists_models(monkeypatch: object) -> None:
     captured = {}
 
-    def fake_get(url: object, headers: object = None, timeout: object = None):
+    def fake_get(url: object, headers: object = None, timeout: object = None) -> object:
         captured["url"] = url
         captured["headers"] = headers
         captured["timeout"] = timeout
@@ -481,7 +481,7 @@ def test_deepseek_model_loader_lists_models(monkeypatch: object) -> None:
 def test_deepseek_model_loader_falls_back_when_list_models_fails(
     monkeypatch: object,
 ) -> None:
-    def fake_get(*args: object, **kwargs: object):
+    def fake_get(*args: object, **kwargs: object) -> None:
         _ = args, kwargs
         message = "network unavailable"
         raise RuntimeError(message)
@@ -508,7 +508,7 @@ def test_qwen_prefixed_model_routes_without_fetched_alias(
 ) -> None:
     captured = {}
 
-    def fake_completion(model: object, *args: object, **kwargs: object):
+    def fake_completion(model: object, *args: object, **kwargs: object) -> object:
         _ = args
         captured["model"] = model
         captured["kwargs"] = kwargs
@@ -516,7 +516,7 @@ def test_qwen_prefixed_model_routes_without_fetched_alias(
 
     monkeypatch.setattr(llm.litellm, "completion", fake_completion)
 
-    def reload_qwen_params(model_id: object, temperature: object):
+    def reload_qwen_params(model_id: object, temperature: object) -> object:
         captured["reload_model"] = model_id
         return llm._reload_qwen_params(model_id, temperature)
 
@@ -681,7 +681,7 @@ def test_stream_litellm_completion_omits_unknown_limit(
 ) -> None:
     captured = {}
 
-    def raise_unknown(_model: object):
+    def raise_unknown(_model: object) -> None:
         message = "unknown model"
         raise ValueError(message)
 
@@ -778,7 +778,7 @@ def test_openai_params_use_litellm_reasoning_capabilities(
 ) -> None:
     captured = {}
 
-    def fake_get_model_info(*, model: object, custom_llm_provider: object):
+    def fake_get_model_info(*, model: object, custom_llm_provider: object) -> object:
         captured["model"] = model
         captured["custom_llm_provider"] = custom_llm_provider
         return model_info
@@ -800,7 +800,7 @@ def test_openai_params_use_litellm_reasoning_capabilities(
 def test_openai_params_fall_back_to_existing_policy_for_unknown_model(
     monkeypatch: object,
 ) -> None:
-    def raise_unknown(*args: object, **kwargs: object):
+    def raise_unknown(*args: object, **kwargs: object) -> None:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -1271,7 +1271,7 @@ def test_litellm_195_native_adapter_contracts() -> None:
 def test_chat_llm_disables_deepseek_thinking(monkeypatch: object, app: object) -> None:
     captured_kwargs = {}
 
-    def fake_completion(*args: object, **kwargs: object):
+    def fake_completion(*args: object, **kwargs: object) -> object:
         _ = args
         captured_kwargs["kwargs"] = kwargs
         return iter([FakeResponse("chunk-1", content="Hi", finish_reason="stop")])
@@ -1343,11 +1343,11 @@ def test_invoke_llm_uses_actual_model_for_provider_params(
 ) -> None:
     captured = {}
 
-    def reload_params(model_id: object, temperature: object):
+    def reload_params(model_id: object, temperature: object) -> object:
         captured["reload_model"] = model_id
         return {"temperature": temperature}
 
-    def fake_completion(model: object, *args: object, **kwargs: object):
+    def fake_completion(model: object, *args: object, **kwargs: object) -> object:
         _ = args
         captured["completion_model"] = model
         captured["completion_kwargs"] = kwargs
@@ -1398,7 +1398,7 @@ def test_chat_llm_ends_partial_response_on_repeated_stream_chunk(
     class RepeatedChunkError(Exception):
         __module__ = "litellm.exceptions"
 
-    def fake_completion(*args: object, **kwargs: object):
+    def fake_completion(*args: object, **kwargs: object) -> object:
         _ = (args, kwargs)
         yield FakeResponse("chunk-1", content="你好")
         message = "The model is repeating the same chunk = ！ ！ ."
@@ -1435,7 +1435,7 @@ def test_chat_llm_streams(monkeypatch: object, app: object) -> None:
     captured_kwargs = {}
     captured_usage = {}
 
-    def fake_completion(*args: object, **kwargs: object):
+    def fake_completion(*args: object, **kwargs: object) -> object:
         _ = args
         captured_kwargs["kwargs"] = kwargs
         chunks = [
@@ -1505,7 +1505,7 @@ def test_chat_llm_streams(monkeypatch: object, app: object) -> None:
 def test_llm_sends_reasoning_output_to_langfuse_without_streaming_it(
     monkeypatch: object, app: object, llm_method: object
 ) -> None:
-    def fake_completion(*args: object, **kwargs: object):
+    def fake_completion(*args: object, **kwargs: object) -> object:
         _ = args, kwargs
         return iter(
             [
@@ -1609,7 +1609,7 @@ def test_extract_reasoning_delta_supports_litellm_fallback_fields(
 def test_chat_llm_falls_back_to_request_trace_id(
     monkeypatch: object, app: object
 ) -> None:
-    def fake_completion(*args: object, **kwargs: object):
+    def fake_completion(*args: object, **kwargs: object) -> object:
         _ = args, kwargs
         return iter([FakeResponse("chunk-1", content="Hi", finish_reason="stop")])
 
@@ -1652,7 +1652,7 @@ class _FakeMidStreamFallbackError(Exception):
     """Stands in for litellm.exceptions.MidStreamFallbackError."""
 
 
-def _stream_chunk(content: object):
+def _stream_chunk(content: object) -> object:
     return SimpleNamespace(
         choices=[
             SimpleNamespace(delta=SimpleNamespace(content=content), finish_reason=None)
@@ -1661,7 +1661,7 @@ def _stream_chunk(content: object):
     )
 
 
-def _reasoning_stream_chunk(reasoning_content: object):
+def _reasoning_stream_chunk(reasoning_content: object) -> object:
     return SimpleNamespace(
         choices=[
             SimpleNamespace(
@@ -1675,7 +1675,7 @@ def _reasoning_stream_chunk(reasoning_content: object):
     )
 
 
-def _patch_retryable_stream_errors(monkeypatch: object):
+def _patch_retryable_stream_errors(monkeypatch: object) -> None:
     # Distinct classes per exception name: a resolver that silently drops one
     # of the names fails that class's parametrized retry test instead of
     # being masked by a shared class.
@@ -1690,7 +1690,7 @@ def _patch_retryable_stream_errors(monkeypatch: object):
     )
 
 
-def _patch_scripted_streams(monkeypatch: object, scripts: object):
+def _patch_scripted_streams(monkeypatch: object, scripts: object) -> object:
     """Each call to _stream_litellm_completion consumes the next script; a script is a list of chunks and/or exceptions raised in order."""
     calls = {"count": 0}
 
@@ -1701,11 +1701,11 @@ def _patch_scripted_streams(monkeypatch: object, scripts: object):
         _messages: object,
         _params: object,
         _kwargs: object,
-    ):
+    ) -> object:
         script = scripts[min(calls["count"], len(scripts) - 1)]
         calls["count"] += 1
 
-        def _gen():
+        def _gen() -> object:
             for item in script:
                 if isinstance(item, BaseException):
                     raise item
@@ -1717,7 +1717,7 @@ def _patch_scripted_streams(monkeypatch: object, scripts: object):
     return calls
 
 
-def _collect_retry_stream(app: object):
+def _collect_retry_stream(app: object) -> object:
     return list(
         llm._iter_stream_with_precontent_retry(
             app, "qwen/test-model", "test-model", [], {}, {}

--- a/src/api/tests/test_mdflow_adapter.py
+++ b/src/api/tests/test_mdflow_adapter.py
@@ -462,7 +462,7 @@ def test_save_shifu_mdflow_rereads_outline_after_risk_control_commit(
 
     def _risk_check_and_reorder(
         _app: object, _check_id: object, _user_id: object, _content: object
-    ):
+    ) -> None:
         with app.app_context():
             latest = (
                 DraftOutlineItem.query.filter_by(
@@ -641,7 +641,7 @@ def test_restore_shifu_mdflow_history_passes_base_revision(
         _outline_bid: object,
         _content: object,
         base_revision: object = None,
-    ):
+    ) -> object:
         captured["base_revision"] = base_revision
         return {"conflict": True, "meta": {"revision": 99}}
 

--- a/src/api/tests/test_openai.py
+++ b/src/api/tests/test_openai.py
@@ -14,7 +14,7 @@ def _install_litellm_stub() -> None:
 
     litellm_stub = types.ModuleType("litellm")
 
-    def get_model_info(*args: object, **kwargs: object):
+    def get_model_info(*args: object, **kwargs: object) -> None:
         _ = args, kwargs
         message = "unknown model"
         raise ValueError(message)
@@ -143,7 +143,7 @@ class FakeUsage:
 def test_invoke_llm_streams_via_litellm(monkeypatch: object, app: object) -> None:
     captured_kwargs = {}
 
-    def fake_completion(*args: object, **kwargs: object):
+    def fake_completion(*args: object, **kwargs: object) -> object:
         captured_kwargs["args"] = args
         captured_kwargs["kwargs"] = kwargs
         usage = FakeUsage(prompt_tokens=5, completion_tokens=4, total_tokens=9)

--- a/src/api/tests/test_order.py
+++ b/src/api/tests/test_order.py
@@ -89,7 +89,7 @@ def test_init_buy_record_refreshes_existing_unpaid_order_promotions(
     )
     apply_calls = {"count": 0}
 
-    def fake_apply_promo_campaigns(*_args: object, **_kwargs: object):
+    def fake_apply_promo_campaigns(*_args: object, **_kwargs: object) -> object:
         apply_calls["count"] += 1
         if apply_calls["count"] == 1:
             return []
@@ -97,7 +97,7 @@ def test_init_buy_record_refreshes_existing_unpaid_order_promotions(
 
     def fake_query_promo_campaign_applications(
         _app: object, _order_id: object, recalc_discount: object
-    ):
+    ) -> object:
         _ = recalc_discount
         if apply_calls["count"] >= 2:
             return [promo_application]

--- a/src/api/tests/test_pingpp.py
+++ b/src/api/tests/test_pingpp.py
@@ -10,7 +10,7 @@ def test_init_pingxx_uses_provider(app: object, monkeypatch: object) -> None:
         def __init__(self) -> None:
             self.called = False
 
-        def ensure_client(self, _app: object):
+        def ensure_client(self, _app: object) -> object:
             self.called = True
             return "client"
 
@@ -28,7 +28,7 @@ def test_create_pingxx_order_builds_request(app: object, monkeypatch: object) ->
     captured = {}
 
     class FakeProvider:
-        def create_payment(self, *, request: object, app: object):
+        def create_payment(self, *, request: object, app: object) -> object:
             _ = app
             captured["request"] = request
             return PaymentCreationResult(

--- a/src/api/tests/test_profile.py
+++ b/src/api/tests/test_profile.py
@@ -25,12 +25,12 @@ def test_add_profile_item_quick_creates_definition(app: object) -> None:
 def test_hide_unused_profile_items_no_unused(monkeypatch: object) -> None:
     calls = []
 
-    def fake_get_unused(app: object, parent_id: object):
+    def fake_get_unused(app: object, parent_id: object) -> object:
         _ = app
         calls.append(("unused", parent_id))
         return []
 
-    def fake_get_defs(app: object, parent_id: object = None):
+    def fake_get_defs(app: object, parent_id: object = None) -> object:
         _ = app
         calls.append(("defs", parent_id))
         return ["defs"]
@@ -52,7 +52,7 @@ def test_hide_unused_profile_items_no_unused(monkeypatch: object) -> None:
 def test_hide_unused_profile_items_updates_hidden(monkeypatch: object) -> None:
     calls = []
 
-    def fake_get_unused(app: object, parent_id: object):
+    def fake_get_unused(app: object, parent_id: object) -> object:
         _ = app
         calls.append(("unused", parent_id))
         return ["v1", "v2"]
@@ -63,7 +63,7 @@ def test_hide_unused_profile_items_updates_hidden(monkeypatch: object) -> None:
         profile_keys: object,
         hidden: object,
         user_id: object,
-    ):
+    ) -> object:
         _ = app
         calls.append(("update", parent_id, tuple(profile_keys), hidden, user_id))
         return ["updated"]

--- a/src/api/tests/test_redislock.py
+++ b/src/api/tests/test_redislock.py
@@ -9,7 +9,7 @@ def test_run_with_redis_executes_once(app: object, monkeypatch: object) -> None:
     fake_redis = FakeRedis()
     monkeypatch.setattr(dao._redis_state, "client", fake_redis)
 
-    def add_one(value: object):
+    def add_one(value: object) -> object:
         return value + 1
 
     result = dao.run_with_redis(app, "lock-key", 10, add_one, [1])

--- a/src/api/tests/test_retry_on_deadlock.py
+++ b/src/api/tests/test_retry_on_deadlock.py
@@ -14,7 +14,7 @@ class _FakeOrigError(Exception):
         self.args = (errno, message)
 
 
-def _operational_error(errno: object):
+def _operational_error(errno: object) -> object:
     return OperationalError("SELECT 1", {}, _FakeOrigError(errno, "boom"))
 
 
@@ -22,7 +22,7 @@ def test_retries_deadlock_then_succeeds() -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def flaky():
+    def flaky() -> object:
         calls["n"] += 1
         if calls["n"] < 3:
             raise _operational_error(1213)
@@ -36,7 +36,7 @@ def test_retries_lock_wait_timeout() -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=2, backoff_seconds=0)
-    def flaky():
+    def flaky() -> object:
         calls["n"] += 1
         if calls["n"] < 2:
             raise _operational_error(1205)
@@ -50,7 +50,7 @@ def test_reraises_after_exhausting_attempts() -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def always_deadlock():
+    def always_deadlock() -> None:
         calls["n"] += 1
         raise _operational_error(1213)
 
@@ -63,7 +63,7 @@ def test_does_not_retry_non_retryable_operational_error() -> None:
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def other_error():
+    def other_error() -> None:
         calls["n"] += 1
         raise _operational_error(1146)  # table doesn't exist
 
@@ -78,7 +78,7 @@ def test_rolls_back_session_on_every_caught_error(monkeypatch: object) -> None:
     monkeypatch.setattr(dao, "db", fake_db)
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def always_deadlock():
+    def always_deadlock() -> None:
         raise _operational_error(1213)
 
     with pytest.raises(OperationalError):
@@ -92,7 +92,7 @@ def test_rolls_back_session_on_non_retryable_error(monkeypatch: object) -> None:
     monkeypatch.setattr(dao, "db", fake_db)
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def other_error():
+    def other_error() -> None:
         raise _operational_error(1146)
 
     with pytest.raises(OperationalError):
@@ -112,7 +112,7 @@ def test_protocol_interrupt_invalidates_and_does_not_retry(monkeypatch: object) 
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def desynced():
+    def desynced() -> None:
         calls["n"] += 1
         raise _operational_error(2014)
 
@@ -134,7 +134,7 @@ def test_rollback_db_failure_escalates_and_stops_retrying(monkeypatch: object) -
     )
 
     class _BrokenSession:
-        def rollback(self):
+        def rollback(self) -> None:
             message = "ROLLBACK"
             raise OperationalError(message, {}, Exception())
 
@@ -145,7 +145,7 @@ def test_rollback_db_failure_escalates_and_stops_retrying(monkeypatch: object) -
     calls = {"n": 0}
 
     @retry_on_deadlock(max_attempts=3, backoff_seconds=0)
-    def deadlocked():
+    def deadlocked() -> None:
         calls["n"] += 1
         raise _operational_error(1213)
 

--- a/src/api/tests/test_shifu_funcs.py
+++ b/src/api/tests/test_shifu_funcs.py
@@ -8,10 +8,10 @@ def test_run_summary_with_error_handling_logs_and_continues(
 ) -> None:
     called = {"apply": False, "summary": False}
 
-    def fake_apply(_snapshot: object):
+    def fake_apply(_snapshot: object) -> None:
         called["apply"] = True
 
-    def fake_summary(_app: object, _shifu_id: object):
+    def fake_summary(_app: object, _shifu_id: object) -> None:
         called["summary"] = True
         message = "boom"
         raise RuntimeError(message)

--- a/src/api/tests/test_sms_aliyun.py
+++ b/src/api/tests/test_sms_aliyun.py
@@ -17,7 +17,7 @@ def test_query_sms_template_list_caps_page_size_at_provider_limit(
 
         def query_sms_template_list_with_options(
             self, request: object, _runtime: object
-        ):
+        ) -> object:
             captured["page_index"] = request.page_index
             captured["page_size"] = request.page_size
             return SimpleNamespace(body=SimpleNamespace(code="OK"))

--- a/src/api/tests/test_wx_pub_order.py
+++ b/src/api/tests/test_wx_pub_order.py
@@ -42,7 +42,7 @@ def test_generate_charge_uses_pingxx_channel(app: object, monkeypatch: object) -
 
     captured = {}
 
-    def fake_generate_pingxx_charge(**kwargs: object):
+    def fake_generate_pingxx_charge(**kwargs: object) -> object:
         captured.update(kwargs)
         return BuyRecordDTO(
             kwargs["buy_record"].order_bid,


### PR DESCRIPTION
## Scope

Enables Ruff ANN202 in the third annotation-rule layer. It replaces private return gaps with concrete `None`, Flask response, string-response, tuple, plugin-list, callback, context-manager, stream-generator, translation-mapping, TTS-iterator, exception-chain, Celery schedule, Decimal wallet, datetime clock, generic coroutine-result, credential-scope, pagination, and diagnostics-logger contracts. It also preserves the Pingxx decorator callable signature.

## Migration-history policy

The bottom layer, [#2649](https://github.com/ai-shifu/ai-shifu/pull/2649), exempts `src/api/migrations/versions/**` from all Ruff rules. Every Alembic-generated revision, including future revisions, is immutable history and remains unchanged by this PR.

## Regression coverage

Runtime annotation tests cover query factories, context managers, TTS, LiteLLM stream chunks, and the Pingxx callable decorator.

## Stack

Base: `ruff/ann201` ([#2645](https://github.com/ai-shifu/ai-shifu/pull/2645))  
Head: `ruff/ann202`

## Validation

- `ruff check --select ANN202 .`
- `ruff format --check .`
- Verified that no migration revision source file is changed in this layer.
