### PR TITLE
chore: migrate db.session.commit() to uow in shifu funcs

### DIFF
--- a/docs/generated/uow-commit-baseline.json
+++ b/docs/generated/uow-commit-baseline.json
@@ -40,7 +40,6 @@
   "service/referral/service.py": 6,
   "service/shifu/admin_operations/courses_transfer_copy.py": 2,
   "service/shifu/admin_operations/voice_clones.py": 1,
-  "service/shifu/funcs.py": 6,
   "service/shifu/route.py": 2,
   "service/shifu/shifu_draft_funcs.py": 4,
   "service/shifu/shifu_import_export_funcs.py": 1,

--- a/src/api/flaskr/service/shifu/funcs.py
+++ b/src/api/flaskr/service/shifu/funcs.py
@@ -16,6 +16,7 @@ import requests
 from flaskr.common.cache_provider import cache as redis
 from flaskr.common.config import get_redis_key_prefix
 from flaskr.dao import db
+from flaskr.dao.uow import unit_of_work
 from flaskr.service.common.models import raise_error
 from flaskr.service.common.oss_utils import OSS_PROFILE_COURSES, get_image_content_type
 from flaskr.service.common.storage import upload_to_storage
@@ -38,19 +39,17 @@ def mark_favorite_shifu(app: object, user_id: str, shifu_id: str) -> bool:
         bool: True if successful
 
     """
-    with app.app_context():
+    with app.app_context(), unit_of_work():
         existing_favorite_shifu = FavoriteScenario.query.filter_by(
             scenario_id=shifu_id, user_id=user_id
         ).first()
         if existing_favorite_shifu:
             existing_favorite_shifu.status = 1
-            db.session.commit()
             return True
         favorite_shifu = FavoriteScenario(
             scenario_id=shifu_id, user_id=user_id, status=1
         )
         db.session.add(favorite_shifu)
-        db.session.commit()
         return True
 
 
@@ -67,13 +66,12 @@ def unmark_favorite_shifu(app: object, user_id: str, shifu_id: str) -> bool:
         bool: True if successful
 
     """
-    with app.app_context():
+    with app.app_context(), unit_of_work():
         favorite_shifu = FavoriteScenario.query.filter_by(
             scenario_id=shifu_id, user_id=user_id
         ).first()
         if favorite_shifu:
             favorite_shifu.status = 0
-            db.session.commit()
             return True
         return False
 
@@ -136,28 +134,27 @@ def upload_file(app: object, user_id: str, resource_id: str, file: object) -> st
             profile=OSS_PROFILE_COURSES,
         )
 
-        if is_update:
-            resource.name = file.filename
-            resource.oss_bucket = result.bucket
-            resource.oss_name = result.object_key
-            resource.url = result.url
-            resource.updated_by = user_id
-            db.session.commit()
-        else:
-            resource = Resource(
-                resource_id=file_id,
-                name=file.filename,
-                type=0,
-                oss_bucket=result.bucket,
-                oss_name=result.object_key,
-                url=result.url,
-                status=0,
-                is_deleted=0,
-                created_by=user_id,
-                updated_by=user_id,
-            )
-            db.session.add(resource)
-            db.session.commit()
+        with unit_of_work():
+            if is_update:
+                resource.name = file.filename
+                resource.oss_bucket = result.bucket
+                resource.oss_name = result.object_key
+                resource.url = result.url
+                resource.updated_by = user_id
+            else:
+                resource = Resource(
+                    resource_id=file_id,
+                    name=file.filename,
+                    type=0,
+                    oss_bucket=result.bucket,
+                    oss_name=result.object_key,
+                    url=result.url,
+                    status=0,
+                    is_deleted=0,
+                    created_by=user_id,
+                    updated_by=user_id,
+                )
+                db.session.add(resource)
 
         return result.url
 
@@ -225,20 +222,20 @@ def upload_url(app: object, user_id: str, url: str) -> str:
                 profile=OSS_PROFILE_COURSES,
             )
 
-            resource = Resource(
-                resource_id=file_id,
-                name=filename,
-                type=0,
-                oss_bucket=result.bucket,
-                oss_name=result.object_key,
-                url=result.url,
-                status=0,
-                is_deleted=0,
-                created_by=user_id,
-                updated_by=user_id,
-            )
-            db.session.add(resource)
-            db.session.commit()
+            with unit_of_work():
+                resource = Resource(
+                    resource_id=file_id,
+                    name=filename,
+                    type=0,
+                    oss_bucket=result.bucket,
+                    oss_name=result.object_key,
+                    url=result.url,
+                    status=0,
+                    is_deleted=0,
+                    created_by=user_id,
+                    updated_by=user_id,
+                )
+                db.session.add(resource)
 
         except requests.RequestException:
             app.logger.exception("Failed to download image from URL: %s", url)

--- a/src/api/tests/test_shifu_funcs.py
+++ b/src/api/tests/test_shifu_funcs.py
@@ -1,6 +1,8 @@
-"""Verify course summaries isolate and report generation failures."""
+"""Verify course summaries and favorite scenarios."""
 
-from flaskr.service.shifu import shifu_publish_funcs
+from flaskr.dao import db
+from flaskr.service.shifu import funcs, shifu_publish_funcs
+from flaskr.service.shifu.models import FavoriteScenario
 
 
 def test_run_summary_with_error_handling_logs_and_continues(
@@ -24,3 +26,56 @@ def test_run_summary_with_error_handling_logs_and_continues(
 
     assert called["apply"] is True
     assert called["summary"] is True
+
+
+def test_favorite_shifu_workflow(app: object) -> None:
+    user_id = "test-user-123"
+    shifu_id = "test-shifu-456"
+
+    with app.app_context():
+        # Cleanup first
+        FavoriteScenario.query.filter_by(user_id=user_id, scenario_id=shifu_id).delete()
+        db.session.commit()
+
+        # Mark as favorite
+        res = funcs.mark_favorite_shifu(app, user_id, shifu_id)
+        assert res is True
+
+        db.session.expire_all()
+        fav = FavoriteScenario.query.filter_by(
+            user_id=user_id, scenario_id=shifu_id
+        ).first()
+        assert fav is not None
+        assert fav.status == 1
+
+        # Unmark as favorite
+        res = funcs.unmark_favorite_shifu(app, user_id, shifu_id)
+        assert res is True
+
+        db.session.expire_all()
+        fav = FavoriteScenario.query.filter_by(
+            user_id=user_id, scenario_id=shifu_id
+        ).first()
+        assert fav is not None
+        assert fav.status == 0
+
+        # Mark or unmark favorite helper
+        res = funcs.mark_or_unmark_favorite_shifu(
+            app, user_id, shifu_id, is_favorite=True
+        )
+        assert res is True
+        db.session.expire_all()
+        fav = FavoriteScenario.query.filter_by(
+            user_id=user_id, scenario_id=shifu_id
+        ).first()
+        assert fav.status == 1
+
+        res = funcs.mark_or_unmark_favorite_shifu(
+            app, user_id, shifu_id, is_favorite=False
+        )
+        assert res is True
+        db.session.expire_all()
+        fav = FavoriteScenario.query.filter_by(
+            user_id=user_id, scenario_id=shifu_id
+        ).first()
+        assert fav.status == 0


### PR DESCRIPTION
Changed:
Replaced direct `db.session.commit()` calls with `unit_of_work()` context blocks in `service/shifu/funcs.py`. Added test coverage for affected endpoints and updated the UoW commit baseline.

Benefit:
Aligns the shifu service with the standard transaction boundary architecture, preventing partial commits and state bleeding during errors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when marking, unmarking, or toggling Shifu favorites.
  * Favorite status changes now save more consistently.
  * Improved transaction handling for favorite actions and resource uploads.

* **Tests**
  * Added coverage for complete Shifu favorite workflows.
  * Added validation that favorite status changes persist correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->