### PR TITLE
fix: make learning toolbar actions easier to recognize

### DIFF
--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
@@ -197,7 +197,7 @@ export const ChatUi = ({
                 {previewMode ? null : (
                   <LearnerCourseShareButton
                     surface='learner_desktop_header'
-                    className='h-8 w-8 shrink-0 text-muted-foreground shadow-none hover:bg-muted/50 hover:text-foreground'
+                    className='h-8 w-8 shrink-0 text-gray-600 shadow-none hover:bg-muted/50 hover:text-foreground'
                     tooltipSide='bottom'
                   />
                 )}

--- a/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/LessonPdfDownloadButton.tsx
+++ b/src/cook-web/src/app/c/[[...id]]/Components/ChatUi/LessonPdfDownloadButton.tsx
@@ -48,7 +48,7 @@ export default function LessonPdfDownloadButton({
       type='button'
       variant='ghost'
       size='icon'
-      className='h-8 w-8 shrink-0 text-muted-foreground shadow-none hover:bg-muted/50 hover:text-foreground aria-disabled:cursor-not-allowed aria-disabled:opacity-50'
+      className='h-8 w-8 shrink-0 text-gray-600 shadow-none hover:bg-muted/50 hover:text-foreground aria-disabled:cursor-not-allowed aria-disabled:opacity-50'
       aria-disabled={isDisabled}
       aria-label={accessibleLabel}
       aria-busy={isPreparing}

--- a/src/cook-web/src/app/c/[[...id]]/Components/LearningModeSwitch.module.scss
+++ b/src/cook-web/src/app/c/[[...id]]/Components/LearningModeSwitch.module.scss
@@ -20,7 +20,7 @@
   border: 0.8px solid transparent;
   border-radius: 32px;
   background: transparent;
-  color: var(--base-muted-foreground, #737373);
+  color: #4b5563;
   font-size: var(--text-xs-font-size, 12px);
   font-weight: var(--font-weight-normal, 400);
   line-height: 14px;


### PR DESCRIPTION
## Summary

- Darken the course share and lesson PDF actions to `gray-600`.
- Use the matching `#4b5563` color for inactive learning-mode buttons.
- Preserve the existing selected, hover, focus, and disabled treatments.

## Verification

- [x] Focused Jest suites for the toolbar components (4 suites, 36 tests)
- [x] `npm run type-check`
- [x] Targeted lefthook pre-commit gate
- [x] `npm run build`
- [x] Playwright visual check of normal, selected, and disabled toolbar states
- [x] `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic color tweaks on learner toolbar controls only; no logic, data, or auth changes.
> 
> **Overview**
> Makes the learner desktop header toolbar easier to scan by **darkening default (inactive) icon and label colors** without changing behavior.
> 
> The course **share** and **lesson PDF** ghost icon buttons switch from `text-muted-foreground` to **`text-gray-600`**, while existing hover, shadow, and disabled styling stay the same. Inactive **learning mode** segment labels in `LearningModeSwitch` use **`#4b5563`** instead of the muted-foreground token (`#737373`), aligned with that gray-600 treatment; selected, hover, and focus styles are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 396d7bda20c60646600479d71c2fe62fc63d4d84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text and icon contrast for course sharing and lesson PDF download controls.
  * Updated learning mode switch colors for more consistent readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->