### PR TITLE
fix: compare compensation decimal values

### DIFF
--- a/src/api/scripts/billing_cache_compensation_common.py
+++ b/src/api/scripts/billing_cache_compensation_common.py
@@ -216,11 +216,11 @@ def _parse_amount(value: object, *, row_number: int) -> Decimal:
     return quantize_credit_amount(parsed)
 
 
-def _normalize_mismatch_value(value: object) -> str:
+def _normalize_mismatch_value(value: object) -> object:
     if isinstance(value, datetime):
         return to_utc_iso(value)
     if isinstance(value, Decimal):
-        return format(value, "f")
+        return value
     return str(value or "").strip()
 
 

--- a/src/api/tests/scripts/test_billing_cache_compensation_scripts.py
+++ b/src/api/tests/scripts/test_billing_cache_compensation_scripts.py
@@ -19,6 +19,7 @@ from billing_cache_compensation_common import (  # noqa: E402
     AMOUNT_HEADER,
     DEFAULT_SHEET_NAME,
     USER_BID_HEADER,
+    add_mismatch,
     load_reference_rows,
 )
 from flaskr.service.billing.consts import (  # noqa: E402
@@ -103,6 +104,19 @@ def test_reference_loader_preserves_xlsx_numeric_zero_amount(tmp_path: Path) -> 
     rows = load_reference_rows(str(xlsx_path), sheet_name=DEFAULT_SHEET_NAME)
 
     assert rows[0].amount == Decimal("0.00")
+
+
+def test_add_mismatch_compares_decimal_values_without_scale_noise() -> None:
+    mismatch: dict[str, object] = {}
+
+    add_mismatch(
+        mismatch,
+        "amount",
+        expected=Decimal("8739.02"),
+        actual=Decimal("8739.0200000000"),
+    )
+
+    assert mismatch == {}
 
 
 def test_existing_credit_grant_reports_amount_mismatch() -> None:


### PR DESCRIPTION
## Summary
- Compare compensation Decimal values numerically so database scale differences do not produce false existing_mismatch results.
- Add regression coverage for scale-only Decimal differences during compensation reruns.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->