### PR TITLE
chore: reuse dependencies across Codex worktrees

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -20,46 +20,32 @@ copy_local_env() {
   fi
 }
 
+reuse_directory_if_compatible() {
+  source_directory="$1"
+  target_directory="$2"
+  source_manifest="$3"
+  target_manifest="$4"
+  if [ -d "$source_directory" ] && [ ! -e "$target_directory" ] && \
+    cmp -s "$source_manifest" "$target_manifest"; then
+    ln -s "$source_directory" "$target_directory"
+  fi
+}
+
 if [ -n "$source_tree" ] && [ "$source_tree" != "$worktree_path" ]; then
   copy_local_env "$source_tree/.env" "$worktree_path/.env"
   copy_local_env "$source_tree/src/api/.env" "$worktree_path/src/api/.env"
   copy_local_env "$source_tree/src/cook-web/.env" "$worktree_path/src/cook-web/.env"
+  reuse_directory_if_compatible \
+    "$source_tree/.venv" \
+    "$worktree_path/.venv" \
+    "$source_tree/src/api/requirements.txt" \
+    "$worktree_path/src/api/requirements.txt"
+  reuse_directory_if_compatible \
+    "$source_tree/src/cook-web/node_modules" \
+    "$worktree_path/src/cook-web/node_modules" \
+    "$source_tree/src/cook-web/package-lock.json" \
+    "$worktree_path/src/cook-web/package-lock.json"
 fi
-
-cd "$worktree_path"
-
-if command -v uv >/dev/null 2>&1; then
-  if [ ! -x .venv/bin/python ]; then
-    uv venv --python 3.11 .venv
-  fi
-  uv pip install --python .venv/bin/python -r src/api/requirements.txt
-  uv pip install --python .venv/bin/python \
-    ruff==0.16.3 commitizen==4.16.2 pre-commit-hooks==6.0.0
-else
-  python_bin="$(command -v python3.11 || true)"
-  if [ -z "$python_bin" ]; then
-    echo "Python 3.11 or uv is required to set up AI-Shifu." >&2
-    exit 1
-  fi
-  if [ ! -x .venv/bin/python ]; then
-    "$python_bin" -m venv .venv
-  fi
-  .venv/bin/python -m pip install --upgrade pip setuptools wheel
-  .venv/bin/python -m pip install -r src/api/requirements.txt
-  .venv/bin/python -m pip install \
-    ruff==0.16.3 commitizen==4.16.2 pre-commit-hooks==6.0.0
-fi
-
-(cd src/cook-web && npm ci)
-
-if ! command -v lefthook >/dev/null 2>&1; then
-  echo "lefthook is required. On macOS, install it with: brew install lefthook" >&2
-  exit 1
-fi
-
-lefthook install
-PATH="$worktree_path/.venv/bin:$PATH" \
-  "$worktree_path/.venv/bin/python" scripts/check_dev_tools.py --strict
 '''
 
 [setup.linux]
@@ -77,46 +63,32 @@ copy_local_env() {
   fi
 }
 
+reuse_directory_if_compatible() {
+  source_directory="$1"
+  target_directory="$2"
+  source_manifest="$3"
+  target_manifest="$4"
+  if [ -d "$source_directory" ] && [ ! -e "$target_directory" ] && \
+    cmp -s "$source_manifest" "$target_manifest"; then
+    ln -s "$source_directory" "$target_directory"
+  fi
+}
+
 if [ -n "$source_tree" ] && [ "$source_tree" != "$worktree_path" ]; then
   copy_local_env "$source_tree/.env" "$worktree_path/.env"
   copy_local_env "$source_tree/src/api/.env" "$worktree_path/src/api/.env"
   copy_local_env "$source_tree/src/cook-web/.env" "$worktree_path/src/cook-web/.env"
+  reuse_directory_if_compatible \
+    "$source_tree/.venv" \
+    "$worktree_path/.venv" \
+    "$source_tree/src/api/requirements.txt" \
+    "$worktree_path/src/api/requirements.txt"
+  reuse_directory_if_compatible \
+    "$source_tree/src/cook-web/node_modules" \
+    "$worktree_path/src/cook-web/node_modules" \
+    "$source_tree/src/cook-web/package-lock.json" \
+    "$worktree_path/src/cook-web/package-lock.json"
 fi
-
-cd "$worktree_path"
-
-if command -v uv >/dev/null 2>&1; then
-  if [ ! -x .venv/bin/python ]; then
-    uv venv --python 3.11 .venv
-  fi
-  uv pip install --python .venv/bin/python -r src/api/requirements.txt
-  uv pip install --python .venv/bin/python \
-    ruff==0.16.3 commitizen==4.16.2 pre-commit-hooks==6.0.0
-else
-  python_bin="$(command -v python3.11 || true)"
-  if [ -z "$python_bin" ]; then
-    echo "Python 3.11 or uv is required to set up AI-Shifu." >&2
-    exit 1
-  fi
-  if [ ! -x .venv/bin/python ]; then
-    "$python_bin" -m venv .venv
-  fi
-  .venv/bin/python -m pip install --upgrade pip setuptools wheel
-  .venv/bin/python -m pip install -r src/api/requirements.txt
-  .venv/bin/python -m pip install \
-    ruff==0.16.3 commitizen==4.16.2 pre-commit-hooks==6.0.0
-fi
-
-(cd src/cook-web && npm ci)
-
-if ! command -v lefthook >/dev/null 2>&1; then
-  echo "lefthook is required. Install it before creating the worktree." >&2
-  exit 1
-fi
-
-lefthook install
-PATH="$worktree_path/.venv/bin:$PATH" \
-  "$worktree_path/.venv/bin/python" scripts/check_dev_tools.py --strict
 '''
 
 [[actions]]


### PR DESCRIPTION
## Summary

- reuse the source checkout's Python virtual environment when backend requirements match
- reuse the source checkout's frontend dependencies when the package lock matches
- stop installing Python, npm, and lefthook dependencies during worktree creation
- preserve the existing local environment file copy behavior

## Verification

- parsed the Local environment TOML and confirmed Darwin/Linux setup parity
- simulated worktree setup and verified environment copies plus dependency symlinks
- ran `python3 scripts/check_dev_tools.py --strict` using the reused source dependencies
- ran `lefthook run pre-commit --all-files`
- ran `python3 scripts/check_repo_harness.py`
- ran `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-environment-only change; worktrees without a compatible source checkout may lack `.venv`/`node_modules` until deps are installed manually in the main tree.
> 
> **Overview**
> Codex **Darwin/Linux worktree setup** no longer creates or installs dependencies. It only copies missing `.env` files (unchanged) and, when `CODEX_SOURCE_TREE_PATH` differs from the worktree, may **symlink** the source checkout’s `.venv` and `src/cook-web/node_modules` if `requirements.txt` and `package-lock.json` match via `cmp`.
> 
> Removed from setup: `uv`/pip venv bootstrap, API and dev-tool pip installs, `npm ci`, `lefthook install`, and `scripts/check_dev_tools.py --strict`. New worktrees are expected to reuse a prepared source tree (or already have deps); setup is faster but won’t self-heal missing Python, npm, or hook tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cc18abcc0a5636325bb3589fda2b364686aff32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development environment setup by reusing compatible existing Python and Node.js dependencies.
  - Preserved environment configuration files when preparing a worktree.
  - Avoided unnecessary dependency installation and setup validation when existing dependencies are compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->