### PR TITLE
feat: improve personalization dialog on mobile

### DIFF
--- a/docs/exec-plans/completed/mobile-personalization-dialog.md
+++ b/docs/exec-plans/completed/mobile-personalization-dialog.md
@@ -1,0 +1,183 @@
+# Mobile Learner Personalization Dialog
+
+## Purpose / Big Picture
+
+The learner personalization dialog should behave as a focused full-screen task
+under 640px while retaining the existing centered Radix Dialog on larger
+screens. The mobile layout must leave more room for the active question or
+editor, avoid iOS input zoom, keep controls clear of safe areas and the soft
+keyboard, and preserve every existing workflow, message, API, analytics event,
+and exit-policy rule.
+
+## Progress
+
+- [x] 2026-08-27 11:54 CST: Fast-forwarded `main` to the merged profile
+      onboarding baseline and created `sunner/mobile-personalization-dialog`.
+- [x] 2026-08-27 11:54 CST: Inspected the dialog, phase views, MarkdownFlow
+      conversation, assistant-answer view, shared Dialog primitive, and focused
+      tests.
+- [x] 2026-08-27 12:10 CST: Implemented the full-screen mobile shell,
+      safe-area spacing, phase-specific footers, inline information controls,
+      focus scrolling, and one scroll owner per phase.
+- [x] 2026-08-27 12:27 CST: Added focused regression coverage for responsive
+      placement, compact-height behavior, input sizing, touch targets, exit
+      policies, confirmations, focus behavior, and the hidden mobile AI entry.
+- [x] 2026-08-27 12:40 CST: Passed focused and full frontend checks plus the
+      repository-level validation gates listed below.
+- [x] 2026-08-27 12:40 CST: Captured local before/after evidence at all accepted
+      viewports and recorded unavailable physical-device validation explicitly.
+
+## Surprises & Discoveries
+
+- The current mobile dialog is a nearly full-height inset card with a decorative
+  drag handle, although the Radix Dialog has no drag-to-dismiss behavior.
+- The shared input primitives use 14px text by default. MarkdownFlow contains a
+  mix of 16px and 14px controls, so the dialog must enforce the mobile minimum
+  on all nested form controls without changing the shared primitives.
+- The existing AI-assistant entry is deliberately `hidden sm:inline-flex` and a
+  focused test treats that as a product contract. This change must not expose
+  it on mobile.
+- Width alone was not sufficient for the accepted 844x390 landscape viewport.
+  The desktop shell left only about 83px for its body, so a max-height 620px
+  compact mode is required while preserving the under-640 full-screen boundary.
+- The save editor's flex section originally shrank below its children's natural
+  height. Expanding the inline details at 320x568 exposed an optimization-card
+  overlap that class-only tests did not catch; compact/mobile save content now
+  uses natural height inside the body scroller.
+- Coarse-pointer emulation exposed a 40px nickname input at 844x390 even after
+  its font reached 16px. Dialog-scoped input/select minimum heights now protect
+  touch devices without changing fine-pointer desktop density.
+
+## Decision Log
+
+- Continue using `src/components/ui/Dialog.tsx` so fullscreen portal routing,
+  focus trapping, and browser-fullscreen behavior remain centralized.
+- Use `100dvh` and safe-area padding before considering any
+  `window.visualViewport` adjustment. A dialog-scoped viewport variable is
+  allowed only if iPhone validation still demonstrates occlusion.
+- Collection owns scrolling inside the conversation/MarkdownFlow region. Save,
+  loading, error, and confirmation states own scrolling in the dialog body.
+- Render information usage as an in-flow mobile `<details>` and retain the
+  existing desktop footer popover. Render the mobile interactive-collection
+  action beside the save heading while retaining the desktop footer action.
+- Use a max-height 620px compact composition for short landscape windows:
+  inline secondary controls replace desktop footer controls, header/body
+  spacing tightens, and footer actions stay on one row.
+- Apply the mobile 16px/44px guarantees again for `any-pointer: coarse` above
+  the width breakpoint so a rotated phone does not inherit fine-pointer desktop
+  sizing.
+- Do not change copy, i18n keys, APIs, persistence, state transitions, events,
+  dependencies, or the mobile visibility of the AI-assistant entry.
+
+## Outcomes & Retrospective
+
+The dialog now fills the dynamic viewport below 640px with safe-area-aware
+header, body, footer, and close-button spacing. Collection keeps scrolling in
+MarkdownFlow; save and confirmation scroll in the dialog body. Mobile and
+short-landscape footers contain only the phase exit and primary actions, while
+the information explanation and interactive-collection action live in the
+active body. The centered desktop Dialog, footer popover, workflow, copy, APIs,
+analytics, and hidden mobile AI-assistant entry are unchanged.
+
+Focused Jest passed 99 tests across the three touched component suites. The
+complete frontend run passed 178 suites and 1564 tests. TypeScript, ESLint,
+changed-file Prettier, `git diff --check`, architecture boundaries, repository
+harness, dev-tools, and lefthook also passed; existing repository lint and React
+test warnings remained non-failing.
+
+Local Chromium measurements using the synchronized real component and mocked
+local API responses produced no horizontal overflow:
+
+- 390x844 Chinese save, collection-ready, and confirmation: full 390x844 shell,
+  69px footer, 678px body, 16px inputs, and no visible target under 44px.
+- 320x568 French: 81px footer and 306px body; expanded information details stay
+  in the body scroller with zero overlap against the optimization card.
+- 844x390 landscape: 69px footer and at least 179px body. Coarse-pointer
+  emulation computes 16px input text, a 44px nickname input, and no undersized
+  visible controls.
+- 390x844 Arabic renders with `dir=rtl`, logical alignment, and no overflow.
+  1280x720 retains the 900px centered desktop Dialog, desktop footer popover,
+  and 14px desktop inputs.
+
+Before/after evidence is under `output/playwright/mobile-personalization/`.
+This host has no `simctl`, no Android emulator, and no connected `adb` device,
+so iPhone Safari and Android Chrome soft-keyboard behavior remains explicitly
+unverified. Chromium focus checks confirmed the 16px sizing and focus-in-view
+path, but are not represented as device-keyboard verification. Because no
+iPhone occlusion could be reproduced, the staged `visualViewport` workaround
+was not added.
+
+## Context and Orientation
+
+- Dialog shell and phase footer:
+  `src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx`
+- Phase views and information usage control:
+  `src/cook-web/src/components/profile-onboarding/LearnerProfileDialogViews.tsx`
+- MarkdownFlow collection region:
+  `src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx`
+- Pasted AI answer editor:
+  `src/cook-web/src/components/profile-onboarding/ProfileAssistantAnswersView.tsx`
+- Focused tests live beside those components.
+
+## Plan of Work
+
+First reshape only the responsive shell and view composition. Then codify the
+responsive contracts in Jest without viewport-dependent JavaScript. After the
+focused suite passes, run the broader frontend and repository checks. Finally,
+exercise the real synchronized component in local browsers at the required
+locales, directions, and viewports and measure footer/body geometry.
+
+## Concrete Steps
+
+1. Remove the decorative handle and make the mobile DialogContent fill the
+   dynamic viewport with no border or radius. Apply physical safe-area padding
+   to header, body, and footer; restore the current desktop dimensions at `sm`.
+2. Make body overflow conditional on the active phase and keep header/footer
+   outside the scroll owner.
+3. Add inline and popover variants for information usage. Place the inline
+   variant inside each phase's primary mobile scroller and hide the footer
+   popover below `sm`.
+4. Add a mobile save-view slot for interactive collection and keep the desktop
+   copy in the footer. Compress each mobile footer to its exit and primary
+   action only.
+5. Enforce at least 16px text on mobile inputs and at least 44px touch targets.
+   On focus, scroll form controls to the nearest visible position inside their
+   existing phase scroller.
+6. Update focused tests, then run the validation commands and browser geometry
+   checks listed below.
+
+## Validation and Acceptance
+
+- At 390x844, Chinese collection, save, and confirmation states use a true
+  full-screen shell with fixed header/footer and no horizontal overflow.
+- At 320x568 in French, inline information details stay in flow; footer height
+  is at most 112px and visible body height is at least 200px.
+- At 844x390, footer height is at most 96px and visible body height is at least
+  140px.
+- At 390x844 in Arabic, logical alignment and controls remain within the visual
+  viewport. At 1280x720, the centered desktop Dialog and footer popover remain.
+- Mobile nickname, profile, assistant-answer, and MarkdownFlow form controls
+  compute to at least 16px. Mobile action targets are at least 44 by 44px.
+- Blocking/dismissible exits, save, review, discard/replace confirmations,
+  focus restoration, and mobile AI-assistant hiding retain existing behavior.
+- Run focused Jest, full frontend regression, type-check, ESLint, Prettier,
+  architecture boundaries, repository harness, dev-tools, and lefthook.
+- iPhone Safari/iOS Simulator and Android Chrome should be used to focus every
+  input and verify that the keyboard and home indicator do not cover the caret
+  or actions. If those environments are unavailable, do not represent Chromium
+  emulation as equivalent verification.
+
+## Idempotence and Recovery
+
+The change has no schema, API, dependency, or persisted-data mutation. Tests,
+formatters, local servers, and screenshot capture are safe to rerun. If a
+responsive class causes a regression, revert only the affected view or slot;
+do not change the shared Dialog portal or global viewport metadata.
+
+## Interfaces and Dependencies
+
+- No public component contract or backend interface changes.
+- Internal view props may add an optional in-scroll content slot, an
+  information-control presentation variant, and the mobile secondary action.
+- No new package is required. Radix Dialog, existing Button/Input/Textarea
+  primitives, Tailwind responsive utilities, and current i18n keys are reused.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -40,6 +40,7 @@ Active and completed ExecPlans live here. The structure and required sections ar
 - [Learner Profile Dialog](./completed/learner-profile-dialog-redesign.md)
 - [Learner Profile Foundation](./completed/learner-profile-foundation.md)
 - [MarkdownFlow Scroll Controls](./completed/markdown-flow-scroll-controls.md)
+- [Mobile Learner Personalization Dialog](./completed/mobile-personalization-dialog.md)
 - [Operator Course B Optimization](./completed/operator-course-b-optimization.md)
 - [Operator Course Detail Tab Splitting](./completed/operator-course-detail-tab-splitting.md)
 - [Operator User Detail Page Slimming](./completed/operator-user-detail-page-slimming.md)

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -53,6 +53,7 @@
 | `docs/exec-plans/completed/learner-profile-dialog-redesign.md` | Learner Profile Dialog | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/learner-profile-foundation.md` | Learner Profile Foundation | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/markdown-flow-scroll-controls.md` | MarkdownFlow Scroll Controls | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
+| `docs/exec-plans/completed/mobile-personalization-dialog.md` | Mobile Learner Personalization Dialog | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/operator-course-b-optimization.md` | Operator Course B Optimization | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/operator-course-detail-tab-splitting.md` | Operator Course Detail Tab Splitting | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/operator-user-detail-page-slimming.md` | Operator User Detail Page Slimming | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -10,7 +10,7 @@ This generated report summarizes the repository harness control plane.
 - Product specs: `10`
 - References: `3`
 - Active ExecPlans: `19`
-- Completed ExecPlans: `23`
+- Completed ExecPlans: `24`
 
 ## Boundary Baseline
 

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
@@ -5,6 +5,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react';
 import {
   completeGuidedProfileOnboarding,
@@ -178,6 +179,7 @@ function MockProfileOnboardingConversation(
         {RETRY_CONVERSATION_LABEL}
       </button>
       {props.errorMessage ? <p>{props.errorMessage}</p> : null}
+      {props.questionScrollFooter}
     </div>
   );
 }
@@ -308,10 +310,13 @@ const saveButton = () =>
   screen.getByRole('button', {
     name: 'module.profileOnboarding.dialog.saveChanges',
   });
-const informationUsageControl = () =>
-  screen.getByTestId('learner-profile-information-usage');
-const informationUsageSummary = () =>
-  informationUsageControl().querySelector('summary') as HTMLElement;
+const informationUsageControl = (variant: 'inline' | 'popover') =>
+  screen.getByTestId(`learner-profile-information-usage-${variant}`);
+const informationUsageSummary = (variant: 'inline' | 'popover') =>
+  informationUsageControl(variant).querySelector('summary') as HTMLElement;
+const interactiveCollectionButton = (
+  placement: 'mobile' | 'desktop' = 'mobile',
+) => screen.getByTestId(`learner-profile-interactive-collection-${placement}`);
 const waitForCollectionSession = async (sessionId = SESSION_ID) => {
   await waitFor(() =>
     expect(screen.getByTestId('mock-collection-session')).toHaveTextContent(
@@ -398,42 +403,125 @@ describe('LearnerProfileDialog', () => {
       'focus-within:outline-none',
       'focus-within:ring-0',
     );
+    expect(screen.getByTestId('learner-profile-dialog-content')).toHaveClass(
+      'inset-0',
+      'h-dvh',
+      'w-screen',
+      'rounded-none',
+      'border-0',
+      'sm:inset-auto',
+      'sm:left-1/2',
+      'sm:top-1/2',
+      'sm:h-[min(88dvh,760px)]',
+      'sm:w-[calc(100vw-48px)]',
+      'sm:max-w-[900px]',
+      'sm:-translate-x-1/2',
+      'sm:-translate-y-1/2',
+      'sm:rounded-2xl',
+      'sm:border',
+      'max-sm:[&_input]:min-h-11',
+      'max-sm:[&_select]:min-h-11',
+      'sm:any-pointer-coarse:[&_button]:min-h-11',
+      'sm:any-pointer-coarse:[&_button]:min-w-11',
+      'sm:any-pointer-coarse:[&_input]:min-h-11',
+      'sm:any-pointer-coarse:[&_input]:text-base',
+      'sm:any-pointer-coarse:[&_select]:min-h-11',
+      'sm:any-pointer-coarse:[&_select]:text-base',
+      'sm:any-pointer-coarse:[&_textarea]:text-base',
+    );
+    expect(
+      screen.queryByTestId('learner-profile-mobile-handle'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen
+        .getByTestId('learner-profile-dialog-content')
+        .querySelector('header'),
+    ).toHaveClass(
+      'pl-[max(1rem,env(safe-area-inset-left,0px))]',
+      'pr-[max(1rem,env(safe-area-inset-right,0px))]',
+      'pt-[max(0.75rem,env(safe-area-inset-top,0px))]',
+      '[@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]',
+    );
+    expect(
+      screen.getByText('module.profileOnboarding.dialog.unifiedTitle'),
+    ).toHaveClass(
+      '[@media(max-height:620px)]:text-xl',
+      '[@media(max-height:620px)]:leading-7',
+    );
+    expect(
+      screen.getByText('module.profileOnboarding.dialog.unifiedDescription'),
+    ).toHaveClass(
+      '[@media(max-height:620px)]:text-sm',
+      '[@media(max-height:620px)]:leading-5',
+    );
     expect(screen.getByTestId('learner-profile-dialog-body')).toHaveClass(
-      'overflow-y-auto',
+      'overflow-hidden',
       'bg-muted/25',
+      '[@media(max-height:620px)]:pb-[calc(var(--learner-profile-footer-height,80px)+0.5rem)]',
+      '[@media(max-height:620px)]:pt-[calc(var(--learner-profile-header-height,80px)+0.5rem)]',
+    );
+    expect(screen.getByTestId('learner-profile-dialog-body')).not.toHaveClass(
+      'overflow-y-auto',
     );
     expect(
       screen.getByTestId('mock-profile-onboarding-conversation').parentElement,
-    ).toHaveClass('min-h-40', '[@media(max-height:620px)]:min-h-32');
+    ).toHaveClass('min-h-0', 'flex-1');
+    expect(
+      screen.getByTestId('mock-profile-onboarding-conversation').parentElement,
+    ).not.toHaveClass('min-h-40');
     expect(screen.getByTestId('learner-profile-dialog-footer')).toHaveClass(
       'absolute',
       'bottom-0',
       'z-10',
+      'pb-[max(0.75rem,env(safe-area-inset-bottom,0px))]',
+      '[@media(max-height:620px)]:flex-nowrap',
+      '[@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))]',
+      '[@media(max-height:620px)]:pt-3',
       'shadow-[0_-10px_30px_-24px_rgba(15,23,42,0.6)]',
     );
+    const inlineInformation = informationUsageControl('inline');
+    const popoverInformation = informationUsageControl('popover');
     expect(
       screen.getByTestId('learner-profile-dialog-footer'),
-    ).toContainElement(informationUsageControl());
-    expect(informationUsageControl()).not.toHaveAttribute('open');
-    fireEvent.click(informationUsageSummary());
-    expect(informationUsageControl()).toHaveAttribute('open');
+    ).toContainElement(popoverInformation);
+    expect(popoverInformation).toHaveClass(
+      'hidden',
+      'sm:block',
+      '[@media(max-height:620px)]:hidden',
+    );
     expect(
-      await screen.findByText(
+      screen.getByTestId('mock-profile-onboarding-conversation'),
+    ).toContainElement(inlineInformation);
+    expect(inlineInformation).toHaveClass(
+      'sm:hidden',
+      '[@media(max-height:620px)]:block',
+    );
+    expect(inlineInformation).not.toHaveAttribute('open');
+    expect(inlineInformation.querySelector('[role="note"]')).not.toHaveClass(
+      'absolute',
+    );
+    expect(popoverInformation.querySelector('[role="note"]')).toHaveClass(
+      'absolute',
+    );
+    fireEvent.click(informationUsageSummary('inline'));
+    expect(inlineInformation).toHaveAttribute('open');
+    expect(
+      await within(inlineInformation).findByText(
         'module.profileOnboarding.dialog.informationUsagePurpose',
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
+      within(inlineInformation).getByText(
         'module.profileOnboarding.dialog.informationUsageSensitive',
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
+      within(inlineInformation).getByText(
         'module.profileOnboarding.dialog.informationUsageEditable',
       ),
     ).toBeInTheDocument();
-    fireEvent.click(informationUsageSummary());
-    expect(informationUsageControl()).not.toHaveAttribute('open');
+    fireEvent.click(informationUsageSummary('inline'));
+    expect(inlineInformation).not.toHaveAttribute('open');
     expect(
       screen.queryByText('module.profileOnboarding.steps.collect'),
     ).not.toBeInTheDocument();
@@ -483,11 +571,7 @@ describe('LearnerProfileDialog', () => {
     expect(
       screen.queryByTestId('mock-profile-onboarding-conversation'),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'module.profileOnboarding.dialog.interactiveCollection',
-      }),
-    ).toBeInTheDocument();
+    expect(interactiveCollectionButton()).toBeInTheDocument();
     expect(mockCreateProfileOnboardingSession).not.toHaveBeenCalled();
   });
 
@@ -639,8 +723,34 @@ describe('LearnerProfileDialog', () => {
       'flex-1',
       'flex-col',
     );
-    expect(profileInput().parentElement).toHaveClass('min-h-40', 'flex-1');
-    expect(profileInput()).toHaveClass('min-h-32', 'flex-1', 'resize-none');
+    expect(profileInput().parentElement).toHaveClass(
+      'min-h-48',
+      'flex-1',
+      'sm:min-h-40',
+      '[@media(max-height:620px)]:min-h-40',
+    );
+    expect(nicknameInput()).toHaveClass(
+      'h-11',
+      'text-base',
+      'sm:h-10',
+      'sm:text-sm',
+    );
+    expect(profileInput()).toHaveClass(
+      'min-h-40',
+      'flex-1',
+      'resize-none',
+      'text-base',
+      'sm:min-h-32',
+      'sm:text-sm',
+      '[@media(max-height:620px)]:min-h-32',
+    );
+    expect(profileInput().closest('section')).toHaveClass(
+      'min-h-60',
+      'flex-1',
+      'sm:min-h-52',
+      '[@media(max-height:620px)]:min-h-52',
+      '[@media(max-height:620px)]:flex-none',
+    );
     expect(
       screen.queryByText('module.profileOnboarding.steps.collect'),
     ).not.toBeInTheDocument();
@@ -662,21 +772,66 @@ describe('LearnerProfileDialog', () => {
     expect(
       screen.queryByTestId('learner-profile-reassurance'),
     ).not.toBeInTheDocument();
-    const interactiveCollectionButton = screen.getByRole('button', {
-      name: 'module.profileOnboarding.dialog.interactiveCollection',
-    });
+    const mobileCollectionButton = interactiveCollectionButton('mobile');
+    const desktopCollectionButton = interactiveCollectionButton('desktop');
     const leftActions = screen.getByTestId(
       'learner-profile-dialog-left-actions',
     );
-    expect(leftActions).toHaveClass('mr-auto', 'justify-start');
-    expect(leftActions).toContainElement(informationUsageControl());
-    expect(leftActions).toContainElement(interactiveCollectionButton);
+    expect(leftActions).toHaveClass('me-auto', 'justify-start');
+    expect(leftActions).toContainElement(informationUsageControl('popover'));
+    expect(leftActions).toContainElement(desktopCollectionButton);
+    expect(desktopCollectionButton).toHaveClass(
+      'hidden',
+      'sm:inline-flex',
+      '[@media(max-height:620px)]:hidden',
+    );
+    expect(screen.getByTestId('learner-profile-save-view')).toContainElement(
+      informationUsageControl('inline'),
+    );
+    expect(screen.getByTestId('learner-profile-save-view')).toContainElement(
+      mobileCollectionButton,
+    );
+    expect(screen.getByTestId('learner-profile-save-heading-row')).toHaveClass(
+      'flex',
+      'items-center',
+      'justify-between',
+      'sm:block',
+      '[@media(max-height:620px)]:flex',
+    );
+    expect(
+      screen.getByTestId('learner-profile-save-heading-row'),
+    ).toContainElement(mobileCollectionButton);
+    expect(mobileCollectionButton).toHaveClass(
+      'min-h-11',
+      'w-fit',
+      'max-w-[48%]',
+      'shrink-0',
+      'justify-start',
+      'sm:hidden',
+      '[@media(max-height:620px)]:inline-flex',
+    );
+    expect(mobileCollectionButton).not.toHaveClass(
+      'w-full',
+      'border-input',
+      'bg-background',
+    );
+    expect(mobileCollectionButton).toHaveAccessibleName(
+      'module.profileOnboarding.dialog.interactiveCollection',
+    );
+    expect(mobileCollectionButton.querySelector('svg')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+    expect(informationUsageControl('inline')).toHaveClass(
+      '[@media(max-height:620px)]:block',
+    );
 
     const saveActions = screen.getByTestId(
       'learner-profile-dialog-save-actions',
     );
-    expect(saveActions).toHaveClass('w-full', 'sm:w-auto');
-    expect(saveActions).not.toContainElement(interactiveCollectionButton);
+    expect(saveActions).toHaveClass('flex-1', 'sm:w-auto', 'sm:flex-none');
+    expect(saveActions).not.toContainElement(mobileCollectionButton);
+    expect(saveActions).not.toContainElement(desktopCollectionButton);
     expect(saveActions).toContainElement(
       screen.getByRole('button', {
         name: 'module.profileOnboarding.dialog.cancel',
@@ -703,26 +858,77 @@ describe('LearnerProfileDialog', () => {
     ).toBeInTheDocument();
   });
 
+  test('scrolls a focused form control into the nearest visible position', async () => {
+    const scrollIntoView = jest.fn();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      renderDialog();
+      await screen.findByDisplayValue(existingProfile.learner_profile);
+      fireEvent.focus(nicknameInput());
+
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: 'nearest',
+        inline: 'nearest',
+      });
+    } finally {
+      Object.defineProperty(window, 'requestAnimationFrame', {
+        configurable: true,
+        value: originalRequestAnimationFrame,
+      });
+      if (originalScrollIntoView) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+          configurable: true,
+          value: originalScrollIntoView,
+        });
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView');
+      }
+    }
+  });
+
   test('offers review after an existing profile starts collection from the menu flow', async () => {
     renderDialog({ autoStartCollection: false });
 
     await screen.findByDisplayValue(existingProfile.learner_profile);
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'module.profileOnboarding.dialog.interactiveCollection',
-      }),
-    );
+    fireEvent.click(interactiveCollectionButton());
     await waitForCollectionSession();
     expect(mockCreateProfileOnboardingSession).toHaveBeenCalledWith(
       'en-US',
       'settings',
+    );
+    expect(
+      screen.getByTestId('learner-profile-dialog-footer'),
+    ).toContainElement(
+      screen.getByRole('button', {
+        name: 'module.profileOnboarding.dialog.cancelResearch',
+      }),
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'finish collection' }));
     const reviewButton = await screen.findByRole('button', {
       name: 'module.profileOnboarding.guided.reviewCollection',
     });
+    const compactCancelButton = screen.getByRole('button', {
+      name: 'module.profileOnboarding.dialog.cancelResearch',
+    });
     expect(reviewButton).toHaveFocus();
+    expect(compactCancelButton).toHaveClass(
+      'sm:hidden',
+      '[@media(max-height:620px)]:inline-flex',
+    );
+    expect(
+      screen.getByTestId('learner-profile-dialog-footer'),
+    ).toContainElement(compactCancelButton);
 
     fireEvent.click(reviewButton);
     expect(
@@ -750,11 +956,7 @@ describe('LearnerProfileDialog', () => {
     const onClose = jest.fn();
     const { rerender, props } = renderDialog({ onClose });
     await screen.findByDisplayValue(existingProfile.learner_profile);
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'module.profileOnboarding.dialog.interactiveCollection',
-      }),
-    );
+    fireEvent.click(interactiveCollectionButton());
     await waitForCollectionSession();
     act(() =>
       mockConversationControls
@@ -788,11 +990,7 @@ describe('LearnerProfileDialog', () => {
       />,
     );
     await screen.findByDisplayValue(existingProfile.learner_profile);
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'module.profileOnboarding.dialog.interactiveCollection',
-      }),
-    );
+    fireEvent.click(interactiveCollectionButton());
     await waitForCollectionSession();
     expect(mockConversationControls.at(-1)?.assistantDraft()).toBe(
       'Keep this paste for later',
@@ -869,7 +1067,7 @@ describe('LearnerProfileDialog', () => {
     renderDialog({ exitPolicy: 'blocking', presentation: 'blocking' });
     await waitForCollectionSession();
     expect(screen.getByTestId('learner-profile-dialog-body')).toHaveClass(
-      'overflow-y-auto',
+      'overflow-hidden',
     );
     fireEvent.click(screen.getByRole('button', { name: 'finish collection' }));
 
@@ -877,7 +1075,7 @@ describe('LearnerProfileDialog', () => {
       await screen.findByText(
         'module.profileOnboarding.guided.collectionComplete',
       ),
-    ).toBeInTheDocument();
+    ).toHaveClass('shrink-0');
     const reviewButton = screen.getByRole('button', {
       name: 'module.profileOnboarding.guided.reviewCollection',
     });
@@ -893,6 +1091,9 @@ describe('LearnerProfileDialog', () => {
     expect(
       await screen.findByDisplayValue('Collection draft'),
     ).toBeInTheDocument();
+    expect(screen.getByTestId('learner-profile-dialog-body')).toHaveClass(
+      'overflow-y-auto',
+    );
     await waitFor(() =>
       expect(
         screen.getByText('module.profileOnboarding.dialog.confirmTitle'),
@@ -900,7 +1101,16 @@ describe('LearnerProfileDialog', () => {
     );
     expect(
       screen.getByTestId('learner-profile-dialog-footer'),
-    ).toContainElement(informationUsageControl());
+    ).toContainElement(informationUsageControl('popover'));
+    expect(informationUsageControl('popover')).toHaveClass(
+      '[@media(max-height:620px)]:hidden',
+    );
+    expect(screen.getByTestId('learner-profile-dialog-body')).toContainElement(
+      informationUsageControl('inline'),
+    );
+    expect(informationUsageControl('inline')).toHaveClass(
+      '[@media(max-height:620px)]:block',
+    );
     expect(
       screen.getByRole('button', {
         name: 'module.profileOnboarding.dialog.optimize',
@@ -1239,11 +1449,7 @@ describe('LearnerProfileDialog', () => {
     await screen.findByDisplayValue(existingProfile.learner_profile);
     fireEvent.change(profileInput(), { target: { value: 'Unsaved edit' } });
 
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'module.profileOnboarding.dialog.interactiveCollection',
-      }),
-    );
+    fireEvent.click(interactiveCollectionButton());
     expect(
       await screen.findByText(
         'module.profileOnboarding.dialog.replaceResearchTitle',
@@ -1260,7 +1466,40 @@ describe('LearnerProfileDialog', () => {
     expect(mockCreateProfileOnboardingSession).not.toHaveBeenCalled();
     expect(
       screen.getByTestId('learner-profile-dialog-footer'),
-    ).toContainElement(informationUsageControl());
+    ).toContainElement(informationUsageControl('popover'));
+    expect(informationUsageControl('popover').parentElement).toHaveClass(
+      '[@media(max-height:620px)]:hidden',
+    );
+    expect(screen.getByTestId('learner-profile-dialog-body')).toContainElement(
+      informationUsageControl('inline'),
+    );
+    expect(informationUsageControl('inline')).toHaveClass(
+      '[@media(max-height:620px)]:block',
+    );
+    expect(
+      screen.getByTestId('learner-profile-confirmation-replace-collection'),
+    ).toHaveClass(
+      'justify-start',
+      'sm:justify-center',
+      '[@media(max-height:620px)]:justify-start',
+    );
+    expect(screen.getByTestId('learner-profile-dialog-body')).toHaveClass(
+      'overflow-y-auto',
+    );
+    const confirmationActions = screen.getByTestId(
+      'learner-profile-dialog-confirmation-actions',
+    );
+    expect(confirmationActions).toHaveClass('w-full', 'sm:w-auto');
+    expect(confirmationActions).toContainElement(
+      screen.getByRole('button', {
+        name: 'module.profileOnboarding.dialog.keepEditing',
+      }),
+    );
+    expect(confirmationActions).toContainElement(
+      screen.getByRole('button', {
+        name: 'module.profileOnboarding.dialog.replaceResearchConfirm',
+      }),
+    );
     expect(mockTrackEvent).not.toHaveBeenCalledWith(
       PROFILE_ONBOARDING_EVENTS.SETTINGS_RERUN_STARTED,
     );
@@ -1278,11 +1517,7 @@ describe('LearnerProfileDialog', () => {
     );
     expect(mockCreateProfileOnboardingSession).not.toHaveBeenCalled();
 
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'module.profileOnboarding.dialog.interactiveCollection',
-      }),
-    );
+    fireEvent.click(interactiveCollectionButton());
     fireEvent.click(
       screen.getByRole('button', {
         name: 'module.profileOnboarding.dialog.replaceResearchConfirm',
@@ -1311,11 +1546,7 @@ describe('LearnerProfileDialog', () => {
   test('cancels settings research back to the untouched local draft without skip or persistence', async () => {
     renderDialog();
     await screen.findByDisplayValue(existingProfile.learner_profile);
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'module.profileOnboarding.dialog.interactiveCollection',
-      }),
-    );
+    fireEvent.click(interactiveCollectionButton());
     await waitForCollectionSession();
 
     fireEvent.click(
@@ -1348,11 +1579,7 @@ describe('LearnerProfileDialog', () => {
     await continueCollectionToSave();
     await screen.findByDisplayValue('Collection draft');
 
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: 'module.profileOnboarding.dialog.interactiveCollection',
-      }),
-    );
+    fireEvent.click(interactiveCollectionButton());
     fireEvent.click(
       screen.getByRole('button', {
         name: 'module.profileOnboarding.dialog.replaceResearchConfirm',
@@ -1410,9 +1637,7 @@ describe('LearnerProfileDialog', () => {
       'learner-profile-dialog-left-actions',
     );
     expect(leftActions).toContainElement(
-      screen.getByRole('button', {
-        name: 'module.profileOnboarding.dialog.interactiveCollection',
-      }),
+      interactiveCollectionButton('desktop'),
     );
     expect(leftActions).toContainElement(
       screen.getByRole('button', {
@@ -1544,9 +1769,7 @@ describe('LearnerProfileDialog', () => {
       'learner-profile-dialog-left-actions',
     );
     expect(leftActions).toContainElement(
-      screen.getByRole('button', {
-        name: 'module.profileOnboarding.dialog.interactiveCollection',
-      }),
+      interactiveCollectionButton('desktop'),
     );
     expect(leftActions).toContainElement(
       screen.getByRole('button', { name: 'module.profileOnboarding.skip' }),
@@ -1647,6 +1870,42 @@ describe('LearnerProfileDialog', () => {
       await screen.findByText('module.profileOnboarding.dialog.discardTitle'),
     ).toBeInTheDocument();
     expect(onClose).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(
+        screen.getByText('module.profileOnboarding.dialog.discardTitle'),
+      ).toHaveFocus(),
+    );
+    expect(screen.getByTestId('learner-profile-dialog-body')).toHaveClass(
+      'overflow-y-auto',
+    );
+    expect(screen.getByTestId('learner-profile-dialog-body')).toContainElement(
+      informationUsageControl('inline'),
+    );
+    expect(
+      screen.getByTestId('learner-profile-dialog-footer'),
+    ).toContainElement(informationUsageControl('popover'));
+    expect(informationUsageControl('popover').parentElement).toHaveClass(
+      '[@media(max-height:620px)]:hidden',
+    );
+    expect(informationUsageControl('inline')).toHaveClass(
+      '[@media(max-height:620px)]:block',
+    );
+    expect(
+      screen.getByTestId('learner-profile-confirmation-discard'),
+    ).toHaveClass('[@media(max-height:620px)]:justify-start');
+    const confirmationActions = screen.getByTestId(
+      'learner-profile-dialog-confirmation-actions',
+    );
+    expect(confirmationActions).toContainElement(
+      screen.getByRole('button', {
+        name: 'module.profileOnboarding.dialog.keepEditing',
+      }),
+    );
+    expect(confirmationActions).toContainElement(
+      screen.getByRole('button', {
+        name: 'module.profileOnboarding.dialog.discard',
+      }),
+    );
 
     fireEvent.click(
       screen.getByRole('button', {

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
@@ -90,6 +90,30 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
     header: number | null;
     footer: number | null;
   }>({ header: null, footer: null });
+  const collectionOwnsScroll = loaded && !confirmation && phase === 'collect';
+
+  const keepFocusedControlVisible = React.useCallback(
+    (event: React.FocusEvent<HTMLDivElement>) => {
+      const target = event.target;
+      if (
+        !(target instanceof HTMLElement) ||
+        !target.matches('input, textarea, select, [contenteditable="true"]')
+      ) {
+        return;
+      }
+
+      const scrollTargetIntoView = () => {
+        if (!target.isConnected) return;
+        target.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+      };
+      if (typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(scrollTargetIntoView);
+      } else {
+        scrollTargetIntoView();
+      }
+    },
+    [],
+  );
 
   React.useEffect(() => {
     contentScrollRef.current?.scrollTo?.({ top: 0, behavior: 'auto' });
@@ -143,9 +167,11 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
       }}
     >
       <DialogContent
+        data-testid='learner-profile-dialog-content'
         data-phase={phase}
         showClose={false}
         overlayClassName='!bg-slate-950/45 backdrop-blur-[1px]'
+        onFocusCapture={keepFocusedControlVisible}
         onEscapeKeyDown={event => {
           if (exitPolicy === 'blocking') {
             event.preventDefault();
@@ -156,23 +182,17 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
             event.preventDefault();
           }
         }}
-        className='bottom-3 left-3 top-3 flex h-auto max-h-none w-[calc(100vw-24px)] max-w-none translate-x-0 translate-y-0 flex-col gap-0 overflow-hidden rounded-2xl p-0 outline-none focus:outline-none focus-visible:outline-none focus-within:outline-none focus-within:ring-0 focus-within:ring-offset-0 motion-reduce:animate-none motion-reduce:duration-0 sm:bottom-auto sm:left-1/2 sm:top-1/2 sm:h-[min(88dvh,760px)] sm:w-[calc(100vw-48px)] sm:max-w-[900px] sm:-translate-x-1/2 sm:-translate-y-1/2'
+        className='inset-0 flex h-dvh max-h-none w-screen max-w-none translate-x-0 translate-y-0 flex-col gap-0 overflow-hidden rounded-none border-0 p-0 shadow-none outline-none focus:outline-none focus-visible:outline-none focus-within:outline-none focus-within:ring-0 focus-within:ring-offset-0 motion-reduce:animate-none motion-reduce:duration-0 max-sm:[&_button]:min-h-11 max-sm:[&_button]:min-w-11 max-sm:[&_input]:min-h-11 max-sm:[&_input]:text-base max-sm:[&_select]:min-h-11 max-sm:[&_select]:text-base max-sm:[&_textarea]:text-base sm:inset-auto sm:left-1/2 sm:top-1/2 sm:h-[min(88dvh,760px)] sm:w-[calc(100vw-48px)] sm:max-w-[900px] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-2xl sm:border sm:shadow-lg sm:any-pointer-coarse:[&_button]:min-h-11 sm:any-pointer-coarse:[&_button]:min-w-11 sm:any-pointer-coarse:[&_input]:min-h-11 sm:any-pointer-coarse:[&_input]:text-base sm:any-pointer-coarse:[&_select]:min-h-11 sm:any-pointer-coarse:[&_select]:text-base sm:any-pointer-coarse:[&_textarea]:text-base'
       >
-        <div
-          data-testid='learner-profile-mobile-handle'
-          className='mx-auto mt-3 h-1 w-10 shrink-0 rounded-full bg-muted-foreground/35 [@media(max-height:620px)]:hidden sm:hidden'
-          aria-hidden='true'
-        />
-
         <header
           ref={headerRef}
-          className='absolute inset-x-0 top-7 z-10 border-b bg-background/95 px-5 pb-4 pt-5 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.6)] backdrop-blur-sm [@media(max-height:620px)]:py-3 sm:top-0 sm:px-8 sm:pb-5 sm:pt-6'
+          className='absolute inset-x-0 top-0 z-10 border-b bg-background/95 pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] shadow-[0_10px_30px_-24px_rgba(15,23,42,0.6)] backdrop-blur-sm sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]'
         >
-          <DialogHeader className='w-full space-y-2 pr-12 text-left [@media(max-height:620px)]:space-y-1'>
-            <DialogTitle className='text-2xl font-bold leading-8 tracking-tight [@media(max-height:620px)]:text-xl [@media(max-height:620px)]:leading-7 sm:text-[28px] sm:leading-9'>
+          <DialogHeader className='w-full space-y-1 pr-12 text-start sm:space-y-2 [@media(max-height:620px)]:space-y-1'>
+            <DialogTitle className='text-xl font-bold leading-7 tracking-tight sm:text-[28px] sm:leading-9 [@media(max-height:620px)]:text-xl [@media(max-height:620px)]:leading-7'>
               {t('module.profileOnboarding.dialog.unifiedTitle')}
             </DialogTitle>
-            <DialogDescription className='max-w-2xl text-left text-sm leading-6 [@media(max-height:620px)]:text-xs [@media(max-height:620px)]:leading-5 sm:text-base'>
+            <DialogDescription className='max-w-2xl text-start text-sm leading-5 sm:text-base sm:leading-6 [@media(max-height:620px)]:text-sm [@media(max-height:620px)]:leading-5'>
               {t('module.profileOnboarding.dialog.unifiedDescription')}
             </DialogDescription>
           </DialogHeader>
@@ -181,7 +201,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
               type='button'
               size='icon'
               variant='ghost'
-              className='absolute right-3 top-3 size-11 rounded-full sm:right-4 sm:top-4'
+              className='absolute right-[max(0.75rem,env(safe-area-inset-right,0px))] top-[max(0.75rem,env(safe-area-inset-top,0px))] size-11 rounded-full sm:right-4 sm:top-4'
               disabled={saving || dismissing || deferring}
               aria-label={t('module.profileOnboarding.dialog.close')}
               onClick={requestClose}
@@ -194,7 +214,10 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
         <div
           ref={contentScrollRef}
           data-testid='learner-profile-dialog-body'
-          className='relative z-0 flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain bg-muted/25 px-5 pb-[calc(var(--learner-profile-footer-height,144px)+1.25rem)] pt-[calc(var(--learner-profile-header-height,116px)+1.25rem)] [scrollbar-gutter:stable] [@media(max-height:620px)]:pb-[calc(var(--learner-profile-footer-height,144px)+0.75rem)] [@media(max-height:620px)]:pt-[calc(var(--learner-profile-header-height,96px)+2.5rem)] sm:px-8 sm:pb-[calc(var(--learner-profile-footer-height,76px)+1.5rem)] sm:pt-[calc(var(--learner-profile-header-height,116px)+1.5rem)]'
+          className={cn(
+            'relative z-0 flex min-h-0 flex-1 flex-col overscroll-contain bg-muted/25 pb-[calc(var(--learner-profile-footer-height,80px)+1rem)] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[calc(var(--learner-profile-header-height,96px)+1rem)] [scrollbar-gutter:stable] sm:px-8 sm:pb-[calc(var(--learner-profile-footer-height,76px)+1.5rem)] sm:pt-[calc(var(--learner-profile-header-height,116px)+1.5rem)] [@media(max-height:620px)]:pb-[calc(var(--learner-profile-footer-height,80px)+0.5rem)] [@media(max-height:620px)]:pt-[calc(var(--learner-profile-header-height,80px)+0.5rem)]',
+            collectionOwnsScroll ? 'overflow-hidden' : 'overflow-y-auto',
+          )}
           style={
             {
               '--learner-profile-header-height': chromeHeights.header
@@ -266,6 +289,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
               optimizationDescription={optimizationDescription}
               optimizationOriginal={optimizationOriginal}
               optimizeDisabled={optimizeDisabled}
+              guidedAvailable={guidedAvailable}
               onNicknameChange={value => {
                 setNickname(value);
                 setError('');
@@ -277,6 +301,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
               }}
               onUndoOptimization={undoOptimization}
               onOptimize={optimizeProfile}
+              onRequestCollection={requestCollection}
             />
           )}
 
@@ -293,18 +318,21 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
         <footer
           data-testid='learner-profile-dialog-footer'
           ref={footerRef}
-          className='absolute inset-x-0 bottom-0 z-10 flex flex-wrap items-center gap-2.5 border-t bg-background/95 px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-4 shadow-[0_-10px_30px_-24px_rgba(15,23,42,0.6)] backdrop-blur-sm sm:justify-end sm:gap-3 sm:px-8 sm:py-4'
+          className='absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 border-t bg-background/95 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 shadow-[0_-10px_30px_-24px_rgba(15,23,42,0.6)] backdrop-blur-sm sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3'
         >
           {confirmation ? (
             <>
-              <div className='mr-auto flex w-full min-w-0 items-center justify-start sm:w-auto'>
-                <ProfileInformationUsageControl />
+              <div className='hidden min-w-0 items-center justify-start sm:me-auto sm:flex sm:w-auto [@media(max-height:620px)]:hidden'>
+                <ProfileInformationUsageControl variant='popover' />
               </div>
-              <div className='ml-auto flex w-full min-w-0 items-center justify-end gap-2.5 sm:w-auto sm:gap-3'>
+              <div
+                data-testid='learner-profile-dialog-confirmation-actions'
+                className='ms-auto flex w-full min-w-0 items-center justify-end gap-2 sm:w-auto sm:gap-3'
+              >
                 <Button
                   type='button'
                   variant='outline'
-                  className='min-h-11 min-w-0 flex-1 !whitespace-normal sm:flex-none'
+                  className='h-auto min-h-11 min-w-0 flex-1 !whitespace-normal sm:flex-none'
                   onClick={() => setConfirmation(null)}
                 >
                   {t('module.profileOnboarding.dialog.keepEditing')}
@@ -312,7 +340,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
                 <Button
                   type='button'
                   className={cn(
-                    'min-h-11 min-w-0 flex-[1.4] !whitespace-normal sm:flex-none',
+                    'h-auto min-h-11 min-w-0 flex-[1.4] !whitespace-normal sm:flex-none',
                     confirmation === 'discard' &&
                       'bg-destructive text-destructive-foreground hover:bg-destructive/90',
                   )}
@@ -330,14 +358,18 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
             <>
               <div
                 data-testid='learner-profile-dialog-left-actions'
-                className='mr-auto flex w-full min-w-0 flex-wrap items-center justify-start gap-2.5 sm:w-auto sm:gap-3'
+                className='me-auto flex min-w-0 flex-wrap items-center justify-start gap-2 sm:w-auto sm:gap-3'
               >
-                <ProfileInformationUsageControl />
+                <ProfileInformationUsageControl
+                  variant='popover'
+                  className='hidden sm:block [@media(max-height:620px)]:hidden'
+                />
                 {guidedAvailable ? (
                   <Button
+                    data-testid='learner-profile-interactive-collection-desktop'
                     type='button'
                     variant='outline'
-                    className='min-h-11 min-w-0 !whitespace-normal'
+                    className='hidden min-h-11 min-w-0 !whitespace-normal sm:inline-flex [@media(max-height:620px)]:hidden'
                     disabled={busy || optimizing}
                     onClick={requestCollection}
                   >
@@ -348,7 +380,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
                   <Button
                     type='button'
                     variant='ghost'
-                    className='min-h-11 px-3 text-muted-foreground !whitespace-normal'
+                    className='h-auto min-h-11 px-3 text-muted-foreground !whitespace-normal'
                     disabled={
                       !onDefer ||
                       saving ||
@@ -366,13 +398,13 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
               </div>
               <div
                 data-testid='learner-profile-dialog-save-actions'
-                className='ml-auto flex w-full min-w-0 items-center justify-end gap-2.5 sm:w-auto sm:gap-3'
+                className='ms-auto flex min-w-0 flex-1 items-center justify-end gap-2 sm:w-auto sm:flex-none sm:gap-3'
               >
                 {exitPolicy === 'dismissible' ? (
                   <Button
                     type='button'
                     variant='outline'
-                    className='min-h-11 min-w-0 flex-1 !whitespace-normal sm:flex-none'
+                    className='h-auto min-h-11 min-w-0 flex-1 !whitespace-normal sm:flex-none'
                     disabled={busy}
                     onClick={requestClose}
                   >
@@ -381,7 +413,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
                 ) : null}
                 <Button
                   type='button'
-                  className='min-h-11 min-w-0 flex-[1.4] !whitespace-normal sm:flex-none'
+                  className='h-auto min-h-11 min-w-0 flex-[1.4] !whitespace-normal sm:flex-none'
                   disabled={!canSave}
                   onClick={() => void saveProfile()}
                 >
@@ -395,14 +427,17 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
             <>
               <div
                 data-testid='learner-profile-dialog-left-actions'
-                className='mr-auto flex w-full min-w-0 flex-wrap items-center justify-start gap-2.5 sm:w-auto sm:gap-3'
+                className='me-auto flex min-w-0 flex-wrap items-center justify-start gap-2 sm:w-auto sm:gap-3'
               >
-                <ProfileInformationUsageControl />
+                <ProfileInformationUsageControl
+                  variant='popover'
+                  className='hidden sm:block [@media(max-height:620px)]:hidden'
+                />
                 {exitPolicy === 'blocking' ? (
                   <Button
                     type='button'
                     variant='ghost'
-                    className='min-h-11 px-3 text-muted-foreground !whitespace-normal'
+                    className='h-auto min-h-11 px-3 text-muted-foreground !whitespace-normal'
                     disabled={
                       !onDefer ||
                       saving ||
@@ -417,12 +452,23 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
                       : t('module.profileOnboarding.skip')}
                   </Button>
                 ) : null}
+                {exitPolicy === 'dismissible' && collectionReady ? (
+                  <Button
+                    type='button'
+                    variant='outline'
+                    className='h-auto min-h-11 min-w-0 flex-1 !whitespace-normal sm:hidden [@media(max-height:620px)]:inline-flex'
+                    disabled={busy}
+                    onClick={cancelCollection}
+                  >
+                    {t('module.profileOnboarding.dialog.cancelResearch')}
+                  </Button>
+                ) : null}
               </div>
               {collectionReady ? (
                 <Button
                   ref={collectionContinueButtonRef}
                   type='button'
-                  className='ml-auto min-h-11 min-w-0 flex-1 !whitespace-normal sm:flex-none'
+                  className='ms-auto h-auto min-h-11 min-w-0 flex-1 !whitespace-normal sm:flex-none'
                   disabled={busy}
                   onClick={continueToSave}
                 >
@@ -432,7 +478,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
                 <Button
                   type='button'
                   variant='outline'
-                  className='ml-auto min-h-11 min-w-0 flex-1 !whitespace-normal sm:flex-none'
+                  className='ms-auto h-auto min-h-11 min-w-0 flex-1 !whitespace-normal sm:flex-none'
                   disabled={busy}
                   onClick={cancelCollection}
                 >

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialogViews.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialogViews.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { CircleHelp, Loader2, Sparkles } from 'lucide-react';
+import {
+  CircleHelp,
+  Loader2,
+  MessageCircleQuestion,
+  Sparkles,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button, buttonVariants } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
@@ -29,10 +34,12 @@ type LearnerProfileSaveViewProps = {
   optimizationDescription: string;
   optimizationOriginal: string | null;
   optimizeDisabled: boolean;
+  guidedAvailable: boolean;
   onNicknameChange: (value: string) => void;
   onProfileChange: (value: string) => void;
   onUndoOptimization: () => void;
   onOptimize: () => void;
+  onRequestCollection: () => void;
 };
 
 export function LearnerProfileSaveView({
@@ -52,10 +59,12 @@ export function LearnerProfileSaveView({
   optimizationDescription,
   optimizationOriginal,
   optimizeDisabled,
+  guidedAvailable,
   onNicknameChange,
   onProfileChange,
   onUndoOptimization,
   onOptimize,
+  onRequestCollection,
 }: LearnerProfileSaveViewProps) {
   const { t } = useTranslation();
 
@@ -64,13 +73,36 @@ export function LearnerProfileSaveView({
       data-testid='learner-profile-save-view'
       className='flex min-h-full flex-1 flex-col gap-5 sm:gap-4'
     >
-      <h2
-        ref={headingRef}
-        tabIndex={-1}
-        className='shrink-0 text-xl font-semibold leading-7 outline-none'
+      <div
+        data-testid='learner-profile-save-heading-row'
+        className='flex shrink-0 items-center justify-between gap-2 sm:block [@media(max-height:620px)]:flex'
       >
-        {t('module.profileOnboarding.dialog.confirmTitle')}
-      </h2>
+        <h2
+          ref={headingRef}
+          tabIndex={-1}
+          className='min-w-0 text-xl font-semibold leading-7 outline-none'
+        >
+          {t('module.profileOnboarding.dialog.confirmTitle')}
+        </h2>
+        {guidedAvailable ? (
+          <Button
+            data-testid='learner-profile-interactive-collection-mobile'
+            type='button'
+            variant='ghost'
+            className='ms-auto h-auto min-h-11 w-fit max-w-[48%] shrink-0 justify-start px-2 py-2 text-start text-sm leading-5 text-muted-foreground !whitespace-normal hover:bg-accent/60 hover:text-foreground sm:hidden [@media(max-height:620px)]:inline-flex'
+            disabled={busy || optimizing}
+            onClick={onRequestCollection}
+          >
+            <MessageCircleQuestion
+              className='shrink-0 text-primary'
+              aria-hidden='true'
+            />
+            <span className='min-w-0'>
+              {t('module.profileOnboarding.dialog.interactiveCollection')}
+            </span>
+          </Button>
+        ) : null}
+      </div>
 
       {manualFallback ? (
         <div className='shrink-0 rounded-xl border border-primary/20 bg-primary/[0.05] px-4 py-3 text-sm leading-6 text-foreground/80'>
@@ -88,7 +120,7 @@ export function LearnerProfileSaveView({
         <div className='space-y-1'>
           <Input
             id='learner-profile-dialog-nickname'
-            className='h-10 rounded-lg shadow-none'
+            className='h-11 rounded-lg text-base shadow-none sm:h-10 sm:text-sm'
             value={nickname}
             disabled={!loaded || busy}
             aria-invalid={nicknameOverLimit || undefined}
@@ -117,7 +149,7 @@ export function LearnerProfileSaveView({
         </div>
       </div>
 
-      <section className='flex min-h-52 flex-1 flex-col gap-3'>
+      <section className='flex min-h-60 flex-1 flex-col gap-3 sm:min-h-52 [@media(max-height:620px)]:min-h-52 [@media(max-height:620px)]:flex-none'>
         <label
           htmlFor='learner-profile-dialog-draft'
           className='text-sm font-medium'
@@ -128,8 +160,8 @@ export function LearnerProfileSaveView({
         <ProfileDraftEditor
           inputId='learner-profile-dialog-draft'
           textareaRef={textareaRef}
-          className='min-h-40 flex-1'
-          textareaClassName='min-h-32 flex-1 resize-none overflow-y-auto rounded-xl border-border px-4 py-3 leading-6 shadow-none'
+          className='min-h-48 flex-1 sm:min-h-40 [@media(max-height:620px)]:min-h-40'
+          textareaClassName='min-h-40 flex-1 resize-none overflow-y-auto rounded-xl border-border px-4 py-3 text-base leading-6 shadow-none sm:min-h-32 sm:text-sm [@media(max-height:620px)]:min-h-32'
           minRows={4}
           autoResize={false}
           value={profile}
@@ -162,7 +194,7 @@ export function LearnerProfileSaveView({
                   type='button'
                   size='sm'
                   variant='outline'
-                  className='min-h-10 flex-1 sm:flex-none'
+                  className='min-h-11 flex-1 sm:min-h-10 sm:flex-none'
                   onClick={onUndoOptimization}
                 >
                   {t('module.profileOnboarding.dialog.undoOptimize')}
@@ -171,7 +203,7 @@ export function LearnerProfileSaveView({
               <Button
                 type='button'
                 size='sm'
-                className='min-h-10 flex-1 px-4 shadow-sm sm:flex-none'
+                className='min-h-11 flex-1 px-4 shadow-sm sm:min-h-10 sm:flex-none'
                 disabled={optimizeDisabled}
                 aria-describedby='learner-profile-optimization-status'
                 onClick={onOptimize}
@@ -197,6 +229,11 @@ export function LearnerProfileSaveView({
           </div>
         </div>
       </section>
+
+      <ProfileInformationUsageControl
+        variant='inline'
+        className='sm:hidden [@media(max-height:620px)]:block'
+      />
     </div>
   );
 }
@@ -215,16 +252,22 @@ export function ProfileCollectionView({
 
   return (
     <section className='flex min-h-0 flex-1 flex-col'>
-      <div className='min-h-40 flex-1 [@media(max-height:620px)]:min-h-32'>
+      <div className='min-h-0 flex-1'>
         <ProfileOnboardingConversation
           key={conversationKey}
           {...conversationProps}
+          questionScrollFooter={
+            <ProfileInformationUsageControl
+              variant='inline'
+              className='mt-4 sm:hidden [@media(max-height:620px)]:block'
+            />
+          }
         />
       </div>
       {collectionReady ? (
         <div
           role='status'
-          className='mt-3 rounded-xl border border-primary/20 bg-primary/[0.05] px-4 py-3 text-sm leading-6 text-foreground/80'
+          className='mt-3 shrink-0 rounded-xl border border-primary/20 bg-primary/[0.05] px-4 py-3 text-sm leading-6 text-foreground/80'
         >
           {t('module.profileOnboarding.guided.collectionComplete')}
         </div>
@@ -245,7 +288,7 @@ export function ProfileDialogConfirmationView({
   return (
     <section
       data-testid={`learner-profile-confirmation-${confirmation}`}
-      className='mx-auto flex h-full min-h-64 max-w-lg flex-col justify-center'
+      className='mx-auto flex h-full min-h-64 max-w-lg flex-col justify-start sm:justify-center [@media(max-height:620px)]:justify-start'
     >
       <h2
         ref={headingRef}
@@ -265,22 +308,40 @@ export function ProfileDialogConfirmationView({
             : 'module.profileOnboarding.dialog.replaceResearchDescription',
         )}
       </p>
+      <ProfileInformationUsageControl
+        variant='inline'
+        className='mt-6 sm:hidden [@media(max-height:620px)]:block'
+      />
     </section>
   );
 }
 
-export function ProfileInformationUsageControl() {
+export function ProfileInformationUsageControl({
+  variant = 'popover',
+  className,
+}: {
+  variant?: 'inline' | 'popover';
+  className?: string;
+}) {
   const { t } = useTranslation();
+  const inline = variant === 'inline';
 
   return (
     <details
-      data-testid='learner-profile-information-usage'
-      className='group relative min-w-0 max-sm:w-full'
+      data-testid={`learner-profile-information-usage-${variant}`}
+      className={cn(
+        'group min-w-0',
+        inline
+          ? 'rounded-xl border border-border/80 bg-background/80'
+          : 'relative',
+        className,
+      )}
     >
       <summary
         className={cn(
           buttonVariants({ variant: 'ghost' }),
-          'min-h-10 min-w-0 list-none justify-start px-2 text-left text-sm font-normal text-muted-foreground !whitespace-normal hover:text-foreground max-sm:w-full [&::-webkit-details-marker]:hidden',
+          'h-auto min-h-11 min-w-0 list-none justify-start px-2 text-start text-sm font-normal text-muted-foreground !whitespace-normal hover:text-foreground [&::-webkit-details-marker]:hidden',
+          inline && 'w-full rounded-xl px-3 py-2.5',
         )}
       >
         <span className='flex min-w-0 items-center gap-2'>
@@ -293,12 +354,17 @@ export function ProfileInformationUsageControl() {
       </summary>
       <div
         role='note'
-        className='absolute bottom-[calc(100%+0.5rem)] left-0 z-[110] w-[min(22rem,calc(100vw-2rem))] rounded-xl border bg-popover p-4 text-popover-foreground shadow-md'
+        className={cn(
+          'text-popover-foreground',
+          inline
+            ? 'border-t border-border/70 px-4 pb-4 pt-3'
+            : 'absolute bottom-[calc(100%+0.5rem)] start-0 z-[110] w-[min(22rem,calc(100vw-2rem))] rounded-xl border bg-popover p-4 shadow-md',
+        )}
       >
         <p className='font-medium leading-6'>
           {t('module.profileOnboarding.dialog.informationUsageTitle')}
         </p>
-        <ul className='mt-2 list-disc space-y-1.5 pl-5 text-sm leading-5 text-muted-foreground'>
+        <ul className='mt-2 list-disc space-y-1.5 ps-5 text-sm leading-5 text-muted-foreground'>
           <li>
             {t('module.profileOnboarding.dialog.informationUsagePurpose')}
           </li>

--- a/src/cook-web/src/components/profile-onboarding/ProfileAssistantAnswersView.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileAssistantAnswersView.test.tsx
@@ -46,6 +46,26 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
+test('keeps the assistant answer and actions mobile-safe inside its scroller', () => {
+  const { input } = setup('Pasted answer');
+  const view = screen.getByTestId('profile-assistant-answers');
+  const copyButton = screen.getByRole('button', {
+    name: 'module.profileOnboarding.assistant.copy',
+  });
+  const backButton = screen.getByRole('button', {
+    name: 'module.profileOnboarding.assistant.back',
+  });
+  const processButton = screen.getByRole('button', {
+    name: 'module.profileOnboarding.assistant.process',
+  });
+
+  expect(view).toHaveClass('overflow-y-auto', 'overscroll-contain');
+  expect(input).toHaveClass('text-base', 'sm:text-sm');
+  expect(copyButton).toHaveClass('min-h-11', 'min-w-20', 'sm:min-h-9');
+  expect(backButton).toHaveClass('min-h-11', 'min-w-11', 'sm:min-h-10');
+  expect(processButton).toHaveClass('min-h-11', 'min-w-11', 'sm:min-h-10');
+});
+
 test('a real stable paste waits for the processing button and submits once', () => {
   const { input, onSubmit } = setup();
   fireEvent.paste(input);

--- a/src/cook-web/src/components/profile-onboarding/ProfileAssistantAnswersView.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileAssistantAnswersView.tsx
@@ -84,7 +84,7 @@ export function ProfileAssistantAnswersView({
               type='button'
               variant='outline'
               size='sm'
-              className='absolute bottom-2 end-2 z-10 min-w-20 rounded-lg bg-background shadow-md'
+              className='absolute bottom-2 end-2 z-10 min-h-11 min-w-20 rounded-lg bg-background shadow-md sm:min-h-9'
               disabled={disabled}
               aria-label={copyLabel}
               title={copyLabel}
@@ -136,7 +136,7 @@ export function ProfileAssistantAnswersView({
           <Textarea
             id='profile-assistant-answer'
             rows={4}
-            className='min-h-32 flex-1 resize-none bg-background shadow-sm md:min-h-0'
+            className='min-h-32 flex-1 resize-none bg-background text-base shadow-sm sm:text-sm md:min-h-0'
             value={value}
             disabled={disabled || unresolved}
             aria-invalid={overLimit || undefined}
@@ -168,6 +168,7 @@ export function ProfileAssistantAnswersView({
         <Button
           type='button'
           variant='ghost'
+          className='min-h-11 min-w-11 sm:min-h-10'
           disabled={disabled || unresolved}
           onClick={onBack}
         >
@@ -175,6 +176,7 @@ export function ProfileAssistantAnswersView({
         </Button>
         <Button
           type='button'
+          className='min-h-11 min-w-11 sm:min-h-10'
           disabled={submissionDisabled || !value.trim() || overLimit}
           onClick={() => onSubmit(value)}
         >

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -581,6 +581,49 @@ describe('ProfileOnboardingConversation', () => {
     await waitFor(() => expect(runSession).toHaveBeenCalledTimes(1));
   });
 
+  test('keeps the question footer inside the sole guided scroller with mobile-safe controls', async () => {
+    const runSession = jest.fn(() => ({ close: jest.fn() }));
+    const { container } = render(
+      <ProfileOnboardingConversation
+        createSession={async () => ({ session_id: 'session-scroll-layout' })}
+        runSession={runSession}
+        onDraftReady={jest.fn()}
+        onError={jest.fn()}
+        questionScrollFooter={<div data-testid='question-scroll-footer' />}
+      />,
+    );
+
+    await waitFor(() => expect(runSession).toHaveBeenCalledTimes(1));
+    const markdownFlow = container.querySelector(
+      '.profile-onboarding-markdownflow',
+    );
+
+    expect(markdownFlow).toContainElement(
+      screen.getByTestId('question-scroll-footer'),
+    );
+    expect(markdownFlow).toHaveClass(
+      'overflow-y-auto',
+      'overscroll-contain',
+      '[scrollbar-gutter:stable]',
+      'max-sm:[&_button]:min-h-11',
+      'max-sm:[&_button]:min-w-11',
+      'max-sm:[&_input]:min-h-11',
+      'max-sm:[&_input]:text-base',
+      'max-sm:[&_select]:min-h-11',
+      'max-sm:[&_select]:text-base',
+      'max-sm:[&_textarea]:text-base',
+      'sm:any-pointer-coarse:[&_button]:min-h-11',
+      'sm:any-pointer-coarse:[&_button]:min-w-11',
+      'sm:any-pointer-coarse:[&_input]:min-h-11',
+      'sm:any-pointer-coarse:[&_input]:text-base',
+      'sm:any-pointer-coarse:[&_select]:min-h-11',
+      'sm:any-pointer-coarse:[&_select]:text-base',
+      'sm:any-pointer-coarse:[&_textarea]:text-base',
+    );
+    expect(container.querySelectorAll('.overflow-y-auto')).toHaveLength(1);
+    expect(container.querySelector('.overflow-y-auto')).toBe(markdownFlow);
+  });
+
   test('delegates guided-question scrolling to the library control', async () => {
     const runSession = jest
       .fn()

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -53,6 +53,7 @@ export type ProfileOnboardingConversationProps = {
   onError: (error: unknown) => void;
   onSessionCreateRejected?: (error: unknown) => void;
   onRetry?: () => void;
+  questionScrollFooter?: React.ReactNode;
 };
 
 export default function ProfileOnboardingConversation({
@@ -70,6 +71,7 @@ export default function ProfileOnboardingConversation({
   onError,
   onSessionCreateRejected,
   onRetry,
+  questionScrollFooter,
 }: ProfileOnboardingConversationProps) {
   const { t, i18n } = useTranslation();
   const [assistantVisible, setAssistantVisible] = React.useState(false);
@@ -167,7 +169,7 @@ export default function ProfileOnboardingConversation({
           ref={questionViewportRef}
           aria-busy={loading || (runInFlight && !assistantProcessing)}
           className={cn(
-            'profile-onboarding-markdownflow h-full min-h-0 overflow-y-auto overscroll-contain pe-1 [scrollbar-gutter:stable]',
+            'profile-onboarding-markdownflow h-full min-h-0 overflow-y-auto overscroll-contain pe-1 [scrollbar-gutter:stable] max-sm:[&_button]:min-h-11 max-sm:[&_button]:min-w-11 max-sm:[&_input]:min-h-11 max-sm:[&_input]:text-base max-sm:[&_select]:min-h-11 max-sm:[&_select]:text-base max-sm:[&_textarea]:text-base sm:any-pointer-coarse:[&_button]:min-h-11 sm:any-pointer-coarse:[&_button]:min-w-11 sm:any-pointer-coarse:[&_input]:min-h-11 sm:any-pointer-coarse:[&_input]:text-base sm:any-pointer-coarse:[&_select]:min-h-11 sm:any-pointer-coarse:[&_select]:text-base sm:any-pointer-coarse:[&_textarea]:text-base',
             canUseAssistant && 'sm:scroll-pb-20 sm:pb-20',
           )}
         >
@@ -176,6 +178,7 @@ export default function ProfileOnboardingConversation({
             initialContentList={contentList}
             onSend={send}
           />
+          {questionScrollFooter}
         </div>
         <ScrollToBottomControl
           viewportRef={questionViewportRef}


### PR DESCRIPTION
## Summary

- turn the learner personalization dialog into a safe-area-aware full-screen task below 640px while preserving the centered desktop dialog
- simplify each mobile phase footer and move information usage plus interactive collection into the active scroll area
- keep mobile and coarse-pointer form controls at accessible sizes, preserve one scroll owner per phase, and scroll focused inputs into view
- place the mobile interactive collection action beside the save heading and let the profile editor use the available viewport height

## Verification

- focused profile onboarding Jest: 3 suites, 99 tests
- full cook-web Jest: 178 suites, 1564 tests
- type-check
- ESLint
- changed-file Prettier
- architecture boundary check
- repository harness
- dev-tools check
- lefthook pre-commit and commit-msg hooks
- local Chromium visual and geometry checks at 320x568, 390x844, 844x390, and 1280x720, including French, Arabic RTL, and desktop regression

## Validation note

Physical iPhone Safari/iOS Simulator and Android Chrome soft-keyboard validation was unavailable on this host. Chromium focus and viewport checks passed; no visualViewport workaround was added without reproduced device occlusion.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->