### PR TITLE
chore: migrate db.session.commit() to uow in billing checkout

### DIFF
--- a/docs/generated/uow-commit-baseline.json
+++ b/docs/generated/uow-commit-baseline.json
@@ -3,7 +3,6 @@
   "command/update_shifu_demo.py": 2,
   "route/user.py": 7,
   "service/billing/campaigns.py": 3,
-  "service/billing/checkout.py": 7,
   "service/billing/cli.py": 5,
   "service/billing/daily_aggregates.py": 2,
   "service/billing/domains.py": 1,

--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -10,6 +10,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from flaskr.common import cache_provider
 from flaskr.common.public_urls import build_stripe_billing_result_url
 from flaskr.dao import db
+from flaskr.dao.uow import unit_of_work
 from flaskr.i18n import _ as translate
 from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.common.native_payment_status import (
@@ -515,7 +516,11 @@ def create_billing_subscription_checkout(
         default_pingxx_channel="alipay_qr",
     )
 
-    with app.app_context(), _subscription_checkout_lock(app, normalized_creator_bid):
+    with (
+        app.app_context(),
+        _subscription_checkout_lock(app, normalized_creator_bid),
+        unit_of_work(),
+    ):
         now = now_utc()
         product = _load_catalog_product(product_bid, BILLING_PRODUCT_TYPE_PLAN)
         provider_price_mapping: BillingProductProviderPrice | None = None
@@ -710,15 +715,13 @@ def create_billing_subscription_checkout(
 
             db.session.add(subscription)
             db.session.flush()
-            checkout_result = _reopen_existing_billing_order_checkout(
+            return _reopen_existing_billing_order_checkout(
                 app,
                 creator_bid=normalized_creator_bid,
                 order=reusable_order,
                 product=product,
                 requested_channel=channel,
             )
-            db.session.commit()
-            return checkout_result
 
         db.session.add(subscription)
         db.session.flush()
@@ -812,7 +815,6 @@ def create_billing_subscription_checkout(
                 channel=channel,
                 provider_price_mapping=provider_price_mapping,
             )
-        db.session.commit()
         _dispatch_billing_paid_order_side_effects(app, paid_order_side_effects)
         return checkout_result
 
@@ -830,7 +832,7 @@ def create_billing_topup_checkout(
         default_pingxx_channel="alipay_qr",
     )
 
-    with app.app_context():
+    with app.app_context(), unit_of_work():
         product = _load_catalog_product(product_bid, BILLING_PRODUCT_TYPE_TOPUP)
         provider_price_mapping: BillingProductProviderPrice | None = None
         if payment_provider == "stripe":
@@ -908,7 +910,7 @@ def create_billing_topup_checkout(
         db.session.add(order)
         db.session.flush()
 
-        checkout_result = _create_provider_checkout(
+        return _create_provider_checkout(
             app,
             creator_bid=normalized_creator_bid,
             order=order,
@@ -918,8 +920,6 @@ def create_billing_topup_checkout(
             channel=channel,
             provider_price_mapping=provider_price_mapping,
         )
-        db.session.commit()
-        return checkout_result
 
 
 def create_billing_order_checkout(
@@ -935,39 +935,42 @@ def create_billing_order_checkout(
 
     with app.app_context():
         now = now_utc()
-        order = (
-            BillingOrder.query.filter(
-                BillingOrder.deleted == 0,
-                BillingOrder.creator_bid == normalized_creator_bid,
-                BillingOrder.bill_order_bid == normalized_order_bid,
+        is_expired = False
+        with unit_of_work():
+            order = (
+                BillingOrder.query.filter(
+                    BillingOrder.deleted == 0,
+                    BillingOrder.creator_bid == normalized_creator_bid,
+                    BillingOrder.bill_order_bid == normalized_order_bid,
+                )
+                .order_by(BillingOrder.id.desc())
+                .first()
             )
-            .order_by(BillingOrder.id.desc())
-            .first()
-        )
-        if order is None:
-            raise_error("server.order.orderNotFound")
-        if _hydrate_legacy_billing_order_expires_at(order):
-            db.session.add(order)
-        if order.status != BILLING_ORDER_STATUS_PENDING:
-            raise_error("server.order.orderStatusError")
-        if _expire_pending_billing_order_if_due(order, now=now):
-            db.session.add(order)
-            db.session.commit()
+            if order is None:
+                raise_error("server.order.orderNotFound")
+            if _hydrate_legacy_billing_order_expires_at(order):
+                db.session.add(order)
+            if order.status != BILLING_ORDER_STATUS_PENDING:
+                raise_error("server.order.orderStatusError")
+            if _expire_pending_billing_order_if_due(order, now=now):
+                db.session.add(order)
+                is_expired = True
+
+        if is_expired:
             raise_error("server.order.orderPayExpired")
 
-        product = _load_billing_product_by_bid(order.product_bid)
-        if product is None:
-            raise_error("server.order.orderNotFound")
+        with unit_of_work():
+            product = _load_billing_product_by_bid(order.product_bid)
+            if product is None:
+                raise_error("server.order.orderNotFound")
 
-        checkout_result = _reopen_existing_billing_order_checkout(
-            app,
-            creator_bid=normalized_creator_bid,
-            order=order,
-            product=product,
-            requested_channel=requested_channel,
-        )
-        db.session.commit()
-        return checkout_result
+            return _reopen_existing_billing_order_checkout(
+                app,
+                creator_bid=normalized_creator_bid,
+                order=order,
+                product=product,
+                requested_channel=requested_channel,
+            )
 
 
 def _reopen_existing_billing_order_checkout(
@@ -1190,7 +1193,7 @@ def refund_billing_order(
     if refund_amount_value not in (None, ""):
         refund_amount = int(refund_amount_value)
 
-    with app.app_context():
+    with app.app_context(), unit_of_work():
         order = (
             BillingOrder.query.filter(
                 BillingOrder.deleted == 0,
@@ -1302,7 +1305,6 @@ def refund_billing_order(
                 effective_from=now,
             )
 
-        db.session.commit()
         return BillingRefundResultDTO(
             bill_order_bid=order.bill_order_bid,
             provider=order.payment_provider,
@@ -1325,7 +1327,11 @@ def sync_billing_order(
     # Hold a per-creator lock across the whole read-modify-commit so the grant
     # idempotency pre-check and the commit run in one critical section (see
     # _credit_ledger_lock).
-    with app.app_context(), _credit_ledger_lock(app, normalized_creator_bid):
+    with (
+        app.app_context(),
+        _credit_ledger_lock(app, normalized_creator_bid),
+        unit_of_work(),
+    ):
         order = (
             BillingOrder.query.filter(
                 BillingOrder.deleted == 0,
@@ -1364,8 +1370,6 @@ def sync_billing_order(
 
         order_update.stage_after_state_changes(app, order)
 
-        db.session.add(order)
-        db.session.commit()
         order_update.dispatch_after_commit(app)
         return _build_billing_order_sync_result(order)
 


### PR DESCRIPTION
Changed:
Replaced direct `db.session.commit()` calls with `unit_of_work()` context blocks in `service/billing/checkout.py` and updated the UoW commit baseline.

Benefit:
Aligns the billing checkout service with the standard transaction boundary architecture, preventing partial commits and state bleeding during errors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction consistency across subscription, top-up, order, refund, and synchronization workflows.
  * Improved reliability when reopening existing orders during checkout.
  * Improved handling of order expiration before checkout resumes.
  * Improved reliability of related billing updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->