### PR TITLE
fix: prevent migration changes from skipping backend tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -203,20 +203,19 @@ jobs:
                   "src/api/AGENTS.md",
                   "src/api/CLAUDE.md",
                   "src/api/SKILL.md",
-                  ".github/workflows/backend-tests.yml",
               }:
                   return True
               return path.startswith("src/api/scripts/")
 
           for path in changed:
               if path in {
+                  ".github/workflows/backend-tests.yml",
                   "src/api/requirements.txt",
+                  "src/api/requirements-ci.txt",
               }:
                   full_run = True
                   break
               if not path.startswith("src/api/"):
-                  if path == ".github/workflows/backend-tests.yml":
-                      continue
                   continue
               if is_control_plane_backend_path(path):
                   continue
@@ -254,8 +253,10 @@ jobs:
               print("Selected targets: <skipped>")
           else:
               print(f"Selected targets: {targets_list}")
+              print(f"Test mode: {'full (no deselection)' if full_run else 'incremental'}")
           with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
               env_file.write(f"SKIP_BACKEND_TESTS={'1' if skip_run else '0'}\n")
+              env_file.write(f"FULL_BACKEND_TESTS={'1' if full_run else '0'}\n")
               env_file.write(f"TEST_TARGETS={targets_list}\n")
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
               summary.write("### Backend test targets (PR)\n")
@@ -264,6 +265,7 @@ jobs:
                   summary.write("- Reason: control-plane or tooling-only backend changes.\n")
               else:
                   summary.write(f"- Targets: `{targets_list}`\n")
+                  summary.write(f"- Mode: `{'full (no deselection)' if full_run else 'incremental'}`\n")
           PY
 
       - name: Skip backend tests (unrelated pull request)
@@ -276,11 +278,18 @@ jobs:
         run: |
           echo "Skipping backend tests because the PR only changed backend control-plane or tooling files."
 
-      - name: Run tests (PR incremental)
+      - name: Run tests (PR)
         if: github.event_name == 'pull_request' && steps.backend-changes.outputs.run == 'true' && env.SKIP_BACKEND_TESTS != '1'
         working-directory: src/api
         run: |
-          python -m pytest --testmon $TEST_TARGETS
+          read -r -a test_targets <<< "$TEST_TARGETS"
+          if [[ "$FULL_BACKEND_TESTS" == "1" ]]; then
+            # Migration discovery and other filesystem dependencies may be
+            # invisible to testmon. A full target set must also disable selection.
+            python -m pytest --testmon-noselect "${test_targets[@]}"
+          else
+            python -m pytest --testmon "${test_targets[@]}"
+          fi
 
       - name: Run tests with coverage (main/full)
         if: github.event_name != 'pull_request'

--- a/src/api/tests/migrations/test_fresh_mysql_upgrade.py
+++ b/src/api/tests/migrations/test_fresh_mysql_upgrade.py
@@ -29,7 +29,7 @@ def test_alembic_migrations_have_single_head() -> None:
     config.set_main_option("script_location", str(API_ROOT / "migrations"))
     heads = ScriptDirectory.from_config(config).get_heads()
 
-    assert heads == ["c7b9e1a2d4f6"]
+    assert len(heads) == 1
 
 
 def _get_base_mysql_uri() -> str:

--- a/src/api/tests/scripts/test_backend_test_workflow.py
+++ b/src/api/tests/scripts/test_backend_test_workflow.py
@@ -1,0 +1,137 @@
+"""Exercise backend CI target selection and the resulting pytest command."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/backend-tests.yml"
+
+
+def _workflow_script(step_name: str) -> str:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    return next(
+        step["run"]
+        for step in workflow["jobs"]["backend-tests"]["steps"]
+        if step["name"] == step_name
+    )
+
+
+def _select_targets(changed_paths: list[str], tmp_path: Path) -> dict[str, str]:
+    # Execute the actual selector, substituting only the git diff output.
+    selector = _workflow_script("Select test targets (PR only)")
+    selector = selector.removeprefix("python - <<'PY'\n").removesuffix("PY\n")
+    selector_file = tmp_path / "selector.py"
+    selector_file.write_text(selector, encoding="utf-8")
+    changed = "\n".join(changed_paths)
+    script = textwrap.dedent(
+        f"""\
+        import runpy
+        from unittest.mock import patch
+        with patch("subprocess.check_output", return_value={changed!r}):
+            runpy.run_path({str(selector_file)!r}, run_name="__main__")
+        """
+    )
+    env_file = tmp_path / "github_env"
+    summary_file = tmp_path / "github_summary"
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env={
+            **os.environ,
+            "BASE_SHA": "base",
+            "HEAD_SHA": "head",
+            "GITHUB_ENV": str(env_file),
+            "GITHUB_STEP_SUMMARY": str(summary_file),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    return dict(
+        line.split("=", 1) for line in env_file.read_text(encoding="utf-8").splitlines()
+    )
+
+
+@pytest.mark.parametrize(
+    ("changed_paths", "expected_targets", "expected_flag"),
+    [
+        (
+            ["src/api/migrations/versions/new_revision.py"],
+            "tests",
+            "--testmon-noselect",
+        ),
+        (["src/api/requirements.txt"], "tests", "--testmon-noselect"),
+        (["src/api/requirements-ci.txt"], "tests", "--testmon-noselect"),
+        (["src/api/flaskr/route/user.py"], "tests", "--testmon-noselect"),
+        ([".github/workflows/backend-tests.yml"], "tests", "--testmon-noselect"),
+        (
+            [
+                "src/api/flaskr/service/billing/models.py",
+                "src/api/migrations/versions/new_revision.py",
+            ],
+            "tests",
+            "--testmon-noselect",
+        ),
+        (
+            ["src/api/flaskr/service/billing/models.py"],
+            "tests/service/billing",
+            "--testmon",
+        ),
+        (
+            [
+                "src/api/flaskr/service/billing/models.py",
+                "src/api/flaskr/service/order/funs.py",
+            ],
+            "tests/service/billing tests/service/order",
+            "--testmon",
+        ),
+        (
+            ["src/api/tests/migrations/test_fresh_mysql_upgrade.py"],
+            "tests/migrations/test_fresh_mysql_upgrade.py",
+            "--testmon",
+        ),
+    ],
+)
+def test_pr_changes_select_the_required_pytest_mode(
+    changed_paths: list[str],
+    expected_targets: str,
+    expected_flag: str,
+    tmp_path: Path,
+) -> None:
+    selection = _select_targets(changed_paths, tmp_path)
+    assert selection["SKIP_BACKEND_TESTS"] == "0"
+    assert selection["TEST_TARGETS"] == expected_targets
+
+    # Capture argv from the actual shell step without running the suite recursively.
+    runner = "python() { printf '%s\\n' \"$@\"; }\n" + _workflow_script(
+        "Run tests (PR)"
+    )
+    result = subprocess.run(
+        ["bash", "-c", runner],
+        env={**os.environ, **selection},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.splitlines() == [
+        "-m",
+        "pytest",
+        expected_flag,
+        *expected_targets.split(),
+    ]
+
+
+def test_pr_control_plane_only_changes_still_skip_backend_tests(tmp_path: Path) -> None:
+    selection = _select_targets(["src/api/AGENTS.md"], tmp_path)
+
+    assert selection["SKIP_BACKEND_TESTS"] == "1"
+    assert selection["TEST_TARGETS"] == ""

--- a/src/api/tests/service/billing/test_provider_catalog_sync.py
+++ b/src/api/tests/service/billing/test_provider_catalog_sync.py
@@ -113,6 +113,9 @@ def test_stripe_product_webhook_stores_unlinked_snapshot_with_metadata_suggestio
     monkeypatch: object,
 ) -> None:
     _patch_account(monkeypatch)
+    # The session-scoped database may already contain mappings from other tests.
+    # Keep the unlinked product distinct from their shared prod_growth fixture.
+    provider_product_id = "prod_catalog_unlinked"
     with app.app_context():
         db.session.add(_product())
         db.session.commit()
@@ -124,7 +127,7 @@ def test_stripe_product_webhook_stores_unlinked_snapshot_with_metadata_suggestio
                 event_type="product.created",
                 created=1_780_000_000,
                 data_object={
-                    "id": "prod_growth",
+                    "id": provider_product_id,
                     "object": "product",
                     "active": True,
                     "livemode": False,
@@ -135,7 +138,7 @@ def test_stripe_product_webhook_stores_unlinked_snapshot_with_metadata_suggestio
         )
 
         snapshot = BillingProviderCatalogSnapshot.query.filter_by(
-            object_type="product", object_id="prod_growth"
+            object_type="product", object_id=provider_product_id
         ).one()
         event = BillingProviderCatalogEvent.query.filter_by(
             provider_event_id="evt_product_created"


### PR DESCRIPTION
## Summary

- Validate that Alembic has one head without pinning a revision.
- Honor full-suite decisions with `--testmon-noselect`, including migrations, dependencies, shared-code fallbacks, and changes to the backend workflow itself.
- Report full versus incremental mode in the job summary while preserving service-local incremental execution and instruction-only skips.
- Isolate the unlinked Stripe product fixture from the shared `prod_growth` mapping used by other tests, so cached test ordering does not change its expected state.

## Verification

- Workflow regression tests: 10 passed, executing the actual selector and pytest shell step.
- Warm-cache reproduction with pytest 9.0.3, testmon 2.2.0, and coverage 7.15.4: after adding a migration, the old incremental command ran zero tests and exited successfully; the corrected workflow step ran the unchanged test and failed as expected.
- [Rebased-head CI run 32923157319](https://github.com/ai-shifu/ai-shifu/actions/runs/32923157319/job/98040604382) exposed an order-dependent Stripe fixture collision: 1 failed, 3287 passed, 23 skipped. The earlier passing run was on the previous head and does not validate this rebased revision.
- Reproduced that failure locally by running the active price-mapping test before the unlinked-product webhook test.
- After isolating the fixture, mapping tests followed by catalog-sync, workflow, and migration tests: 42 passed, 1 skipped. Catalog-sync and mapping modules in reverse order: 31 passed.
- Full local backend validation on `62355ac44` with a warm cache and `--testmon-noselect`: 3289 passed, 22 skipped, 733 warnings, 46 subtests passed; exit code 0 (pytest 9.0.3, testmon 2.2.0, coverage 7.15.4).
- [Latest backend CI run 32924124159](https://github.com/ai-shifu/ai-shifu/actions/runs/32924124159/job/98043418433) passed: 3290 passed, 23 skipped, 3313 collected. It restored the earlier `c34bcf933` testmon cache, reported `full (no deselection)` and `selection deactivated`, and ran all 11 catalog-sync tests and all 10 workflow regression tests.
- CI checked out merge commit `c0f2e1864`, combining PR head `62355ac44` with current main `9e9bd5811`; this includes the two additional main-branch tests not present in the local branch. All current PR checks are successful. The branch is still marked BEHIND; this report is a validation result, not a merge action.
- Ruff check/format, repository harness, architecture boundaries, core development tools, and staged-file commit hooks passed. The repository-wide hook run could not complete frontend ESLint/Prettier checks because this worktree has no frontend dependencies; no frontend files changed.

## Impact

Full-suite PRs run every backend test even with a warm cache, so these runs can take longer. Service-local PRs retain testmon selection. No runtime application behavior changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated migration validation to support evolving migration histories.
  * Improved backend test selection so configuration and dependency changes trigger comprehensive validation.
  * Added coverage for incremental and full test runs, migration fallbacks, service changes, and control-plane-only updates.
  * Improved billing integration test reliability by preventing conflicts between test data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




