### PR TITLE
feat: animate personalization guidance

### DIFF
--- a/src/api/flaskr/service/profile_research/events.py
+++ b/src/api/flaskr/service/profile_research/events.py
@@ -14,6 +14,7 @@ def _profile_research_event(
     event_type: str,
     content: object,
     *,
+    element_type: str | None = None,
     generated_block_bid: str | None = None,
     run_session_bid: str | None = None,
     is_terminal: bool | None = None,
@@ -25,6 +26,8 @@ def _profile_research_event(
     }
     if generated_block_bid is not None:
         event["generated_block_bid"] = generated_block_bid
+    if element_type is not None:
+        event["element_type"] = element_type
     if run_session_bid is not None:
         event["run_session_bid"] = run_session_bid
     if is_terminal is not None:

--- a/src/api/flaskr/service/profile_research/runtime.py
+++ b/src/api/flaskr/service/profile_research/runtime.py
@@ -558,7 +558,10 @@ class ProfileResearchRuntime:
         provider = self._provider_factory(self.app, session, root_span)
         events: list[dict[str, Any]] = []
         outcome = _StepOutcome()
-        element_content_by_number: dict[int, str] = {}
+        element_content_by_segment: dict[tuple[int, int], str] = {}
+        element_segment_count_by_number: dict[int, int] = {}
+        active_element_identity: tuple[int, str] | None = None
+        active_element_segment = 0
         rerendered_interaction = ""
         try:
             flow = self._build_flow(session, provider)
@@ -637,13 +640,28 @@ class ProfileResearchRuntime:
                     and raw_element_number >= 0
                     else 0
                 )
+                element_identity = (element_number, element_type)
+                if element_identity != active_element_identity:
+                    active_element_identity = element_identity
+                    active_element_segment = element_segment_count_by_number.get(
+                        element_number, 0
+                    )
+                    element_segment_count_by_number[element_number] = (
+                        active_element_segment + 1
+                    )
+                segment_key = (element_number, active_element_segment)
                 element_content = (
-                    element_content_by_number.get(element_number, "") + content
+                    element_content_by_segment.get(segment_key, "") + content
                 )
-                element_content_by_number[element_number] = element_content
+                element_content_by_segment[segment_key] = element_content
                 element_bid = event_bid
-                if not rendering_interaction and element_number > 0:
-                    element_bid = f"{event_bid}:{element_number}"
+                if not rendering_interaction:
+                    if active_element_segment > 0:
+                        element_bid = (
+                            f"{event_bid}:{element_number}:{active_element_segment}"
+                        )
+                    elif element_number > 0:
+                        element_bid = f"{event_bid}:{element_number}"
                 next_event = _event(
                     "interaction" if rendering_interaction else "content",
                     element_content,

--- a/src/api/flaskr/service/profile_research/runtime.py
+++ b/src/api/flaskr/service/profile_research/runtime.py
@@ -560,6 +560,7 @@ class ProfileResearchRuntime:
         outcome = _StepOutcome()
         element_content_by_segment: dict[tuple[int, int], str] = {}
         element_segment_count_by_number: dict[int, int] = {}
+        html_segment_by_number: dict[int, int] = {}
         active_element_identity: tuple[int, str] | None = None
         active_element_segment = 0
         rerendered_interaction = ""
@@ -643,12 +644,20 @@ class ProfileResearchRuntime:
                 element_identity = (element_number, element_type)
                 if element_identity != active_element_identity:
                     active_element_identity = element_identity
-                    active_element_segment = element_segment_count_by_number.get(
-                        element_number, 0
-                    )
-                    element_segment_count_by_number[element_number] = (
-                        active_element_segment + 1
-                    )
+                    previous_html_segment = html_segment_by_number.get(element_number)
+                    if element_type == "html" and previous_html_segment is not None:
+                        active_element_segment = previous_html_segment
+                    else:
+                        active_element_segment = element_segment_count_by_number.get(
+                            element_number, 0
+                        )
+                        element_segment_count_by_number[element_number] = (
+                            active_element_segment + 1
+                        )
+                        if element_type == "html":
+                            html_segment_by_number[element_number] = (
+                                active_element_segment
+                            )
                 segment_key = (element_number, active_element_segment)
                 element_content = (
                     element_content_by_segment.get(segment_key, "") + content

--- a/src/api/flaskr/service/profile_research/runtime.py
+++ b/src/api/flaskr/service/profile_research/runtime.py
@@ -558,6 +558,7 @@ class ProfileResearchRuntime:
         provider = self._provider_factory(self.app, session, root_span)
         events: list[dict[str, Any]] = []
         outcome = _StepOutcome()
+        element_content_by_number: dict[int, str] = {}
         rerendered_interaction = ""
         try:
             flow = self._build_flow(session, provider)
@@ -620,10 +621,34 @@ class ProfileResearchRuntime:
                     # The generated profile is a structured terminal result,
                     # not part of the learner-visible MarkdownFlow transcript.
                     continue
+                raw_element_type = getattr(llm_result, "type", "")
+                element_type = str(
+                    getattr(raw_element_type, "value", raw_element_type) or ""
+                )
+                if rendering_interaction:
+                    element_type = "interaction"
+                elif not element_type:
+                    element_type = "text"
+                raw_element_number = getattr(llm_result, "number", 0)
+                element_number = (
+                    raw_element_number
+                    if isinstance(raw_element_number, int)
+                    and not isinstance(raw_element_number, bool)
+                    and raw_element_number >= 0
+                    else 0
+                )
+                element_content = (
+                    element_content_by_number.get(element_number, "") + content
+                )
+                element_content_by_number[element_number] = element_content
+                element_bid = event_bid
+                if not rendering_interaction and element_number > 0:
+                    element_bid = f"{event_bid}:{element_number}"
                 next_event = _event(
                     "interaction" if rendering_interaction else "content",
-                    outcome.content,
-                    generated_block_bid=event_bid,
+                    element_content,
+                    element_type=element_type,
+                    generated_block_bid=element_bid,
                     run_session_bid=session.session_id,
                     is_terminal=False,
                 )
@@ -714,6 +739,7 @@ class ProfileResearchRuntime:
                 _event(
                     "interaction",
                     execution.rerendered_interaction,
+                    element_type="interaction",
                     generated_block_bid=(
                         f"profile-research:{session.session_id}:{processed_block_index}"
                     ),

--- a/src/api/tests/service/profile_research/test_runtime.py
+++ b/src/api/tests/service/profile_research/test_runtime.py
@@ -928,6 +928,45 @@ def test_preserved_content_context_uses_markdownflow_output_without_placeholders
     assert "__MDFLOW_CODE_BLOCK_" not in str(sent_messages)
 
 
+def test_preserved_content_streams_structured_element_types() -> None:
+    _app, runtime, _providers = _make_runtime()
+    session = runtime.start_session(
+        user_bid="user-1",
+        document=(
+            "!===\n"
+            "Intro text\n"
+            "<div>Visual card</div>\n"
+            "Closing text\n"
+            "!===\n\n---\n\n?[继续]"
+        ),
+        purpose=PROFILE_ONBOARDING_PURPOSE,
+        config_revision=1,
+        output_language=None,
+    )
+
+    events = list(
+        runtime.stream_session(
+            user_bid="user-1",
+            session_id=session["session_id"],
+            user_input=None,
+            expected_purpose=PROFILE_ONBOARDING_PURPOSE,
+        )
+    )
+    content_events = [event for event in events if event["event_type"] == "content"]
+
+    assert [event["element_type"] for event in content_events] == [
+        "text",
+        "html",
+        "text",
+    ]
+    assert [event["content"] for event in content_events] == [
+        "Intro text\n",
+        "<div>Visual card</div>\n",
+        "Closing text",
+    ]
+    assert len({event["generated_block_bid"] for event in content_events}) == 3
+
+
 def test_non_assignment_answer_reaches_the_next_markdownflow_content_block() -> None:
     _app, runtime, providers = _make_runtime(["个性化回应"])
     session = runtime.start_session(

--- a/src/api/tests/service/profile_research/test_runtime.py
+++ b/src/api/tests/service/profile_research/test_runtime.py
@@ -992,6 +992,51 @@ def test_preserved_heading_and_text_with_one_number_use_distinct_bids() -> None:
     assert len({event["generated_block_bid"] for event in content_events}) == 2
 
 
+def test_preserved_html_append_reuses_original_element_bid() -> None:
+    _app, runtime, _providers = _make_runtime()
+    session = runtime.start_session(
+        user_bid="user-1",
+        document=(
+            "!===\n"
+            '<div id="card">Visual card</div>\n'
+            "Between\n"
+            '<script>document.getElementById("card").remove()</script>\n'
+            "!===\n\n---\n\n?[继续]"
+        ),
+        purpose=PROFILE_ONBOARDING_PURPOSE,
+        config_revision=1,
+        output_language=None,
+    )
+
+    events = list(
+        runtime.stream_session(
+            user_bid="user-1",
+            session_id=session["session_id"],
+            user_input=None,
+            expected_purpose=PROFILE_ONBOARDING_PURPOSE,
+        )
+    )
+    content_events = [event for event in events if event["event_type"] == "content"]
+
+    assert [event["element_type"] for event in content_events] == [
+        "html",
+        "text",
+        "html",
+    ]
+    assert content_events[2]["content"] == (
+        '<div id="card">Visual card</div>\n'
+        '<script>document.getElementById("card").remove()</script>'
+    )
+    assert (
+        content_events[2]["generated_block_bid"]
+        == content_events[0]["generated_block_bid"]
+    )
+    assert (
+        content_events[1]["generated_block_bid"]
+        != content_events[0]["generated_block_bid"]
+    )
+
+
 def test_non_assignment_answer_reaches_the_next_markdownflow_content_block() -> None:
     _app, runtime, providers = _make_runtime(["个性化回应"])
     session = runtime.start_session(

--- a/src/api/tests/service/profile_research/test_runtime.py
+++ b/src/api/tests/service/profile_research/test_runtime.py
@@ -967,6 +967,31 @@ def test_preserved_content_streams_structured_element_types() -> None:
     assert len({event["generated_block_bid"] for event in content_events}) == 3
 
 
+def test_preserved_heading_and_text_with_one_number_use_distinct_bids() -> None:
+    _app, runtime, _providers = _make_runtime()
+    session = runtime.start_session(
+        user_bid="user-1",
+        document="!===\n# Heading\nBody\n!===\n\n---\n\n?[继续]",
+        purpose=PROFILE_ONBOARDING_PURPOSE,
+        config_revision=1,
+        output_language=None,
+    )
+
+    events = list(
+        runtime.stream_session(
+            user_bid="user-1",
+            session_id=session["session_id"],
+            user_input=None,
+            expected_purpose=PROFILE_ONBOARDING_PURPOSE,
+        )
+    )
+    content_events = [event for event in events if event["event_type"] == "content"]
+
+    assert [event["element_type"] for event in content_events] == ["title", "text"]
+    assert [event["content"] for event in content_events] == ["# Heading\n", "Body"]
+    assert len({event["generated_block_bid"] for event in content_events}) == 2
+
+
 def test_non_assignment_answer_reaches_the_next_markdownflow_content_block() -> None:
     _app, runtime, providers = _make_runtime(["个性化回应"])
     session = runtime.start_session(

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -21,6 +21,8 @@ const DEFAULT_RENDERER_SUBMISSION: OnSendContentParams = {
   inputText: '学会 AI',
 };
 let mockRendererSubmission: OnSendContentParams = DEFAULT_RENDERER_SUBMISSION;
+let mockAutoFinishTypewriter = true;
+let mockLatestTypeFinished: (() => void) | undefined;
 
 type MockScrollControlProps = {
   ariaLabel: string;
@@ -72,7 +74,8 @@ jest.mock('markdown-flow-ui/renderer', () => ({
     onTypeFinished?: () => void;
   }) => {
     React.useEffect(() => {
-      onTypeFinished?.();
+      mockLatestTypeFinished = onTypeFinished;
+      if (mockAutoFinishTypewriter) onTypeFinished?.();
     }, [onTypeFinished]);
     // Match the library's inline custom-variable renderer: an unnecessary
     // MarkdownFlow re-render remounts the input and loses unsent local state.
@@ -119,6 +122,8 @@ const getLatestScrollControlProps = () => {
 describe('ProfileOnboardingConversation', () => {
   beforeEach(() => {
     mockRendererSubmission = DEFAULT_RENDERER_SUBMISSION;
+    mockAutoFinishTypewriter = true;
+    mockLatestTypeFinished = undefined;
     mockScrollToBottomControl.mockClear();
   });
 
@@ -775,6 +780,49 @@ describe('ProfileOnboardingConversation', () => {
     await waitFor(() => {
       expect(getLatestScrollControlProps().contentVersion).toBe(2);
     });
+  });
+
+  test('updates scroll content version when a gated question becomes visible', async () => {
+    mockAutoFinishTypewriter = false;
+    const runSession = jest.fn(({ onMessage }) => {
+      queueMicrotask(() => {
+        onMessage({
+          type: 'element',
+          content: {
+            element_bid: 'scroll-guidance',
+            element_type: 'text',
+            content: 'Read this first',
+          },
+        });
+        onMessage({
+          type: 'element',
+          content: {
+            element_bid: 'scroll-question',
+            element_type: 'interaction',
+            content: '?[%{{goal}}...Then answer]',
+          },
+        });
+      });
+      return { close: jest.fn() };
+    });
+
+    render(
+      <ProfileOnboardingConversation
+        createSession={async () => ({ session_id: 'session-scroll-reveal' })}
+        runSession={runSession}
+        onDraftReady={jest.fn()}
+        onError={jest.fn()}
+      />,
+    );
+
+    await screen.findByText('Read this first');
+    expect(screen.queryByText('?[%{{goal}}...Then answer]')).toBeNull();
+    expect(getLatestScrollControlProps().contentVersion).toBe(1);
+
+    act(() => mockLatestTypeFinished?.());
+
+    await screen.findByText('?[%{{goal}}...Then answer]');
+    expect(getLatestScrollControlProps().contentVersion).toBe(2);
   });
 
   test('submits without ES2023 array methods and returns the server profile draft', async () => {

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -61,6 +61,7 @@ jest.mock('markdown-flow-ui/renderer', () => ({
     onSend,
     enableTypewriter,
     typingSpeed,
+    onTypeFinished,
   }: {
     content: string;
     readonly?: boolean;
@@ -68,7 +69,11 @@ jest.mock('markdown-flow-ui/renderer', () => ({
     onSend?: (value: OnSendContentParams) => void;
     enableTypewriter?: boolean;
     typingSpeed?: number;
+    onTypeFinished?: () => void;
   }) => {
+    React.useEffect(() => {
+      onTypeFinished?.();
+    }, [onTypeFinished]);
     // Match the library's inline custom-variable renderer: an unnecessary
     // MarkdownFlow re-render remounts the input and loses unsent local state.
     const UnsentAnswer = () => (

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -194,6 +194,39 @@ describe('ProfileOnboardingConversation', () => {
     expect(typewriter).toHaveAttribute('data-speed', '30');
   });
 
+  test('renders guided interaction controls without a typewriter delay', async () => {
+    const runSession = jest.fn(({ onMessage }) => {
+      queueMicrotask(() => {
+        onMessage({
+          type: 'element',
+          content: {
+            element_bid: 'profile-interaction',
+            element_type: 'interaction',
+            content: '?[%{{profile_goal}}...What do you want to learn?]',
+          },
+        });
+      });
+      return { close: jest.fn() };
+    });
+
+    render(
+      <ProfileOnboardingConversation
+        createSession={async () => ({ session_id: 'session-interaction' })}
+        runSession={runSession}
+        onDraftReady={jest.fn()}
+        onError={jest.fn()}
+      />,
+    );
+
+    await screen.findByRole('button', {
+      name: ANSWER_GUIDED_QUESTION_LABEL,
+    });
+    expect(screen.getByTestId('profile-onboarding-typewriter')).toHaveAttribute(
+      'data-enabled',
+      'false',
+    );
+  });
+
   test('keeps an over-limit Unicode answer editable until a valid correction', async () => {
     const onError = jest.fn();
     mockRendererSubmission = {

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -54,17 +54,20 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('markdown-flow-ui/renderer', () => ({
-  MarkdownFlow: ({
-    initialContentList,
+  ContentRender: ({
+    content,
+    userInput,
+    readonly,
     onSend,
+    enableTypewriter,
+    typingSpeed,
   }: {
-    initialContentList: Array<{
-      content: string;
-      isFinished?: boolean;
-      readonly?: boolean;
-      userInput?: string;
-    }>;
-    onSend: (value: OnSendContentParams) => void;
+    content: string;
+    readonly?: boolean;
+    userInput?: string;
+    onSend?: (value: OnSendContentParams) => void;
+    enableTypewriter?: boolean;
+    typingSpeed?: number;
   }) => {
     // Match the library's inline custom-variable renderer: an unnecessary
     // MarkdownFlow re-render remounts the input and loses unsent local state.
@@ -77,18 +80,17 @@ jest.mock('markdown-flow-ui/renderer', () => ({
     return (
       <div>
         <UnsentAnswer />
-        {initialContentList.map((item, index) => (
-          <div key={`${item.content}-${index}`}>
-            <span>{item.content}</span>
-            {item.userInput ? <span>{item.userInput}</span> : null}
-          </div>
-        ))}
-        {initialContentList.some(item => !item.isFinished) ? (
+        <span>{content}</span>
+        {userInput ? <span>{userInput}</span> : null}
+        <span
+          data-testid='profile-onboarding-typewriter'
+          data-enabled={String(Boolean(enableTypewriter))}
+          data-speed={String(typingSpeed)}
+        />
+        {onSend ? (
           <button
             type='button'
-            disabled={initialContentList.some(
-              item => !item.isFinished && item.readonly,
-            )}
+            disabled={readonly}
             onClick={() => onSend(mockRendererSubmission)}
           >
             {ANSWER_GUIDED_QUESTION_LABEL}
@@ -160,6 +162,36 @@ describe('ProfileOnboardingConversation', () => {
         'c'.repeat(2_001),
       ]),
     ).toBe(false);
+  });
+
+  test('uses the learning page typewriter cadence for guided content', async () => {
+    const runSession = jest.fn(({ onMessage }) => {
+      queueMicrotask(() => {
+        onMessage({
+          type: 'element',
+          content: {
+            element_bid: 'profile-typewriter-content',
+            element_type: 'text',
+            content: '欢迎，先一起确认你的学习偏好。',
+          },
+        });
+      });
+      return { close: jest.fn() };
+    });
+
+    render(
+      <ProfileOnboardingConversation
+        createSession={async () => ({ session_id: 'session-typewriter' })}
+        runSession={runSession}
+        onDraftReady={jest.fn()}
+        onError={jest.fn()}
+      />,
+    );
+
+    await screen.findByText('欢迎，先一起确认你的学习偏好。');
+    const typewriter = screen.getByTestId('profile-onboarding-typewriter');
+    expect(typewriter).toHaveAttribute('data-enabled', 'true');
+    expect(typewriter).toHaveAttribute('data-speed', '30');
   });
 
   test('keeps an over-limit Unicode answer editable until a valid correction', async () => {

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -29,7 +29,6 @@ type MockScrollControlProps = {
   ariaLabel: string;
   autoScrollOnInit?: boolean;
   bottomOffset?: number;
-  contentRef?: React.RefObject<HTMLElement | null>;
   contentVersion?: unknown;
   endRef?: React.RefObject<HTMLElement | null>;
   followNewContent?: boolean;
@@ -796,14 +795,13 @@ describe('ProfileOnboardingConversation', () => {
         autoScrollOnInit: true,
         bottomOffset: 36,
         contentVersion: 1,
-        followNewContent: true,
+        followNewContent: false,
         placement: 'bottom-center',
         position: 'absolute',
         zIndex: 10,
       }),
     );
     expect(firstProps).not.toHaveProperty('endRef');
-    expect(firstProps.contentRef?.current).toHaveClass('markdown-flow');
     expect(firstProps.viewportRef).toBe(firstProps.scrollTarget);
     expect(firstProps.viewportRef.current).toHaveClass(
       'profile-onboarding-markdownflow',

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -527,6 +527,7 @@ describe('ProfileOnboardingConversation', () => {
   });
 
   test('waits without progress indicators after the final response until the draft is ready', async () => {
+    mockAutoFinishTypewriter = false;
     let finalOnMessage: ((event: Record<string, unknown>) => void) | undefined;
     const onDraftReady = jest.fn();
     const runSession = jest
@@ -575,7 +576,7 @@ describe('ProfileOnboardingConversation', () => {
         type: 'element',
         content: {
           element_bid: 'final-feedback',
-          element_type: 'content',
+          element_type: 'text',
           content: '信息收集完成。',
         },
       });
@@ -596,6 +597,8 @@ describe('ProfileOnboardingConversation', () => {
       });
     });
 
+    expect(onDraftReady).not.toHaveBeenCalled();
+    act(() => mockLatestTypeFinished?.());
     await waitFor(() =>
       expect(onDraftReady).toHaveBeenCalledWith(
         '最终个人介绍',

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -803,7 +803,7 @@ describe('ProfileOnboardingConversation', () => {
       }),
     );
     expect(firstProps).not.toHaveProperty('endRef');
-    expect(firstProps.contentRef.current).toHaveClass('markdown-flow');
+    expect(firstProps.contentRef?.current).toHaveClass('markdown-flow');
     expect(firstProps.viewportRef).toBe(firstProps.scrollTarget);
     expect(firstProps.viewportRef.current).toHaveClass(
       'profile-onboarding-markdownflow',

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -240,6 +240,35 @@ describe('ProfileOnboardingConversation', () => {
     );
   });
 
+  test('renders HTML content without a typewriter delay', async () => {
+    const runSession = jest.fn(({ onMessage }) => {
+      queueMicrotask(() => {
+        onMessage({
+          type: 'content',
+          element_type: 'html',
+          generated_block_bid: 'profile-html-content',
+          content: '<div>Visual card</div>',
+        });
+      });
+      return { close: jest.fn() };
+    });
+
+    render(
+      <ProfileOnboardingConversation
+        createSession={async () => ({ session_id: 'session-html' })}
+        runSession={runSession}
+        onDraftReady={jest.fn()}
+        onError={jest.fn()}
+      />,
+    );
+
+    await screen.findByText('<div>Visual card</div>');
+    expect(screen.getByTestId('profile-onboarding-typewriter')).toHaveAttribute(
+      'data-enabled',
+      'false',
+    );
+  });
+
   test('keeps an over-limit Unicode answer editable until a valid correction', async () => {
     const onError = jest.fn();
     mockRendererSubmission = {

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -29,6 +29,7 @@ type MockScrollControlProps = {
   ariaLabel: string;
   autoScrollOnInit?: boolean;
   bottomOffset?: number;
+  contentRef?: React.RefObject<HTMLElement | null>;
   contentVersion?: unknown;
   endRef?: React.RefObject<HTMLElement | null>;
   followNewContent?: boolean;
@@ -795,13 +796,14 @@ describe('ProfileOnboardingConversation', () => {
         autoScrollOnInit: true,
         bottomOffset: 36,
         contentVersion: 1,
-        followNewContent: false,
+        followNewContent: true,
         placement: 'bottom-center',
         position: 'absolute',
         zIndex: 10,
       }),
     );
     expect(firstProps).not.toHaveProperty('endRef');
+    expect(firstProps.contentRef.current).toHaveClass('markdown-flow');
     expect(firstProps.viewportRef).toBe(firstProps.scrollTarget);
     expect(firstProps.viewportRef.current).toHaveClass(
       'profile-onboarding-markdownflow',

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx
@@ -23,6 +23,7 @@ const DEFAULT_RENDERER_SUBMISSION: OnSendContentParams = {
 let mockRendererSubmission: OnSendContentParams = DEFAULT_RENDERER_SUBMISSION;
 let mockAutoFinishTypewriter = true;
 let mockLatestTypeFinished: (() => void) | undefined;
+let mockRenderedContents: string[] = [];
 
 type MockScrollControlProps = {
   ariaLabel: string;
@@ -73,6 +74,7 @@ jest.mock('markdown-flow-ui/renderer', () => ({
     typingSpeed?: number;
     onTypeFinished?: () => void;
   }) => {
+    mockRenderedContents.push(content);
     React.useEffect(() => {
       mockLatestTypeFinished = onTypeFinished;
       if (mockAutoFinishTypewriter) onTypeFinished?.();
@@ -124,6 +126,7 @@ describe('ProfileOnboardingConversation', () => {
     mockRendererSubmission = DEFAULT_RENDERER_SUBMISSION;
     mockAutoFinishTypewriter = true;
     mockLatestTypeFinished = undefined;
+    mockRenderedContents = [];
     mockScrollToBottomControl.mockClear();
   });
 
@@ -823,6 +826,71 @@ describe('ProfileOnboardingConversation', () => {
 
     await screen.findByText('?[%{{goal}}...Then answer]');
     expect(getLatestScrollControlProps().contentVersion).toBe(2);
+  });
+
+  test('hides later questions immediately when finished text content changes', async () => {
+    mockAutoFinishTypewriter = false;
+    let emitMessage: Parameters<ProfileOnboardingRunSession>[0]['onMessage'] =
+      () => undefined;
+    const runSession = jest.fn(({ onMessage }) => {
+      emitMessage = onMessage;
+      queueMicrotask(() => {
+        onMessage({
+          type: 'element',
+          content: {
+            element_bid: 'changing-guidance',
+            element_type: 'text',
+            content: 'Initial guidance',
+          },
+        });
+        onMessage({
+          type: 'element',
+          content: {
+            element_bid: 'later-question',
+            element_type: 'interaction',
+            content: '?[%{{goal}}...Later question]',
+          },
+        });
+      });
+      return { close: jest.fn() };
+    });
+
+    render(
+      <ProfileOnboardingConversation
+        createSession={async () => ({ session_id: 'session-content-change' })}
+        runSession={runSession}
+        onDraftReady={jest.fn()}
+        onError={jest.fn()}
+      />,
+    );
+
+    await screen.findByText('Initial guidance');
+    expect(screen.queryByText('?[%{{goal}}...Later question]')).toBeNull();
+
+    act(() => mockLatestTypeFinished?.());
+    await screen.findByText('?[%{{goal}}...Later question]');
+    const questionRenderCount = mockRenderedContents.filter(
+      content => content === '?[%{{goal}}...Later question]',
+    ).length;
+
+    act(() => {
+      emitMessage({
+        type: 'element',
+        content: {
+          element_bid: 'changing-guidance',
+          element_type: 'text',
+          content: 'Updated guidance',
+        },
+      });
+    });
+
+    await screen.findByText('Updated guidance');
+    expect(screen.queryByText('?[%{{goal}}...Later question]')).toBeNull();
+    expect(
+      mockRenderedContents.filter(
+        content => content === '?[%{{goal}}...Later question]',
+      ),
+    ).toHaveLength(questionRenderCount);
   });
 
   test('submits without ES2023 array methods and returns the server profile draft', async () => {

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -197,9 +197,10 @@ export default function ProfileOnboardingConversation({
     const visibleItems: typeof contentList = [];
     for (const item of contentList) {
       visibleItems.push(item);
+      const cacheEntry = typewriterCache[item.elementBid];
       if (
         item.elementType === 'text' &&
-        !typewriterCache[item.elementBid]?.isFinished
+        (!cacheEntry?.isFinished || cacheEntry.content !== item.content)
       ) {
         break;
       }

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -295,7 +295,7 @@ export default function ProfileOnboardingConversation({
           viewportRef={questionViewportRef}
           scrollTarget={questionViewportRef}
           autoScrollOnInit
-          contentVersion={items.length}
+          contentVersion={visibleContentList.length}
           followNewContent={false}
           ariaLabel={t('common.core.scrollToBottom')}
           placement='bottom-center'

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -149,6 +149,8 @@ export default function ProfileOnboardingConversation({
     onSessionCreateRejected,
     onRetry,
   });
+  const itemsRef = React.useRef(items);
+  itemsRef.current = items;
 
   const locale = resolveMarkdownFlowLocale(
     i18n.resolvedLanguage ?? i18n.language,
@@ -208,11 +210,31 @@ export default function ProfileOnboardingConversation({
   const handleTypeFinished = React.useCallback((elementBid: string) => {
     setTypewriterCache(previousCache => {
       const entry = previousCache[elementBid];
-      return entry
-        ? { ...previousCache, [elementBid]: { ...entry, isFinished: true } }
-        : previousCache;
+      const item = itemsRef.current.find(
+        candidate => candidate.elementBid === elementBid,
+      );
+      if (!entry && !item) return previousCache;
+      return {
+        ...previousCache,
+        [elementBid]: {
+          content: entry?.content ?? item?.content ?? '',
+          isFinished: true,
+          isSuppressed: entry?.isSuppressed ?? false,
+        },
+      };
     });
   }, []);
+  const typeFinishedCallbacksRef = React.useRef(new Map<string, () => void>());
+  const getTypeFinishedCallback = React.useCallback(
+    (elementBid: string) => {
+      const existingCallback = typeFinishedCallbacksRef.current.get(elementBid);
+      if (existingCallback) return existingCallback;
+      const callback = () => handleTypeFinished(elementBid);
+      typeFinishedCallbacksRef.current.set(elementBid, callback);
+      return callback;
+    },
+    [handleTypeFinished],
+  );
 
   return (
     <div
@@ -250,7 +272,11 @@ export default function ProfileOnboardingConversation({
                     )
                   }
                   typingSpeed={CHAT_TYPEWRITER_SPEED_MS}
-                  onTypeFinished={() => handleTypeFinished(item.elementBid)}
+                  onTypeFinished={
+                    item.elementType === 'text'
+                      ? getTypeFinishedCallback(item.elementBid)
+                      : undefined
+                  }
                 />
               ))
             ) : (

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -62,6 +62,12 @@ export type ProfileOnboardingConversationProps = {
   questionScrollFooter?: React.ReactNode;
 };
 
+type PendingProfileDraft = {
+  profileDraft: string;
+  sessionId: string;
+  nickname?: string;
+};
+
 export default function ProfileOnboardingConversation({
   createSession,
   runSession,
@@ -98,6 +104,14 @@ export default function ProfileOnboardingConversation({
   );
   const [typewriterCache, setTypewriterCache] =
     React.useState<ProfileOnboardingTypewriterCache>({});
+  const [pendingProfileDraft, setPendingProfileDraft] =
+    React.useState<PendingProfileDraft | null>(null);
+  const holdProfileDraft = React.useCallback(
+    (profileDraft: string, sessionId: string, nickname?: string) => {
+      setPendingProfileDraft({ profileDraft, sessionId, nickname });
+    },
+    [],
+  );
 
   React.useEffect(() => {
     const syncVisibility = () =>
@@ -144,7 +158,7 @@ export default function ProfileOnboardingConversation({
     },
     onSessionStarted,
     onRunInFlightChange,
-    onDraftReady,
+    onDraftReady: holdProfileDraft,
     onError,
     onSessionCreateRejected,
     onRetry,
@@ -191,6 +205,39 @@ export default function ProfileOnboardingConversation({
       ),
     );
   }, [isDocumentVisible, items]);
+
+  React.useEffect(() => {
+    if (!pendingProfileDraft) return;
+    const hasUnfinishedGuidance =
+      isDocumentVisible &&
+      items.some(item => {
+        if (item.elementType !== 'text') return false;
+        const cacheEntry = typewriterCache[item.elementBid];
+        return (
+          cacheEntry?.isFinished !== true || cacheEntry.content !== item.content
+        );
+      });
+    if (hasUnfinishedGuidance) return;
+    setPendingProfileDraft(null);
+    if (pendingProfileDraft.nickname) {
+      onDraftReady(
+        pendingProfileDraft.profileDraft,
+        pendingProfileDraft.sessionId,
+        pendingProfileDraft.nickname,
+      );
+    } else {
+      onDraftReady(
+        pendingProfileDraft.profileDraft,
+        pendingProfileDraft.sessionId,
+      );
+    }
+  }, [
+    isDocumentVisible,
+    items,
+    onDraftReady,
+    pendingProfileDraft,
+    typewriterCache,
+  ]);
 
   const visibleContentList = React.useMemo(() => {
     if (!isDocumentVisible) return contentList;

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import React from 'react';
-import { MarkdownFlow } from 'markdown-flow-ui/renderer';
+import { ContentRender } from 'markdown-flow-ui/renderer';
 import { ScrollToBottomControl } from 'markdown-flow-ui/scroll';
 import { Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/Button';
+import { CHAT_TYPEWRITER_SPEED_MS } from '@/c-constants/uiConstants';
 import { resolveMarkdownFlowLocale } from '@/lib/markdown-flow-locale';
 import { cn } from '@/lib/utils';
 import type {
@@ -18,7 +19,7 @@ import { useProfileOnboardingSession } from './useProfileOnboardingSession';
 
 // ContentRender recreates its custom interaction component on every render.
 // Isolate it from sibling view/copy/paste state to preserve unsent input.
-const StableMarkdownFlow = React.memo(MarkdownFlow);
+const StableProfileContentRender = React.memo(ContentRender);
 
 export {
   isProfileOnboardingSubmissionWithinLimits,
@@ -147,6 +148,7 @@ export default function ProfileOnboardingConversation({
   const contentList = React.useMemo(
     () =>
       items.map(item => ({
+        elementBid: item.elementBid,
         content: item.content,
         isFinished: item.finished,
         readonly: questionReadonly || item.finished || !item.interaction,
@@ -173,11 +175,30 @@ export default function ProfileOnboardingConversation({
             canUseAssistant && 'sm:scroll-pb-20 sm:pb-20',
           )}
         >
-          <StableMarkdownFlow
-            locale={locale}
-            initialContentList={contentList}
-            onSend={send}
-          />
+          <div className='markdown-flow'>
+            {contentList.length ? (
+              contentList.map(item => (
+                <StableProfileContentRender
+                  key={item.elementBid}
+                  locale={locale}
+                  content={item.content}
+                  userInput={item.userInput}
+                  readonly={item.readonly}
+                  onSend={item.isFinished ? undefined : send}
+                  enableTypewriter
+                  typingSpeed={CHAT_TYPEWRITER_SPEED_MS}
+                />
+              ))
+            ) : (
+              <StableProfileContentRender
+                locale={locale}
+                content=''
+                readonly
+                enableTypewriter
+                typingSpeed={CHAT_TYPEWRITER_SPEED_MS}
+              />
+            )}
+          </div>
           {questionScrollFooter}
         </div>
         <ScrollToBottomControl

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -190,6 +190,30 @@ export default function ProfileOnboardingConversation({
     );
   }, [isDocumentVisible, items]);
 
+  const visibleContentList = React.useMemo(() => {
+    if (!isDocumentVisible) return contentList;
+    const visibleItems: typeof contentList = [];
+    for (const item of contentList) {
+      visibleItems.push(item);
+      if (
+        item.elementType === 'text' &&
+        !typewriterCache[item.elementBid]?.isFinished
+      ) {
+        break;
+      }
+    }
+    return visibleItems;
+  }, [contentList, isDocumentVisible, typewriterCache]);
+
+  const handleTypeFinished = React.useCallback((elementBid: string) => {
+    setTypewriterCache(previousCache => {
+      const entry = previousCache[elementBid];
+      return entry
+        ? { ...previousCache, [elementBid]: { ...entry, isFinished: true } }
+        : previousCache;
+    });
+  }, []);
+
   return (
     <div
       data-testid='profile-onboarding-conversation'
@@ -209,8 +233,8 @@ export default function ProfileOnboardingConversation({
           )}
         >
           <div className='markdown-flow'>
-            {contentList.length ? (
-              contentList.map(item => (
+            {visibleContentList.length ? (
+              visibleContentList.map(item => (
                 <StableProfileContentRender
                   key={item.elementBid}
                   locale={locale}
@@ -226,6 +250,7 @@ export default function ProfileOnboardingConversation({
                     )
                   }
                   typingSpeed={CHAT_TYPEWRITER_SPEED_MS}
+                  onTypeFinished={() => handleTypeFinished(item.elementBid)}
                 />
               ))
             ) : (

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -92,7 +92,10 @@ export default function ProfileOnboardingConversation({
   const assistantHeadingRef = React.useRef<HTMLHeadingElement>(null);
   const assistantEntryRef = React.useRef<HTMLButtonElement>(null);
   const previousAssistantVisibleRef = React.useRef(false);
-  const [isDocumentVisible, setIsDocumentVisible] = React.useState(true);
+  const [isDocumentVisible, setIsDocumentVisible] = React.useState(
+    () =>
+      typeof document === 'undefined' || document.visibilityState !== 'hidden',
+  );
   const [typewriterCache, setTypewriterCache] =
     React.useState<ProfileOnboardingTypewriterCache>({});
 

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -95,7 +95,6 @@ export default function ProfileOnboardingConversation({
       : null;
   const showAssistant = assistantVisible && assistantView !== null;
   const questionViewportRef = React.useRef<HTMLDivElement>(null);
-  const questionContentRef = React.useRef<HTMLDivElement>(null);
   const assistantHeadingRef = React.useRef<HTMLHeadingElement>(null);
   const assistantEntryRef = React.useRef<HTMLButtonElement>(null);
   const previousAssistantVisibleRef = React.useRef(false);
@@ -303,10 +302,7 @@ export default function ProfileOnboardingConversation({
             canUseAssistant && 'sm:scroll-pb-20 sm:pb-20',
           )}
         >
-          <div
-            ref={questionContentRef}
-            className='markdown-flow'
-          >
+          <div className='markdown-flow'>
             {visibleContentList.length ? (
               visibleContentList.map(item => (
                 <StableProfileContentRender
@@ -345,11 +341,10 @@ export default function ProfileOnboardingConversation({
         </div>
         <ScrollToBottomControl
           viewportRef={questionViewportRef}
-          contentRef={questionContentRef}
           scrollTarget={questionViewportRef}
           autoScrollOnInit
           contentVersion={visibleContentList.length}
-          followNewContent
+          followNewContent={false}
           ariaLabel={t('common.core.scrollToBottom')}
           placement='bottom-center'
           position='absolute'

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -95,6 +95,7 @@ export default function ProfileOnboardingConversation({
       : null;
   const showAssistant = assistantVisible && assistantView !== null;
   const questionViewportRef = React.useRef<HTMLDivElement>(null);
+  const questionContentRef = React.useRef<HTMLDivElement>(null);
   const assistantHeadingRef = React.useRef<HTMLHeadingElement>(null);
   const assistantEntryRef = React.useRef<HTMLButtonElement>(null);
   const previousAssistantVisibleRef = React.useRef(false);
@@ -302,7 +303,10 @@ export default function ProfileOnboardingConversation({
             canUseAssistant && 'sm:scroll-pb-20 sm:pb-20',
           )}
         >
-          <div className='markdown-flow'>
+          <div
+            ref={questionContentRef}
+            className='markdown-flow'
+          >
             {visibleContentList.length ? (
               visibleContentList.map(item => (
                 <StableProfileContentRender
@@ -341,10 +345,11 @@ export default function ProfileOnboardingConversation({
         </div>
         <ScrollToBottomControl
           viewportRef={questionViewportRef}
+          contentRef={questionContentRef}
           scrollTarget={questionViewportRef}
           autoScrollOnInit
           contentVersion={visibleContentList.length}
-          followNewContent={false}
+          followNewContent
           ariaLabel={t('common.core.scrollToBottom')}
           placement='bottom-center'
           position='absolute'

--- a/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
+++ b/src/cook-web/src/components/profile-onboarding/ProfileOnboardingConversation.tsx
@@ -13,6 +13,11 @@ import type {
   ProfileOnboardingAssistantAnswers,
   ProfileOnboardingRunSession,
   ProfileOnboardingSessionInfo,
+  ProfileOnboardingTypewriterCache,
+} from './profileOnboardingConversationModel';
+import {
+  shouldEnableProfileOnboardingTypewriter,
+  syncProfileOnboardingTypewriterCache,
 } from './profileOnboardingConversationModel';
 import { ProfileAssistantAnswersView } from './ProfileAssistantAnswersView';
 import { useProfileOnboardingSession } from './useProfileOnboardingSession';
@@ -87,6 +92,18 @@ export default function ProfileOnboardingConversation({
   const assistantHeadingRef = React.useRef<HTMLHeadingElement>(null);
   const assistantEntryRef = React.useRef<HTMLButtonElement>(null);
   const previousAssistantVisibleRef = React.useRef(false);
+  const [isDocumentVisible, setIsDocumentVisible] = React.useState(true);
+  const [typewriterCache, setTypewriterCache] =
+    React.useState<ProfileOnboardingTypewriterCache>({});
+
+  React.useEffect(() => {
+    const syncVisibility = () =>
+      setIsDocumentVisible(document.visibilityState !== 'hidden');
+    syncVisibility();
+    document.addEventListener('visibilitychange', syncVisibility);
+    return () =>
+      document.removeEventListener('visibilitychange', syncVisibility);
+  }, []);
 
   React.useEffect(() => {
     if (previousAssistantVisibleRef.current === showAssistant) return;
@@ -151,11 +168,24 @@ export default function ProfileOnboardingConversation({
         elementBid: item.elementBid,
         content: item.content,
         isFinished: item.finished,
+        finished: item.finished,
+        interaction: item.interaction,
         readonly: questionReadonly || item.finished || !item.interaction,
         userInput: item.userInput,
+        elementType: item.elementType,
       })),
     [items, questionReadonly],
   );
+
+  React.useEffect(() => {
+    setTypewriterCache(previousCache =>
+      syncProfileOnboardingTypewriterCache(
+        items,
+        previousCache,
+        !isDocumentVisible,
+      ),
+    );
+  }, [isDocumentVisible, items]);
 
   return (
     <div
@@ -185,7 +215,13 @@ export default function ProfileOnboardingConversation({
                   userInput={item.userInput}
                   readonly={item.readonly}
                   onSend={item.isFinished ? undefined : send}
-                  enableTypewriter
+                  enableTypewriter={
+                    isDocumentVisible &&
+                    shouldEnableProfileOnboardingTypewriter(
+                      item,
+                      typewriterCache[item.elementBid],
+                    )
+                  }
                   typingSpeed={CHAT_TYPEWRITER_SPEED_MS}
                 />
               ))
@@ -194,7 +230,7 @@ export default function ProfileOnboardingConversation({
                 locale={locale}
                 content=''
                 readonly
-                enableTypewriter
+                enableTypewriter={isDocumentVisible}
                 typingSpeed={CHAT_TYPEWRITER_SPEED_MS}
               />
             )}

--- a/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.test.ts
+++ b/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.test.ts
@@ -7,6 +7,7 @@ import {
 const interaction: ProfileOnboardingConversationItem = {
   content: '?[%{{goal}}...Goal?]',
   elementBid: 'question-1',
+  elementType: 'interaction',
   interaction: true,
   finished: false,
 };

--- a/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.test.ts
+++ b/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.test.ts
@@ -5,6 +5,7 @@ import {
   resolveProfileOnboardingElement,
   syncProfileOnboardingTypewriterCache,
   type ProfileOnboardingConversationItem,
+  upsertConversationItem,
 } from './profileOnboardingConversationModel';
 
 const interaction: ProfileOnboardingConversationItem = {
@@ -140,5 +141,29 @@ describe('resolveProfileOnboardingElement', () => {
     expect(element && isProfileOnboardingTypewriterCandidate(element)).toBe(
       false,
     );
+  });
+});
+
+describe('upsertConversationItem', () => {
+  it('moves a rejected interaction behind its new validation feedback', () => {
+    const answeredInteraction = {
+      ...interaction,
+      finished: true,
+      userInput: 'invalid answer',
+    };
+    const validationFeedback: ProfileOnboardingConversationItem = {
+      content: 'Please choose one of the available options.',
+      elementBid: 'question-1:feedback',
+      elementType: 'text',
+      interaction: false,
+      finished: true,
+    };
+
+    expect(
+      upsertConversationItem(
+        [answeredInteraction, validationFeedback],
+        interaction,
+      ).map(item => item.elementBid),
+    ).toEqual(['question-1:feedback', 'question-1']);
   });
 });

--- a/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.test.ts
+++ b/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.test.ts
@@ -1,6 +1,7 @@
 import {
   initialProfileOnboardingConversationState,
   profileOnboardingConversationReducer,
+  syncProfileOnboardingTypewriterCache,
   type ProfileOnboardingConversationItem,
 } from './profileOnboardingConversationModel';
 
@@ -90,5 +91,31 @@ describe('profileOnboardingConversationReducer', () => {
         { type: 'accept_submission', userInput: 'late' },
       ),
     ).toBe(initialProfileOnboardingConversationState);
+  });
+});
+
+describe('syncProfileOnboardingTypewriterCache', () => {
+  it('keeps suppressed text finished when its content changes on restore', () => {
+    const textItem: ProfileOnboardingConversationItem = {
+      content: 'Longer guidance',
+      elementBid: 'text-1',
+      elementType: 'text',
+      interaction: false,
+      finished: true,
+    };
+
+    expect(
+      syncProfileOnboardingTypewriterCache(
+        [textItem],
+        {
+          'text-1': {
+            content: 'Guidance',
+            isFinished: true,
+            isSuppressed: true,
+          },
+        },
+        false,
+      )['text-1'],
+    ).toMatchObject({ isFinished: true, isSuppressed: true });
   });
 });

--- a/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.test.ts
+++ b/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.test.ts
@@ -1,6 +1,8 @@
 import {
   initialProfileOnboardingConversationState,
+  isProfileOnboardingTypewriterCandidate,
   profileOnboardingConversationReducer,
+  resolveProfileOnboardingElement,
   syncProfileOnboardingTypewriterCache,
   type ProfileOnboardingConversationItem,
 } from './profileOnboardingConversationModel';
@@ -117,5 +119,26 @@ describe('syncProfileOnboardingTypewriterCache', () => {
         false,
       )['text-1'],
     ).toMatchObject({ isFinished: true, isSuppressed: true });
+  });
+});
+
+describe('resolveProfileOnboardingElement', () => {
+  it('preserves HTML element types from legacy content events', () => {
+    const element = resolveProfileOnboardingElement({
+      type: 'content',
+      element_type: 'html',
+      generated_block_bid: 'html-1',
+      content: '<div>Visual card</div>',
+    });
+
+    expect(element).toMatchObject({
+      content: '<div>Visual card</div>',
+      elementBid: 'html-1',
+      elementType: 'html',
+      interaction: false,
+    });
+    expect(element && isProfileOnboardingTypewriterCandidate(element)).toBe(
+      false,
+    );
   });
 });

--- a/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.test.ts
+++ b/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.test.ts
@@ -159,11 +159,15 @@ describe('upsertConversationItem', () => {
       finished: true,
     };
 
-    expect(
-      upsertConversationItem(
-        [answeredInteraction, validationFeedback],
-        interaction,
-      ).map(item => item.elementBid),
-    ).toEqual(['question-1:feedback', 'question-1']);
+    const items = upsertConversationItem(
+      [answeredInteraction, validationFeedback],
+      interaction,
+    );
+
+    expect(items.map(item => item.elementBid)).toEqual([
+      'question-1:feedback',
+      'question-1',
+    ]);
+    expect(items[1].userInput).toBeUndefined();
   });
 });

--- a/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.ts
+++ b/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.ts
@@ -61,6 +61,7 @@ export const syncProfileOnboardingTypewriterCache = (
       content: item.content,
       isFinished:
         suppressTypewriter ||
+        previousEntry?.isSuppressed === true ||
         (previousEntry?.isFinished === true &&
           previousEntry.content === item.content),
       isSuppressed: previousEntry?.isSuppressed || suppressTypewriter,

--- a/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.ts
+++ b/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.ts
@@ -459,7 +459,12 @@ export const upsertConversationItem = (
   if (index < 0) {
     return [...items, item];
   }
+  const existing = items[index];
+  const merged = { ...existing, ...item };
+  if (existing.interaction && existing.finished && item.interaction) {
+    return [...items.slice(0, index), ...items.slice(index + 1), merged];
+  }
   const next = [...items];
-  next[index] = { ...next[index], ...item };
+  next[index] = merged;
   return next;
 };

--- a/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.ts
+++ b/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.ts
@@ -33,10 +33,44 @@ export type ProfileOnboardingAssistantAnswers = (params: {
 export type ProfileOnboardingConversationItem = {
   content: string;
   elementBid: string;
+  elementType: string;
   interaction: boolean;
   userInput?: string;
   finished: boolean;
 };
+
+export type ProfileOnboardingTypewriterCache = Record<
+  string,
+  { content: string; isSuppressed: boolean }
+>;
+
+export const isProfileOnboardingTypewriterCandidate = (
+  item: ProfileOnboardingConversationItem,
+) => item.elementType === 'text';
+
+export const syncProfileOnboardingTypewriterCache = (
+  items: ProfileOnboardingConversationItem[],
+  previousCache: ProfileOnboardingTypewriterCache,
+  suppressTypewriter: boolean,
+): ProfileOnboardingTypewriterCache => {
+  const nextCache: ProfileOnboardingTypewriterCache = {};
+  for (const item of items) {
+    if (!isProfileOnboardingTypewriterCandidate(item)) continue;
+    const previousEntry = previousCache[item.elementBid];
+    nextCache[item.elementBid] = {
+      content: item.content,
+      isSuppressed: previousEntry?.isSuppressed || suppressTypewriter,
+    };
+  }
+  return nextCache;
+};
+
+export const shouldEnableProfileOnboardingTypewriter = (
+  item: ProfileOnboardingConversationItem,
+  cacheEntry?: { content: string; isSuppressed: boolean },
+) =>
+  isProfileOnboardingTypewriterCandidate(item) &&
+  cacheEntry?.isSuppressed !== true;
 
 export type ProfileOnboardingConversationStatus =
   | 'creating'
@@ -383,6 +417,7 @@ export const resolveProfileOnboardingElement = (
         event.generated_block_bid ||
         nextFallbackElementBid(),
       interaction: elementType === 'interaction',
+      elementType,
       userInput:
         typeof payload.user_input === 'string' ? payload.user_input : undefined,
       finished: elementType !== 'interaction',
@@ -397,6 +432,7 @@ export const resolveProfileOnboardingElement = (
       content: event.content,
       elementBid: event.generated_block_bid || nextFallbackElementBid(),
       interaction: type === 'interaction',
+      elementType: type === 'interaction' ? 'interaction' : 'text',
       finished: type !== 'interaction',
     };
   }

--- a/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.ts
+++ b/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.ts
@@ -41,7 +41,7 @@ export type ProfileOnboardingConversationItem = {
 
 export type ProfileOnboardingTypewriterCache = Record<
   string,
-  { content: string; isSuppressed: boolean }
+  { content: string; isFinished: boolean; isSuppressed: boolean }
 >;
 
 export const isProfileOnboardingTypewriterCandidate = (
@@ -59,6 +59,10 @@ export const syncProfileOnboardingTypewriterCache = (
     const previousEntry = previousCache[item.elementBid];
     nextCache[item.elementBid] = {
       content: item.content,
+      isFinished:
+        suppressTypewriter ||
+        (previousEntry?.isFinished === true &&
+          previousEntry.content === item.content),
       isSuppressed: previousEntry?.isSuppressed || suppressTypewriter,
     };
   }

--- a/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.ts
+++ b/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.ts
@@ -462,7 +462,11 @@ export const upsertConversationItem = (
   const existing = items[index];
   const merged = { ...existing, ...item };
   if (existing.interaction && existing.finished && item.interaction) {
-    return [...items.slice(0, index), ...items.slice(index + 1), merged];
+    return [
+      ...items.slice(0, index),
+      ...items.slice(index + 1),
+      { ...merged, userInput: item.userInput },
+    ];
   }
   const next = [...items];
   next[index] = merged;

--- a/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.ts
+++ b/src/cook-web/src/components/profile-onboarding/profileOnboardingConversationModel.ts
@@ -433,12 +433,19 @@ export const resolveProfileOnboardingElement = (
     typeof event.content === 'string' &&
     event.content
   ) {
+    const elementType =
+      typeof event.element_type === 'string' && event.element_type
+        ? event.element_type
+        : type === 'interaction'
+          ? 'interaction'
+          : 'text';
+    const interaction = elementType === 'interaction';
     return {
       content: event.content,
       elementBid: event.generated_block_bid || nextFallbackElementBid(),
-      interaction: type === 'interaction',
-      elementType: type === 'interaction' ? 'interaction' : 'text',
-      finished: type !== 'interaction',
+      interaction,
+      elementType,
+      finished: !interaction,
     };
   }
   return null;

--- a/src/cook-web/src/lib/profileOnboardingSse.ts
+++ b/src/cook-web/src/lib/profileOnboardingSse.ts
@@ -10,6 +10,7 @@ import { buildTraceHeaders } from '@/lib/request-trace';
 export type ProfileOnboardingStreamEvent = {
   type?: string;
   event_type?: string;
+  element_type?: string;
   content?: unknown;
   is_terminal?: boolean;
   generated_block_bid?: string | null;


### PR DESCRIPTION
## Summary
- animate only text guidance in the personalization conversation with the learning page's shared 30ms cadence
- preserve MarkdownFlow element types so HTML and interaction content render immediately, including type transitions that reuse an element number
- clear rejected answers before retrying a personalization question
- sequence validation feedback and final guidance before questions or review actions become available
- preserve the established manual scrolling behavior while guidance types

## Verification
- .venv/bin/python -m pytest -q src/api/tests/service/profile_research/test_runtime.py (80 passed)
- npm test -- --runInBand src/components/profile-onboarding/profileOnboardingConversationModel.test.ts src/components/profile-onboarding/ProfileOnboardingConversation.test.tsx (56 passed)
- npm run type-check
- npm run lint (passes with existing repository warnings)
- targeted Ruff checks
- lefthook pre-commit

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typewriter animation for guided profile onboarding content.
  * Improved rendering of onboarding questions, responses, HTML content, and interaction controls.
  * Added support for displaying an empty conversation state.
  * Updated conversation scrolling when gated questions become visible.

* **Bug Fixes**
  * Corrected response controls so they are disabled appropriately for read-only content.
  * Prevented typewriter animation when the page is hidden or content has already been displayed.
  * Preserved completed content when onboarding guidance changes.
  * Improved visibility of follow-up questions as guidance progresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
