### PR TITLE
fix: clarify operator package grant plan labels

### DIFF
--- a/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.test.tsx
+++ b/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.test.tsx
@@ -414,7 +414,7 @@ describe('UserCreditGrantDialog', () => {
           product_bid: 'bill-product-plan-monthly',
           product_code: 'creator-plan-monthly',
           product_type: 'plan',
-          display_name: 'module.billing.catalog.plans.creatorMonthly.title',
+          display_name: 'Growth',
           description:
             'module.billing.catalog.plans.creatorMonthly.description',
           billing_interval: 'month',
@@ -422,6 +422,20 @@ describe('UserCreditGrantDialog', () => {
           currency: 'CNY',
           price_amount: 990,
           credit_amount: 5,
+          auto_renew_enabled: true,
+          highlights: [],
+        },
+        {
+          product_bid: 'bill-product-plan-yearly',
+          product_code: 'creator-plan-yearly',
+          product_type: 'plan',
+          display_name: 'Growth',
+          description: 'module.billing.catalog.plans.creatorYearly.description',
+          billing_interval: 'year',
+          billing_interval_count: 1,
+          currency: 'CNY',
+          price_amount: 9900,
+          credit_amount: 60,
           auto_renew_enabled: true,
           highlights: [],
         },
@@ -451,9 +465,14 @@ describe('UserCreditGrantDialog', () => {
         name: 'module.operationsUser.grantDialog.modeOptions.package',
       }),
     );
+    expect(
+      await screen.findByRole('button', {
+        name: 'Growth module.billing.admin.providerPrices.billingLabel.yearly',
+      }),
+    ).toBeInTheDocument();
     fireEvent.click(
       await screen.findByRole('button', {
-        name: 'module.billing.catalog.plans.creatorMonthly.title',
+        name: 'Growth module.billing.admin.providerPrices.billingLabel.monthly',
       }),
     );
     fireEvent.change(

--- a/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
+++ b/src/cook-web/src/app/admin/operations/users/UserCreditGrantDialog.tsx
@@ -10,6 +10,7 @@ import { useToast } from '@/hooks/useToast';
 import { ErrorWithCode } from '@/lib/request';
 import {
   formatBillingCompactDateTime,
+  formatBillingPlanInterval,
   resolveBillingPlanValidityLabel,
 } from '@/lib/billing';
 import { Button } from '@/components/ui/Button';
@@ -252,6 +253,29 @@ const resolveEstimatedPlanExpiry = (
 
 const stripValidityLabelPrefix = (value: string): string =>
   value.replace(/^[^:：]+[:：]\s*/, '').trim();
+
+const resolvePackagePlanLabel = (
+  t: (key: string, options?: Record<string, unknown>) => string,
+  product: BillingPlan,
+): string => {
+  const productName = t(product.display_name);
+  const intervalCount = Math.max(product.billing_interval_count || 0, 1);
+  let intervalLabel = '';
+
+  if (product.billing_interval === 'month' && intervalCount === 1) {
+    intervalLabel = t(
+      'module.billing.admin.providerPrices.billingLabel.monthly',
+    );
+  } else if (product.billing_interval === 'year' && intervalCount === 1) {
+    intervalLabel = t(
+      'module.billing.admin.providerPrices.billingLabel.yearly',
+    );
+  } else {
+    intervalLabel = formatBillingPlanInterval(t, product);
+  }
+
+  return intervalLabel ? `${productName} ${intervalLabel}` : productName;
+};
 
 const SummaryField = ({
   label,
@@ -545,7 +569,9 @@ export default function UserCreditGrantDialog({
     selectedPlan,
     grantedAt,
   );
-  const packageName = selectedPlan ? t(selectedPlan.display_name) : '--';
+  const packageName = selectedPlan
+    ? resolvePackagePlanLabel(t, selectedPlan)
+    : '--';
   const packageCreditsLabel = selectedPlan
     ? formatAdminCredits(Number(selectedPlan.credit_amount || 0), i18n.language)
     : '--';
@@ -1143,7 +1169,7 @@ export default function UserCreditGrantDialog({
                                 key={plan.product_bid}
                                 value={plan.product_bid}
                               >
-                                {t(plan.display_name)}
+                                {resolvePackagePlanLabel(t, plan)}
                               </SelectItem>
                             ))
                           )}


### PR DESCRIPTION
## Summary
Clarifies the package grant dropdown in overseas operator user management so same-tier monthly and yearly plans are distinguishable.

## Change
- Appends billing interval labels to package grant plan options.
- Reuses the same full package label in selected package details and confirmation summaries.
- Updates the focused package grant dialog test to cover same-name monthly and yearly plan options.

## Benefit
Operators can choose the correct monthly or yearly package before granting it to a user.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Package plans now display billing intervals, such as monthly or yearly, alongside the plan name.
  - Billing intervals for longer or custom periods are shown using localized formatting.
  - Updated package selections and confirmation summaries use the enhanced plan labels.

- **Bug Fixes**
  - Improved plan identification when multiple billing periods share the same display name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->