### PR TITLE
fix: queue ElevenLabs speech requests

### DIFF
--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -1078,6 +1078,16 @@ ELEVENLABS_API_KEY=""
 # (Optional - default: )
 ELEVENLABS_TTS_VOICES_JSON=""
 
+# Maximum in-flight ElevenLabs TTS requests per API key across workers; 0 disables the concurrency gate
+# (Optional - default: 4)
+# Type: int
+ELEVENLABS_TTS_MAX_CONCURRENT_REQUESTS="4"
+
+# Maximum seconds an ElevenLabs TTS request waits for a concurrency slot
+# (Optional - default: 45)
+# Type: int
+ELEVENLABS_TTS_CONCURRENCY_MAX_WAIT_SECONDS="45"
+
 # Max concurrent block-audio TTS syntheses per (user, outline); 0 disables the concurrency cap
 # (Optional - default: 6)
 # Type: int

--- a/src/api/flaskr/api/tts/elevenlabs_provider.py
+++ b/src/api/flaskr/api/tts/elevenlabs_provider.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import math
+import threading
+import time
+import uuid
+from contextlib import contextmanager
 from typing import Any
 from urllib.parse import quote
 
@@ -29,6 +34,7 @@ ELEVENLABS_TTS_API_URL = "https://api.elevenlabs.io/v1/text-to-speech"
 ELEVENLABS_OUTPUT_FORMAT = "mp3_44100_128"
 ELEVENLABS_DEFAULT_MODEL = "eleven_multilingual_v2"
 ELEVENLABS_REQUEST_TIMEOUT = (10, 90)
+ELEVENLABS_CONCURRENCY_LEASE_SECONDS = 120
 ELEVENLABS_MODELS = [
     {
         "value": "eleven_v3_conversational",
@@ -40,6 +46,28 @@ ELEVENLABS_MODELS = [
 ]
 _ELEVENLABS_MODEL_IDS = {item["value"] for item in ELEVENLABS_MODELS}
 _ERROR_DETAIL_LIMIT = 500
+_LOCAL_CONCURRENCY_LOCK = threading.RLock()
+_LOCAL_CONCURRENCY_SEMAPHORES: dict[str, threading.BoundedSemaphore] = {}
+
+_LUA_ACQUIRE_CONCURRENCY_SLOT = """
+local key = KEYS[1]
+local holder = ARGV[1]
+local max_count = tonumber(ARGV[2])
+local now_ms = tonumber(ARGV[3])
+local lease_ms = tonumber(ARGV[4])
+redis.call('zremrangebyscore', key, '-inf', now_ms)
+if redis.call('zcard', key) < max_count then
+    redis.call('zadd', key, now_ms + lease_ms, holder)
+    redis.call('pexpire', key, lease_ms)
+    return 1
+end
+return 0
+"""
+
+_LUA_RELEASE_CONCURRENCY_SLOT = """
+redis.call('zrem', KEYS[1], ARGV[1])
+return 1
+"""
 
 
 def parse_elevenlabs_voices(value: object) -> list[dict[str, str]]:
@@ -115,6 +143,128 @@ def _extract_request_id(response: Response) -> str:
         if key.lower() in {"request-id", "x-request-id"}:
             return str(value or "").strip()
     return ""
+
+
+def _coerce_int_config(name: str, default: int) -> int:
+    try:
+        return int(get_config(name) or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float_config(name: str, default: float) -> float:
+    try:
+        return float(get_config(name) or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _elevenlabs_concurrency_scope_key(api_key: str) -> str:
+    key_hash = hashlib.sha256((api_key or "").encode("utf-8")).hexdigest()[:24]
+    return f"elevenlabs:{key_hash}"
+
+
+def _get_redis_client() -> object:
+    from flaskr.dao import get_redis_client
+
+    redis_client = get_redis_client()
+    if redis_client is None:
+        message = "Redis is not configured"
+        raise RuntimeError(message)
+    return redis_client
+
+
+def _acquire_redis_concurrency_slot(
+    *,
+    key: str,
+    holder: str,
+    max_count: int,
+    deadline: float,
+) -> bool:
+    redis_client = _get_redis_client()
+    lease_ms = int(ELEVENLABS_CONCURRENCY_LEASE_SECONDS * 1000)
+    while True:
+        now = time.time()
+        acquired = redis_client.eval(
+            _LUA_ACQUIRE_CONCURRENCY_SLOT,
+            1,
+            key,
+            holder,
+            str(max_count),
+            str(int(now * 1000)),
+            str(lease_ms),
+        )
+        if bool(acquired):
+            return True
+        if now >= deadline:
+            return False
+        time.sleep(min(0.2, max(deadline - now, 0.0)))
+
+
+def _release_redis_concurrency_slot(*, key: str, holder: str) -> None:
+    redis_client = _get_redis_client()
+    redis_client.eval(_LUA_RELEASE_CONCURRENCY_SLOT, 1, key, holder)
+
+
+def _get_local_concurrency_semaphore(
+    key: str, max_count: int
+) -> threading.BoundedSemaphore:
+    with _LOCAL_CONCURRENCY_LOCK:
+        semaphore = _LOCAL_CONCURRENCY_SEMAPHORES.get(key)
+        if semaphore is None:
+            semaphore = threading.BoundedSemaphore(max_count)
+            _LOCAL_CONCURRENCY_SEMAPHORES[key] = semaphore
+        return semaphore
+
+
+@contextmanager
+def _elevenlabs_concurrency_slot(api_key: str) -> object:
+    max_count = max(_coerce_int_config("ELEVENLABS_TTS_MAX_CONCURRENT_REQUESTS", 4), 0)
+    if max_count <= 0:
+        yield
+        return
+
+    max_wait_seconds = max(
+        _coerce_float_config("ELEVENLABS_TTS_CONCURRENCY_MAX_WAIT_SECONDS", 45.0),
+        0.0,
+    )
+    key = f"tts:concurrency:{_elevenlabs_concurrency_scope_key(api_key)}"
+    holder = uuid.uuid4().hex
+    deadline = time.time() + max_wait_seconds
+    acquired_with_redis = False
+    local_semaphore: threading.BoundedSemaphore | None = None
+
+    try:
+        acquired_with_redis = _acquire_redis_concurrency_slot(
+            key=key,
+            holder=holder,
+            max_count=max_count,
+            deadline=deadline,
+        )
+    except Exception as exc:
+        logger.warning(
+            "ElevenLabs concurrency Redis gate unavailable; using process-local gate: %s",
+            exc,
+        )
+        local_semaphore = _get_local_concurrency_semaphore(key, max_count)
+        acquired = local_semaphore.acquire(timeout=max_wait_seconds)
+        if not acquired:
+            message = "ElevenLabs TTS concurrency queue timed out"
+            raise ValueError(message) from exc
+    if not acquired_with_redis and local_semaphore is None:
+        message = "ElevenLabs TTS concurrency queue timed out"
+        raise ValueError(message)
+
+    try:
+        yield
+    finally:
+        if acquired_with_redis:
+            try:
+                _release_redis_concurrency_slot(key=key, holder=holder)
+            except Exception:
+                logger.warning("Failed to release ElevenLabs concurrency slot")
+        if local_semaphore is not None:
+            local_semaphore.release()
 
 
 class ElevenLabsTTSProvider(BaseTTSProvider):
@@ -214,14 +364,15 @@ class ElevenLabsTTSProvider(BaseTTSProvider):
         }
 
         try:
-            response = requests.post(
-                url,
-                params={"output_format": ELEVENLABS_OUTPUT_FORMAT},
-                headers=headers,
-                json=payload,
-                timeout=ELEVENLABS_REQUEST_TIMEOUT,
-                allow_redirects=False,
-            )
+            with _elevenlabs_concurrency_slot(api_key):
+                response = requests.post(
+                    url,
+                    params={"output_format": ELEVENLABS_OUTPUT_FORMAT},
+                    headers=headers,
+                    json=payload,
+                    timeout=ELEVENLABS_REQUEST_TIMEOUT,
+                    allow_redirects=False,
+                )
         except requests.RequestException as exc:
             logger.warning(
                 "ElevenLabs TTS request failed: model=%s voice=%s text_len=%s error_type=%s",

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1583,6 +1583,23 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         group="tts",
         required=False,
     ),
+    "ELEVENLABS_TTS_MAX_CONCURRENT_REQUESTS": EnvVar(
+        name="ELEVENLABS_TTS_MAX_CONCURRENT_REQUESTS",
+        default=4,
+        type=int,
+        description=(
+            "Maximum in-flight ElevenLabs TTS requests per API key across "
+            "workers; 0 disables the concurrency gate"
+        ),
+        group="tts",
+    ),
+    "ELEVENLABS_TTS_CONCURRENCY_MAX_WAIT_SECONDS": EnvVar(
+        name="ELEVENLABS_TTS_CONCURRENCY_MAX_WAIT_SECONDS",
+        default=45,
+        type=int,
+        description="Maximum seconds an ElevenLabs TTS request waits for a concurrency slot",
+        group="tts",
+    ),
     "TTS_MAX_SEGMENT_CHARS": EnvVar(
         name="TTS_MAX_SEGMENT_CHARS",
         default=300,

--- a/src/api/tests/service/tts/test_elevenlabs_provider.py
+++ b/src/api/tests/service/tts/test_elevenlabs_provider.py
@@ -22,12 +22,35 @@ def _patch_config(
     *,
     api_key: str = "test-elevenlabs-key",
     voices: object = None,
+    extra: dict[str, object] | None = None,
 ) -> None:
     values = {
         "ELEVENLABS_API_KEY": api_key,
         "ELEVENLABS_TTS_VOICES_JSON": (_voice_json() if voices is None else voices),
     }
+    values.update(extra or {})
     monkeypatch.setattr(module, "get_config", lambda key, *_args: values.get(key, ""))
+
+
+class _FakeConcurrencyRedis:
+    def __init__(self, *, initially_full: bool = False) -> None:
+        self.holders: set[str] = {"existing"} if initially_full else set()
+        self.release_calls = 0
+
+    def eval(self, script: object, _numkeys: object, key: object, *args: object) -> int:
+        _ = key
+        script_text = str(script)
+        if "zrem" in script_text and "zadd" not in script_text:
+            self.release_calls += 1
+            self.holders.discard(str(args[0]))
+            return 1
+
+        holder = str(args[0])
+        max_count = int(args[1])
+        if len(self.holders) >= max_count:
+            return 0
+        self.holders.add(holder)
+        return 1
 
 
 def test_parse_elevenlabs_voices_normalizes_whitespace() -> None:
@@ -183,6 +206,71 @@ def test_synthesize_sends_encoded_approved_request_and_returns_mp3(
     assert result.format == "mp3"
     assert result.word_count == len("Hello world")
     assert result.usage_characters == len("Hello world")
+
+
+def test_synthesize_uses_elevenlabs_global_concurrency_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config(
+        monkeypatch,
+        extra={
+            "ELEVENLABS_TTS_MAX_CONCURRENT_REQUESTS": "1",
+            "ELEVENLABS_TTS_CONCURRENCY_MAX_WAIT_SECONDS": "1",
+        },
+    )
+    fake_redis = _FakeConcurrencyRedis()
+    observed_holder_counts: list[int] = []
+
+    class DummyResponse:
+        status_code = 200
+        content = b"mp3-bytes"
+        reason = "OK"
+        headers: ClassVar[dict[str, str]] = {}
+
+    def fake_post(*_args: object, **_kwargs: object) -> object:
+        observed_holder_counts.append(len(fake_redis.holders))
+        return DummyResponse()
+
+    monkeypatch.setattr(module, "_get_redis_client", lambda: fake_redis)
+    monkeypatch.setattr(module.requests, "post", fake_post)
+    monkeypatch.setattr(
+        module, "try_get_audio_duration_ms", lambda *_args, **_kwargs: 123
+    )
+
+    result = module.ElevenLabsTTSProvider().synthesize("Hello")
+
+    assert result.audio_data == b"mp3-bytes"
+    assert observed_holder_counts == [1]
+    assert fake_redis.holders == set()
+    assert fake_redis.release_calls == 1
+
+
+def test_synthesize_times_out_before_hitting_elevenlabs_when_gate_is_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config(
+        monkeypatch,
+        extra={
+            "ELEVENLABS_TTS_MAX_CONCURRENT_REQUESTS": "1",
+            "ELEVENLABS_TTS_CONCURRENCY_MAX_WAIT_SECONDS": "0",
+        },
+    )
+    post_called = False
+
+    def fake_post(*_args: object, **_kwargs: object) -> object:
+        nonlocal post_called
+        post_called = True
+        return object()
+
+    monkeypatch.setattr(
+        module, "_get_redis_client", lambda: _FakeConcurrencyRedis(initially_full=True)
+    )
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    with pytest.raises(ValueError, match="concurrency queue timed out"):
+        module.ElevenLabsTTSProvider().synthesize("Hello")
+
+    assert post_called is False
 
 
 def test_synthesize_rejects_redirect_without_following(


### PR DESCRIPTION
## Summary
Fixes overseas ElevenLabs TTS failures caused by account-level concurrent request limits being exceeded by multiple pods and workers.

## Change
- Add a Redis-backed ElevenLabs concurrency gate scoped by API key before calling the provider.
- Add configurable concurrency and queue wait limits with safe defaults.
- Fall back to a process-local gate if Redis is unavailable.
- Add regression coverage for slot acquire/release and full-queue behavior.

## Benefit
Overseas audio generation waits for a shared ElevenLabs slot instead of immediately hitting provider 429 errors, reducing user-facing TTS failures during concurrent usage.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional controls for limiting concurrent ElevenLabs text-to-speech requests.
  - Added a configurable maximum wait time for requests waiting for an available slot.
  - Supports disabling the concurrency limit when configured to zero.

- **Bug Fixes**
  - Prevents requests from proceeding when the concurrency queue times out, providing clearer failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->