### PR TITLE
fix: hide internal input from debug preview

### DIFF
--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.test.tsx
@@ -465,21 +465,31 @@ describe('ShifuEdit draft conflict checks', () => {
     });
   });
 
-  test('hides sys_user_style from editor and preview variable displays', async () => {
+  test('hides internal system variables from editor and preview variable displays', async () => {
     setLessonNode();
-    mockShifuState.mdflow = 'Hello {{sys_user_style}}';
+    mockShifuState.mdflow = 'Hello {{sys_user_style}} {{sys_user_input}}';
     mockShifuState.systemVariables = [
       { name: 'sys_user_nickname', label: 'Nickname' },
       { name: 'sys_user_style', label: 'Style' },
+      { name: 'sys_user_input', label: 'User Input' },
     ];
     baseActions.previewParse.mockResolvedValue({
       variables: {
         sys_user_nickname: 'Learner',
         sys_user_style: 'Concise',
+        sys_user_input: 'Internal input',
       },
       blocksCount: 1,
-      systemVariableKeys: ['sys_user_nickname', 'sys_user_style'],
-      allVariableKeys: ['sys_user_nickname', 'sys_user_style'],
+      systemVariableKeys: [
+        'sys_user_nickname',
+        'sys_user_style',
+        'sys_user_input',
+      ],
+      allVariableKeys: [
+        'sys_user_nickname',
+        'sys_user_style',
+        'sys_user_input',
+      ],
       unusedKeys: [],
     });
 
@@ -502,11 +512,14 @@ describe('ShifuEdit draft conflict checks', () => {
     expect(mockLessonPreview.mock.lastCall?.[0].hiddenVariableKeys).toContain(
       'sys_user_style',
     );
+    expect(mockLessonPreview.mock.lastCall?.[0].hiddenVariableKeys).toContain(
+      'sys_user_input',
+    );
     expect(mockLessonPreview.mock.lastCall?.[0].systemVariableKeys).toEqual([
       'sys_user_nickname',
     ]);
     expect(baseActions.previewParse).toHaveBeenCalledWith(
-      'Hello {{sys_user_style}}',
+      'Hello {{sys_user_style}} {{sys_user_input}}',
       'shifu-1',
       'lesson-1',
     );

--- a/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
+++ b/src/cook-web/src/components/shifu-edit/ShifuEdit.tsx
@@ -82,7 +82,10 @@ const MarkdownFlowEditor = dynamic(
   },
 );
 
-const HIDDEN_SYSTEM_VARIABLE_KEYS = new Set(['sys_user_style']);
+const HIDDEN_SYSTEM_VARIABLE_KEYS = new Set([
+  'sys_user_style',
+  'sys_user_input',
+]);
 
 const OUTLINE_DEFAULT_WIDTH = 256;
 const OUTLINE_COLLAPSED_WIDTH = 60;


### PR DESCRIPTION
Changed:
- Hide sys_user_input from course editor system-variable suggestions and debug preview variable displays.
- Add regression coverage for the hidden internal system variables.

Benefit:
Internal request input no longer appears as an editable or visible debug variable.

Validation:
- npm test -- --runInBand src/components/shifu-edit/ShifuEdit.test.tsx
- npm run type-check
- Prettier check
- Lefthook pre-commit and commit-msg hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change in the course editor variable filtering; no auth, API, or persistence changes.
> 
> **Overview**
> Treats **`sys_user_input`** as an internal system variable by adding it to `HIDDEN_SYSTEM_VARIABLE_KEYS` alongside `sys_user_style`.
> 
> That set already drives which system variables appear in the MarkdownFlow editor suggestions and which keys are passed to lesson preview as hidden, so internal request input no longer shows up as an editable or visible debug variable.
> 
> Tests were broadened to cover multiple internal variables and assert `sys_user_input` is filtered from the editor list and included in preview `hiddenVariableKeys`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd62e425da13f6c1717bba3043ca1943c37b31e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hid the internal user-input variable from system-variable displays and previews, matching the behavior of other internal variables.
  * Improved handling when multiple internal variables are present in editor content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->