### PR TITLE
chore: update local development actions

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -45,8 +45,7 @@ if [ -n "$source_tree" ] && [ "$source_tree" != "$worktree_path" ]; then
     "$worktree_path/src/cook-web/node_modules" \
     "$source_tree/src/cook-web/package-lock.json" \
     "$worktree_path/src/cook-web/package-lock.json"
-fi
-'''
+fi'''
 
 [setup.linux]
 script = '''
@@ -88,16 +87,14 @@ if [ -n "$source_tree" ] && [ "$source_tree" != "$worktree_path" ]; then
     "$worktree_path/src/cook-web/node_modules" \
     "$source_tree/src/cook-web/package-lock.json" \
     "$worktree_path/src/cook-web/package-lock.json"
-fi
-'''
+fi'''
 
 [[actions]]
 name = "Cook Web"
-icon = "run"
+icon = "debug"
 command = '''
 cd src/cook-web
-exec npm run dev
-'''
+exec npm run dev'''
 
 [[actions]]
 name = "Backend API"
@@ -105,36 +102,30 @@ icon = "run"
 command = '''
 cd src/api
 export FLASK_APP=app.py
-exec ../../.venv/bin/python -m flask run --host 0.0.0.0 --port 5800
-'''
+exec ../../.venv/bin/python -m flask run --host 0.0.0.0 --port 5800'''
 
 [[actions]]
 name = "Backend tests"
 icon = "test"
 command = '''
 cd src/api
-../../.venv/bin/python -m pytest -q
-'''
+../../.venv/bin/python -m pytest -q'''
 
 [[actions]]
 name = "Frontend tests"
 icon = "test"
 command = '''
 cd src/cook-web
-npm run test:ci
-'''
+npm run test:ci'''
 
 [[actions]]
 name = "Repository checks"
 icon = "test"
-command = '''
-PATH="$PWD/.venv/bin:$PATH" lefthook run pre-commit --all-files
-'''
+command = "PATH=\"$PWD/.venv/bin:$PATH\" lefthook run pre-commit --all-files"
 
 [[actions]]
 name = "Rebase latest main"
 icon = "tool"
 command = '''
 git fetch origin main
-git rebase origin/main
-'''
+git rebase origin/main'''


### PR DESCRIPTION
## Changed

Updated Codex environment action formatting and changed the Cook Web action icon to debug.

## Benefit

Local development actions match the current Codex environment configuration and are easier to launch and inspect.

## Verification

- Commit hooks passed.
- python3 scripts/check_dev_tools.py completed, but the local environment is missing ruff 0.16.3.
- Ruff hooks were skipped because no Ruff-managed files were staged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-environment TOML formatting and one UI icon only; no changes to application runtime or deployment.
> 
> **Overview**
> Updates **Codex** local dev config in `environment.toml` only—no app code.
> 
> **Cook Web** action icon changes from `run` to **`debug`**. Setup scripts (darwin/linux) and most action `command` blocks are tightened so multiline `'''` strings close on the same line as the final shell line (e.g. `fi'''`, `exec npm run dev'''`).
> 
> **Repository checks** switches from a multiline triple-quoted command to a single double-quoted string with escaped inner quotes; behavior is unchanged (`lefthook run pre-commit --all-files` with `.venv` on `PATH`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa47401bfccedf10c197a0c1eb5ef53ce308494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->