### PR TITLE
fix: refresh admin sidebar labels after language changes

### DIFF
--- a/src/cook-web/src/app/admin/layout.test.tsx
+++ b/src/cook-web/src/app/admin/layout.test.tsx
@@ -8,7 +8,9 @@ import AdminLayout from './layout';
 import { SidebarContent } from './SidebarContent';
 
 const footerLabel = 'footer';
-const mockTranslate = (key: string) => key;
+let mockI18nLanguage = 'en-US';
+let mockTranslationPrefix = '';
+const mockTranslate = (key: string) => `${mockTranslationPrefix}${key}`;
 const mockUsePathname = jest.fn(() => '/admin');
 const mockApplyCreatorBranding = jest.fn();
 const mockRefreshUserInfo = jest.fn();
@@ -129,7 +131,8 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: mockTranslate,
     i18n: {
-      language: 'en-US',
+      language: mockI18nLanguage,
+      resolvedLanguage: mockI18nLanguage,
     },
   }),
 }));
@@ -559,6 +562,8 @@ describe('AdminLayout', () => {
     mockMainMenuModal.mockClear();
     mockLearnerProfileDialog.mockClear();
     mockSearchParamsValue = '';
+    mockI18nLanguage = 'en-US';
+    mockTranslationPrefix = '';
     mockEnvState.logoWideUrl = '/logo.png';
     mockEnvState.logoHorizontal = '';
     mockEnvState.logoSquareUrl = '';
@@ -651,6 +656,43 @@ describe('AdminLayout', () => {
       screen.queryByRole('link', { name: 'common.core.shifu' }),
     ).not.toBeInTheDocument();
     expect(window.location.href).toBe('http://localhost:3000');
+  });
+
+  test('refreshes sidebar menu labels when the active language changes', () => {
+    mockUserStoreState.userInfo = {
+      user_id: 'user-1',
+      is_operator: true,
+    };
+    mockI18nLanguage = 'en-US';
+    mockTranslationPrefix = 'en:';
+
+    const { rerender } = render(
+      <AdminLayout>
+        <div>{childText}</div>
+      </AdminLayout>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'en:common.core.operations' }),
+    );
+    expect(
+      screen.getByRole('link', { name: 'en:common.core.courseManagement' }),
+    ).toBeInTheDocument();
+
+    mockI18nLanguage = 'zh-CN';
+    mockTranslationPrefix = 'zh:';
+    rerender(
+      <AdminLayout>
+        <div>{childText}</div>
+      </AdminLayout>,
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'zh:common.core.courseManagement' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'en:common.core.courseManagement' }),
+    ).not.toBeInTheDocument();
   });
 
   test('opens learner profile settings for the current account and refreshes user info after save', async () => {

--- a/src/cook-web/src/app/admin/layout.tsx
+++ b/src/cook-web/src/app/admin/layout.tsx
@@ -196,16 +196,25 @@ const MainInterface = ({
     [billingEnabled, normalizedPaymentChannels, stripeEnabled],
   );
 
-  const menuItems = useMemo(
-    () =>
-      buildAdminMenuItems({
-        t,
-        isOperator,
-        showReferralInvite,
-        showPackageManagement,
-      }),
-    [isOperator, showPackageManagement, showReferralInvite, t],
-  );
+  const activeAdminLanguage = i18n.resolvedLanguage || i18n.language;
+  const menuItems = useMemo(() => {
+    const translateMenuLabel = (key: string) => {
+      void activeAdminLanguage;
+      return t(key);
+    };
+    return buildAdminMenuItems({
+      t: translateMenuLabel,
+      isOperator,
+      showReferralInvite,
+      showPackageManagement,
+    });
+  }, [
+    activeAdminLanguage,
+    isOperator,
+    showPackageManagement,
+    showReferralInvite,
+    t,
+  ]);
 
   const {
     data: billingOverview,


### PR DESCRIPTION
## Summary
Fixes the admin sidebar staying in the previous language after operators switch languages.

## Change
Rebuilds admin sidebar menu labels when the active i18n language changes and adds regression coverage for the rerender path.

## Benefit
Operators no longer see mixed Chinese and English navigation in overseas or domestic admin pages after changing language.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin sidebar menu labels now refresh correctly when the active language changes.
  * Language selection now consistently uses the resolved language for menu translations.

* **Tests**
  * Added coverage to verify sidebar labels update after switching languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->