### PR TITLE
fix: refine dialog glass surfaces

### DIFF
--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
@@ -477,7 +477,9 @@ describe('LearnerProfileDialog', () => {
       '[@media(max-height:620px)]:flex-nowrap',
       '[@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))]',
       '[@media(max-height:620px)]:pt-3',
-      'shadow-[0_-10px_30px_-22px_rgba(15,23,42,0.35)]',
+      'bg-background/90',
+      'backdrop-blur-md',
+      'shadow-[0_-8px_18px_-14px_rgba(15,23,42,0.22)]',
     );
     const inlineInformation = informationUsageControl('inline');
     const popoverInformation = informationUsageControl('popover');

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
@@ -477,7 +477,7 @@ describe('LearnerProfileDialog', () => {
       '[@media(max-height:620px)]:flex-nowrap',
       '[@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))]',
       '[@media(max-height:620px)]:pt-3',
-      'shadow-[0_-10px_30px_-22px_rgba(15,23,42,0.4)]',
+      'shadow-[0_-10px_30px_-22px_rgba(15,23,42,0.35)]',
     );
     const inlineInformation = informationUsageControl('inline');
     const popoverInformation = informationUsageControl('popover');

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
@@ -457,8 +457,10 @@ describe('LearnerProfileDialog', () => {
     expect(screen.getByTestId('learner-profile-dialog-body')).toHaveClass(
       'overflow-hidden',
       'bg-muted/25',
-      '[@media(max-height:620px)]:pb-[calc(var(--learner-profile-footer-height,80px)+0.5rem)]',
-      '[@media(max-height:620px)]:pt-[calc(var(--learner-profile-header-height,80px)+0.5rem)]',
+      'pb-[calc(var(--learner-profile-footer-height,80px)+1rem)]',
+      'pt-[calc(var(--learner-profile-header-height,96px)+1rem)]',
+      '[@media(max-height:620px)]:pb-[calc(var(--learner-profile-footer-height,80px)+1rem)]',
+      '[@media(max-height:620px)]:pt-[calc(var(--learner-profile-header-height,80px)+1rem)]',
     );
     expect(screen.getByTestId('learner-profile-dialog-body')).not.toHaveClass(
       'overflow-y-auto',

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
@@ -455,16 +455,19 @@ describe('LearnerProfileDialog', () => {
       '[@media(max-height:620px)]:leading-5',
     );
     expect(screen.getByTestId('learner-profile-dialog-header')).toHaveClass(
-      'after:-bottom-3',
-      'after:h-3',
-      'after:bg-background/60',
+      'border-b',
+      'after:-bottom-6',
+      'after:h-6',
+      'after:bg-background/55',
       'after:backdrop-blur-md',
     );
     expect(screen.getByTestId('learner-profile-dialog-body')).toHaveClass(
       'overflow-hidden',
       'bg-muted/25',
-      'pb-[calc(var(--learner-profile-footer-height,80px)+0.75rem)]',
-      'pt-[calc(var(--learner-profile-header-height,96px)+0.75rem)]',
+      'pb-[var(--learner-profile-footer-height,80px)]',
+      'pt-[var(--learner-profile-header-height,96px)]',
+      'sm:pb-[var(--learner-profile-footer-height,76px)]',
+      'sm:pt-[var(--learner-profile-header-height,116px)]',
     );
     expect(screen.getByTestId('learner-profile-dialog-body')).not.toHaveClass(
       'overflow-y-auto',
@@ -483,11 +486,12 @@ describe('LearnerProfileDialog', () => {
       '[@media(max-height:620px)]:flex-nowrap',
       '[@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))]',
       '[@media(max-height:620px)]:pt-3',
+      'border-t',
       'bg-background/90',
-      'backdrop-blur-md',
-      'before:-top-3',
-      'before:h-3',
-      'before:bg-background/60',
+      'backdrop-blur-xl',
+      'before:-top-6',
+      'before:h-6',
+      'before:bg-background/55',
       'before:backdrop-blur-md',
     );
     const inlineInformation = informationUsageControl('inline');
@@ -723,6 +727,8 @@ describe('LearnerProfileDialog', () => {
     expect(mockOptimizeLearnerProfile).not.toHaveBeenCalled();
     expect(screen.getByTestId('learner-profile-dialog-body')).toHaveClass(
       'overflow-y-auto',
+      'pb-[calc(var(--learner-profile-footer-height,80px)+1.5rem)]',
+      'pt-[calc(var(--learner-profile-header-height,96px)+1.5rem)]',
     );
     expect(screen.getByTestId('learner-profile-dialog-footer')).toHaveClass(
       'absolute',

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
@@ -454,10 +454,17 @@ describe('LearnerProfileDialog', () => {
       '[@media(max-height:620px)]:text-sm',
       '[@media(max-height:620px)]:leading-5',
     );
+    expect(screen.getByTestId('learner-profile-dialog-header')).toHaveClass(
+      'after:-bottom-3',
+      'after:h-3',
+      'after:bg-background/60',
+      'after:backdrop-blur-md',
+    );
     expect(screen.getByTestId('learner-profile-dialog-body')).toHaveClass(
       'overflow-hidden',
       'bg-muted/25',
-      'shadow-[inset_0_10px_16px_-16px_rgba(15,23,42,0.28),inset_0_-10px_16px_-16px_rgba(15,23,42,0.28)]',
+      'pb-[calc(var(--learner-profile-footer-height,80px)+0.75rem)]',
+      'pt-[calc(var(--learner-profile-header-height,96px)+0.75rem)]',
     );
     expect(screen.getByTestId('learner-profile-dialog-body')).not.toHaveClass(
       'overflow-y-auto',
@@ -478,7 +485,10 @@ describe('LearnerProfileDialog', () => {
       '[@media(max-height:620px)]:pt-3',
       'bg-background/90',
       'backdrop-blur-md',
-      'shadow-[0_-8px_18px_-14px_rgba(15,23,42,0.22)]',
+      'before:-top-3',
+      'before:h-3',
+      'before:bg-background/60',
+      'before:backdrop-blur-md',
     );
     const inlineInformation = informationUsageControl('inline');
     const popoverInformation = informationUsageControl('popover');

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
@@ -457,10 +457,7 @@ describe('LearnerProfileDialog', () => {
     expect(screen.getByTestId('learner-profile-dialog-body')).toHaveClass(
       'overflow-hidden',
       'bg-muted/25',
-      'pb-[calc(var(--learner-profile-footer-height,80px)+1rem)]',
-      'pt-[calc(var(--learner-profile-header-height,96px)+1rem)]',
-      '[@media(max-height:620px)]:pb-[calc(var(--learner-profile-footer-height,80px)+1rem)]',
-      '[@media(max-height:620px)]:pt-[calc(var(--learner-profile-header-height,80px)+1rem)]',
+      'shadow-[inset_0_10px_16px_-16px_rgba(15,23,42,0.28),inset_0_-10px_16px_-16px_rgba(15,23,42,0.28)]',
     );
     expect(screen.getByTestId('learner-profile-dialog-body')).not.toHaveClass(
       'overflow-y-auto',

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
@@ -477,7 +477,7 @@ describe('LearnerProfileDialog', () => {
       '[@media(max-height:620px)]:flex-nowrap',
       '[@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))]',
       '[@media(max-height:620px)]:pt-3',
-      'shadow-[0_-10px_30px_-24px_rgba(15,23,42,0.6)]',
+      'shadow-[0_-10px_30px_-22px_rgba(15,23,42,0.4)]',
     );
     const inlineInformation = informationUsageControl('inline');
     const popoverInformation = informationUsageControl('popover');

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.test.tsx
@@ -545,6 +545,73 @@ describe('LearnerProfileDialog', () => {
     ).not.toBeInTheDocument();
   });
 
+  test('measures dialog chrome after a closed dialog opens even when loading fails', async () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    const observe = jest.fn();
+    const disconnect = jest.fn();
+    const resizeObserver = {
+      disconnect,
+      observe,
+      unobserve: jest.fn(),
+    } as unknown as ResizeObserver;
+    let resizeCallback: ResizeObserverCallback | undefined;
+    const ResizeObserverMock = jest.fn((callback: ResizeObserverCallback) => {
+      resizeCallback = callback;
+      return resizeObserver;
+    });
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      configurable: true,
+      value: ResizeObserverMock,
+    });
+    mockGetLearnerProfile.mockRejectedValueOnce(
+      new Error('Profile unavailable'),
+    );
+
+    try {
+      const { props, rerender } = renderDialog({ open: false });
+      expect(ResizeObserverMock).not.toHaveBeenCalled();
+
+      rerender(
+        <LearnerProfileDialog
+          {...props}
+          open
+        />,
+      );
+
+      expect(
+        await screen.findByText('Profile unavailable'),
+      ).toBeInTheDocument();
+      const header = screen.getByTestId('learner-profile-dialog-header');
+      const footer = screen.getByTestId('learner-profile-dialog-footer');
+      jest
+        .spyOn(header, 'getBoundingClientRect')
+        .mockReturnValue({ height: 104 } as DOMRect);
+      jest
+        .spyOn(footer, 'getBoundingClientRect')
+        .mockReturnValue({ height: 72 } as DOMRect);
+
+      await waitFor(() => {
+        expect(observe).toHaveBeenCalledWith(header);
+        expect(observe).toHaveBeenCalledWith(footer);
+      });
+      act(() => resizeCallback?.([], resizeObserver));
+
+      expect(screen.getByTestId('learner-profile-dialog-body')).toHaveStyle({
+        '--learner-profile-footer-height': '72px',
+        '--learner-profile-header-height': '104px',
+      });
+    } finally {
+      if (originalResizeObserver) {
+        Object.defineProperty(globalThis, 'ResizeObserver', {
+          configurable: true,
+          value: originalResizeObserver,
+        });
+      } else {
+        Reflect.deleteProperty(globalThis, 'ResizeObserver');
+      }
+    }
+  });
+
   test('shows an existing profile without waiting for optional onboarding status', async () => {
     const statusRequest = deferred<ReturnType<typeof onboardingStatus>>();
     mockGetLearnerProfile.mockResolvedValue(existingProfile);

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
@@ -186,7 +186,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
       >
         <header
           ref={headerRef}
-          className='absolute inset-x-0 top-0 z-10 border-b border-border/60 bg-gradient-to-b from-background/70 via-background/35 to-transparent pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] shadow-[0_10px_30px_-22px_rgba(15,23,42,0.35)] backdrop-blur-[2px] sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]'
+          className="absolute inset-x-0 top-0 z-10 border-b border-border/60 bg-background pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] shadow-[0_10px_30px_-22px_rgba(15,23,42,0.35)] after:pointer-events-none after:absolute after:inset-x-0 after:-bottom-8 after:h-8 after:bg-gradient-to-b after:from-background/80 after:to-transparent after:content-[''] sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]"
         >
           <DialogHeader className='w-full space-y-1 pr-12 text-start sm:space-y-2 [@media(max-height:620px)]:space-y-1'>
             <DialogTitle className='text-xl font-bold leading-7 tracking-tight sm:text-[28px] sm:leading-9 [@media(max-height:620px)]:text-xl [@media(max-height:620px)]:leading-7'>
@@ -215,7 +215,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
           ref={contentScrollRef}
           data-testid='learner-profile-dialog-body'
           className={cn(
-            'relative z-0 flex min-h-0 flex-1 flex-col overscroll-contain bg-muted/25 pb-[calc(var(--learner-profile-footer-height,80px)+1rem)] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[calc(var(--learner-profile-header-height,96px)+1rem)] [scrollbar-gutter:stable] sm:px-8 sm:pb-[calc(var(--learner-profile-footer-height,76px)+1.5rem)] sm:pt-[calc(var(--learner-profile-header-height,116px)+1.5rem)] [@media(max-height:620px)]:pb-[calc(var(--learner-profile-footer-height,80px)+0.5rem)] [@media(max-height:620px)]:pt-[calc(var(--learner-profile-header-height,80px)+0.5rem)]',
+            'relative z-0 flex min-h-0 flex-1 flex-col overscroll-contain bg-muted/25 pb-[var(--learner-profile-footer-height,80px)] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[var(--learner-profile-header-height,96px)] [scrollbar-gutter:stable] sm:px-8 sm:pb-[var(--learner-profile-footer-height,76px)] sm:pt-[var(--learner-profile-header-height,116px)] [@media(max-height:620px)]:pb-[var(--learner-profile-footer-height,80px)] [@media(max-height:620px)]:pt-[var(--learner-profile-header-height,80px)]',
             collectionOwnsScroll ? 'overflow-hidden' : 'overflow-y-auto',
           )}
           style={
@@ -318,7 +318,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
         <footer
           data-testid='learner-profile-dialog-footer'
           ref={footerRef}
-          className='absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 border-t border-border/60 bg-gradient-to-t from-background/70 via-background/35 to-transparent pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 shadow-[0_-10px_30px_-22px_rgba(15,23,42,0.35)] backdrop-blur-[2px] sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3'
+          className="absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 border-t border-border/60 bg-background pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 shadow-[0_-10px_30px_-22px_rgba(15,23,42,0.35)] before:pointer-events-none before:absolute before:inset-x-0 before:-top-8 before:h-8 before:bg-gradient-to-t before:from-background/80 before:to-transparent before:content-[''] sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3"
         >
           {confirmation ? (
             <>

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
@@ -215,7 +215,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
           ref={contentScrollRef}
           data-testid='learner-profile-dialog-body'
           className={cn(
-            'relative z-0 flex min-h-0 flex-1 flex-col overscroll-contain bg-muted/25 pb-[var(--learner-profile-footer-height,80px)] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[var(--learner-profile-header-height,96px)] [scrollbar-gutter:stable] sm:px-8 sm:pb-[var(--learner-profile-footer-height,76px)] sm:pt-[var(--learner-profile-header-height,116px)] [@media(max-height:620px)]:pb-[var(--learner-profile-footer-height,80px)] [@media(max-height:620px)]:pt-[var(--learner-profile-header-height,80px)]',
+            'relative z-0 flex min-h-0 flex-1 flex-col overscroll-contain bg-muted/25 pb-[calc(var(--learner-profile-footer-height,80px)+1rem)] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[calc(var(--learner-profile-header-height,96px)+1rem)] [scrollbar-gutter:stable] sm:px-8 sm:pb-[calc(var(--learner-profile-footer-height,76px)+1rem)] sm:pt-[calc(var(--learner-profile-header-height,116px)+1rem)] [@media(max-height:620px)]:pb-[calc(var(--learner-profile-footer-height,80px)+1rem)] [@media(max-height:620px)]:pt-[calc(var(--learner-profile-header-height,80px)+1rem)]',
             collectionOwnsScroll ? 'overflow-hidden' : 'overflow-y-auto',
           )}
           style={

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
@@ -81,8 +81,12 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
   const viewHeadingRef = React.useRef<HTMLHeadingElement | null>(null);
   const confirmationHeadingRef = React.useRef<HTMLHeadingElement | null>(null);
   const contentScrollRef = React.useRef<HTMLDivElement | null>(null);
-  const headerRef = React.useRef<HTMLElement | null>(null);
-  const footerRef = React.useRef<HTMLElement | null>(null);
+  const [headerElement, setHeaderElement] = React.useState<HTMLElement | null>(
+    null,
+  );
+  const [footerElement, setFooterElement] = React.useState<HTMLElement | null>(
+    null,
+  );
   const collectionContinueButtonRef = React.useRef<HTMLButtonElement | null>(
     null,
   );
@@ -134,9 +138,11 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
   }, [collectionReady, phase]);
 
   React.useLayoutEffect(() => {
+    if (!open || !headerElement || !footerElement) return;
+
     const updateChromeHeights = () => {
-      const header = headerRef.current?.getBoundingClientRect().height ?? 0;
-      const footer = footerRef.current?.getBoundingClientRect().height ?? 0;
+      const header = headerElement.getBoundingClientRect().height;
+      const footer = footerElement.getBoundingClientRect().height;
       if (header > 0 || footer > 0) {
         setChromeHeights(current => {
           const next = { header: header || null, footer: footer || null };
@@ -152,10 +158,10 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
     if (typeof ResizeObserver === 'undefined') return;
 
     const observer = new ResizeObserver(updateChromeHeights);
-    if (headerRef.current) observer.observe(headerRef.current);
-    if (footerRef.current) observer.observe(footerRef.current);
+    observer.observe(headerElement);
+    observer.observe(footerElement);
     return () => observer.disconnect();
-  }, [confirmation, loaded, phase]);
+  }, [confirmation, footerElement, headerElement, loaded, open, phase]);
 
   return (
     <Dialog
@@ -186,7 +192,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
       >
         <header
           data-testid='learner-profile-dialog-header'
-          ref={headerRef}
+          ref={setHeaderElement}
           className="absolute inset-x-0 top-0 z-10 border-b border-slate-300/80 bg-background/90 pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] shadow-[0_6px_16px_-12px_rgba(15,23,42,0.45)] backdrop-blur-xl after:pointer-events-none after:absolute after:inset-x-0 after:-bottom-6 after:h-6 after:bg-background/55 after:backdrop-blur-md after:content-[''] sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]"
         >
           <DialogHeader className='w-full space-y-1 pr-12 text-start sm:space-y-2 [@media(max-height:620px)]:space-y-1'>
@@ -320,7 +326,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
 
         <footer
           data-testid='learner-profile-dialog-footer'
-          ref={footerRef}
+          ref={setFooterElement}
           className="absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 border-t border-slate-300/80 bg-background/90 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 shadow-[0_-6px_16px_-12px_rgba(15,23,42,0.45)] backdrop-blur-xl before:pointer-events-none before:absolute before:inset-x-0 before:-top-6 before:h-6 before:bg-background/55 before:backdrop-blur-md before:content-[''] sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3"
         >
           {confirmation ? (

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
@@ -186,7 +186,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
       >
         <header
           ref={headerRef}
-          className='absolute inset-x-0 top-0 z-10 border-b bg-background/55 pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] shadow-[0_10px_30px_-22px_rgba(15,23,42,0.4)] backdrop-blur-sm sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]'
+          className='absolute inset-x-0 top-0 z-10 border-b border-border/60 bg-gradient-to-b from-background/70 via-background/35 to-transparent pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] shadow-[0_10px_30px_-22px_rgba(15,23,42,0.35)] backdrop-blur-[2px] sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]'
         >
           <DialogHeader className='w-full space-y-1 pr-12 text-start sm:space-y-2 [@media(max-height:620px)]:space-y-1'>
             <DialogTitle className='text-xl font-bold leading-7 tracking-tight sm:text-[28px] sm:leading-9 [@media(max-height:620px)]:text-xl [@media(max-height:620px)]:leading-7'>
@@ -318,7 +318,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
         <footer
           data-testid='learner-profile-dialog-footer'
           ref={footerRef}
-          className='absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 border-t bg-background/55 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 shadow-[0_-10px_30px_-22px_rgba(15,23,42,0.4)] backdrop-blur-sm sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3'
+          className='absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 border-t border-border/60 bg-gradient-to-t from-background/70 via-background/35 to-transparent pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 shadow-[0_-10px_30px_-22px_rgba(15,23,42,0.35)] backdrop-blur-[2px] sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3'
         >
           {confirmation ? (
             <>

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
@@ -215,7 +215,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
           ref={contentScrollRef}
           data-testid='learner-profile-dialog-body'
           className={cn(
-            'relative z-0 flex min-h-0 flex-1 flex-col overscroll-contain bg-muted/25 pb-[calc(var(--learner-profile-footer-height,80px)+1rem)] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[calc(var(--learner-profile-header-height,96px)+1rem)] [scrollbar-gutter:stable] sm:px-8 sm:pb-[calc(var(--learner-profile-footer-height,76px)+1rem)] sm:pt-[calc(var(--learner-profile-header-height,116px)+1rem)] [@media(max-height:620px)]:pb-[calc(var(--learner-profile-footer-height,80px)+1rem)] [@media(max-height:620px)]:pt-[calc(var(--learner-profile-header-height,80px)+1rem)]',
+            'relative z-0 flex min-h-0 flex-1 flex-col overscroll-contain bg-muted/25 pb-[var(--learner-profile-footer-height,80px)] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[var(--learner-profile-header-height,96px)] shadow-[inset_0_10px_16px_-16px_rgba(15,23,42,0.28),inset_0_-10px_16px_-16px_rgba(15,23,42,0.28)] [scrollbar-gutter:stable] sm:px-8 sm:pb-[var(--learner-profile-footer-height,76px)] sm:pt-[var(--learner-profile-header-height,116px)] [@media(max-height:620px)]:pb-[var(--learner-profile-footer-height,80px)] [@media(max-height:620px)]:pt-[var(--learner-profile-header-height,80px)]',
             collectionOwnsScroll ? 'overflow-hidden' : 'overflow-y-auto',
           )}
           style={

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
@@ -186,7 +186,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
       >
         <header
           ref={headerRef}
-          className='absolute inset-x-0 top-0 z-10 border-b bg-background/95 pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] shadow-[0_10px_30px_-24px_rgba(15,23,42,0.6)] backdrop-blur-sm sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]'
+          className='absolute inset-x-0 top-0 z-10 border-b bg-background/55 pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] shadow-[0_10px_30px_-22px_rgba(15,23,42,0.4)] backdrop-blur-sm sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]'
         >
           <DialogHeader className='w-full space-y-1 pr-12 text-start sm:space-y-2 [@media(max-height:620px)]:space-y-1'>
             <DialogTitle className='text-xl font-bold leading-7 tracking-tight sm:text-[28px] sm:leading-9 [@media(max-height:620px)]:text-xl [@media(max-height:620px)]:leading-7'>
@@ -318,7 +318,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
         <footer
           data-testid='learner-profile-dialog-footer'
           ref={footerRef}
-          className='absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 border-t bg-background/95 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 shadow-[0_-10px_30px_-24px_rgba(15,23,42,0.6)] backdrop-blur-sm sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3'
+          className='absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 border-t bg-background/55 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 shadow-[0_-10px_30px_-22px_rgba(15,23,42,0.4)] backdrop-blur-sm sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3'
         >
           {confirmation ? (
             <>

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
@@ -187,7 +187,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
         <header
           data-testid='learner-profile-dialog-header'
           ref={headerRef}
-          className="absolute inset-x-0 top-0 z-10 bg-background/90 pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] backdrop-blur-md after:pointer-events-none after:absolute after:inset-x-0 after:-bottom-3 after:h-3 after:border-b after:border-border/70 after:bg-background/60 after:shadow-[0_6px_12px_-10px_rgba(15,23,42,0.32)] after:backdrop-blur-md after:content-[''] sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]"
+          className="absolute inset-x-0 top-0 z-10 border-b border-slate-300/80 bg-background/90 pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] shadow-[0_6px_16px_-12px_rgba(15,23,42,0.45)] backdrop-blur-xl after:pointer-events-none after:absolute after:inset-x-0 after:-bottom-6 after:h-6 after:bg-background/55 after:backdrop-blur-md after:content-[''] sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]"
         >
           <DialogHeader className='w-full space-y-1 pr-12 text-start sm:space-y-2 [@media(max-height:620px)]:space-y-1'>
             <DialogTitle className='text-xl font-bold leading-7 tracking-tight sm:text-[28px] sm:leading-9 [@media(max-height:620px)]:text-xl [@media(max-height:620px)]:leading-7'>
@@ -216,8 +216,10 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
           ref={contentScrollRef}
           data-testid='learner-profile-dialog-body'
           className={cn(
-            'relative z-0 flex min-h-0 flex-1 flex-col overscroll-contain bg-muted/25 pb-[calc(var(--learner-profile-footer-height,80px)+0.75rem)] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[calc(var(--learner-profile-header-height,96px)+0.75rem)] [scrollbar-gutter:stable] sm:px-8 sm:pb-[calc(var(--learner-profile-footer-height,76px)+0.75rem)] sm:pt-[calc(var(--learner-profile-header-height,116px)+0.75rem)] [@media(max-height:620px)]:pb-[calc(var(--learner-profile-footer-height,80px)+0.75rem)] [@media(max-height:620px)]:pt-[calc(var(--learner-profile-header-height,80px)+0.75rem)]',
-            collectionOwnsScroll ? 'overflow-hidden' : 'overflow-y-auto',
+            'relative z-0 flex min-h-0 flex-1 flex-col overscroll-contain bg-muted/25 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] [scrollbar-gutter:stable] sm:px-8',
+            collectionOwnsScroll
+              ? 'overflow-hidden pb-[var(--learner-profile-footer-height,80px)] pt-[var(--learner-profile-header-height,96px)] sm:pb-[var(--learner-profile-footer-height,76px)] sm:pt-[var(--learner-profile-header-height,116px)] [@media(max-height:620px)]:pb-[var(--learner-profile-footer-height,80px)] [@media(max-height:620px)]:pt-[var(--learner-profile-header-height,80px)]'
+              : 'overflow-y-auto pb-[calc(var(--learner-profile-footer-height,80px)+1.5rem)] pt-[calc(var(--learner-profile-header-height,96px)+1.5rem)] sm:pb-[calc(var(--learner-profile-footer-height,76px)+1.5rem)] sm:pt-[calc(var(--learner-profile-header-height,116px)+1.5rem)] [@media(max-height:620px)]:pb-[calc(var(--learner-profile-footer-height,80px)+1.5rem)] [@media(max-height:620px)]:pt-[calc(var(--learner-profile-header-height,80px)+1.5rem)]',
           )}
           style={
             {
@@ -319,7 +321,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
         <footer
           data-testid='learner-profile-dialog-footer'
           ref={footerRef}
-          className="absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 bg-background/90 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 backdrop-blur-md before:pointer-events-none before:absolute before:inset-x-0 before:-top-3 before:h-3 before:border-t before:border-border/70 before:bg-background/60 before:shadow-[0_-6px_12px_-10px_rgba(15,23,42,0.32)] before:backdrop-blur-md before:content-[''] sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3"
+          className="absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 border-t border-slate-300/80 bg-background/90 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 shadow-[0_-6px_16px_-12px_rgba(15,23,42,0.45)] backdrop-blur-xl before:pointer-events-none before:absolute before:inset-x-0 before:-top-6 before:h-6 before:bg-background/55 before:backdrop-blur-md before:content-[''] sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3"
         >
           {confirmation ? (
             <>

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
@@ -186,7 +186,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
       >
         <header
           ref={headerRef}
-          className="absolute inset-x-0 top-0 z-10 border-b border-border/60 bg-background pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] shadow-[0_10px_30px_-22px_rgba(15,23,42,0.35)] after:pointer-events-none after:absolute after:inset-x-0 after:-bottom-8 after:h-8 after:bg-gradient-to-b after:from-background/80 after:to-transparent after:content-[''] sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]"
+          className='absolute inset-x-0 top-0 z-10 border-b border-border/70 bg-background/90 pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] shadow-[0_8px_18px_-14px_rgba(15,23,42,0.22)] backdrop-blur-md sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]'
         >
           <DialogHeader className='w-full space-y-1 pr-12 text-start sm:space-y-2 [@media(max-height:620px)]:space-y-1'>
             <DialogTitle className='text-xl font-bold leading-7 tracking-tight sm:text-[28px] sm:leading-9 [@media(max-height:620px)]:text-xl [@media(max-height:620px)]:leading-7'>
@@ -318,7 +318,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
         <footer
           data-testid='learner-profile-dialog-footer'
           ref={footerRef}
-          className="absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 border-t border-border/60 bg-background pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 shadow-[0_-10px_30px_-22px_rgba(15,23,42,0.35)] before:pointer-events-none before:absolute before:inset-x-0 before:-top-8 before:h-8 before:bg-gradient-to-t before:from-background/80 before:to-transparent before:content-[''] sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3"
+          className='absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 border-t border-border/70 bg-background/90 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 shadow-[0_-8px_18px_-14px_rgba(15,23,42,0.22)] backdrop-blur-md sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3'
         >
           {confirmation ? (
             <>

--- a/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
+++ b/src/cook-web/src/components/profile-onboarding/LearnerProfileDialog.tsx
@@ -185,8 +185,9 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
         className='inset-0 flex h-dvh max-h-none w-screen max-w-none translate-x-0 translate-y-0 flex-col gap-0 overflow-hidden rounded-none border-0 p-0 shadow-none outline-none focus:outline-none focus-visible:outline-none focus-within:outline-none focus-within:ring-0 focus-within:ring-offset-0 motion-reduce:animate-none motion-reduce:duration-0 max-sm:[&_button]:min-h-11 max-sm:[&_button]:min-w-11 max-sm:[&_input]:min-h-11 max-sm:[&_input]:text-base max-sm:[&_select]:min-h-11 max-sm:[&_select]:text-base max-sm:[&_textarea]:text-base sm:inset-auto sm:left-1/2 sm:top-1/2 sm:h-[min(88dvh,760px)] sm:w-[calc(100vw-48px)] sm:max-w-[900px] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-2xl sm:border sm:shadow-lg sm:any-pointer-coarse:[&_button]:min-h-11 sm:any-pointer-coarse:[&_button]:min-w-11 sm:any-pointer-coarse:[&_input]:min-h-11 sm:any-pointer-coarse:[&_input]:text-base sm:any-pointer-coarse:[&_select]:min-h-11 sm:any-pointer-coarse:[&_select]:text-base sm:any-pointer-coarse:[&_textarea]:text-base'
       >
         <header
+          data-testid='learner-profile-dialog-header'
           ref={headerRef}
-          className='absolute inset-x-0 top-0 z-10 border-b border-border/70 bg-background/90 pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] shadow-[0_8px_18px_-14px_rgba(15,23,42,0.22)] backdrop-blur-md sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]'
+          className="absolute inset-x-0 top-0 z-10 bg-background/90 pb-3 pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[max(0.75rem,env(safe-area-inset-top,0px))] backdrop-blur-md after:pointer-events-none after:absolute after:inset-x-0 after:-bottom-3 after:h-3 after:border-b after:border-border/70 after:bg-background/60 after:shadow-[0_6px_12px_-10px_rgba(15,23,42,0.32)] after:backdrop-blur-md after:content-[''] sm:px-8 sm:pb-5 sm:pt-6 [@media(max-height:620px)]:pb-2 [@media(max-height:620px)]:pt-[max(0.75rem,env(safe-area-inset-top,0px))]"
         >
           <DialogHeader className='w-full space-y-1 pr-12 text-start sm:space-y-2 [@media(max-height:620px)]:space-y-1'>
             <DialogTitle className='text-xl font-bold leading-7 tracking-tight sm:text-[28px] sm:leading-9 [@media(max-height:620px)]:text-xl [@media(max-height:620px)]:leading-7'>
@@ -215,7 +216,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
           ref={contentScrollRef}
           data-testid='learner-profile-dialog-body'
           className={cn(
-            'relative z-0 flex min-h-0 flex-1 flex-col overscroll-contain bg-muted/25 pb-[var(--learner-profile-footer-height,80px)] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[var(--learner-profile-header-height,96px)] shadow-[inset_0_10px_16px_-16px_rgba(15,23,42,0.28),inset_0_-10px_16px_-16px_rgba(15,23,42,0.28)] [scrollbar-gutter:stable] sm:px-8 sm:pb-[var(--learner-profile-footer-height,76px)] sm:pt-[var(--learner-profile-header-height,116px)] [@media(max-height:620px)]:pb-[var(--learner-profile-footer-height,80px)] [@media(max-height:620px)]:pt-[var(--learner-profile-header-height,80px)]',
+            'relative z-0 flex min-h-0 flex-1 flex-col overscroll-contain bg-muted/25 pb-[calc(var(--learner-profile-footer-height,80px)+0.75rem)] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-[calc(var(--learner-profile-header-height,96px)+0.75rem)] [scrollbar-gutter:stable] sm:px-8 sm:pb-[calc(var(--learner-profile-footer-height,76px)+0.75rem)] sm:pt-[calc(var(--learner-profile-header-height,116px)+0.75rem)] [@media(max-height:620px)]:pb-[calc(var(--learner-profile-footer-height,80px)+0.75rem)] [@media(max-height:620px)]:pt-[calc(var(--learner-profile-header-height,80px)+0.75rem)]',
             collectionOwnsScroll ? 'overflow-hidden' : 'overflow-y-auto',
           )}
           style={
@@ -318,7 +319,7 @@ export default function LearnerProfileDialog(props: LearnerProfileDialogProps) {
         <footer
           data-testid='learner-profile-dialog-footer'
           ref={footerRef}
-          className='absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 border-t border-border/70 bg-background/90 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 shadow-[0_-8px_18px_-14px_rgba(15,23,42,0.22)] backdrop-blur-md sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3'
+          className="absolute inset-x-0 bottom-0 z-10 flex flex-nowrap items-center gap-2 bg-background/90 pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] pl-[max(1rem,env(safe-area-inset-left,0px))] pr-[max(1rem,env(safe-area-inset-right,0px))] pt-3 backdrop-blur-md before:pointer-events-none before:absolute before:inset-x-0 before:-top-3 before:h-3 before:border-t before:border-border/70 before:bg-background/60 before:shadow-[0_-6px_12px_-10px_rgba(15,23,42,0.32)] before:backdrop-blur-md before:content-[''] sm:flex-wrap sm:justify-end sm:gap-3 sm:px-8 sm:py-4 [@media(max-height:620px)]:flex-nowrap [@media(max-height:620px)]:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] [@media(max-height:620px)]:pt-3"
         >
           {confirmation ? (
             <>

--- a/src/cook-web/src/components/profile-onboarding/ProfileAssistantAnswersView.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileAssistantAnswersView.test.tsx
@@ -59,7 +59,7 @@ test('keeps the assistant answer and actions mobile-safe inside its scroller', (
     name: 'module.profileOnboarding.assistant.process',
   });
 
-  expect(view).toHaveClass('overflow-y-auto', 'overscroll-contain');
+  expect(view).toHaveClass('overflow-y-auto', 'overscroll-contain', 'py-6');
   expect(input).toHaveClass('text-base', 'sm:text-sm');
   expect(copyButton).toHaveClass('min-h-11', 'min-w-20', 'sm:min-h-9');
   expect(backButton).toHaveClass('min-h-11', 'min-w-11', 'sm:min-h-10');

--- a/src/cook-web/src/components/profile-onboarding/ProfileAssistantAnswersView.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileAssistantAnswersView.tsx
@@ -62,7 +62,7 @@ export function ProfileAssistantAnswersView({
 
   return (
     <section
-      className='flex h-full min-h-0 flex-1 flex-col gap-4 overflow-y-auto overscroll-contain pe-1'
+      className='flex h-full min-h-0 flex-1 flex-col gap-4 overflow-y-auto overscroll-contain py-6 pe-1'
       data-testid='profile-assistant-answers'
     >
       <div className='shrink-0 space-y-1'>

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -1919,9 +1919,14 @@ describe('assistant answers in the existing session', () => {
       '.profile-onboarding-markdownflow',
     );
 
-    expect(entry).toHaveClass('hidden', 'sm:inline-flex');
-    expect(entry).toHaveClass('max-w-[calc(50%-2.75rem)]');
-    expect(markdownFlow).toHaveClass('sm:scroll-pb-20', 'sm:pb-20');
+    expect(entry).toHaveClass(
+      'bottom-9',
+      'hidden',
+      'max-w-[calc(50%-2.75rem)]',
+      'shadow-[0_6px_12px_-8px_rgba(15,23,42,0.38)]',
+      'sm:inline-flex',
+    );
+    expect(markdownFlow).toHaveClass('py-6', 'sm:scroll-pb-20', 'sm:pb-20');
     expect(markdownFlow).not.toHaveClass('scroll-pb-20', 'pb-20');
   });
 

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -683,7 +683,7 @@ describe('ProfileOnboardingConversation', () => {
       expect.objectContaining({
         ariaLabel: 'common.core.scrollToBottom',
         autoScrollOnInit: true,
-        bottomOffset: 20,
+        bottomOffset: 36,
         contentVersion: 1,
         followNewContent: false,
         placement: 'bottom-center',

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -1044,6 +1044,8 @@ describe('ProfileOnboardingConversation', () => {
         name: 'module.profileOnboarding.guided.retry',
       }),
     ).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveClass('order-first', 'pt-6');
+    expect(screen.getByRole('status')).not.toHaveClass('pb-6');
     expect(onDraftReady).not.toHaveBeenCalled();
   });
 
@@ -1101,6 +1103,8 @@ describe('ProfileOnboardingConversation', () => {
     const retryButton = await screen.findByRole('button', {
       name: 'module.profileOnboarding.guided.retry',
     });
+    expect(screen.getByRole('status')).toHaveClass('pb-6');
+    expect(screen.getByRole('status')).not.toHaveClass('order-first', 'pt-6');
     expect(onError.mock.calls[0][0]).toEqual(
       new Error('module.profileOnboarding.guided.retryableError'),
     );

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -169,7 +169,7 @@ export default function ProfileOnboardingConversation({
           ref={questionViewportRef}
           aria-busy={loading || (runInFlight && !assistantProcessing)}
           className={cn(
-            'profile-onboarding-markdownflow h-full min-h-0 overflow-y-auto overscroll-contain pe-1 [scrollbar-gutter:stable] max-sm:[&_button]:min-h-11 max-sm:[&_button]:min-w-11 max-sm:[&_input]:min-h-11 max-sm:[&_input]:text-base max-sm:[&_select]:min-h-11 max-sm:[&_select]:text-base max-sm:[&_textarea]:text-base sm:any-pointer-coarse:[&_button]:min-h-11 sm:any-pointer-coarse:[&_button]:min-w-11 sm:any-pointer-coarse:[&_input]:min-h-11 sm:any-pointer-coarse:[&_input]:text-base sm:any-pointer-coarse:[&_select]:min-h-11 sm:any-pointer-coarse:[&_select]:text-base sm:any-pointer-coarse:[&_textarea]:text-base',
+            'profile-onboarding-markdownflow h-full min-h-0 overflow-y-auto overscroll-contain py-6 pe-1 [scrollbar-gutter:stable] max-sm:[&_button]:min-h-11 max-sm:[&_button]:min-w-11 max-sm:[&_input]:min-h-11 max-sm:[&_input]:text-base max-sm:[&_select]:min-h-11 max-sm:[&_select]:text-base max-sm:[&_textarea]:text-base sm:any-pointer-coarse:[&_button]:min-h-11 sm:any-pointer-coarse:[&_button]:min-w-11 sm:any-pointer-coarse:[&_input]:min-h-11 sm:any-pointer-coarse:[&_input]:text-base sm:any-pointer-coarse:[&_select]:min-h-11 sm:any-pointer-coarse:[&_select]:text-base sm:any-pointer-coarse:[&_textarea]:text-base',
             canUseAssistant && 'sm:scroll-pb-20 sm:pb-20',
           )}
         >
@@ -196,7 +196,7 @@ export default function ProfileOnboardingConversation({
           <Button
             ref={assistantEntryRef}
             type='button'
-            className='absolute bottom-3 right-3 z-10 hidden h-auto min-h-10 max-w-[calc(50%-2.75rem)] whitespace-normal rounded-full px-4 py-2 text-start shadow-lg sm:inline-flex'
+            className='absolute bottom-9 right-3 z-10 hidden h-auto min-h-10 max-w-[calc(50%-2.75rem)] whitespace-normal rounded-full px-4 py-2 text-start shadow-[0_6px_12px_-8px_rgba(15,23,42,0.38)] sm:inline-flex'
             disabled={disabled}
             onClick={() => setAssistantVisible(true)}
           >

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -189,7 +189,7 @@ export default function ProfileOnboardingConversation({
           ariaLabel={t('common.core.scrollToBottom')}
           placement='bottom-center'
           position='absolute'
-          bottomOffset={20}
+          bottomOffset={36}
           zIndex={10}
         />
         {!showAssistant && canUseAssistant ? (

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -227,7 +227,7 @@ export default function ProfileOnboardingConversation({
         <div
           className={cn(
             'flex min-h-9 shrink-0 items-center gap-2 text-sm text-muted-foreground',
-            !items.length && 'order-first',
+            !items.length ? 'order-first pt-6' : 'pb-6',
           )}
           role={visibleErrorMessage ? 'alert' : 'status'}
           aria-live={visibleErrorMessage ? 'assertive' : 'polite'}


### PR DESCRIPTION
## Summary
- add 24px blurred glass bands where scrolling content meets the dialog header and footer
- keep 24px breathing room inside the active scroll surface so content is comfortably spaced at rest and moves beneath the glass while scrolling
- retain visible border and short-shadow cues on both dialog boundaries
- raise the AI answer and scroll-to-bottom controls above the footer glass, and tighten the AI answer shadow to prevent a visible seam
- keep assistant-answer content and standalone status messages clear of both glass bands
- re-measure mounted header and footer nodes when a closed dialog opens, including the load-error path

## Validation
- focused LearnerProfileDialog, ProfileOnboardingConversation, and ProfileAssistantAnswersView Jest suites: 100 tests passed
- ESLint passed for all six changed component and test files
- frontend type-check passed
- local dev-toolchain check passed with the repository-required Ruff version
- pre-commit hooks passed
