### PR TITLE
fix: localize overseas billing number formats

### DIFF
--- a/src/cook-web/src/app/admin/billing/components/GlobalBillingPricing.test.tsx
+++ b/src/cook-web/src/app/admin/billing/components/GlobalBillingPricing.test.tsx
@@ -20,6 +20,7 @@ let mockBillingSubscription: BillingSubscription | null = null;
 let mockBillingOverview:
   | { subscription: BillingSubscription | null }
   | undefined;
+let mockResolvedLanguage = 'zh-CN';
 
 jest.mock('@/c-common/hooks/useTracking', () => ({
   useTracking: () => ({ trackEvent: mockTrackEvent }),
@@ -200,8 +201,8 @@ jest.mock('react-i18next', () => ({
       t: translate,
       i18n: {
         getFixedT: () => translate,
-        language: 'zh-CN',
-        resolvedLanguage: 'zh-CN',
+        language: mockResolvedLanguage,
+        resolvedLanguage: mockResolvedLanguage,
       },
     };
   },
@@ -288,6 +289,7 @@ describe('GlobalBillingPricing', () => {
     mockBillingOverview = {
       subscription: mockBillingSubscription,
     };
+    mockResolvedLanguage = 'zh-CN';
     mockGetBillingCatalog.mockResolvedValue(buildGlobalCatalog());
   });
 
@@ -405,6 +407,23 @@ describe('GlobalBillingPricing', () => {
     expect(
       screen.queryByText('module.billing.globalPricing.subtitle'),
     ).not.toBeInTheDocument();
+  });
+
+  test('formats annual savings with the active language locale', async () => {
+    mockResolvedLanguage = 'fr-FR';
+
+    renderPricing();
+
+    const studio = await screen.findByTestId('global-plan-studio');
+    const growth = await screen.findByTestId('global-plan-growth');
+    expect(within(studio).getByText(/59\s\$/)).toBeInTheDocument();
+    expect(within(growth).getByText(/183\s\$/)).toBeInTheDocument();
+    expect(
+      within(growth).getByText(/Save 549\s\$ per year \(20,0%\)/),
+    ).toBeInTheDocument();
+    expect(
+      within(growth).getByText(/50\s000 credits per 12-month billing period/),
+    ).toBeInTheDocument();
   });
 
   test('switches to monthly pricing without a Studio first-month offer', async () => {

--- a/src/cook-web/src/app/admin/billing/components/GlobalBillingPricing.tsx
+++ b/src/cook-web/src/app/admin/billing/components/GlobalBillingPricing.tsx
@@ -21,6 +21,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import {
   buildBillingSwrKey,
   formatBillingCredits,
+  formatBillingPercent,
   formatBillingPrice,
   openBillingCheckoutUrl,
 } from '@/lib/billing';
@@ -705,8 +706,11 @@ function PlanCard({
     ? monthlyProduct.price_amount * 12 - annualProduct.price_amount
     : 0;
   const annualSavingsPercent = annualProduct
-    ? ((annualSavings / (monthlyProduct.price_amount * 12)) * 100).toFixed(1)
-    : '0.0';
+    ? formatBillingPercent(
+        (annualSavings / (monthlyProduct.price_amount * 12)) * 100,
+        locale,
+      )
+    : formatBillingPercent(0, locale);
   const featureIncludeKey = PLAN_FEATURE_INCLUDE_KEYS[tierSpec.tier];
   const pricingDetailsClassName =
     cycle === 'annual' ? 'min-h-[150px]' : 'min-h-[86px]';

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.test.tsx
@@ -7,12 +7,14 @@ import {
 } from '@/hooks/useBillingData';
 import { BillingCreditDetailsPanel } from './BillingCreditDetailsPanel';
 
+let mockResolvedLanguage = 'zh-CN';
+
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) =>
       key === 'module.billing.details.emptyValidityLabel' ? '--' : key,
     i18n: {
-      language: 'zh-CN',
+      language: mockResolvedLanguage,
     },
   }),
 }));
@@ -36,6 +38,7 @@ describe('BillingCreditDetailsPanel', () => {
     jest.useFakeTimers().setSystemTime(new Date('2026-04-15T00:00:00Z'));
     mockUseBillingOverview.mockReset();
     mockUseBillingWalletBuckets.mockReset();
+    mockResolvedLanguage = 'zh-CN';
 
     mockUseBillingOverview.mockReturnValue({
       data: {
@@ -167,6 +170,15 @@ describe('BillingCreditDetailsPanel', () => {
     );
 
     expect(onUpgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test('formats the total credit balance with the active language locale', () => {
+    mockResolvedLanguage = 'fr-FR';
+
+    render(<BillingCreditDetailsPanel />);
+
+    expect(screen.getByText(/1\s110/)).toBeInTheDocument();
+    expect(screen.queryByText('1,110')).not.toBeInTheDocument();
   });
 
   test('summarizes topup buckets as no-expiration credits across eligibility windows', () => {

--- a/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
+++ b/src/cook-web/src/components/billing/BillingCreditDetailsPanel.tsx
@@ -257,6 +257,7 @@ export function BillingCreditDetailsPanel({
 
   const totalCreditsLabel = formatBillingCreditBalance(
     overview?.wallet.available_credits || 0,
+    i18n.language,
   );
   const emptyValidityLabel = t('module.billing.details.emptyValidityLabel');
   const neverExpiresLabel = t('module.billing.ledger.neverExpires');

--- a/src/cook-web/src/lib/__tests__/billing.test.ts
+++ b/src/cook-web/src/lib/__tests__/billing.test.ts
@@ -5,6 +5,7 @@ import {
   formatBillingCredits,
   formatBillingNumber,
   formatBillingPlanInterval,
+  formatBillingPercent,
   formatBillingPrice,
   getBillingProductCampaignBonusCredits,
   hasBillingProductBonusCampaign,
@@ -79,6 +80,7 @@ describe('formatBillingNumber (unified display rule)', () => {
     expect(formatBillingNumber(1234567, 'en-US')).toBe('1,234,567');
     expect(formatBillingNumber(1234567, 'zh-CN')).toBe('1,234,567');
     expect(formatBillingNumber(1234567.89, 'en-US')).toBe('1,234,567.89');
+    expect(formatBillingNumber(1234567.89, 'fr-FR')).toBe('1 234 567,89');
   });
 
   test('falls back to zero for non-finite or nullish input', () => {
@@ -107,6 +109,7 @@ describe('formatBillingCredits', () => {
   test('renders integers without decimals and groups thousands', () => {
     expect(formatBillingCredits(5, 'en-US')).toBe('5');
     expect(formatBillingCredits(10000, 'en-US')).toBe('10,000');
+    expect(formatBillingCredits(10000, 'fr-FR')).toBe('10 000');
   });
 
   test('keeps meaningful decimals up to two places', () => {
@@ -167,6 +170,7 @@ describe('formatBillingCreditBalance', () => {
     expect(formatBillingCreditBalance(1.99)).toBe('1');
     expect(formatBillingCreditBalance(10000)).toBe('10,000');
     expect(formatBillingCreditBalance(32277.76)).toBe('32,277');
+    expect(formatBillingCreditBalance(32277.76, 'fr-FR')).toBe('32 277');
   });
 
   test('falls back to zero for non-finite or nullish input', () => {
@@ -259,6 +263,14 @@ describe('formatBillingCreditDetail', () => {
   });
 });
 
+describe('formatBillingPercent', () => {
+  test('formats one decimal with locale-specific separators', () => {
+    expect(formatBillingPercent(20, 'en-US')).toBe('20.0');
+    expect(formatBillingPercent(20, 'fr-FR')).toBe('20,0');
+    expect(formatBillingPercent(20.55, 'fr-FR')).toBe('20,6');
+  });
+});
+
 describe('formatBillingPrice', () => {
   test('formats minor units to currency without trailing zeros', () => {
     expect(formatBillingPrice(1, 'CNY', 'zh-CN')).toBe('¥0.01');
@@ -273,6 +285,7 @@ describe('formatBillingPrice', () => {
 
   test('supports other currencies', () => {
     expect(formatBillingPrice(9950, 'USD', 'en-US')).toBe('$99.5');
+    expect(formatBillingPrice(219900, 'USD', 'fr-FR')).toBe('2 199 $');
   });
 
   test('handles 0-decimal currency (JPY) without dividing by 100', () => {

--- a/src/cook-web/src/lib/billing.ts
+++ b/src/cook-web/src/lib/billing.ts
@@ -363,10 +363,20 @@ export function formatBillingCredits(value: number, locale: string): string {
   return formatBillingNumber(value, locale);
 }
 
-export function formatBillingCreditBalance(value: number): string {
+export function formatBillingPercent(value: number, locale: string): string {
+  return formatBillingNumber(value, locale, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+}
+
+export function formatBillingCreditBalance(
+  value: number,
+  locale = 'en-US',
+): string {
   const numeric = Number(value ?? 0);
   const floored = Number.isFinite(numeric) ? Math.floor(numeric) : 0;
-  return formatBillingNumber(floored, 'en-US', { maximumFractionDigits: 0 });
+  return formatBillingNumber(floored, locale, { maximumFractionDigits: 0 });
 }
 
 export function formatBillingCreditAmount(value: number): string {


### PR DESCRIPTION
## Summary
- Format overseas billing annual savings percentages with the active locale.
- Keep billing credit detail totals aligned with the active language while preserving existing default formatting.
- Add focused coverage for French price, percentage, credit, and total balance formatting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Billing prices, savings percentages, credit quantities, and balances now follow the selected language and regional number formatting.
  * Annual plan savings display consistently uses one decimal place.
  * Credit totals and balances now support localized formatting, including French-style separators and conventions.

* **Tests**
  * Added coverage for localized billing displays across multiple languages and regional formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->