### PR TITLE
feat: reorder operator menus

### DIFF
--- a/src/cook-web/src/app/admin/admin-menu.test.tsx
+++ b/src/cook-web/src/app/admin/admin-menu.test.tsx
@@ -60,9 +60,24 @@ describe('buildAdminMenuItems', () => {
           href: '/admin/operations/promotions',
         },
         {
+          id: 'operations-brand-payments',
+          label: 'common.core.brandPaymentsManagement',
+          href: '/admin/operations/billing',
+        },
+        {
+          id: 'operations-config',
+          label: 'common.core.rateManagement',
+          href: '/admin/operations/config',
+        },
+        {
           id: 'operations-credit-notification',
           label: 'common.core.creditNotificationManagement',
           href: '/admin/operations/credit-notifications',
+        },
+        {
+          id: 'operations-referrals',
+          label: 'common.core.referralInvitation',
+          href: '/admin/operations/referrals',
         },
         {
           id: 'operations-voice-clone',
@@ -74,35 +89,29 @@ describe('buildAdminMenuItems', () => {
           label: 'common.core.profileOnboardingManagement',
           href: '/admin/operations/profile-onboarding',
         },
-        {
-          id: 'operations-config',
-          label: 'common.core.rateManagement',
-          href: '/admin/operations/config',
-        },
-        {
-          id: 'operations-brand-payments',
-          label: 'common.core.brandPaymentsManagement',
-          href: '/admin/operations/billing',
-        },
       ],
     });
   });
 
-  test('shows package management for Stripe operator environments', () => {
+  test('shows package management in the requested Stripe operator menu order', () => {
     const menuItems = buildAdminMenuItems({
       t,
       isOperator: true,
       showPackageManagement: true,
     });
 
-    expect(menuItems.at(-1)?.children).toEqual(
-      expect.arrayContaining([
-        {
-          id: 'operations-package-management',
-          label: 'common.core.packageManagement',
-          href: '/admin/operations/provider-prices',
-        },
-      ]),
-    );
+    expect(menuItems.at(-1)?.children?.map(item => item.id)).toEqual([
+      'operations-course',
+      'operations-user',
+      'operations-order',
+      'operations-promotion',
+      'operations-package-management',
+      'operations-brand-payments',
+      'operations-config',
+      'operations-credit-notification',
+      'operations-referrals',
+      'operations-voice-clone',
+      'operations-profile-onboarding',
+    ]);
   });
 });

--- a/src/cook-web/src/app/admin/admin-menu.test.tsx
+++ b/src/cook-web/src/app/admin/admin-menu.test.tsx
@@ -76,7 +76,7 @@ describe('buildAdminMenuItems', () => {
         },
         {
           id: 'operations-referrals',
-          label: 'common.core.referralInvitation',
+          label: 'module.referral.operator.title',
           href: '/admin/operations/referrals',
         },
         {

--- a/src/cook-web/src/app/admin/admin-menu.tsx
+++ b/src/cook-web/src/app/admin/admin-menu.tsx
@@ -85,10 +85,34 @@ export const buildAdminMenuItems = ({
           label: t('common.core.promotionManagement'),
           href: '/admin/operations/promotions',
         },
+        ...(showPackageManagement
+          ? [
+              {
+                id: 'operations-package-management',
+                label: t('common.core.packageManagement'),
+                href: '/admin/operations/provider-prices',
+              },
+            ]
+          : []),
+        {
+          id: 'operations-brand-payments',
+          label: t('common.core.brandPaymentsManagement'),
+          href: '/admin/operations/billing',
+        },
+        {
+          id: 'operations-config',
+          label: t('common.core.rateManagement'),
+          href: '/admin/operations/config',
+        },
         {
           id: 'operations-credit-notification',
           label: t('common.core.creditNotificationManagement'),
           href: '/admin/operations/credit-notifications',
+        },
+        {
+          id: 'operations-referrals',
+          label: t('common.core.referralInvitation'),
+          href: '/admin/operations/referrals',
         },
         {
           id: 'operations-voice-clone',
@@ -100,25 +124,6 @@ export const buildAdminMenuItems = ({
           label: t('common.core.profileOnboardingManagement'),
           href: '/admin/operations/profile-onboarding',
         },
-        {
-          id: 'operations-config',
-          label: t('common.core.rateManagement'),
-          href: '/admin/operations/config',
-        },
-        {
-          id: 'operations-brand-payments',
-          label: t('common.core.brandPaymentsManagement'),
-          href: '/admin/operations/billing',
-        },
-        ...(showPackageManagement
-          ? [
-              {
-                id: 'operations-package-management',
-                label: t('common.core.packageManagement'),
-                href: '/admin/operations/provider-prices',
-              },
-            ]
-          : []),
       ],
     });
   }

--- a/src/cook-web/src/app/admin/admin-menu.tsx
+++ b/src/cook-web/src/app/admin/admin-menu.tsx
@@ -111,7 +111,7 @@ export const buildAdminMenuItems = ({
         },
         {
           id: 'operations-referrals',
-          label: t('common.core.referralInvitation'),
+          label: t('module.referral.operator.title'),
           href: '/admin/operations/referrals',
         },
         {


### PR DESCRIPTION
## Summary
Reorders the operator operations submenu to match the requested navigation sequence.

## Change
- Moves package management directly after promotions when the Stripe package menu is enabled.
- Moves commercialization operations and rate management before credit notifications.
- Adds the operator invite referral entry before voice clone and profile onboarding.
- Updates the admin menu unit test to lock the expected operator menu order.

## Benefit
Operators can find course, user, order, promotion, package, commercialization, rate, notification, referral, voice clone, and profile onboarding tools in the intended order.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operator menu entries for brand payments, rate management, and referral invitations.
  * Updated package management placement and menu ordering for a clearer administration experience.
  * Improved the referral menu label for operator-specific navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->