### PR TITLE
chore: upgrade Ruff to 0.16.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install tools
         run: |
           python -m pip install --upgrade pip
-          pip install "ruff==0.16.3" "pre-commit-hooks==6.0.0"
+          pip install "ruff==0.16.5" "pre-commit-hooks==6.0.0"
           (cd src/cook-web && npm ci)
 
       - name: Collect files changed in this PR

--- a/INSTALL_MANUAL.md
+++ b/INSTALL_MANUAL.md
@@ -196,7 +196,7 @@ Then install the remaining development tools from the repository root:
 
 ```bash
 # From the repository root
-pip install ruff==0.16.3 commitizen==4.16.2 pre-commit-hooks==6.0.0
+pip install ruff==0.16.5 commitizen==4.16.2 pre-commit-hooks==6.0.0
 (cd src/cook-web && npm ci)   # provides prettier + eslint
 lefthook install
 

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -58,7 +58,7 @@ npm install -g @evilmartians/lefthook
 Then install the remaining development tools:
 
 ```bash
-pip install ruff==0.16.3 commitizen==4.16.2 pre-commit-hooks==6.0.0
+pip install ruff==0.16.5 commitizen==4.16.2 pre-commit-hooks==6.0.0
 (cd src/cook-web && npm ci)   # provides prettier + eslint
 lefthook install
 ```

--- a/docs/exec-plans/active/ruff-rule-minimization.md
+++ b/docs/exec-plans/active/ruff-rule-minimization.md
@@ -554,7 +554,7 @@ Start with these files:
   surfaces.
 - `src/api/AGENTS.md` and the nearest service `AGENTS.md` files constrain
   backend changes. Read the nearest file before editing each Ruff finding.
-- `lefthook.yml` and `.github/workflows/lint.yml` pin Ruff 0.16.3 and run both
+- `lefthook.yml` and `.github/workflows/lint.yml` pin Ruff 0.16.5 and run both
   check and format gates.
 
 The baseline command for currently enforced rules is:
@@ -676,7 +676,7 @@ earliest unmerged branch first, then replay successors in order.
 
 ## Interfaces and Dependencies
 
-- Ruff is pinned at 0.16.3 in `lefthook.yml`,
+- Ruff is pinned at 0.16.5 in `lefthook.yml`,
   `.github/workflows/lint.yml`, `docs/engineering-baseline.md`, and
   `scripts/check_dev_tools.py`, with the contributor install command mirrored
   in `INSTALL_MANUAL.md`. The doctor verifies the binary on `PATH`, so a Ruff

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,7 @@
 # One-time setup (see AGENTS.md / docs/engineering-baseline.md):
 #   macOS: brew install lefthook
 #   Linux/Windows: npm install -g @evilmartians/lefthook
-#   pip install ruff==0.16.3 commitizen==4.16.2 pre-commit-hooks==6.0.0
+#   pip install ruff==0.16.5 commitizen==4.16.2 pre-commit-hooks==6.0.0
 #   (cd src/cook-web && npm ci)   # provides prettier + eslint
 #   lefthook install
 #

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -41,8 +41,8 @@ else:
     LEFTHOOK_PKG_INSTALL = (
         "npm install -g @evilmartians/lefthook  # (or use your package manager)"
     )
-PIP_INSTALL = "pip install ruff==0.16.3 commitizen==4.16.2 pre-commit-hooks==6.0.0"
-RUFF_VERSION = "0.16.3"
+PIP_INSTALL = "pip install ruff==0.16.5 commitizen==4.16.2 pre-commit-hooks==6.0.0"
+RUFF_VERSION = "0.16.5"
 NPM_INSTALL = "cd src/cook-web && npm ci"
 LEFTHOOK_INSTALL = "lefthook install"
 NODE_INSTALL = "install Node.js (see INSTALL_MANUAL.md for the supported version)"


### PR DESCRIPTION
## Summary
- upgrade the fixed Ruff version from 0.16.3 to 0.16.5
- keep CI, local tool verification, and contributor installation guidance aligned

## Verification
- python3 scripts/check_dev_tools.py
- ruff check .
- ruff format --check .
- python3 scripts/check_repo_harness.py
- lefthook run pre-commit --all-files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI/dev pin updates only; no runtime or lint rule policy changes in this diff.
> 
> **Overview**
> Bumps the **pinned Ruff version from 0.16.3 to 0.16.5** everywhere the repo defines or enforces that pin, so CI, local hooks, the dev-tools doctor, and contributor docs stay in sync.
> 
> **CI** (`.github/workflows/lint.yml`) installs `ruff==0.16.5` for PR lint and autofix. **Local setup** updates the `pip install` line in `lefthook.yml`, `INSTALL_MANUAL.md`, and `docs/engineering-baseline.md`. **`scripts/check_dev_tools.py`** now expects `ruff 0.16.5` on `PATH` and prints the matching install hint. The active Ruff minimization exec plan documents the new pin in its interfaces section.
> 
> There are **no `ruff.toml` or application code changes**—only toolchain and documentation alignment for the patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff8994e60a4099b0d213db51d1120ddcd038b6e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned Ruff version to 0.16.5 across development tooling and automated lint checks.
  * Synchronized installation instructions, developer setup guidance, and validation checks with the updated Ruff version.

* **Documentation**
  * Refreshed engineering and contributor documentation to reflect the current Ruff version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->