### PR TITLE
chore: make Cook Web the default local action

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -92,20 +92,20 @@ fi
 '''
 
 [[actions]]
+name = "Cook Web"
+icon = "run"
+command = '''
+cd src/cook-web
+exec npm run dev
+'''
+
+[[actions]]
 name = "Backend API"
 icon = "run"
 command = '''
 cd src/api
 export FLASK_APP=app.py
 exec ../../.venv/bin/python -m flask run --host 0.0.0.0 --port 5800
-'''
-
-[[actions]]
-name = "Cook Web"
-icon = "run"
-command = '''
-cd src/cook-web
-exec npm run dev
 '''
 
 [[actions]]


### PR DESCRIPTION
## Summary

- move the Cook Web startup action to the first position
- keep all local action commands unchanged

## Verification

- `python3 scripts/check_repo_harness.py`
- `git diff --check`
- repository pre-commit hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-environment UI ordering only; no runtime, API, or deployment behavior changes.
> 
> **Overview**
> Reorders the Codex **AI-Shifu local** run actions in `.codex/environments/environment.toml` so **Cook Web** (`npm run dev` in `src/cook-web`) is listed first and **Backend API** (Flask on port 5800) is second.
> 
> Startup commands are unchanged; only action order changes so the default/first local run target is the frontend dev server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 678871c9accfe979b6d29991182f96998874ccb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reordered the development actions so “Cook Web” appears before “Backend API.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->