### PR TITLE
fix: require a bound openid for WeChat JSAPI charges

### DIFF
--- a/src/api/flaskr/service/billing/api.py
+++ b/src/api/flaskr/service/billing/api.py
@@ -27,6 +27,7 @@ from flaskr.service.billing.credit_notifications import (
 from flaskr.service.billing.customization import (
     build_provider_config_overrides,
     resolve_creator_public_integrations,
+    resolve_creator_wechat_oauth_app_id,
     resolve_payment_integration_for_new_order,
     resolve_provider_credential_context,
 )
@@ -152,6 +153,7 @@ __all__ = [
     "resolve_creator_bid_by_host",
     "resolve_creator_limit_state",
     "resolve_creator_public_integrations",
+    "resolve_creator_wechat_oauth_app_id",
     "resolve_credit_multiplier_label",
     "resolve_effective_custom_origin",
     "resolve_payment_integration_for_new_order",

--- a/src/api/flaskr/service/billing/checkout.py
+++ b/src/api/flaskr/service/billing/checkout.py
@@ -1981,7 +1981,10 @@ def _build_pingxx_provider_options(
         charge_extra = {}
     elif normalized_channel == "wx_pub":
         user = load_user_aggregate(creator_bid)
-        charge_extra = {"open_id": user.wechat_open_id} if user else {}
+        open_id = str(user.wechat_open_id or "").strip() if user else ""
+        if not open_id:
+            raise_error("server.pay.wechatOpenIdRequired")
+        charge_extra = {"open_id": open_id}
     elif normalized_channel == "wx_wap":
         charge_extra = {}
     else:

--- a/src/api/flaskr/service/billing/customization.py
+++ b/src/api/flaskr/service/billing/customization.py
@@ -615,6 +615,26 @@ def resolve_creator_public_integrations(
     return result
 
 
+def resolve_creator_wechat_oauth_app_id(creator_bid: str) -> str:
+    """Resolve the WeChat OAuth app id a creator signs their learners in with.
+
+    Returns an empty string when the creator has no verified WeChat OAuth
+    integration of their own, meaning learners are signed in through the
+    platform app.
+    """
+    normalized = normalize_bid(creator_bid)
+    if not normalized:
+        return ""
+    custom_wechat = resolve_creator_public_integrations(normalized).get("wechat_oauth")
+    if not custom_wechat:
+        return ""
+    app_id = str(custom_wechat.get("app_id") or "").strip()
+    if not app_id:
+        message = "Custom WeChat OAuth integration is missing app_id"
+        raise RuntimeError(message)
+    return app_id
+
+
 def resolve_provider_credential_context(
     app: Flask,
     *,

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -779,7 +779,10 @@ def _generate_pingxx_charge(
         qr_url_key = "alipay_qr"
     elif channel == "wx_pub":  # wxpay JSAPI
         user = load_user_aggregate(buy_record.user_bid)
-        charge_extra = {"open_id": user.wechat_open_id} if user else {}
+        open_id = str(user.wechat_open_id or "").strip() if user else ""
+        if not open_id:
+            raise_error("server.pay.wechatOpenIdRequired")
+        charge_extra = {"open_id": open_id}
         qr_url_key = "wx_pub"
     elif channel == "wx_wap":  # wxpay H5
         charge_extra = {}

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -22,6 +22,7 @@ from flaskr.i18n import _
 from flaskr.service.billing.api import (
     build_provider_config_overrides,
     resolve_creator_public_integrations,
+    resolve_creator_wechat_oauth_app_id,
     resolve_payment_integration_for_new_order,
     resolve_provider_credential_context,
 )
@@ -732,6 +733,29 @@ def _resolve_custom_payment_provider_hints(creator_bid: str) -> set[str]:
     }
 
 
+def _resolve_charge_wechat_app_id(app: Flask, creator_bid: str) -> str:
+    """Return the WeChat app whose open ID this order must be charged with.
+
+    Learners of a creator running their own official account hold an open ID
+    scoped to that app, and WeChat rejects an open ID issued by a different one.
+    The creator comes from the order rather than the request-scoped shifu
+    context, which this endpoint does not set up. A creator without a WeChat
+    integration -- or a lookup that fails -- means the platform app, which is
+    also the safe answer for a money flow: never a new failure path.
+    """
+    if not creator_bid:
+        return ""
+    try:
+        return resolve_creator_wechat_oauth_app_id(creator_bid)
+    except Exception:
+        app.logger.warning(
+            "failed to resolve creator WeChat app; creator_bid=%s",
+            creator_bid,
+            exc_info=True,
+        )
+        return ""
+
+
 def _format_response_channel(payment_channel: str, provider_channel: str) -> str:
     if payment_channel == "stripe":
         return (
@@ -779,7 +803,14 @@ def _generate_pingxx_charge(
         qr_url_key = "alipay_qr"
     elif channel == "wx_pub":  # wxpay JSAPI
         user = load_user_aggregate(buy_record.user_bid)
-        open_id = str(user.wechat_open_id or "").strip() if user else ""
+        wechat_app_id = _resolve_charge_wechat_app_id(
+            app, str(buy_record.creator_bid or "")
+        )
+        open_id = (
+            str(user.wechat_open_id_for_app(wechat_app_id) or "").strip()
+            if user
+            else ""
+        )
         if not open_id:
             raise_error("server.pay.wechatOpenIdRequired")
         charge_extra = {"open_id": open_id}
@@ -1101,7 +1132,14 @@ def _generate_wechatpay_charge(
     }
     if channel == "wx_pub":
         user = load_user_aggregate(buy_record.user_bid)
-        open_id = str(user.wechat_open_id or "").strip() if user else ""
+        wechat_app_id = _resolve_charge_wechat_app_id(
+            app, str(buy_record.creator_bid or "")
+        )
+        open_id = (
+            str(user.wechat_open_id_for_app(wechat_app_id) or "").strip()
+            if user
+            else ""
+        )
         if not open_id:
             raise_error("server.pay.wechatOpenIdRequired")
         extra["open_id"] = open_id

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -173,7 +173,14 @@ class UserAggregate:
         if not matches:
             return ""
         scoped = [credential for credential in matches if credential.app_id == app_id]
-        return _preferred_credential(scoped or matches).subject_id
+        if scoped:
+            return _preferred_credential(scoped).subject_id
+        if app_id:
+            # A subject issued by a different app is not a usable substitute:
+            # WeChat rejects it outright. Report nothing so the caller can say
+            # so, rather than handing over a value that is certain to fail.
+            return ""
+        return _preferred_credential(matches).subject_id
 
     def wechat_open_id_for_app(self, app_id: str = "") -> str:
         """Return the WeChat open ID issued by ``app_id``, if present.
@@ -181,10 +188,13 @@ class UserAggregate:
         An account can legitimately hold one open ID per WeChat app: the
         platform app plus, for learners of a creator who runs their own
         official account, that creator's app. WeChat JSAPI payment only accepts
-        the open ID issued by the app it is charging through, so callers that
-        know which app is asking must say so; pass an empty ``app_id`` for the
-        platform app. Callers with no app in hand fall back to the best row
-        overall so they still get a stable answer.
+        the open ID issued by the app it is charging through, so a caller that
+        names an app gets that app's subject or nothing at all.
+
+        Passing an empty ``app_id`` asks a weaker question -- "is this account
+        bound to WeChat at all?" -- and prefers the platform app while accepting
+        any other subject. That is what the serialized profile answers, and what
+        callers with no app in hand need.
         """
         return self._wechat_subject(WECHAT_OPEN_ID_FORMAT, app_id)
 

--- a/src/api/flaskr/service/user/repository.py
+++ b/src/api/flaskr/service/user/repository.py
@@ -51,6 +51,10 @@ STATE_MAPPING = {
     "1104": USER_STATE_PAID,
 }
 
+WECHAT_PROVIDER = "wechat"
+WECHAT_OPEN_ID_FORMAT = "open_id"
+WECHAT_UNION_ID_FORMAT = "unicon_id"
+
 STATE_TO_PUBLIC_STATE = {
     USER_STATE_UNREGISTERED: 0,
     USER_STATE_REGISTERED: 1,
@@ -75,6 +79,35 @@ class CredentialSummary:
     def is_verified(self) -> bool:
         """Return whether the credential is verified."""
         return self.state == CREDENTIAL_STATE_VERIFIED
+
+    @property
+    def app_id(self) -> str:
+        """Return the provider app that issued this credential, if scoped.
+
+        Subjects issued by a creator's own provider app are stored as
+        ``"<app_id>:<subject_id>"`` so they cannot collide with the ones the
+        platform app issues; a bare subject means the platform app.
+        """
+        suffix = f":{self.subject_id}"
+        if self.subject_id and self.identifier.endswith(suffix):
+            return self.identifier[: -len(suffix)]
+        return ""
+
+
+def _preferred_credential(credentials: list[CredentialSummary]) -> CredentialSummary:
+    """Pick one credential out of several equally valid ones.
+
+    Verified beats unverified, then the most recently written row wins: when a
+    learner signs in from a second account of the same provider app, the new
+    subject lands in a new row and the old one is what they just stopped using.
+    Rows reach the aggregate in primary-key order (see ``list_credentials``), so
+    the later position is the later write -- a more reliable ordering than
+    ``created_at``, which backfilled rows can share down to the second.
+    """
+    return max(
+        enumerate(credentials),
+        key=lambda item: (item[1].is_verified, item[0]),
+    )[1]
 
 
 @dataclass
@@ -130,27 +163,44 @@ class UserAggregate:
             return self.identify
         return ""
 
+    def _wechat_subject(self, subject_format: str, app_id: str) -> str:
+        matches = [
+            credential
+            for credential in self.credentials
+            if credential.provider == WECHAT_PROVIDER
+            and credential.subject_format == subject_format
+        ]
+        if not matches:
+            return ""
+        scoped = [credential for credential in matches if credential.app_id == app_id]
+        return _preferred_credential(scoped or matches).subject_id
+
+    def wechat_open_id_for_app(self, app_id: str = "") -> str:
+        """Return the WeChat open ID issued by ``app_id``, if present.
+
+        An account can legitimately hold one open ID per WeChat app: the
+        platform app plus, for learners of a creator who runs their own
+        official account, that creator's app. WeChat JSAPI payment only accepts
+        the open ID issued by the app it is charging through, so callers that
+        know which app is asking must say so; pass an empty ``app_id`` for the
+        platform app. Callers with no app in hand fall back to the best row
+        overall so they still get a stable answer.
+        """
+        return self._wechat_subject(WECHAT_OPEN_ID_FORMAT, app_id)
+
+    def wechat_union_id_for_app(self, app_id: str = "") -> str:
+        """Return the WeChat union ID issued by ``app_id``, if present."""
+        return self._wechat_subject(WECHAT_UNION_ID_FORMAT, app_id)
+
     @property
     def wechat_open_id(self) -> str:
-        """Return the available WeChat open ID, if present."""
-        for credential in self.credentials:
-            if (
-                credential.provider == "wechat"
-                and credential.subject_format == "open_id"
-            ):
-                return credential.subject_id
-        return ""
+        """Return the platform app's WeChat open ID, or the best one available."""
+        return self.wechat_open_id_for_app()
 
     @property
     def wechat_union_id(self) -> str:
-        """Return the available WeChat union ID, if present."""
-        for credential in self.credentials:
-            if (
-                credential.provider == "wechat"
-                and credential.subject_format == "unicon_id"
-            ):
-                return credential.subject_id
-        return ""
+        """Return the platform app's WeChat union ID, or the best one available."""
+        return self.wechat_union_id_for_app()
 
     @property
     def username(self) -> str:
@@ -822,11 +872,14 @@ def find_credential(
 def list_credentials(
     *, user_bid: str, provider_name: str | None = None
 ) -> list[AuthCredential]:
-    """Return credentials."""
+    """Return credentials, oldest first."""
     query = AuthCredential.query.filter_by(user_bid=user_bid, deleted=0)
     if provider_name:
         query = query.filter_by(provider_name=provider_name)
-    return query.all()
+    # Callers pick one row out of several (see ``_preferred_credential``), so the
+    # order has to be the same on every read rather than whatever the engine
+    # happens to return.
+    return query.order_by(AuthCredential.id.asc()).all()
 
 
 def get_first_verified_credential_created_at(*, user_bid: str) -> datetime | None:

--- a/src/api/flaskr/service/user/user.py
+++ b/src/api/flaskr/service/user/user.py
@@ -12,7 +12,7 @@ from flask import Flask
 from flaskr.api.wechat import get_wechat_access_token
 from flaskr.common.shifu_context import get_shifu_creator_bid as get_context_creator_bid
 from flaskr.dao import db
-from flaskr.service.billing.api import resolve_creator_public_integrations
+from flaskr.service.billing.api import resolve_creator_wechat_oauth_app_id
 from flaskr.service.common.dtos import USER_STATE_UNREGISTERED, UserToken
 from flaskr.service.common.models import raise_error
 from flaskr.service.common.oss_utils import (
@@ -91,7 +91,7 @@ def generate_temp_user(
                 wx_openid = wx_data.get("openid", "")
                 wx_unionid = wx_data.get("unionid", "")
         wx_open_identifier, wx_union_identifier = _wechat_identifiers(
-            app, wx_openid, wx_unionid
+            _context_wechat_app_id(app), wx_openid, wx_unionid
         )
         if not convert_user:
             if wx_openid != "":
@@ -183,10 +183,13 @@ def update_user_open_id(app: Flask, user_id: str, wx_code: str) -> str:
 
         wx_openid = wx_data.get("openid", "")
         wx_unionid = wx_data.get("unionid", "")
+        wx_app_id = _context_wechat_app_id(app)
         wx_open_identifier, wx_union_identifier = _wechat_identifiers(
-            app, wx_openid, wx_unionid
+            wx_app_id, wx_openid, wx_unionid
         )
-        if wx_openid and aggregate.wechat_open_id != wx_openid:
+        # Compare within the same WeChat app: an open ID this account holds for
+        # another app is a different binding, not a stale copy of this one.
+        if wx_openid and aggregate.wechat_open_id_for_app(wx_app_id) != wx_openid:
             upsert_wechat_credentials(
                 app,
                 user_bid=aggregate.user_bid,
@@ -205,27 +208,25 @@ def update_user_open_id(app: Flask, user_id: str, wx_code: str) -> str:
         return wx_openid
 
 
-def _wechat_identifiers(app: Flask, open_id: str, union_id: str) -> tuple[str, str]:
-    """Scope custom-app subjects while preserving platform-app identifiers."""
+def _context_wechat_app_id(app: Flask) -> str:
+    """Return the WeChat OAuth app the current shifu context signs learners in with."""
     creator_bid = str(get_context_creator_bid() or "").strip()
     if not creator_bid:
-        return open_id, union_id
+        return ""
     try:
-        custom_wechat = resolve_creator_public_integrations(creator_bid).get(
-            "wechat_oauth"
-        )
+        return resolve_creator_wechat_oauth_app_id(creator_bid)
     except Exception:
         app.logger.exception(
             "Failed to resolve WeChat OAuth integration for creator %s",
             creator_bid,
         )
         raise
-    if not custom_wechat:
-        return open_id, union_id
-    app_id = str(custom_wechat.get("app_id") or "").strip()
+
+
+def _wechat_identifiers(app_id: str, open_id: str, union_id: str) -> tuple[str, str]:
+    """Scope custom-app subjects while preserving platform-app identifiers."""
     if not app_id:
-        message = "Custom WeChat OAuth integration is missing app_id"
-        raise RuntimeError(message)
+        return open_id, union_id
     return (
         f"{app_id}:{open_id}" if open_id else "",
         f"{app_id}:{union_id}" if union_id else "",

--- a/src/api/tests/service/billing/test_billing_pingxx_jsapi_openid_guard.py
+++ b/src/api/tests/service/billing/test_billing_pingxx_jsapi_openid_guard.py
@@ -1,0 +1,74 @@
+"""Verify billing Ping++ JSAPI options refuse a missing WeChat openid."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from flaskr.service.billing import checkout as billing_checkout
+from flaskr.service.common.models import AppError
+
+WECHAT_OPEN_ID_REQUIRED_CODE = 5002
+
+
+def _build(channel: str) -> dict:
+    return billing_checkout._build_pingxx_provider_options(
+        creator_bid="creator-jsapi-openid",
+        product=SimpleNamespace(product_bid="product-jsapi-openid"),
+        channel=channel,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_app_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        billing_checkout, "get_config", lambda *_args, **_kwargs: "app_test"
+    )
+
+
+@pytest.mark.parametrize("open_id", ["", "   ", None])
+def test_jsapi_options_reject_missing_open_id(
+    monkeypatch: pytest.MonkeyPatch, open_id: str | None
+) -> None:
+    monkeypatch.setattr(
+        billing_checkout,
+        "load_user_aggregate",
+        lambda _creator_bid: SimpleNamespace(wechat_open_id=open_id),
+    )
+
+    with pytest.raises(AppError) as excinfo:
+        _build("wx_pub")
+
+    assert excinfo.value.code == WECHAT_OPEN_ID_REQUIRED_CODE
+
+
+def test_jsapi_options_reject_unknown_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        billing_checkout, "load_user_aggregate", lambda _creator_bid: None
+    )
+
+    with pytest.raises(AppError) as excinfo:
+        _build("wx_pub")
+
+    assert excinfo.value.code == WECHAT_OPEN_ID_REQUIRED_CODE
+
+
+def test_jsapi_options_pass_bound_open_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        billing_checkout,
+        "load_user_aggregate",
+        lambda _creator_bid: SimpleNamespace(wechat_open_id="  o_test_openid  "),
+    )
+
+    assert _build("wx_pub")["charge_extra"] == {"open_id": "o_test_openid"}
+
+
+def test_qr_options_do_not_need_open_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fail(_creator_bid: str) -> None:
+        message = "QR channels must not load the user aggregate"
+        raise AssertionError(message)
+
+    monkeypatch.setattr(billing_checkout, "load_user_aggregate", _fail)
+
+    assert _build("wx_pub_qr")["charge_extra"] == {"product_id": "product-jsapi-openid"}
+    assert _build("alipay_qr")["charge_extra"] == {}

--- a/src/api/tests/service/billing/test_creator_customization.py
+++ b/src/api/tests/service/billing/test_creator_customization.py
@@ -1022,12 +1022,14 @@ def test_custom_wechat_identifiers_are_scoped_by_app_id(
 ) -> None:
     set_shifu_context("shifu-1", "creator-wechat-1")
     monkeypatch.setattr(
-        user_service,
+        customization,
         "resolve_creator_public_integrations",
         lambda _creator_bid: {"wechat_oauth": {"app_id": "wx-owner-1"}},
     )
     try:
-        assert user_service._wechat_identifiers(app, "openid-1", "unionid-1") == (
+        app_id = user_service._context_wechat_app_id(app)
+        assert app_id == "wx-owner-1"
+        assert user_service._wechat_identifiers(app_id, "openid-1", "unionid-1") == (
             "wx-owner-1:openid-1",
             "wx-owner-1:unionid-1",
         )
@@ -1035,18 +1037,27 @@ def test_custom_wechat_identifiers_are_scoped_by_app_id(
         clear_shifu_context()
 
 
+def test_platform_wechat_identifiers_stay_unscoped(app: object) -> None:
+    """No creator context means the platform app, whose subjects are bare."""
+    assert user_service._context_wechat_app_id(app) == ""
+    assert user_service._wechat_identifiers("", "openid-1", "unionid-1") == (
+        "openid-1",
+        "unionid-1",
+    )
+
+
 def test_custom_wechat_identifiers_fail_when_integration_resolution_fails(
     app: object, monkeypatch: object
 ) -> None:
     set_shifu_context("shifu-1", "creator-wechat-broken")
     monkeypatch.setattr(
-        user_service,
+        customization,
         "resolve_creator_public_integrations",
         lambda _creator_bid: (_ for _ in ()).throw(RuntimeError("resolver failed")),
     )
     try:
         with pytest.raises(RuntimeError, match="resolver failed"):
-            user_service._wechat_identifiers(app, "openid-1", "unionid-1")
+            user_service._context_wechat_app_id(app)
     finally:
         clear_shifu_context()
 
@@ -1056,12 +1067,12 @@ def test_custom_wechat_identifiers_require_custom_app_id(
 ) -> None:
     set_shifu_context("shifu-1", "creator-wechat-missing-app")
     monkeypatch.setattr(
-        user_service,
+        customization,
         "resolve_creator_public_integrations",
         lambda _creator_bid: {"wechat_oauth": {"app_id": ""}},
     )
     try:
         with pytest.raises(RuntimeError, match="missing app_id"):
-            user_service._wechat_identifiers(app, "openid-1", "unionid-1")
+            user_service._context_wechat_app_id(app)
     finally:
         clear_shifu_context()

--- a/src/api/tests/service/order/test_pingxx_jsapi_openid_guard.py
+++ b/src/api/tests/service/order/test_pingxx_jsapi_openid_guard.py
@@ -1,0 +1,139 @@
+"""Verify Ping++ JSAPI charges refuse to run without a bound WeChat openid."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+from flaskr.service.common.models import AppError
+from flaskr.service.order import funs as order_funs
+from flaskr.service.order.consts import ORDER_STATUS_INIT
+from flaskr.service.order.models import Order
+from flaskr.service.order.payment_providers.base import PaymentCreationResult
+
+if TYPE_CHECKING:
+    from flask import Flask
+    from flaskr.service.order.payment_providers import PaymentRequest
+
+WECHAT_OPEN_ID_REQUIRED_CODE = 5002
+
+
+class _RecordingProvider:
+    """Capture the charge payload instead of calling Ping++."""
+
+    def __init__(self) -> None:
+        self.requests: list[PaymentRequest] = []
+
+    def create_payment(
+        self, *, request: PaymentRequest, app: Flask
+    ) -> PaymentCreationResult:
+        del app
+        self.requests.append(request)
+        return PaymentCreationResult(
+            provider_reference="ch_test",
+            raw_response={
+                "id": "ch_test",
+                "order_no": request.order_bid,
+                "app": "app_test",
+                "channel": request.channel,
+                "currency": request.currency,
+                "subject": request.subject,
+                "body": request.body,
+                "client_ip": request.client_ip,
+                "extra": request.extra.get("charge_extra", {}),
+                "credential": {"wx_pub": {"package": "prepay_id=test"}},
+            },
+        )
+
+
+@pytest.fixture
+def pingxx_provider(monkeypatch: pytest.MonkeyPatch) -> _RecordingProvider:
+    provider = _RecordingProvider()
+    monkeypatch.setattr(order_funs, "get_payment_provider", lambda _name: provider)
+    monkeypatch.setattr(order_funs, "get_config", lambda *_args, **_kwargs: "app_test")
+    return provider
+
+
+def _make_order() -> Order:
+    return Order(
+        order_bid="order-jsapi-openid",
+        shifu_bid="shifu-jsapi-openid",
+        user_bid="user-jsapi-openid",
+        payable_price=Decimal("10.00"),
+        paid_price=Decimal("10.00"),
+        status=ORDER_STATUS_INIT,
+    )
+
+
+def _generate(app: Flask) -> object:
+    return order_funs._generate_pingxx_charge(
+        app=app,
+        buy_record=_make_order(),
+        course=SimpleNamespace(bid="shifu-jsapi-openid", title="Course"),
+        channel="wx_pub",
+        client_ip="127.0.0.1",
+        amount=1000,
+        subject="Course",
+        body="Course",
+        order_no="order-jsapi-openid",
+    )
+
+
+@pytest.mark.parametrize("open_id", ["", "   ", None])
+def test_jsapi_charge_rejects_missing_open_id(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    pingxx_provider: _RecordingProvider,
+    open_id: str | None,
+) -> None:
+    monkeypatch.setattr(
+        order_funs,
+        "load_user_aggregate",
+        lambda _user_bid: SimpleNamespace(wechat_open_id=open_id),
+    )
+
+    with app.app_context(), pytest.raises(AppError) as excinfo:
+        _generate(app)
+
+    assert excinfo.value.code == WECHAT_OPEN_ID_REQUIRED_CODE
+    assert pingxx_provider.requests == []
+
+
+def test_jsapi_charge_rejects_unknown_user(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    pingxx_provider: _RecordingProvider,
+) -> None:
+    monkeypatch.setattr(order_funs, "load_user_aggregate", lambda _user_bid: None)
+
+    with app.app_context(), pytest.raises(AppError) as excinfo:
+        _generate(app)
+
+    assert excinfo.value.code == WECHAT_OPEN_ID_REQUIRED_CODE
+    assert pingxx_provider.requests == []
+
+
+def test_jsapi_charge_sends_bound_open_id(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    pingxx_provider: _RecordingProvider,
+) -> None:
+    monkeypatch.setattr(
+        order_funs,
+        "load_user_aggregate",
+        lambda _user_bid: SimpleNamespace(wechat_open_id="  o_test_openid  "),
+    )
+
+    with app.app_context():
+        result = _generate(app)
+
+    assert len(pingxx_provider.requests) == 1
+    assert pingxx_provider.requests[0].extra["charge_extra"] == {
+        "open_id": "o_test_openid"
+    }
+    assert result.payment_channel == "pingxx"
+    assert result.payment_payload["credential"] == {
+        "wx_pub": {"package": "prepay_id=test"}
+    }

--- a/src/api/tests/service/order/test_pingxx_jsapi_openid_guard.py
+++ b/src/api/tests/service/order/test_pingxx_jsapi_openid_guard.py
@@ -199,3 +199,24 @@ def test_jsapi_charge_falls_back_to_the_platform_app_when_resolution_fails(
     assert pingxx_provider.requests[0].extra["charge_extra"] == {
         "open_id": "o_platform"
     }
+
+
+def test_jsapi_charge_refuses_a_foreign_apps_open_id(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    pingxx_provider: _RecordingProvider,
+) -> None:
+    """Charging a creator's app with a platform open ID would be rejected."""
+    user = _UserStub({"": "o_platform"})
+    monkeypatch.setattr(order_funs, "load_user_aggregate", lambda _user_bid: user)
+    monkeypatch.setattr(
+        order_funs,
+        "resolve_creator_wechat_oauth_app_id",
+        lambda _creator_bid: "wx-creator-app",
+    )
+
+    with app.app_context(), pytest.raises(AppError) as excinfo:
+        _generate(app, creator_bid="creator-with-wechat")
+
+    assert excinfo.value.code == WECHAT_OPEN_ID_REQUIRED_CODE
+    assert pingxx_provider.requests == []

--- a/src/api/tests/service/order/test_pingxx_jsapi_openid_guard.py
+++ b/src/api/tests/service/order/test_pingxx_jsapi_openid_guard.py
@@ -56,21 +56,22 @@ def pingxx_provider(monkeypatch: pytest.MonkeyPatch) -> _RecordingProvider:
     return provider
 
 
-def _make_order() -> Order:
+def _make_order(creator_bid: str = "") -> Order:
     return Order(
         order_bid="order-jsapi-openid",
         shifu_bid="shifu-jsapi-openid",
         user_bid="user-jsapi-openid",
+        creator_bid=creator_bid,
         payable_price=Decimal("10.00"),
         paid_price=Decimal("10.00"),
         status=ORDER_STATUS_INIT,
     )
 
 
-def _generate(app: Flask) -> object:
+def _generate(app: Flask, creator_bid: str = "") -> object:
     return order_funs._generate_pingxx_charge(
         app=app,
-        buy_record=_make_order(),
+        buy_record=_make_order(creator_bid),
         course=SimpleNamespace(bid="shifu-jsapi-openid", title="Course"),
         channel="wx_pub",
         client_ip="127.0.0.1",
@@ -79,6 +80,22 @@ def _generate(app: Flask) -> object:
         body="Course",
         order_no="order-jsapi-openid",
     )
+
+
+class _UserStub:
+    """Stand in for the user aggregate, recording which app was asked about."""
+
+    def __init__(self, open_ids: dict[str, str | None]) -> None:
+        self._open_ids = open_ids
+        self.requested_app_ids: list[str] = []
+
+    def wechat_open_id_for_app(self, app_id: str = "") -> str | None:
+        self.requested_app_ids.append(app_id)
+        return self._open_ids.get(app_id)
+
+    @property
+    def wechat_open_id(self) -> str | None:
+        return self.wechat_open_id_for_app()
 
 
 @pytest.mark.parametrize("open_id", ["", "   ", None])
@@ -91,7 +108,7 @@ def test_jsapi_charge_rejects_missing_open_id(
     monkeypatch.setattr(
         order_funs,
         "load_user_aggregate",
-        lambda _user_bid: SimpleNamespace(wechat_open_id=open_id),
+        lambda _user_bid: _UserStub({"": open_id}),
     )
 
     with app.app_context(), pytest.raises(AppError) as excinfo:
@@ -123,7 +140,7 @@ def test_jsapi_charge_sends_bound_open_id(
     monkeypatch.setattr(
         order_funs,
         "load_user_aggregate",
-        lambda _user_bid: SimpleNamespace(wechat_open_id="  o_test_openid  "),
+        lambda _user_bid: _UserStub({"": "  o_test_openid  "}),
     )
 
     with app.app_context():
@@ -136,4 +153,49 @@ def test_jsapi_charge_sends_bound_open_id(
     assert result.payment_channel == "pingxx"
     assert result.payment_payload["credential"] == {
         "wx_pub": {"package": "prepay_id=test"}
+    }
+
+
+def test_jsapi_charge_uses_the_creator_own_wechat_app(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    pingxx_provider: _RecordingProvider,
+) -> None:
+    """A learner of a creator with their own official account holds its open ID."""
+    user = _UserStub({"": "o_platform", "wx-creator-app": "o_creator"})
+    monkeypatch.setattr(order_funs, "load_user_aggregate", lambda _user_bid: user)
+    monkeypatch.setattr(
+        order_funs,
+        "resolve_creator_wechat_oauth_app_id",
+        lambda _creator_bid: "wx-creator-app",
+    )
+
+    with app.app_context():
+        _generate(app, creator_bid="creator-with-wechat")
+
+    assert user.requested_app_ids == ["wx-creator-app"]
+    assert pingxx_provider.requests[0].extra["charge_extra"] == {"open_id": "o_creator"}
+
+
+def test_jsapi_charge_falls_back_to_the_platform_app_when_resolution_fails(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+    pingxx_provider: _RecordingProvider,
+) -> None:
+    """A broken lookup must not add a new failure path to a money flow."""
+
+    def _explode(_creator_bid: str) -> str:
+        message = "integration lookup failed"
+        raise RuntimeError(message)
+
+    user = _UserStub({"": "o_platform"})
+    monkeypatch.setattr(order_funs, "load_user_aggregate", lambda _user_bid: user)
+    monkeypatch.setattr(order_funs, "resolve_creator_wechat_oauth_app_id", _explode)
+
+    with app.app_context():
+        _generate(app, creator_bid="creator-with-broken-integration")
+
+    assert user.requested_app_ids == [""]
+    assert pingxx_provider.requests[0].extra["charge_extra"] == {
+        "open_id": "o_platform"
     }

--- a/src/api/tests/service/user/test_user_info_serialization_contract.py
+++ b/src/api/tests/service/user/test_user_info_serialization_contract.py
@@ -1,0 +1,76 @@
+"""Pin the serialized account-profile keys the web client reads.
+
+The learner web client decides whether to offer WeChat JSAPI payment from
+``userInfo.openid``. That key is produced here and nowhere else, and a rename
+would silently switch JSAPI off for every account rather than fail loudly --
+frontend tests stub the field and cannot catch it. These assertions are the
+contract.
+"""
+
+from __future__ import annotations
+
+from flaskr.service.common.dtos import UserInfo
+from flaskr.service.user.consts import CREDENTIAL_STATE_VERIFIED, USER_STATE_REGISTERED
+from flaskr.service.user.repository import (
+    CredentialSummary,
+    UserAggregate,
+    build_user_info_from_aggregate,
+)
+
+
+def _user_info(wx_openid: str = "o_test_openid") -> UserInfo:
+    return UserInfo(
+        user_id="user-serialization-1",
+        username="13800000000",
+        name="Learner",
+        email="",
+        mobile="13800000000",
+        user_state=1,
+        wx_openid=wx_openid,
+        language="zh-CN",
+    )
+
+
+def test_open_id_is_serialized_as_openid() -> None:
+    payload = _user_info().__json__()
+
+    assert payload["openid"] == "o_test_openid"
+
+
+def test_unbound_account_serializes_an_empty_openid() -> None:
+    payload = _user_info(wx_openid="").__json__()
+
+    assert payload["openid"] == ""
+
+
+def test_aggregate_open_id_reaches_the_serialized_payload() -> None:
+    """The whole path: credential row -> aggregate -> DTO -> response key."""
+    aggregate = UserAggregate(
+        user_bid="user-serialization-2",
+        identify="13800000000",
+        nickname="Learner",
+        learner_profile="",
+        learner_profile_updated_at=None,
+        avatar="",
+        birthday=None,
+        language="zh-CN",
+        state=USER_STATE_REGISTERED,
+        deleted=False,
+        created_at=None,
+        creator_activated_at=None,
+        updated_at=None,
+        credentials=[
+            CredentialSummary(
+                credential_bid="credential-serialization-2",
+                provider="wechat",
+                identifier="o_from_aggregate",
+                subject_id="o_from_aggregate",
+                subject_format="open_id",
+                state=CREDENTIAL_STATE_VERIFIED,
+            )
+        ],
+    )
+
+    payload = build_user_info_from_aggregate(aggregate).__json__()
+
+    assert payload["openid"] == "o_from_aggregate"

--- a/src/api/tests/service/user/test_wechat_open_id_selection.py
+++ b/src/api/tests/service/user/test_wechat_open_id_selection.py
@@ -1,0 +1,151 @@
+"""Verify WeChat subject selection is scoped by app and deterministic."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+from flask import Flask
+from flaskr import dao
+from flaskr.dao import db
+from flaskr.service.user.consts import (
+    CREDENTIAL_STATE_UNVERIFIED,
+    CREDENTIAL_STATE_VERIFIED,
+    USER_STATE_REGISTERED,
+)
+from flaskr.service.user.models import AuthCredential
+from flaskr.service.user.models import UserInfo as UserEntity
+from flaskr.service.user.repository import create_user_entity, load_user_aggregate
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+PLATFORM_APP = ""
+CREATOR_APP = "wx-creator-app"
+
+
+@pytest.fixture
+def app() -> Iterator[Flask]:
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_BINDS={
+            "ai_shifu_saas": "sqlite:///:memory:",
+            "ai_shifu_admin": "sqlite:///:memory:",
+        },
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    dao.db.init_app(app)
+    with app.app_context():
+        dao.db.create_all()
+        yield app
+        dao.db.session.remove()
+        dao.db.drop_all()
+
+
+def _create_learner() -> str:
+    user_bid = uuid.uuid4().hex[:32]
+    create_user_entity(
+        user_bid=user_bid,
+        identify="13800000000",
+        nickname="Learner",
+        language="zh-CN",
+        avatar="",
+        state=USER_STATE_REGISTERED,
+    )
+    db.session.flush()
+    return user_bid
+
+
+def _insert_open_id(
+    user_bid: str,
+    open_id: str,
+    *,
+    app_id: str = PLATFORM_APP,
+    state: int = CREDENTIAL_STATE_VERIFIED,
+) -> None:
+    """Insert one open_id row the way ``upsert_wechat_credentials`` would."""
+    identifier = f"{app_id}:{open_id}" if app_id else open_id
+    db.session.add(
+        AuthCredential(
+            credential_bid=uuid.uuid4().hex[:32],
+            user_bid=user_bid,
+            provider_name="wechat",
+            subject_id=open_id,
+            subject_format="open_id",
+            identifier=identifier,
+            raw_profile='{"provider": "wechat", "metadata": {}}',
+            state=state,
+            deleted=0,
+        )
+    )
+    db.session.flush()
+
+
+def _cleanup(user_bid: str) -> None:
+    AuthCredential.query.filter_by(user_bid=user_bid).delete()
+    UserEntity.query.filter_by(user_bid=user_bid).delete()
+    db.session.commit()
+
+
+def test_returns_empty_without_any_wechat_credential(app: Flask) -> None:
+    with app.app_context():
+        user_bid = _create_learner()
+        try:
+            aggregate = load_user_aggregate(user_bid)
+            assert aggregate.wechat_open_id == ""
+            assert aggregate.wechat_open_id_for_app(CREATOR_APP) == ""
+        finally:
+            _cleanup(user_bid)
+
+
+def test_each_app_gets_its_own_open_id(app: Flask) -> None:
+    """A learner holds one open ID per WeChat app; charging must not mix them."""
+    with app.app_context():
+        user_bid = _create_learner()
+        _insert_open_id(user_bid, "o_platform")
+        _insert_open_id(user_bid, "o_creator", app_id=CREATOR_APP)
+        try:
+            aggregate = load_user_aggregate(user_bid)
+            assert aggregate.wechat_open_id_for_app(PLATFORM_APP) == "o_platform"
+            assert aggregate.wechat_open_id_for_app(CREATOR_APP) == "o_creator"
+            assert aggregate.wechat_open_id == "o_platform"
+        finally:
+            _cleanup(user_bid)
+
+
+def test_newest_binding_wins_within_one_app(app: Flask) -> None:
+    """Signing in from another WeChat account adds a row; the new one is current."""
+    with app.app_context():
+        user_bid = _create_learner()
+        _insert_open_id(user_bid, "o_previous")
+        _insert_open_id(user_bid, "o_current")
+        try:
+            assert load_user_aggregate(user_bid).wechat_open_id == "o_current"
+        finally:
+            _cleanup(user_bid)
+
+
+def test_verified_beats_a_newer_unverified_binding(app: Flask) -> None:
+    with app.app_context():
+        user_bid = _create_learner()
+        _insert_open_id(user_bid, "o_verified")
+        _insert_open_id(user_bid, "o_unverified", state=CREDENTIAL_STATE_UNVERIFIED)
+        try:
+            assert load_user_aggregate(user_bid).wechat_open_id == "o_verified"
+        finally:
+            _cleanup(user_bid)
+
+
+def test_falls_back_across_apps_rather_than_returning_nothing(app: Flask) -> None:
+    """A creator may run their own OAuth app while charging through the platform."""
+    with app.app_context():
+        user_bid = _create_learner()
+        _insert_open_id(user_bid, "o_creator", app_id=CREATOR_APP)
+        try:
+            aggregate = load_user_aggregate(user_bid)
+            assert aggregate.wechat_open_id_for_app(PLATFORM_APP) == "o_creator"
+            assert aggregate.wechat_open_id == "o_creator"
+        finally:
+            _cleanup(user_bid)

--- a/src/api/tests/service/user/test_wechat_open_id_selection.py
+++ b/src/api/tests/service/user/test_wechat_open_id_selection.py
@@ -138,8 +138,8 @@ def test_verified_beats_a_newer_unverified_binding(app: Flask) -> None:
             _cleanup(user_bid)
 
 
-def test_falls_back_across_apps_rather_than_returning_nothing(app: Flask) -> None:
-    """A creator may run their own OAuth app while charging through the platform."""
+def test_asking_about_any_binding_accepts_another_apps_subject(app: Flask) -> None:
+    """The bare question is "bound to WeChat at all?", which the profile answers."""
     with app.app_context():
         user_bid = _create_learner()
         _insert_open_id(user_bid, "o_creator", app_id=CREATOR_APP)
@@ -147,5 +147,18 @@ def test_falls_back_across_apps_rather_than_returning_nothing(app: Flask) -> Non
             aggregate = load_user_aggregate(user_bid)
             assert aggregate.wechat_open_id_for_app(PLATFORM_APP) == "o_creator"
             assert aggregate.wechat_open_id == "o_creator"
+        finally:
+            _cleanup(user_bid)
+
+
+def test_a_named_app_never_borrows_another_apps_open_id(app: Flask) -> None:
+    """WeChat rejects a foreign open ID, so reporting nothing is the honest answer."""
+    with app.app_context():
+        user_bid = _create_learner()
+        _insert_open_id(user_bid, "o_platform")
+        try:
+            assert (
+                load_user_aggregate(user_bid).wechat_open_id_for_app(CREATOR_APP) == ""
+            )
         finally:
             _cleanup(user_bid)

--- a/src/cook-web/src/app/c/[[...id]]/Components/Pay/PayModal.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/Pay/PayModal.tsx
@@ -22,6 +22,7 @@ import {
   PAY_CHANNEL_WECHAT_JSAPI,
   PAY_CHANNEL_ZHIFUBAO,
 } from './constans';
+import { isWechatJsapiAvailable } from './wechatJsapi';
 import type {
   NativePaymentPayload,
   PaymentChannel,
@@ -158,12 +159,11 @@ export const PayModal = ({
     () => typeof navigator !== 'undefined' && inWechat(),
     [],
   );
-  // JSAPI payment needs an openid, which is only obtainable when the WeChat
-  // code flow is enabled (it is disabled on custom domains).
-  const wechatJsapiAvailable =
-    isWechatBrowser &&
-    typeof enableWxcode === 'string' &&
-    enableWxcode.toLowerCase() === 'true';
+  const wechatJsapiAvailable = isWechatJsapiAvailable({
+    inWechatBrowser: isWechatBrowser,
+    enableWxcode,
+    openId: userInfo?.openid,
+  });
   const isWechatQrAvailable = pingxxChannelEnabled || wechatpayChannelEnabled;
   const isAlipayQrAvailable = pingxxChannelEnabled || alipayChannelEnabled;
   const qrChannelEnabled = isWechatQrAvailable || isAlipayQrAvailable;

--- a/src/cook-web/src/app/c/[[...id]]/Components/Pay/PayModalM.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/Pay/PayModalM.tsx
@@ -25,6 +25,7 @@ import {
   PAY_CHANNEL_ZHIFUBAO,
   PAY_CHANNEL_STRIPE,
 } from './constans';
+import { isWechatJsapiAvailable } from './wechatJsapi';
 import MainButtonM from '@/c-components/m/MainButtonM';
 import StripeCardForm from './StripeCardForm';
 
@@ -116,7 +117,12 @@ export const PayModalM = ({
   const skipNextCancelEventRef = useRef(false);
 
   const courseId = getStringEnv('courseId');
-  const isLoggedIn = useUserStore(state => state.isLoggedIn);
+  const { isLoggedIn, userInfo } = useUserStore(
+    useShallow(state => ({
+      isLoggedIn: state.isLoggedIn,
+      userInfo: state.userInfo,
+    })),
+  );
   const { t } = useTranslation();
   const { trackEvent } = useTracking();
   const { payByJsApi } = useWechat();
@@ -219,12 +225,11 @@ export const PayModalM = ({
     () => typeof navigator !== 'undefined' && inWechat(),
     [],
   );
-  // JSAPI payment needs an openid, which is only obtainable when the WeChat
-  // code flow is enabled (it is disabled on custom domains).
-  const wechatJsapiAvailable =
-    isWechatBrowser &&
-    typeof enableWxcode === 'string' &&
-    enableWxcode.toLowerCase() === 'true';
+  const wechatJsapiAvailable = isWechatJsapiAvailable({
+    inWechatBrowser: isWechatBrowser,
+    enableWxcode,
+    openId: userInfo?.openid,
+  });
   const wechatPaymentAvailable =
     pingxxChannelEnabled || wechatpayChannelEnabled;
   const alipayPaymentAvailable = pingxxChannelEnabled || alipayChannelEnabled;

--- a/src/cook-web/src/app/c/[[...id]]/Components/Pay/wechatJsapi.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/Pay/wechatJsapi.test.ts
@@ -1,0 +1,45 @@
+import { isWechatCodeFlowEnabled, isWechatJsapiAvailable } from './wechatJsapi';
+
+describe('isWechatCodeFlowEnabled', () => {
+  test.each(['true', 'TRUE', 'True'])('accepts %s', value => {
+    expect(isWechatCodeFlowEnabled(value)).toBe(true);
+  });
+
+  test.each(['false', '', 'yes', null, undefined])(
+    'rejects %s',
+    (value: string | null | undefined) => {
+      expect(isWechatCodeFlowEnabled(value)).toBe(false);
+    },
+  );
+});
+
+describe('isWechatJsapiAvailable', () => {
+  const available = {
+    inWechatBrowser: true,
+    enableWxcode: 'true',
+    openId: 'o_test_openid',
+  };
+
+  test('allows JSAPI only with an openid in hand', () => {
+    expect(isWechatJsapiAvailable(available)).toBe(true);
+  });
+
+  test.each([null, undefined, ''])(
+    'refuses JSAPI when the account openid is %p',
+    (openId: string | null | undefined) => {
+      expect(isWechatJsapiAvailable({ ...available, openId })).toBe(false);
+    },
+  );
+
+  test('refuses JSAPI outside the WeChat browser', () => {
+    expect(
+      isWechatJsapiAvailable({ ...available, inWechatBrowser: false }),
+    ).toBe(false);
+  });
+
+  test('refuses JSAPI when the code flow is disabled', () => {
+    expect(
+      isWechatJsapiAvailable({ ...available, enableWxcode: 'false' }),
+    ).toBe(false);
+  });
+});

--- a/src/cook-web/src/app/c/[[...id]]/Components/Pay/wechatJsapi.test.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/Pay/wechatJsapi.test.ts
@@ -24,7 +24,7 @@ describe('isWechatJsapiAvailable', () => {
     expect(isWechatJsapiAvailable(available)).toBe(true);
   });
 
-  test.each([null, undefined, ''])(
+  test.each([null, undefined, '', '   '])(
     'refuses JSAPI when the account openid is %p',
     (openId: string | null | undefined) => {
       expect(isWechatJsapiAvailable({ ...available, openId })).toBe(false);

--- a/src/cook-web/src/app/c/[[...id]]/Components/Pay/wechatJsapi.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/Pay/wechatJsapi.ts
@@ -1,0 +1,25 @@
+/**
+ * WeChat JSAPI payment availability.
+ *
+ * JSAPI charges are rejected by the payment gateway without an openid bound to
+ * the paying account. The code flow that grants one is disabled on custom
+ * domains, and even where it is enabled the binding can be missing (the OAuth
+ * code is single-use and may have been spent by guest registration), so the
+ * openid itself has to be checked rather than assumed.
+ */
+
+export const isWechatCodeFlowEnabled = (
+  enableWxcode: string | null | undefined,
+): boolean =>
+  typeof enableWxcode === 'string' && enableWxcode.toLowerCase() === 'true';
+
+export const isWechatJsapiAvailable = ({
+  inWechatBrowser,
+  enableWxcode,
+  openId,
+}: {
+  inWechatBrowser: boolean;
+  enableWxcode: string | null | undefined;
+  openId: string | null | undefined;
+}): boolean =>
+  inWechatBrowser && isWechatCodeFlowEnabled(enableWxcode) && Boolean(openId);

--- a/src/cook-web/src/app/c/[[...id]]/Components/Pay/wechatJsapi.ts
+++ b/src/cook-web/src/app/c/[[...id]]/Components/Pay/wechatJsapi.ts
@@ -22,4 +22,8 @@ export const isWechatJsapiAvailable = ({
   enableWxcode: string | null | undefined;
   openId: string | null | undefined;
 }): boolean =>
-  inWechatBrowser && isWechatCodeFlowEnabled(enableWxcode) && Boolean(openId);
+  inWechatBrowser &&
+  isWechatCodeFlowEnabled(enableWxcode) &&
+  // Trimmed because the backend trims before deciding it has one: a blank
+  // string is not a binding, and offering JSAPI on it fails at the gateway.
+  Boolean(openId?.trim());

--- a/src/cook-web/src/app/c/[[...id]]/page.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.test.tsx
@@ -12,6 +12,9 @@ import ChatPage from './page';
 const mockGetProfileOnboarding = jest.fn();
 const mockSkipProfileOnboarding = jest.fn();
 const mockUpdateWxcode = jest.fn();
+const mockWechatLogin = jest.fn();
+let mockInWechat = false;
+let mockInMiniProgram = false;
 const mockRefreshUserInfo = jest.fn();
 const mockUpdateCourseId = jest.fn();
 const mockLoadTree = jest.fn();
@@ -228,6 +231,7 @@ type MockUserInfo = {
   name: string;
   email: string;
   language: string;
+  openid?: string;
 };
 
 type MockUserStoreState = {
@@ -279,6 +283,12 @@ const mockUiLayoutStoreState = {
   updateFrameLayout: jest.fn(),
 };
 
+const mockEnvStoreState = {
+  updateCourseId: mockUpdateCourseId,
+  enableWxcode: 'true',
+  appId: 'wx-app-id',
+};
+
 jest.mock('next/dynamic', () => ({
   __esModule: true,
   default: () =>
@@ -313,22 +323,17 @@ jest.mock('@/c-constants/uiConstants', () => ({
   FRAME_LAYOUT_MOBILE: 'mobile',
   LISTEN_MODE_VH_FALLBACK_CLASSNAME: 'listen-mode-vh-fallback',
   calcFrameLayout: () => 'desktop',
-  inWechat: () => false,
-  inMiniProgram: () => false,
+  inWechat: () => mockInWechat,
+  inMiniProgram: () => mockInMiniProgram,
+  wechatLogin: (...args: unknown[]) => mockWechatLogin(...args),
 }));
 
 jest.mock('@/c-store', () => ({
   useEnvStore: Object.assign(
-    (
-      selector?: (state: {
-        updateCourseId: typeof mockUpdateCourseId;
-      }) => unknown,
-    ) =>
-      selector ? selector({ updateCourseId: mockUpdateCourseId }) : undefined,
+    (selector?: (state: typeof mockEnvStoreState) => unknown) =>
+      selector ? selector(mockEnvStoreState) : undefined,
     {
-      getState: () => ({
-        updateCourseId: mockUpdateCourseId,
-      }),
+      getState: () => mockEnvStoreState,
     },
   ),
   useCourseStore: Object.assign(
@@ -488,6 +493,12 @@ describe('ChatPage profile onboarding gate', () => {
     };
     mockSystemStoreState.previewMode = false;
     mockSystemStoreState.learningMode = 'read';
+    mockSystemStoreState.wechatCode = '';
+    mockEnvStoreState.enableWxcode = 'true';
+    mockEnvStoreState.appId = 'wx-app-id';
+    mockInWechat = false;
+    mockInMiniProgram = false;
+    sessionStorage.clear();
     mockUiLayoutStoreState.frameLayout = 'desktop';
     mockSelectedLessonId = 'lesson-1';
     mockToast.mockReset();
@@ -1360,5 +1371,114 @@ describe('ChatPage profile onboarding gate', () => {
       'data-runtime-ready',
       'true',
     );
+  });
+
+  describe('WeChat openid rebinding', () => {
+    const renderInWechat = () => {
+      mockInWechat = true;
+      mockUserStoreState.userInfo = {
+        ...defaultMockUserInfo,
+        openid: '',
+      };
+      return render(<ChatPage />);
+    };
+
+    test('binds the openid and refreshes the account when one is missing', async () => {
+      mockSystemStoreState.wechatCode = 'code-1';
+      mockUpdateWxcode.mockResolvedValue('o_new_openid');
+
+      renderInWechat();
+
+      await waitFor(() =>
+        expect(mockUpdateWxcode).toHaveBeenCalledWith({ wxcode: 'code-1' }),
+      );
+      await waitFor(() => expect(mockRefreshUserInfo).toHaveBeenCalled());
+      expect(mockWechatLogin).not.toHaveBeenCalled();
+    });
+
+    test('leaves an already bound account alone', async () => {
+      mockSystemStoreState.wechatCode = 'code-1';
+      mockInWechat = true;
+      mockUserStoreState.userInfo = {
+        ...defaultMockUserInfo,
+        openid: 'o_existing',
+      };
+
+      render(<ChatPage />);
+
+      await waitFor(() => expect(mockGetProfileOnboarding).toHaveBeenCalled());
+      expect(mockUpdateWxcode).not.toHaveBeenCalled();
+      expect(mockWechatLogin).not.toHaveBeenCalled();
+    });
+
+    test('does not spend the same code twice when the exchange yields nothing', async () => {
+      mockSystemStoreState.wechatCode = 'code-1';
+      mockUpdateWxcode.mockResolvedValue('');
+
+      renderInWechat();
+
+      await waitFor(() => expect(mockUpdateWxcode).toHaveBeenCalledTimes(1));
+      expect(mockRefreshUserInfo).not.toHaveBeenCalled();
+
+      mockSystemStoreState.wechatCode = 'code-2';
+      render(<ChatPage />);
+
+      await waitFor(() => expect(mockUpdateWxcode).toHaveBeenCalledTimes(2));
+      expect(mockUpdateWxcode).toHaveBeenLastCalledWith({ wxcode: 'code-2' });
+    });
+
+    test('requests a fresh code once per session when none is left', async () => {
+      mockSystemStoreState.wechatCode = '';
+
+      renderInWechat();
+
+      await waitFor(() => expect(mockWechatLogin).toHaveBeenCalledTimes(1));
+      expect(mockWechatLogin).toHaveBeenCalledWith(
+        expect.objectContaining({ appId: 'wx-app-id' }),
+      );
+      expect(mockUpdateWxcode).not.toHaveBeenCalled();
+
+      render(<ChatPage />);
+
+      await waitFor(() => expect(mockGetProfileOnboarding).toHaveBeenCalled());
+      expect(mockWechatLogin).toHaveBeenCalledTimes(1);
+    });
+
+    test('waits for the account profile before judging the openid', async () => {
+      mockSystemStoreState.wechatCode = '';
+      mockInWechat = true;
+      mockUserStoreState.userInfo = null;
+
+      render(<ChatPage />);
+
+      await waitFor(() => expect(mockGetProfileOnboarding).toHaveBeenCalled());
+      expect(mockWechatLogin).not.toHaveBeenCalled();
+      expect(mockUpdateWxcode).not.toHaveBeenCalled();
+    });
+
+    test('stays out of the WeChat flow outside WeChat', async () => {
+      mockSystemStoreState.wechatCode = 'code-1';
+      mockUserStoreState.userInfo = {
+        ...defaultMockUserInfo,
+        openid: '',
+      };
+
+      render(<ChatPage />);
+
+      await waitFor(() => expect(mockGetProfileOnboarding).toHaveBeenCalled());
+      expect(mockUpdateWxcode).not.toHaveBeenCalled();
+      expect(mockWechatLogin).not.toHaveBeenCalled();
+    });
+
+    test('does not act when the WeChat code flow is disabled', async () => {
+      mockSystemStoreState.wechatCode = 'code-1';
+      mockEnvStoreState.enableWxcode = 'false';
+
+      renderInWechat();
+
+      await waitFor(() => expect(mockGetProfileOnboarding).toHaveBeenCalled());
+      expect(mockUpdateWxcode).not.toHaveBeenCalled();
+      expect(mockWechatLogin).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/cook-web/src/app/c/[[...id]]/page.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.test.tsx
@@ -1396,8 +1396,8 @@ describe('ChatPage profile onboarding gate', () => {
       expect(mockWechatLogin).not.toHaveBeenCalled();
     });
 
-    test('leaves an already bound account alone', async () => {
-      mockSystemStoreState.wechatCode = 'code-1';
+    test('leaves a bound account alone when no code is left to spend', async () => {
+      mockSystemStoreState.wechatCode = '';
       mockInWechat = true;
       mockUserStoreState.userInfo = {
         ...defaultMockUserInfo,
@@ -1408,6 +1408,41 @@ describe('ChatPage profile onboarding gate', () => {
 
       await waitFor(() => expect(mockGetProfileOnboarding).toHaveBeenCalled());
       expect(mockUpdateWxcode).not.toHaveBeenCalled();
+      expect(mockWechatLogin).not.toHaveBeenCalled();
+    });
+
+    test('moves the binding over when another WeChat account signs in', async () => {
+      mockSystemStoreState.wechatCode = 'code-from-other-wechat';
+      mockInWechat = true;
+      mockUserStoreState.userInfo = {
+        ...defaultMockUserInfo,
+        openid: 'o_previous',
+      };
+      mockUpdateWxcode.mockResolvedValue('o_other_account');
+
+      render(<ChatPage />);
+
+      await waitFor(() =>
+        expect(mockUpdateWxcode).toHaveBeenCalledWith({
+          wxcode: 'code-from-other-wechat',
+        }),
+      );
+      await waitFor(() => expect(mockRefreshUserInfo).toHaveBeenCalled());
+    });
+
+    test('skips the refresh when the code resolves to the bound openid', async () => {
+      mockSystemStoreState.wechatCode = 'code-1';
+      mockInWechat = true;
+      mockUserStoreState.userInfo = {
+        ...defaultMockUserInfo,
+        openid: 'o_same',
+      };
+      mockUpdateWxcode.mockResolvedValue('o_same');
+
+      render(<ChatPage />);
+
+      await waitFor(() => expect(mockUpdateWxcode).toHaveBeenCalledTimes(1));
+      expect(mockRefreshUserInfo).not.toHaveBeenCalled();
       expect(mockWechatLogin).not.toHaveBeenCalled();
     });
 

--- a/src/cook-web/src/app/c/[[...id]]/page.test.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.test.tsx
@@ -1462,6 +1462,52 @@ describe('ChatPage profile onboarding gate', () => {
       expect(mockUpdateWxcode).toHaveBeenLastCalledWith({ wxcode: 'code-2' });
     });
 
+    test('buys a fresh code when the exchange yields nothing', async () => {
+      mockSystemStoreState.wechatCode = 'spent-code';
+      mockUpdateWxcode.mockResolvedValue('');
+
+      renderInWechat();
+
+      await waitFor(() => expect(mockWechatLogin).toHaveBeenCalledTimes(1));
+    });
+
+    test('buys a fresh code when the exchange is rejected', async () => {
+      mockSystemStoreState.wechatCode = 'spent-code';
+      mockUpdateWxcode.mockRejectedValue(new Error('exchange failed'));
+
+      renderInWechat();
+
+      await waitFor(() => expect(mockWechatLogin).toHaveBeenCalledTimes(1));
+    });
+
+    test('does not buy a fresh code for an account that is already bound', async () => {
+      mockSystemStoreState.wechatCode = 'code-1';
+      mockInWechat = true;
+      mockUserStoreState.userInfo = {
+        ...defaultMockUserInfo,
+        openid: 'o_existing',
+      };
+      mockUpdateWxcode.mockResolvedValue('');
+
+      render(<ChatPage />);
+
+      await waitFor(() => expect(mockUpdateWxcode).toHaveBeenCalledTimes(1));
+      expect(mockWechatLogin).not.toHaveBeenCalled();
+    });
+
+    test('treats a blank openid as no binding at all', async () => {
+      mockSystemStoreState.wechatCode = '';
+      mockInWechat = true;
+      mockUserStoreState.userInfo = {
+        ...defaultMockUserInfo,
+        openid: '   ',
+      };
+
+      render(<ChatPage />);
+
+      await waitFor(() => expect(mockWechatLogin).toHaveBeenCalledTimes(1));
+    });
+
     test('requests a fresh code once per session when none is left', async () => {
       mockSystemStoreState.wechatCode = '';
 

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -193,20 +193,19 @@ export default function ChatPage() {
   // failed exchange is not retried in a loop with the same (single-use) code.
   const attemptedWechatCodeRef = useRef('');
 
-  // WeChat JSAPI payment needs an openid bound to the account. The OAuth code
-  // carried by the URL can be consumed elsewhere first (guest registration) or
-  // its exchange can fail, and the code is then dropped from the URL on login,
-  // which used to leave the account without an openid for good. Retry the
-  // binding whenever the openid is still missing, and fetch a fresh code once
-  // per session when no usable one is left.
+  // WeChat JSAPI payment needs the openid of the WeChat account currently
+  // viewing the page. Every unspent code is handed to the backend, which only
+  // writes when the openid actually differs, so signing in from another WeChat
+  // account moves the binding over instead of paying with a stale openid. The
+  // code itself can be consumed elsewhere first (guest registration) or fail to
+  // exchange, and login drops it from the URL, which used to leave an account
+  // without any openid for good -- so when none is left and nothing is bound,
+  // fetch a fresh code once per session.
   useEffect(() => {
     if (!initialized) {
       return;
     }
     if (!isLoggedIn || !isUserProfileLoaded) {
-      return;
-    }
-    if (wechatOpenId) {
       return;
     }
     if (!inWechat() || inMiniProgram() || !wxcodeEnabled) {
@@ -219,7 +218,9 @@ export default function ChatPage() {
     }
 
     if (!wechatCode) {
-      requestWechatCodeForOpenIdRebind();
+      if (!wechatOpenId) {
+        requestWechatCodeForOpenIdRebind();
+      }
       return;
     }
     if (attemptedWechatCodeRef.current === wechatCode) {
@@ -231,6 +232,9 @@ export default function ChatPage() {
       .then(openid => {
         if (!openid) {
           debugWarn('[lesson-page] WeChat OpenID binding returned no openid');
+          return undefined;
+        }
+        if (openid === wechatOpenId) {
           return undefined;
         }
         return refreshUserInfo();

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -151,6 +151,13 @@ const requestWechatCodeForOpenIdRebind = () => {
   });
 };
 
+const requestWechatCodeForOpenIdRebindIfUnbound = (openId: string) => {
+  if (openId) {
+    return;
+  }
+  requestWechatCodeForOpenIdRebind();
+};
+
 export default function ChatPage() {
   const { t, i18n } = useTranslation();
   const { trackEvent } = useTracking();
@@ -185,7 +192,10 @@ export default function ChatPage() {
     (state: EnvStoreState) => state.enableWxcode,
   );
   const wxcodeEnabled = isWechatCodeFlowEnabled(enableWxcode);
-  const wechatOpenId = userInfo?.openid || '';
+  // Trimmed to match the backend, which strips the value before deciding
+  // whether it has one: a blank string must take the rebinding path here
+  // rather than reach the gateway as a missing parameter.
+  const wechatOpenId = (userInfo?.openid || '').trim();
   // The account profile arrives after the login state does, and a not-yet-loaded
   // profile must not be read as "this account has no openid".
   const isUserProfileLoaded = Boolean(userInfo);
@@ -218,9 +228,7 @@ export default function ChatPage() {
     }
 
     if (!wechatCode) {
-      if (!wechatOpenId) {
-        requestWechatCodeForOpenIdRebind();
-      }
+      requestWechatCodeForOpenIdRebindIfUnbound(wechatOpenId);
       return;
     }
     if (attemptedWechatCodeRef.current === wechatCode) {
@@ -232,6 +240,10 @@ export default function ChatPage() {
       .then(openid => {
         if (!openid) {
           debugWarn('[lesson-page] WeChat OpenID binding returned no openid');
+          // The code is spent either way, and the ref stops this effect from
+          // trying again with it, so an unbound account would stay unbound for
+          // the rest of the session. Spend the one fresh code instead.
+          requestWechatCodeForOpenIdRebindIfUnbound(wechatOpenId);
           return undefined;
         }
         if (openid === wechatOpenId) {
@@ -241,6 +253,7 @@ export default function ChatPage() {
       })
       .catch(err => {
         debugWarn('[lesson-page] failed to update WeChat OpenID', err);
+        requestWechatCodeForOpenIdRebindIfUnbound(wechatOpenId);
       });
   }, [
     initialized,

--- a/src/cook-web/src/app/c/[[...id]]/page.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/page.tsx
@@ -15,6 +15,7 @@ import {
   FRAME_LAYOUT_MOBILE,
   inWechat,
   inMiniProgram,
+  wechatLogin,
 } from '@/c-constants/uiConstants';
 import { LESSON_STATUS_VALUE } from '@/c-constants/courseConstants';
 import { EVENT_NAMES, events } from './events';
@@ -39,6 +40,7 @@ import type { EnvStoreState } from '@/c-types/store';
 import {
   buildLoginRedirectPath,
   getLessonIdFromQuery,
+  removeParamFromUrl,
   replaceCurrentUrlWithLessonId,
 } from '@/c-utils/urlUtils';
 
@@ -56,6 +58,7 @@ import {
 import dynamic from 'next/dynamic';
 import ChatMobileHeader from './Components/ChatMobileHeader';
 import MiniProgramPayGuide from './Components/Pay/MiniProgramPayGuide';
+import { isWechatCodeFlowEnabled } from './Components/Pay/wechatJsapi';
 import { trackCourseVisitIfNeeded } from './courseVisitTracking';
 import { useCourseProfileOnboardingGate } from './hooks/useCourseProfileOnboardingGate';
 import DebugConsoleOverlay from '@/components/debug/DebugConsoleOverlay';
@@ -117,6 +120,37 @@ const isEditableElementFocused = () => {
   return isEditableElement(document.activeElement);
 };
 
+const OPENID_REBIND_SESSION_KEY = 'wechat_openid_rebind_attempted';
+
+/**
+ * Send the user through the WeChat code flow once per session to recover an
+ * openid the account never got bound. The redirect target drops the spent
+ * `code`/`state` so the fresh one does not stack onto them.
+ */
+const requestWechatCodeForOpenIdRebind = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const { appId } = useEnvStore.getState() as EnvStoreState;
+  if (!appId) {
+    return;
+  }
+  try {
+    if (sessionStorage.getItem(OPENID_REBIND_SESSION_KEY)) {
+      return;
+    }
+    sessionStorage.setItem(OPENID_REBIND_SESSION_KEY, '1');
+  } catch {
+    // Without session storage there is no way to bound the retries, so skip
+    // the redirect rather than risk looping through OAuth.
+    return;
+  }
+  wechatLogin({
+    appId,
+    redirectUrl: removeParamFromUrl(window.location.href, ['code', 'state']),
+  });
+};
+
 export default function ChatPage() {
   const { t, i18n } = useTranslation();
   const { trackEvent } = useTracking();
@@ -147,14 +181,35 @@ export default function ChatPage() {
   const [lessonUpdateNoticeVisible, setLessonUpdateNoticeVisible] =
     useState(false);
 
+  const enableWxcode = useEnvStore(
+    (state: EnvStoreState) => state.enableWxcode,
+  );
+  const wxcodeEnabled = isWechatCodeFlowEnabled(enableWxcode);
+  const wechatOpenId = userInfo?.openid || '';
+  // The account profile arrives after the login state does, and a not-yet-loaded
+  // profile must not be read as "this account has no openid".
+  const isUserProfileLoaded = Boolean(userInfo);
+  // Tracks which OAuth code this page already spent on a binding attempt, so a
+  // failed exchange is not retried in a loop with the same (single-use) code.
+  const attemptedWechatCodeRef = useRef('');
+
+  // WeChat JSAPI payment needs an openid bound to the account. The OAuth code
+  // carried by the URL can be consumed elsewhere first (guest registration) or
+  // its exchange can fail, and the code is then dropped from the URL on login,
+  // which used to leave the account without an openid for good. Retry the
+  // binding whenever the openid is still missing, and fetch a fresh code once
+  // per session when no usable one is left.
   useEffect(() => {
     if (!initialized) {
       return;
     }
-    if (!isLoggedIn) {
+    if (!isLoggedIn || !isUserProfileLoaded) {
       return;
     }
-    if (!wechatCode || !inWechat()) {
+    if (wechatOpenId) {
+      return;
+    }
+    if (!inWechat() || inMiniProgram() || !wxcodeEnabled) {
       return;
     }
 
@@ -163,10 +218,35 @@ export default function ChatPage() {
       return;
     }
 
-    void updateWxcode({ wxcode: wechatCode }).catch(err => {
-      debugWarn('[lesson-page] failed to update WeChat OpenID', err);
-    });
-  }, [initialized, isLoggedIn, wechatCode]);
+    if (!wechatCode) {
+      requestWechatCodeForOpenIdRebind();
+      return;
+    }
+    if (attemptedWechatCodeRef.current === wechatCode) {
+      return;
+    }
+    attemptedWechatCodeRef.current = wechatCode;
+
+    void updateWxcode({ wxcode: wechatCode })
+      .then(openid => {
+        if (!openid) {
+          debugWarn('[lesson-page] WeChat OpenID binding returned no openid');
+          return undefined;
+        }
+        return refreshUserInfo();
+      })
+      .catch(err => {
+        debugWarn('[lesson-page] failed to update WeChat OpenID', err);
+      });
+  }, [
+    initialized,
+    isLoggedIn,
+    isUserProfileLoaded,
+    refreshUserInfo,
+    wechatCode,
+    wechatOpenId,
+    wxcodeEnabled,
+  ]);
 
   // NOTE: User-related features should be organized into one module
   const gotoLogin = useCallback(() => {
@@ -181,15 +261,14 @@ export default function ChatPage() {
    */
   const { frameLayout, updateFrameLayout } = useUiLayoutStore(state => state);
   const mobileStyle = frameLayout === FRAME_LAYOUT_MOBILE;
-  const enableWxcode = useEnvStore(
-    (state: EnvStoreState) => state.enableWxcode,
-  );
-  // WeChat JSAPI payment needs an openid, which is only obtainable when the
-  // WeChat code flow is enabled (i.e. not on custom domains). Without it,
-  // guide the user to pay in an external browser instead.
-  const wxcodeEnabled =
-    typeof enableWxcode === 'string' && enableWxcode.toLowerCase() === 'true';
-  const wechatPayUnavailable = inWechat() && !inMiniProgram() && !wxcodeEnabled;
+  // WeChat JSAPI payment needs an openid: the code flow that grants one is
+  // disabled on custom domains, and the binding can also be missing on domains
+  // where it is enabled. Without an openid, guide the user to pay in an
+  // external browser instead of showing a QR code they cannot scan in place.
+  const wechatPayUnavailable =
+    inWechat() &&
+    !inMiniProgram() &&
+    (!wxcodeEnabled || (isLoggedIn && isUserProfileLoaded && !wechatOpenId));
   const showPayGuide = inMiniProgram() || wechatPayUnavailable;
   const [listenMobileViewMode, setListenMobileViewMode] =
     useState<MobileViewMode>(DEFAULT_LISTEN_MOBILE_VIEW_MODE);


### PR DESCRIPTION
## Problem

A production learner hit an unhandled 500 on `POST /api/order/reqiure-to-pay`:

```
pingpp.error.InvalidRequestError: missing request parameter: open_id
```

The account (phone login, no WeChat credential row) had an empty
`wechat_open_id`, but `_generate_pingxx_charge` passed it into the charge extra
regardless:

```python
charge_extra = {"open_id": user.wechat_open_id} if user else {}
```

The gateway rejected the empty field, the order stayed at `INIT` and no charge
was ever created — a silently dropped purchase. The native WeChat Pay path
already guarded this exact case with `server.pay.wechatOpenIdRequired`; only the
two Ping++ call sites were missing it.

Pulling that thread surfaced two more ways the JSAPI open ID goes wrong:

- **The frontend never checked the account had one.** JSAPI was selected from
  `inWechat() && enableWxcode` alone, which says the code flow is available on
  this domain — not that this account is bound. The single-use OAuth code may
  already be spent by guest registration (`registerTmp` sends the same `wxcode`)
  and is stripped from the URL on login, after which nothing retried.
- **The wrong open ID could be sent even when one existed.** An account can hold
  one open ID per WeChat app — the platform app plus, for learners of a creator
  running their own official account, that creator's app (stored scoped as
  `{app_id}:{subject}`). A second sign-in appends a row rather than replacing
  one, `list_credentials` had no `ORDER BY`, and `wechat_open_id` returned the
  first match — so the value was effectively arbitrary, and never asked which app
  was being charged.

## Changes

**Reject instead of forwarding an unusable open ID**

- `_generate_pingxx_charge` and `_build_pingxx_provider_options` raise
  `server.pay.wechatOpenIdRequired` (5002) when the open ID is missing, matching
  the native WeChat Pay guard. Learners see the existing localized message
  instead of a 500.

**Send the open ID of the app actually being charged**

- Credentials load in primary-key order, and selection is deterministic: the app
  asked for, then verified over unverified, then the most recent write.
- **A caller that names an app gets that app's subject or nothing** — a foreign
  open ID is a certain gateway rejection, so reporting nothing lets the charge
  raise the readable error instead. The bare `wechat_open_id` accessor keeps the
  looser behaviour, since it answers "is this account bound to WeChat at all",
  which is what the serialized profile asks.
- Both JSAPI charge paths resolve that app from the **order's** creator
  (`buy_record.creator_bid`, set by `generate_charge`) rather than the
  request-scoped shifu context, which this endpoint never sets up and which can
  therefore hold a previous request's creator on a reused worker thread. A failed
  lookup degrades to the platform app: a money flow gains no new failure path.
- `update_user_open_id` compares within the same app, so an open ID held for
  another app is treated as a separate binding rather than a stale copy.
- `billing/checkout.py` stays on the plain property deliberately: its
  `creator_bid` is a creator buying credits on the platform, so platform scope is
  already correct.

**Do not offer JSAPI without an open ID, and repair the binding**

- New `isWechatJsapiAvailable` / `isWechatCodeFlowEnabled` helpers replace the
  predicate duplicated across `PayModal`, `PayModalM` and the lesson page; JSAPI
  now additionally requires a non-blank `userInfo.openid`, trimmed to match the
  backend, which strips before deciding whether it has one.
- Without one in WeChat, the lesson page falls back to the existing
  external-browser pay guide rather than a QR code that cannot be scanned in
  place.
- The lesson page hands every unspent code to `update_openid` (which writes only
  when the open ID differs) and never spends a code twice. An exchange that
  returns nothing or throws spends the one per-session code request, so an
  account whose code was consumed elsewhere recovers on the same visit instead of
  waiting for a new session. The effect waits for the account profile to load so
  an unloaded profile is not read as "no openid".
- A backend contract test pins the serialized `openid` key the JSAPI gate reads;
  frontend tests stub that field and cannot catch a rename.

## Known limitation

A learner holding only a platform open ID on a creator-OAuth course now gets the
readable error, but the rebinding effect will not fetch a creator-scoped code for
them, because it only acts when *no* open ID is bound. Closing that needs the
frontend to know which app the course signs learners in with.

## Verification

- `pytest tests/service/user tests/service/order tests/service/billing tests/test_wx_pub_order.py tests/test_pingpp.py tests/test_user.py` — 1218 passed, 10 skipped
- `jest src/app/c/[[...id]]/page.test.tsx src/app/c/[[...id]]/Components/Pay/wechatJsapi.test.ts` — 55 passed
- New tests were mutation-checked: reverting the selection to "first match wins"
  turns three red, reintroducing the "skip when an open ID exists" shortcut turns
  two red, removing the empty-open-ID guard turns two more red, and renaming the
  serialized key to `wx_openid` turns all three contract tests red.
- `lefthook run pre-commit` (architecture baseline unchanged at 133, 0 new),
  `tsc --noEmit`, `eslint` — clean

No migration and no deploy-config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)