### PR TITLE
fix: keep Stripe subscriptions on supported payment methods

### DIFF
--- a/src/api/flaskr/service/order/payment_providers/stripe.py
+++ b/src/api/flaskr/service/order/payment_providers/stripe.py
@@ -115,10 +115,11 @@ class StripeProvider(PaymentProvider):
                     metadata.update(existing_metadata)
                 payment_intent_data["metadata"] = metadata
                 params["payment_intent_data"] = payment_intent_data
+            is_subscription_mode = params.get("mode") == "subscription"
             params["payment_method_types"] = ["card"]
-            if get_config("STRIPE_ALIPAY_ENABLED"):
+            if not is_subscription_mode and get_config("STRIPE_ALIPAY_ENABLED"):
                 params["payment_method_types"].append("alipay")
-            if get_config("STRIPE_WECHAT_PAY_ENABLED"):
+            if not is_subscription_mode and get_config("STRIPE_WECHAT_PAY_ENABLED"):
                 params["payment_method_types"].append("wechat_pay")
                 params["payment_method_options"] = {"wechat_pay": {"client": "web"}}
 

--- a/src/api/tests/service/order/test_provider_public_urls.py
+++ b/src/api/tests/service/order/test_provider_public_urls.py
@@ -29,6 +29,8 @@ def clear_provider_public_url_config_cache() -> Iterator[None]:
         "PATH_PREFIX",
         "WECHATPAY_APP_ID",
         "WECHATPAY_MCH_ID",
+        "STRIPE_ALIPAY_ENABLED",
+        "STRIPE_WECHAT_PAY_ENABLED",
     )
     _reset_config_cache(*keys)
     yield
@@ -217,6 +219,128 @@ def test_stripe_subscription_discount_coupon_uses_lowercase_currency_and_idempot
     assert captured_session["discounts"] == [{"coupon": "coupon-1"}]
     assert captured_session["api_key"] == "sk_test"
     assert captured_session["stripe_version"] == "2024-06-20"
+
+
+def test_stripe_subscription_checkout_uses_card_only(
+    monkeypatch: object,
+) -> None:
+    monkeypatch.setenv("STRIPE_ALIPAY_ENABLED", "true")
+    monkeypatch.setenv("STRIPE_WECHAT_PAY_ENABLED", "true")
+    _reset_config_cache("STRIPE_ALIPAY_ENABLED", "STRIPE_WECHAT_PAY_ENABLED")
+    captured_session: dict[str, object] = {}
+
+    class FakeSession:
+        @staticmethod
+        def create(**kwargs: object) -> object:
+            captured_session.update(kwargs)
+            return type(
+                "SessionResponse",
+                (),
+                {
+                    "to_dict": lambda _self: {
+                        "id": "cs_subscription_1",
+                        "url": "https://stripe.test/checkout",
+                        "payment_intent": "",
+                    }
+                },
+            )()
+
+    class FakeCheckout:
+        Session = FakeSession
+
+    class FakeStripe:
+        checkout = FakeCheckout
+
+    provider = StripeProvider()
+    monkeypatch.setattr(provider, "_client_options", lambda _app: (FakeStripe, {}))
+
+    result = provider.create_subscription(
+        request=PaymentRequest(
+            order_bid="bill-order-subscription-methods",
+            user_bid="creator-1",
+            shifu_bid="",
+            amount=5900,
+            channel="checkout_session",
+            currency="USD",
+            subject="Creator Plan",
+            body="Creator Plan",
+            client_ip="127.0.0.1",
+            extra={
+                "success_url": "https://app.test/success",
+                "cancel_url": "https://app.test/cancel",
+                "line_items": [{"price": "price_1", "quantity": 1}],
+            },
+        ),
+        app=Flask(__name__),
+    )
+
+    assert result.checkout_session_id == "cs_subscription_1"
+    assert captured_session["mode"] == "subscription"
+    assert captured_session["payment_method_types"] == ["card"]
+    assert "payment_method_options" not in captured_session
+
+
+def test_stripe_payment_checkout_keeps_wechat_pay_when_enabled(
+    monkeypatch: object,
+) -> None:
+    monkeypatch.setenv("STRIPE_ALIPAY_ENABLED", "true")
+    monkeypatch.setenv("STRIPE_WECHAT_PAY_ENABLED", "true")
+    _reset_config_cache("STRIPE_ALIPAY_ENABLED", "STRIPE_WECHAT_PAY_ENABLED")
+    captured_session: dict[str, object] = {}
+
+    class FakeSession:
+        @staticmethod
+        def create(**kwargs: object) -> object:
+            captured_session.update(kwargs)
+            return type(
+                "SessionResponse",
+                (),
+                {
+                    "to_dict": lambda _self: {
+                        "id": "cs_payment_1",
+                        "url": "https://stripe.test/checkout",
+                        "payment_intent": "",
+                    }
+                },
+            )()
+
+    class FakeCheckout:
+        Session = FakeSession
+
+    class FakeStripe:
+        checkout = FakeCheckout
+
+    provider = StripeProvider()
+    monkeypatch.setattr(provider, "_client_options", lambda _app: (FakeStripe, {}))
+
+    result = provider.create_payment(
+        request=PaymentRequest(
+            order_bid="bill-order-payment-methods",
+            user_bid="creator-1",
+            shifu_bid="",
+            amount=12500,
+            channel="checkout_session",
+            currency="USD",
+            subject="Credits",
+            body="Credits",
+            client_ip="127.0.0.1",
+            extra={
+                "mode": "checkout_session",
+                "success_url": "https://app.test/success",
+                "cancel_url": "https://app.test/cancel",
+                "session_params": {"mode": "payment"},
+                "line_items": [{"price": "price_1", "quantity": 1}],
+            },
+        ),
+        app=Flask(__name__),
+    )
+
+    assert result.checkout_session_id == "cs_payment_1"
+    assert captured_session["mode"] == "payment"
+    assert captured_session["payment_method_types"] == ["card", "alipay", "wechat_pay"]
+    assert captured_session["payment_method_options"] == {
+        "wechat_pay": {"client": "web"}
+    }
 
 
 def test_stripe_subscription_discount_coupon_is_cleaned_up_on_session_failure(


### PR DESCRIPTION
## Summary
- Limit Stripe subscription checkout sessions to card payments so recurring plan purchases do not include unsupported Alipay or WeChat Pay methods.
- Preserve configured Alipay and WeChat Pay methods for one-time Stripe checkout sessions.
- Add focused provider tests for subscription and one-time Checkout payment method selection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Stripe subscription checkout now supports card payments only.
  - Alipay and WeChat Pay remain available for eligible one-time payments.
  - WeChat Pay checkout options are applied correctly for one-time purchases.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->