### PR TITLE
fix: accept string roles in SSE replay tests

### DIFF
--- a/src/api/tests/service/learn/test_sse_element_split_from_db.py
+++ b/src/api/tests/service/learn/test_sse_element_split_from_db.py
@@ -48,6 +48,17 @@ VALID_EVENT_TYPES = {
 VALID_TYPE_CODES = set(range(201, 214))
 
 
+def _coerce_block_role(value: object) -> int:
+    """Normalize legacy numeric and newer string role values from seed data."""
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "teacher":
+            return ROLE_TEACHER
+        if normalized == "student":
+            return ROLE_STUDENT
+    return int(value or 0)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -77,7 +88,7 @@ def _fetch_blocks_raw(app: object, limit: object = 100) -> object:
                 "outline_item_bid": r.outline_item_bid,
                 "user_bid": r.user_bid,
                 "progress_record_bid": r.progress_record_bid,
-                "role": int(r.role or 0),
+                "role": _coerce_block_role(r.role),
                 "type": int(r.type or 0),
                 "position": int(r.position or 0),
                 "generated_content": r.generated_content or "",


### PR DESCRIPTION
## Summary
Fix the backend SSE replay test so it accepts both legacy numeric roles and string role labels from generated block seed data.

## Change
- Normalize generated block roles in the test helper before replaying SSE samples.
- Map teacher and student string labels to the existing numeric role constants.
- Keep runtime SSE behavior unchanged.

## Benefit
Backend CI no longer fails when the test database contains role labels such as teacher or student.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of teacher and student roles when loading generated content.
  * Added compatibility for legacy numeric role values to prevent loading errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->