### PR TITLE
chore: define frontend analytics requirements

### DIFF
--- a/.cursor/rules/repository-ai-collab.mdc
+++ b/.cursor/rules/repository-ai-collab.mdc
@@ -51,6 +51,23 @@ alwaysApply: true
   change global Ruff policy only in a dedicated rule PR tracked by the active
   Ruff ExecPlan.
 
+- Treat product analytics as part of the definition of done for every new
+  user-facing Cook Web capability or interaction path. The same change must
+  add or extend a decision-relevant Umami event family and focused tests. Only
+  behavior-preserving visual, copy, performance, test, or refactoring work is
+  exempt; a new user-observable path introduced for accessibility still
+  requires analytics.
+
+- Treat every new or changed Cook Web Umami event as a versioned data contract
+  governed by `docs/references/frontend-product-analytics.md`. Changes to
+  event names, semantics, counted populations, deduplication, or payload
+  fields must update producers, consumers, documentation, and tests together.
+
+- Keep Cook Web Umami telemetry fail-open and non-authoritative: it must not
+  block product behavior or serve as the source of truth for billing,
+  permissions, or audit decisions. This rule does not define Langfuse or
+  backend observability contracts.
+
 - Keep generated knowledge artifacts in sync by running
   `python scripts/build_repo_knowledge_index.py` after docs structure or
   metadata changes.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,6 +46,23 @@
   change global Ruff policy only in a dedicated rule PR tracked by the active
   Ruff ExecPlan.
 
+- Treat product analytics as part of the definition of done for every new
+  user-facing Cook Web capability or interaction path. The same change must
+  add or extend a decision-relevant Umami event family and focused tests. Only
+  behavior-preserving visual, copy, performance, test, or refactoring work is
+  exempt; a new user-observable path introduced for accessibility still
+  requires analytics.
+
+- Treat every new or changed Cook Web Umami event as a versioned data contract
+  governed by `docs/references/frontend-product-analytics.md`. Changes to
+  event names, semantics, counted populations, deduplication, or payload
+  fields must update producers, consumers, documentation, and tests together.
+
+- Keep Cook Web Umami telemetry fail-open and non-authoritative: it must not
+  block product behavior or serve as the source of truth for billing,
+  permissions, or audit decisions. This rule does not define Langfuse or
+  backend observability contracts.
+
 - Regenerate repository knowledge indexes with
   `python scripts/build_repo_knowledge_index.py` after moving docs or changing
   required metadata.

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -19,6 +19,32 @@ applyTo: "src/cook-web/**/*.ts,src/cook-web/**/*.tsx,src/cook-web/**/*.js,src/co
 - Keep user-facing strings in shared i18n JSON under `src/i18n/` and preserve
   the unified business-code handling path.
 
+- Every new user-facing Cook Web capability or interaction path must add or
+  extend its Umami contract, producer, and focused tests in the same change.
+  Capture a meaningful feature exposure, accepted use, or a meaningful
+  outcome, and add exposure when the metric needs an eligible-view
+  denominator. A generic SPA pageview is insufficient unless route entry is
+  the documented adoption signal. Exempt only behavior-preserving work; new
+  accessibility invocation paths still require analytics.
+
+- For Umami product analytics, read
+  `docs/references/frontend-product-analytics.md`, send business events
+  through `useTracking` or the shared tracking helper, and leave SPA pageviews
+  to `UmamiLoader`; do not call `window.umami`, identify users, or emit events
+  during render from business components.
+
+- Treat every new or changed Umami event name and metric semantic as a stable
+  contract. Use static `snake_case` names, put dynamic IDs in payload fields,
+  and define the real trigger, counted population, deduplication, and terminal
+  outcome before implementation.
+
+- Use deny-by-default payloads for every new or changed Umami event or
+  identity change, with explicitly listed flat scalar fields. Do not send
+  personal or free-form content, credentials, raw errors, or complete URLs,
+  queries, or referrers; changed pageview handling must strip queries and
+  sensitive URL data, and truncation or hashing does not replace privacy
+  review.
+
 - For clickable UI, prefer semantic elements (`button`, `a`, `summary`) or
   shared Radix/shadcn primitives. If a non-semantic element must handle
   clicks, mark the actual clickable target with `data-clickable="true"` and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,25 @@ to.
 - Keep shared instruction surfaces aligned. When shared rules move, update the
   touched `AGENTS.md`, `CLAUDE.md`, generated `.cursor` rules, and generated
   `.github` instructions in the same change.
+- Treat product analytics as a completion requirement for every new user-facing
+  Cook Web capability or interaction path. In the same change, define or extend
+  a decision-relevant Umami event family, implement its producer, and add
+  focused regression coverage according to
+  `docs/references/frontend-product-analytics.md`; the feature is not complete
+  while that analytics contract is missing. Pure visual styling, copy-only,
+  performance-only, test-only, and behavior-preserving refactoring changes do
+  not require a new event. Any new user-observable action, state transition, or
+  invocation path, including one introduced for accessibility, does; changed
+  behavior already covered by analytics must update its existing contract.
+- Treat new or changed Cook Web Umami events as versioned product-analytics
+  contracts. Before implementation, define the decision or metric, exact
+  trigger, eligible population and exclusions, deduplication scope, stable
+  payload schema, and downstream consumer according to
+  `docs/references/frontend-product-analytics.md`.
+- Keep product analytics best-effort and independent from the user-visible
+  operation. When an event name, meaning, eligibility rule, deduplication rule,
+  or payload contract changes, update its producers, consumers, canonical
+  product documentation, compatibility plan, and regression tests together.
 - Keep code-facing text in English and keep user-facing text in shared i18n
   JSON under `src/i18n/`.
 - Store and compute all timestamps in UTC. On the backend, use the shared
@@ -78,6 +97,17 @@ to.
 - Do not start modifying code from guesswork when the local implementation and
   neighboring tests have not been inspected.
 - Do not hardcode user-facing strings, secrets, or environment-specific URLs.
+- Do not add free-form or user-authored text, prompts or model output, names,
+  contact details, profile content, titles or descriptions, coupon codes,
+  tokens, raw errors, or complete URLs, queries, or referrers to new or changed
+  Umami events or identity metadata. Use an explicit allowlist of necessary
+  stable machine IDs, booleans, numbers, durations, and low-cardinality enums;
+  truncation or hashing does not make a sensitive field safe to collect. New or
+  changed pageview handling must strip query strings, fragments, credentials,
+  and sensitive path data before tracking.
+- Do not use best-effort Umami data as the source of truth for billing,
+  permissions, auditing, or another correctness-sensitive business decision,
+  and do not block or alter a user action when analytics is unavailable.
 - Do not create new root `tasks.md` checklists. Complex execution now belongs
   in ExecPlans under `docs/exec-plans/`.
 - Do not let shared guidance drift from generated mirrors or from the current
@@ -194,6 +224,10 @@ Pin release versions of both before merging.
   widen only when the change crosses a shared contract or multiple surfaces.
 - When a task touches only docs or instruction files, at minimum run
   `python scripts/check_repo_harness.py`.
+- When a task adds or changes a frontend Umami event, test the exact name and
+  payload, negatively assert that sensitive fields are absent, cover trigger
+  timing, eligibility, deduplication and terminal outcomes, and prove that a
+  tracking failure does not change the user-visible result.
 - When a Ruff-driven rewrite changes runtime behavior or a public/internal
   contract, add or identify a focused regression test; a clean lint result is
   not behavior coverage.

--- a/docs/QUALITY_SCORE.md
+++ b/docs/QUALITY_SCORE.md
@@ -37,9 +37,18 @@ governance work can be prioritized mechanically.
 
 - Current grade: `B`
 - Gaps: route and component tests exist, but the browser harness still covers
-  only the minimum login, admin, and learner paths.
+  only the minimum login, admin, and learner paths. Grandfathered Umami debt
+  also remains in legacy dynamic event names, free-text or object-derived
+  payloads, localized timestamps, query-bearing pageviews, identify session
+  metadata, and missing focused tests for the low-level tracking transport.
+  This debt is non-blocking for the analytics-governance documentation change,
+  is not approval for those patterns, and must not be copied into new or
+  changed events.
 - Next action: keep the Playwright smoke suite green under the default dev
-  harness and widen it only after the current three paths stay stable.
+  harness and widen it only after the current three paths stay stable. Pay down
+  the analytics debt through dedicated, compatibility-aware migrations while
+  enforcing `docs/references/frontend-product-analytics.md` for all new or
+  changed Cook Web Umami events.
 
 ### runtime harness
 

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -83,5 +83,6 @@
 | `docs/product-specs/teacher-analytics-dashboard.md` | Teacher Analytics Dashboard (v1) | `product-spec` | `implemented` | `shared` | `2026-08-16` | `true` |
 | `docs/product-specs/transfer-course-creator.md` | Operator Course Creator Transfer | `product-spec` | `implemented` | `shared` | `2026-05-12` | `true` |
 | `docs/references/architecture-boundaries.md` | Architecture Boundaries | `reference` | `reference` | `repo` | `-` | `true` |
+| `docs/references/frontend-product-analytics.md` | Frontend Product Analytics | `reference` | `reference` | `repo` | `-` | `true` |
 | `docs/references/i18n.md` | Internationalization (i18n) Guide | `reference` | `reference` | `repo` | `-` | `true` |
 | `docs/references/scripts.md` | Scripts Overview | `reference` | `reference` | `repo` | `-` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -8,7 +8,7 @@ This generated report summarizes the repository harness control plane.
 
 - Design docs: `12`
 - Product specs: `10`
-- References: `3`
+- References: `4`
 - Active ExecPlans: `20`
 - Completed ExecPlans: `27`
 

--- a/docs/references/frontend-product-analytics.md
+++ b/docs/references/frontend-product-analytics.md
@@ -1,0 +1,322 @@
+# Frontend Product Analytics
+
+This reference is the canonical contract for new or changed Cook Web Umami
+product-behavior events. Existing events are grandfathered only while they
+remain untouched. Legacy behavior described at the end of this document is
+debt to migrate, not a precedent for new code.
+
+## Scope and System Boundaries
+
+Use Umami to answer product-behavior questions such as whether a user saw,
+started, completed, cancelled, or failed an interaction. An Umami event is a
+versioned data contract between its producer and every query, dashboard,
+experiment, or report that consumes it.
+
+Umami is not the source of truth for:
+
+- model and prompt traces, which belong in Langfuse;
+- billing, credit consumption, or financial records;
+- authorization, entitlements, compliance, or audit records; or
+- application logs, errors, metrics, and operational traces.
+
+Analytics must be fail-open. Missing configuration, a blocked script, an
+identify failure, or an event delivery failure must never block, delay, or
+change the user workflow. Product behavior must not depend on an event being
+accepted by Umami.
+
+This document is intentionally not a registry of all events. It defines the
+contract required whenever a Cook Web Umami event is added or changed.
+
+## Contract-First Changes
+
+Write or update the event contract before changing a producer. Treat changes to
+the event name, meaning, trigger, measured population, count unit,
+deduplication, payload fields, or enum values as contract changes. Coordinate
+the producer, known consumers, documentation, and tests in the same change or
+in an explicitly staged compatibility migration.
+
+Adding a field is not automatically harmless: queries may group by it, its
+cardinality may raise cost, and its contents may change the privacy posture.
+Removing or renaming an event or field requires identifying consumers and
+defining how historical and new data will coexist. Do not silently reuse an
+old event name for a new meaning.
+
+## New UI Feature Requirement
+
+Product analytics is part of the definition of done for every new user-facing
+Cook Web capability or interaction path. The same feature change must include:
+
+- a documented new or extended event family with a business question and
+  metric definition;
+- at least one decision-relevant signal for meaningful feature exposure,
+  accepted use, or a meaningful outcome;
+- the producer implementation through the shared tracking path; and
+- focused tests for the trigger, eligible population, deduplication, payload,
+  prohibited fields, and failure isolation.
+
+Add an exposure event when the metric requires an eligible-view denominator.
+Use separate attempt and terminal-result events when an asynchronous workflow
+cannot be measured accurately with one signal. Do not create render-count or
+incidental-click noise merely to satisfy this requirement; the event must
+represent the feature's documented adoption or outcome question.
+
+An existing generic SPA pageview does not satisfy this requirement unless
+entering that route is itself the documented feature-adoption signal.
+An existing event family may satisfy the requirement only when its contract is
+explicitly extended in the same change and remains semantically accurate for
+its producers and consumers.
+
+A new action, control, route, workflow, interaction mode, or user-visible state
+transition counts as new functionality. So does any new user-observable
+invocation path, including one introduced for keyboard, screen-reader, or other
+accessibility use. Pure visual styling, copy-only edits, performance-only work,
+test-only changes, and behavior-preserving refactors do not require a new
+event. If such work changes behavior already covered by analytics, update that
+existing contract. If a privacy-safe, decision-relevant contract cannot be
+designed, do not ship the new capability until the product and privacy decision
+is resolved.
+
+## Contract Template
+
+Every new event family, and every changed existing event, must document the
+following information in its product spec or ExecPlan. Keep the contract close
+to the feature decision; link back to this reference rather than copying these
+rules.
+
+```markdown
+### <event family>
+
+- Business question: <the decision this data will support>
+- Metric definition: <numerator, denominator, time window, and distinctness>
+- Event name(s): <stable snake_case names>
+- Actor and surface: <who can emit it and the fixed surface enum>
+- Trigger: <the exact state transition or user action>
+- Population: <guest/member/teacher coverage and explicit exclusions>
+- Count unit: <event, attempt, user, session, course, or another named unit>
+- Deduplication: <key, time or lifecycle boundary, and storage mechanism>
+- Correlation: <required stable identifiers and what they may be joined to>
+- Consumers: <queries, dashboards, reports, experiments, or owners>
+- Compatibility: <additive, dual-write, rename, backfill, or new version>
+- Verification: <producer, exclusion, deduplication, privacy, and consumer tests>
+
+| Field | Type | Allowed values | Cardinality | Privacy class | Why required |
+| --- | --- | --- | --- | --- | --- |
+| `<field>` | string/number/boolean | enum or validation rule | low/high | non-personal/pseudonymous | <metric or join need> |
+```
+
+The business question and metric definition are required. “Track usage” is not
+a metric definition. State whether the metric counts raw events, distinct
+users, distinct sessions, or distinct business objects, and state the time
+window. If click and result events cannot be correlated one to one, document
+that limitation rather than presenting their aggregate ratio as an exact
+conversion rate.
+
+## Event Names and Semantics
+
+- Use stable lowercase `snake_case` names. Prefer
+  `<actor>_<object>_<action-or-state>` when one actor owns the event. A shared
+  event may omit the actor when a fixed `surface` field distinguishes the
+  contexts clearly.
+- Keep dynamic IDs, labels, locales, titles, and state in reviewed payload
+  fields. Never interpolate them into an event name.
+- Name a state that actually occurred. Emit from an event handler or effect
+  tied to the documented transition, never during React render.
+- A `click` records one accepted user interaction after re-entry or disabled
+  guards. An `attempt` records the point at which the product starts an
+  operation after local validation. A `success` records confirmed completion.
+  A `failed` result records a terminal failure. A `cancelled` result records an
+  explicit user cancellation and is not a failure.
+- If an interaction needs both intent and outcome measurement, use separate
+  intent and terminal-result events. Emit at most one terminal result for each
+  accepted attempt.
+- Define whether guests are included, whether teacher or learner preview is
+  included, and whether internal/test traffic is excluded. Do not let the
+  current rendering location answer these questions implicitly.
+- Define the deduplication boundary even when the answer is “none.” For
+  visibility events, state whether deduplication is per mount, route visit,
+  browser session, user, or persisted lifecycle. For actions, prevent render,
+  retry, and double-click behavior from inflating counts unless repeat actions
+  are the intended count unit.
+
+Enum values are stable API values, not localized display text. Use short
+English `snake_case` values and document the complete allowed set. Adding,
+removing, or changing an enum value is a contract change.
+
+## Payload Shape and Cardinality
+
+Event payloads must be explicit, flat records of scalar strings, finite
+numbers, and booleans.
+
+- Spell out every field at the call site or in a feature-owned typed helper.
+  Do not spread a form, store, API response, configuration object, error, or
+  arbitrary metadata object into analytics.
+- Use stable `snake_case` field names. Keep enum fields low-cardinality and
+  bounded by the documented allowed values.
+- Add a high-cardinality stable machine identifier only when a named metric,
+  join, or deduplication rule requires it. Examples include a course bid or a
+  workflow/session ID. Do not add a duplicate user identifier when the shared
+  tracking context already supplies identity.
+- Send durations as finite numeric values with the unit in the field name,
+  such as `duration_ms`. Send timestamps only when the event's metric requires
+  a business timestamp that differs from Umami's ingestion time; serialize it
+  as UTC ISO-8601 with a trailing `Z`.
+- Map failures to a reviewed, bounded error category or code. Never send an
+  exception message, stack, response body, or arbitrary provider error.
+- Do not rely on field order, automatic string conversion, truncation, or the
+  transport's fallback serialization as part of an event contract.
+
+The shared transport currently caps event names at 50 characters, keys at 64
+characters, string values at 240 characters, payloads at 30 fields and 1,024
+JSON characters, and pageview URL/referrer values at 500 characters. These
+limits are delivery safeguards, not authoring targets. Silent truncation or
+dropped fields can corrupt a metric, and sanitation does not make prohibited
+data safe to collect.
+
+## Privacy Default: Deny
+
+Do not collect a field unless the contract explains why it is necessary. New or
+changed application-event payloads and identify session metadata must not
+include:
+
+- nickname, name, email address, phone number, or other direct identifiers;
+- learner profile/background content or personalization answers;
+- prompts, model input/output, chat content, or free-form user text;
+- course, lesson, chapter, document, or conversation titles and descriptions;
+- discount/coupon codes, credentials, secrets, authorization values, or tokens;
+- raw errors, exception messages, stack traces, or provider response bodies; or
+- complete URLs, query strings, fragments, or referrers.
+
+Necessary stable machine IDs, booleans, finite numbers, durations, and reviewed
+low-cardinality enums are allowed when declared in the contract. Stable machine
+IDs remain pseudonymous data: minimize them, scope access appropriately, and do
+not expose them in user-facing reports.
+
+The shared identify path is not an exception to this privacy rule. Any new or
+changed identity field must have a documented analytics need and explicit
+privacy review. Prefer the one stable pseudonymous distinct ID; do not attach
+direct identifiers, free text, or duplicated identity without a defined metric.
+
+Hashing, encoding, or truncating a prohibited value does not make it approved.
+If a URL-derived distinction is necessary, define a bounded route or source
+enum instead of sending the URL. Pageview URL handling is transport-owned and
+is not permission for application events to add URL or referrer fields. New or
+changed pageview handling must remove query strings, fragments, credentials,
+and sensitive path values before delivery; a complete referrer requires its own
+documented contract and privacy review.
+
+## Transport Invariants
+
+- Product code emits events through `useTracking` or a shared, reviewed
+  tracking helper. It must not call `window.umami`, `umami.track`, or
+  `umami.identify` directly.
+- `UmamiLoader` is the single owner of SPA pageviews. Umami auto-tracking stays
+  disabled, route changes are deduplicated, and feature components do not emit
+  pageviews.
+- Preserve the identify → queue → drain order. Pageviews and events that occur
+  before Umami and user identity are ready are queued with their captured
+  context, then drained after identify completes.
+- Preserve transport-level name, key, value, field-count, JSON-size, URL, and
+  referrer sanitation. Feature code must still satisfy the stricter contract
+  before sanitation.
+- Tracking calls and identify/pageview work remain fail-open. Callers do not
+  await analytics before navigation, native browser actions, or user-visible
+  success/failure handling.
+- Do not emit during render. Use the true user handler or a guarded effect for
+  a documented visibility/state transition.
+
+## Positive Example: Course Sharing
+
+`course_share_click` and `course_share_result` demonstrate a small event family
+with stable names, explicit fields, terminal outcomes, and no course content.
+They are an example, not the start of an event registry.
+
+### Business and metric contract
+
+- Business question: which eligible share surfaces lead users to initiate a
+  share, and which method/outcome completes the attempt?
+- Actors and population: teachers in the authoring header and eligible
+  learners, including guests when the learner share control is rendered.
+  Learner preview is excluded. Teacher drafts are included because sharing is
+  independent of publication.
+- Count unit: one accepted share-button interaction. Concurrent re-entry is
+  blocked; later deliberate interactions count again. There is no persisted
+  cross-session deduplication.
+- Metric limitation: `shifu_bid` supports aggregate grouping by course, but
+  there is no per-attempt correlation ID. Click/result counts must not be
+  presented as exact row-level joins.
+- Consumer: aggregate course-sharing adoption and outcome analysis.
+
+### Events and feature-owned payloads
+
+| Event | Trigger | Feature-owned fields |
+| --- | --- | --- |
+| `course_share_click` | After the re-entry guard accepts the deliberate click and before URL resolution/native sharing | `shifu_bid`, `surface` |
+| `course_share_result` | Once after the accepted interaction reaches a terminal outcome | `shifu_bid`, `surface`, `method`, `outcome` |
+
+| Field | Type | Allowed values | Cardinality | Privacy class | Why required |
+| --- | --- | --- | --- | --- | --- |
+| `shifu_bid` | string | stable course bid | high | pseudonymous machine ID | group adoption by course |
+| `surface` | string | `teacher_header`, `learner_desktop_header`, `learner_mobile_header`, `learner_mobile_fullscreen` | low | non-personal enum | compare entry points and infer actor context |
+| `method` | string | `native`, `clipboard` | low | non-personal enum | compare completion paths |
+| `outcome` | string | `success`, `failed`, `cancelled` | low | non-personal enum | measure terminal result without raw errors |
+
+This table lists the fields owned by the sharing producers, not every field in
+the payload currently delivered to Umami. The shared `useTracking` helper also
+adds `user_type`, `user_id`, `device`, and the grandfathered localized
+`timeStamp`. Those helper-added fields are inherited transport behavior, not a
+positive part of this example and not approved as dependencies for new
+consumers.
+
+Every event contract must inventory both layers: the feature-owned allowlist
+and the complete payload after shared-helper enrichment. Label inherited
+legacy fields explicitly, audit them against the privacy rules, and do not
+claim that the final schema is fully compliant until the relevant transport
+debt is migrated. Removing or changing helper-added fields requires the same
+compatibility review as any other consumed schema change.
+
+The existing producer tests assert the exact feature-owned fields for native
+success, clipboard success/failure, cancellation, and invalid input. They also
+assert that course title, description, and URL never enter the producer
+payload. Because those tests mock `useTracking`, they do not prove the final
+helper-enriched payload; that missing low-level coverage remains tracked as
+legacy debt.
+
+## Verification
+
+For every new or changed event, add focused tests that cover:
+
+- exact event names, trigger order, and feature-owned payload keys, types, and
+  enum values;
+- every terminal result, including cancellation and failure when applicable;
+- guest/member/teacher and preview inclusion or exclusion;
+- re-render, retry, double-click, route-change, and deduplication behavior;
+- absence of prohibited or incidental fields; and
+- consumer calculations or fixtures when an existing query/dashboard changes.
+
+The contract review must also record the complete helper-enriched payload,
+including any explicitly grandfathered transport fields. A feature-level test
+that mocks `useTracking` verifies only the producer boundary and must not be
+presented as proof of the final delivered schema.
+
+When changing the shared transport, also cover identify-before-drain ordering,
+events emitted before script readiness, SPA pageview deduplication, sanitation
+limits, and fail-open behavior. Local producer tests prove the code contract;
+they do not prove that a production Umami site, filter, or dashboard is current.
+Verify deployed analytics separately before reporting live coverage.
+
+## Grandfathered Legacy Debt
+
+The following existing behavior is tracked as non-blocking migration debt in
+`docs/QUALITY_SCORE.md`:
+
+- dynamic event names at legacy call sites;
+- free-text or object-derived payload values;
+- the localized `timeStamp` field added by `useTracking`;
+- pageviews that include query strings;
+- identify session metadata such as nickname, user state, and language; and
+- missing focused tests for the low-level tracking transport.
+
+These behaviors are not approved examples. New code must not copy them. When a
+legacy event or the shared transport is changed, apply this contract and use a
+dedicated compatibility migration when historical consumers or event meaning
+would otherwise break.

--- a/docs/references/index.md
+++ b/docs/references/index.md
@@ -5,5 +5,6 @@
 Evergreen repository references and operational guides live here.
 
 - [Architecture Boundaries](../references/architecture-boundaries.md)
+- [Frontend Product Analytics](../references/frontend-product-analytics.md)
 - [Internationalization (i18n) Guide](../references/i18n.md)
 - [Scripts Overview](../references/scripts.md)

--- a/scripts/check_repo_harness.py
+++ b/scripts/check_repo_harness.py
@@ -36,6 +36,10 @@ MANUAL_AGENTS = {
         "PLANS.md",
         "docs/engineering-baseline.md",
         "docs/exec-plans/active/",
+        "docs/references/frontend-product-analytics.md",
+        "Umami",
+        "product analytics as a completion requirement",
+        "best-effort",
         "python scripts/check_repo_harness.py",
         "python scripts/check_architecture_boundaries.py",
     ),
@@ -48,6 +52,11 @@ MANUAL_AGENTS = {
     ROOT / "src" / "cook-web" / "AGENTS.md": (
         "../../ARCHITECTURE.md",
         "../../docs/engineering-baseline.md",
+        "../../docs/references/frontend-product-analytics.md",
+        "Umami",
+        "new user-facing Cook Web capability or interaction path",
+        "useTracking",
+        "fail-open",
         "src/lib/request.ts",
         "npm run test:e2e",
     ),
@@ -63,10 +72,18 @@ REQUIRED_ROOT_DOCS = (
     DOCS_ROOT / "exec-plans" / "tech-debt-tracker.md",
     DOCS_ROOT / "design-docs" / "agent-first-harness-phase-2.md",
     DOCS_ROOT / "references" / "architecture-boundaries.md",
+    DOCS_ROOT / "references" / "frontend-product-analytics.md",
     BOUNDARY_BASELINE,
     HARNESS_HEALTH,
     GARDENING_SUMMARY_PATH,
 )
+REQUIRED_DOC_MARKERS = {
+    DOCS_ROOT / "references" / "frontend-product-analytics.md": (
+        "New UI Feature Requirement",
+        "definition of done",
+        "generic SPA pageview does not satisfy this requirement",
+    ),
+}
 REQUIRED_DIRS = (
     DOCS_ROOT / "design-docs",
     DOCS_ROOT / "product-specs",
@@ -201,6 +218,15 @@ def check_root_docs(errors: list[str]) -> None:
         for path in REQUIRED_DIRS
         if not path.exists()
     )
+    for path, markers in REQUIRED_DOC_MARKERS.items():
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        errors.extend(
+            f"Missing marker '{marker}' in {path}"
+            for marker in markers
+            if marker not in text
+        )
     errors.extend(
         f"Missing required harness workflow: {path}"
         for path in REQUIRED_WORKFLOWS

--- a/scripts/generate_ai_collab_docs.py
+++ b/scripts/generate_ai_collab_docs.py
@@ -1029,8 +1029,8 @@ FRONTEND_META = {
     ),
     "c-common": FrontendDomainMeta(
         summary=(
-            "small shared hooks and tracking helpers that support the legacy `c` "
-            "frontend experience"
+            "small shared hooks and the Umami tracking transport used across the "
+            "Cook Web frontend, including the legacy `c` experience"
         ),
         key_files=(
             "hooks/useDisclosure.ts",
@@ -1038,20 +1038,25 @@ FRONTEND_META = {
             "tools/tracking.ts",
         ),
         invariants=(
-            "keep lightweight legacy helpers centralized so the `c` experience "
-            "does not grow duplicated micro-utilities",
-            "preserve tracking and disclosure behavior because the same patterns "
-            "can appear across multiple legacy pages",
-            "treat these helpers as compatibility surfaces until the legacy "
-            "experience is fully retired or migrated",
+            "keep business events on the shared `useTracking` hook and keep raw "
+            "Umami transport ownership in `tools/tracking.ts` instead of adding "
+            "page-local analytics entry points",
+            "preserve identify -> queue -> drain ordering and SPA pageview "
+            "deduplication, including the previous tracked URL as the referrer",
+            "keep the transport fail-open and preserve its size and type "
+            "sanitization bounds; sanitization protects delivery limits but does "
+            "not make an unapproved payload privacy-safe",
         ),
         avoid_points=(
-            "do not fork tracking helpers for one page when a shared legacy hook "
-            "already exists",
-            "do not let these helpers drift from the stores or constants they are "
-            "expected to coordinate with",
-            "do not move shared compatibility behavior into page files where it "
-            "becomes hard to discover and reuse",
+            "do not call `window.umami`, invoke identify, or implement pageview "
+            "tracking from business components when the shared hook, transport, "
+            "and `UmamiLoader` own those responsibilities",
+            "do not treat truncation, stringification, or hashing as privacy "
+            "review; event and identity callers must pass only explicitly "
+            "approved flat scalar fields, and changed pageview handling must "
+            "strip queries and sensitive URL data",
+            "do not let analytics loading, identification, queue draining, or "
+            "delivery errors block the user action or change its business result",
         ),
         test_focus="src/cook-web/src/c-common/",
     ),
@@ -1614,6 +1619,23 @@ def build_documents() -> dict[Path, str]:
                 "focused tests first, use only narrow coded suppressions for "
                 "intentional constructs, and change global Ruff policy only in "
                 "a dedicated rule PR tracked by the active Ruff ExecPlan.",
+                "Treat product analytics as part of the definition of done for "
+                "every new user-facing Cook Web capability or interaction path. "
+                "The same change must add or extend a decision-relevant Umami "
+                "event family and focused tests. Only behavior-preserving visual, "
+                "copy, performance, test, or refactoring work is exempt; a new "
+                "user-observable path introduced for accessibility still "
+                "requires analytics.",
+                "Treat every new or changed Cook Web Umami event as a versioned "
+                "data contract governed by "
+                "`docs/references/frontend-product-analytics.md`. Changes to event "
+                "names, semantics, counted populations, deduplication, or payload "
+                "fields must update producers, consumers, documentation, and "
+                "tests together.",
+                "Keep Cook Web Umami telemetry fail-open and non-authoritative: "
+                "it must not block product behavior or serve as the source of "
+                "truth for billing, permissions, or audit decisions. This rule "
+                "does not define Langfuse or backend observability contracts.",
                 "Keep generated knowledge artifacts in sync by running "
                 "`python scripts/build_repo_knowledge_index.py` after docs "
                 "structure or metadata changes.",
@@ -1745,6 +1767,32 @@ def build_documents() -> dict[Path, str]:
                 "path or ad-hoc component fetch logic.",
                 "Keep user-facing strings in shared i18n JSON under `src/i18n/` "
                 "and preserve the unified request/business-code handling flow.",
+                "Every new user-facing Cook Web capability or interaction path "
+                "must add or extend its Umami contract, producer, and focused "
+                "tests in the same change. Capture a meaningful feature "
+                "exposure, accepted use, or a meaningful outcome, and add "
+                "exposure when the metric "
+                "needs an eligible-view denominator. A generic SPA pageview is "
+                "insufficient unless route entry is the documented adoption "
+                "signal. Exempt only behavior-preserving work; new accessibility "
+                "invocation paths still require analytics.",
+                "For Umami product analytics, read "
+                "`docs/references/frontend-product-analytics.md`, send business "
+                "events through `useTracking` or the shared tracking helper, and "
+                "leave SPA pageviews to `UmamiLoader`; do not call "
+                "`window.umami`, identify users, or emit events during render from "
+                "business components.",
+                "Treat every new or changed Umami event name and metric semantic "
+                "as a stable contract. Use static `snake_case` names, put dynamic "
+                "IDs in payload fields, and define the real trigger, counted "
+                "population, deduplication, and terminal outcome before "
+                "implementation.",
+                "Use deny-by-default payloads for every new or changed Umami "
+                "event or identity change, with explicitly listed flat scalar "
+                "fields. Do not send personal or free-form content, credentials, "
+                "raw errors, or complete URLs, queries, or referrers; changed "
+                "pageview handling must strip queries and sensitive URL data, "
+                "and truncation or hashing does not replace privacy review.",
                 "For clickable UI, prefer semantic elements (`button`, `a`, "
                 "`summary`) or shared Radix/shadcn primitives. If a "
                 "non-semantic element must handle clicks, mark the actual "
@@ -1804,6 +1852,23 @@ def build_documents() -> dict[Path, str]:
                 "focused tests first, use only narrow coded suppressions for "
                 "intentional constructs, and change global Ruff policy only in "
                 "a dedicated rule PR tracked by the active Ruff ExecPlan.",
+                "Treat product analytics as part of the definition of done for "
+                "every new user-facing Cook Web capability or interaction path. "
+                "The same change must add or extend a decision-relevant Umami "
+                "event family and focused tests. Only behavior-preserving visual, "
+                "copy, performance, test, or refactoring work is exempt; a new "
+                "user-observable path introduced for accessibility still "
+                "requires analytics.",
+                "Treat every new or changed Cook Web Umami event as a versioned "
+                "data contract governed by "
+                "`docs/references/frontend-product-analytics.md`. Changes to event "
+                "names, semantics, counted populations, deduplication, or payload "
+                "fields must update producers, consumers, documentation, and "
+                "tests together.",
+                "Keep Cook Web Umami telemetry fail-open and non-authoritative: "
+                "it must not block product behavior or serve as the source of "
+                "truth for billing, permissions, or audit decisions. This rule "
+                "does not define Langfuse or backend observability contracts.",
                 "Regenerate repository knowledge indexes with "
                 "`python scripts/build_repo_knowledge_index.py` after moving docs "
                 "or changing required metadata.",
@@ -1888,6 +1953,32 @@ def build_documents() -> dict[Path, str]:
                 "implementations or ad-hoc component fetch logic.",
                 "Keep user-facing strings in shared i18n JSON under `src/i18n/` "
                 "and preserve the unified business-code handling path.",
+                "Every new user-facing Cook Web capability or interaction path "
+                "must add or extend its Umami contract, producer, and focused "
+                "tests in the same change. Capture a meaningful feature "
+                "exposure, accepted use, or a meaningful outcome, and add "
+                "exposure when the metric "
+                "needs an eligible-view denominator. A generic SPA pageview is "
+                "insufficient unless route entry is the documented adoption "
+                "signal. Exempt only behavior-preserving work; new accessibility "
+                "invocation paths still require analytics.",
+                "For Umami product analytics, read "
+                "`docs/references/frontend-product-analytics.md`, send business "
+                "events through `useTracking` or the shared tracking helper, and "
+                "leave SPA pageviews to `UmamiLoader`; do not call "
+                "`window.umami`, identify users, or emit events during render from "
+                "business components.",
+                "Treat every new or changed Umami event name and metric semantic "
+                "as a stable contract. Use static `snake_case` names, put dynamic "
+                "IDs in payload fields, and define the real trigger, counted "
+                "population, deduplication, and terminal outcome before "
+                "implementation.",
+                "Use deny-by-default payloads for every new or changed Umami "
+                "event or identity change, with explicitly listed flat scalar "
+                "fields. Do not send personal or free-form content, credentials, "
+                "raw errors, or complete URLs, queries, or referrers; changed "
+                "pageview handling must strip queries and sensitive URL data, "
+                "and truncation or hashing does not replace privacy review.",
                 "For clickable UI, prefer semantic elements (`button`, `a`, "
                 "`summary`) or shared Radix/shadcn primitives. If a "
                 "non-semantic element must handle clicks, mark the actual "

--- a/src/cook-web/.cursor/rules/cook-web.mdc
+++ b/src/cook-web/.cursor/rules/cook-web.mdc
@@ -21,6 +21,32 @@ alwaysApply: false
 - Keep user-facing strings in shared i18n JSON under `src/i18n/` and preserve
   the unified request/business-code handling flow.
 
+- Every new user-facing Cook Web capability or interaction path must add or
+  extend its Umami contract, producer, and focused tests in the same change.
+  Capture a meaningful feature exposure, accepted use, or a meaningful
+  outcome, and add exposure when the metric needs an eligible-view
+  denominator. A generic SPA pageview is insufficient unless route entry is
+  the documented adoption signal. Exempt only behavior-preserving work; new
+  accessibility invocation paths still require analytics.
+
+- For Umami product analytics, read
+  `docs/references/frontend-product-analytics.md`, send business events
+  through `useTracking` or the shared tracking helper, and leave SPA pageviews
+  to `UmamiLoader`; do not call `window.umami`, identify users, or emit events
+  during render from business components.
+
+- Treat every new or changed Umami event name and metric semantic as a stable
+  contract. Use static `snake_case` names, put dynamic IDs in payload fields,
+  and define the real trigger, counted population, deduplication, and terminal
+  outcome before implementation.
+
+- Use deny-by-default payloads for every new or changed Umami event or
+  identity change, with explicitly listed flat scalar fields. Do not send
+  personal or free-form content, credentials, raw errors, or complete URLs,
+  queries, or referrers; changed pageview handling must strip queries and
+  sensitive URL data, and truncation or hashing does not replace privacy
+  review.
+
 - For clickable UI, prefer semantic elements (`button`, `a`, `summary`) or
   shared Radix/shadcn primitives. If a non-semantic element must handle
   clicks, mark the actual clickable target with `data-clickable="true"` and

--- a/src/cook-web/AGENTS.md
+++ b/src/cook-web/AGENTS.md
@@ -25,6 +25,38 @@ hard frontend constraints close to `src/cook-web/`.
   local Docker dev stack.
 - Treat legacy `c-*` directories as maintained compatibility surfaces until a
   planned migration removes them.
+- Every new user-facing Cook Web capability or interaction path must add or
+  extend its Umami event family contract, producer, and focused tests in the
+  same change. At minimum, capture a meaningful feature exposure, accepted use,
+  or a meaningful outcome; add an exposure event when the metric needs an
+  eligible-view denominator, and use attempt plus terminal-result events when
+  one signal cannot describe an asynchronous workflow accurately. An existing
+  generic SPA pageview does not satisfy this requirement unless route entry is
+  itself the documented feature-adoption signal. The feature is incomplete
+  without this coverage. Pure visual styling, copy-only, performance-only,
+  test-only, and behavior-preserving refactoring changes do not require a new
+  event. Any new user-observable action, state transition, or invocation path,
+  including one introduced for accessibility, does.
+- Follow `../../docs/references/frontend-product-analytics.md` for every new or
+  changed Umami event. Send business events through the shared `useTracking`
+  and `tracking` path; only the centralized tracking implementation may access
+  `window.umami`, identify users, queue calls, or sanitize provider payloads.
+- Keep SPA pageview ownership in `UmamiLoader`. Emit business events from a real
+  user action or a post-commit effect with stable inputs, never during render;
+  define the guest and preview policy plus the per-render, per-open, per-session,
+  or other deduplication scope explicitly.
+- Give new events stable `snake_case` names, normally
+  `<actor>_<object>_<action-or-state>`. Put stable resource identifiers in an
+  explicit payload field instead of constructing dynamic event names, and do
+  not rename or repurpose a consumed event without a coordinated migration.
+- Build payloads from an explicit allowlist of flat scalar fields. Report
+  attempts and terminal `success`, `failed`, or `cancelled` outcomes at the
+  transition they actually describe, and keep tracking fail-open so the main
+  user action never depends on analytics delivery.
+- Treat changes to centralized identify and pageview metadata as privacy
+  contract changes too. Allow only necessary pseudonymous identity and reviewed
+  session enums, and remove queries, fragments, credentials, and sensitive path
+  data from any new or changed pageview handling.
 - For clickable UI, prefer semantic elements (`button`, `a`, `summary`) or
   shared Radix/shadcn primitives. If a non-semantic element must handle clicks,
   mark the actual clickable target with `data-clickable="true"` and preserve
@@ -39,6 +71,12 @@ hard frontend constraints close to `src/cook-web/`.
 - Do not add ad-hoc component fetch logic or a second request abstraction.
 - Do not hardcode user-facing strings or auth/request header construction in
   UI components.
+- Do not call `window.umami` or identify users from feature code, add a second
+  pageview path, treat an awaited tracking call as delivery confirmation, or
+  use analytics results to drive product state.
+- Do not spread form values, API responses, configuration objects, user-authored
+  content, complete URLs, queries, referrers, or raw errors into an Umami event
+  or identity payload. Size sanitization is not privacy sanitization.
 - Do not treat legacy `c-*` paths as dead code that can be broken casually.
 - Do not add new complex-work checklists outside ExecPlans.
 
@@ -52,6 +90,10 @@ hard frontend constraints close to `src/cook-web/`.
 ## Tests
 
 - Run focused Jest tests for the touched domain first.
+- For each new or changed Umami event, assert the exact event name and allowlisted
+  payload, sensitive-field absence, trigger timing, eligibility and deduplication,
+  all relevant terminal outcomes, and continued business behavior when tracking
+  throws or is unavailable.
 - Run `npm run type-check` and `npm run lint` when shared route, hook, store,
   or request behavior changes.
 - Run `npm run test:e2e` when browser harness code or smoke selectors change.

--- a/src/cook-web/src/c-common/AGENTS.md
+++ b/src/cook-web/src/c-common/AGENTS.md
@@ -8,8 +8,8 @@ domain-specific frontend ownership.
 
 ## Scope
 
-- This domain owns small shared hooks and tracking helpers that support the
-  legacy `c` frontend experience.
+- This domain owns small shared hooks and the Umami tracking transport used
+  across the Cook Web frontend, including the legacy `c` experience.
 
 - Representative files in this subtree:
   `src/cook-web/src/c-common/hooks/useDisclosure.ts`,
@@ -27,25 +27,30 @@ domain-specific frontend ownership.
 - Start from the local entry files and preserve how `c-common` currently
   separates route code, shared logic, state, and utilities.
 
-- Keep lightweight legacy helpers centralized so the `c` experience does not
-  grow duplicated micro-utilities.
+- Keep business events on the shared `useTracking` hook and keep raw Umami
+  transport ownership in `tools/tracking.ts` instead of adding page-local
+  analytics entry points.
 
-- Preserve tracking and disclosure behavior because the same patterns can
-  appear across multiple legacy pages.
+- Preserve identify -> queue -> drain ordering and SPA pageview deduplication,
+  including the previous tracked URL as the referrer.
 
-- Treat these helpers as compatibility surfaces until the legacy experience is
-  fully retired or migrated.
+- Keep the transport fail-open and preserve its size and type sanitization
+  bounds; sanitization protects delivery limits but does not make an
+  unapproved payload privacy-safe.
 
 ## Avoid
 
-- Do not fork tracking helpers for one page when a shared legacy hook already
-  exists.
+- Do not call `window.umami`, invoke identify, or implement pageview tracking
+  from business components when the shared hook, transport, and `UmamiLoader`
+  own those responsibilities.
 
-- Do not let these helpers drift from the stores or constants they are
-  expected to coordinate with.
+- Do not treat truncation, stringification, or hashing as privacy review;
+  event and identity callers must pass only explicitly approved flat scalar
+  fields, and changed pageview handling must strip queries and sensitive URL
+  data.
 
-- Do not move shared compatibility behavior into page files where it becomes
-  hard to discover and reuse.
+- Do not let analytics loading, identification, queue draining, or delivery
+  errors block the user action or change its business result.
 
 - Avoid pushing domain-local rules up to shared docs unless another frontend
   subtree truly depends on the same constraint.


### PR DESCRIPTION
## Summary

- Define Cook Web Umami events as versioned product-analytics contracts with explicit metric, trigger, population, deduplication, schema, privacy, consumer, and compatibility requirements.
- Require every new user-facing Cook Web capability or interaction path to add or extend analytics coverage, its producer, and focused tests in the same change.
- Add a canonical frontend product analytics reference and record existing tracking behavior as grandfathered migration debt rather than approved precedent.
- Strengthen generated Cursor, Copilot, and shared transport guidance, and make the repository harness protect the new rules and reference markers.

## Scope

- Governance and generated guidance only; no existing event migration or tracking API changes.
- Langfuse, backend observability, billing, authorization, and audit contracts remain out of scope.

## Validation

- `python3 scripts/generate_ai_collab_docs.py`
- `python3 scripts/build_repo_knowledge_index.py`
- `python3 scripts/check_repo_harness.py`
- `python3 scripts/check_architecture_boundaries.py`
- `python3 scripts/check_dev_tools.py`
- `lefthook run pre-commit --all-files --no-stage-fixed --exclude '.codex/**' --no-tty`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and harness checks only; no runtime tracking or product behavior changes in this PR.
> 
> **Overview**
> Introduces **`docs/references/frontend-product-analytics.md`** as the canonical contract for new or changed Cook Web Umami events (metrics, triggers, populations, deduplication, deny-by-default payloads, `useTracking`/`UmamiLoader` transport rules, verification, and grandfathered legacy debt).
> 
> **Definition of done** is extended across root and Cook Web **`AGENTS.md`**, generated Cursor/Copilot/frontend instructions, and **`c-common`** guidance: every new user-facing capability or interaction path (including accessibility paths) must ship an Umami event family, producer, and focused tests in the same change; analytics stay **fail-open** and non-authoritative for billing or permissions.
> 
> **`docs/QUALITY_SCORE.md`** records existing tracking patterns as migration debt, not precedent. **`scripts/check_repo_harness.py`** and **`generate_ai_collab_docs.py`** enforce the reference doc, required markers, and aligned generated mirrors; knowledge indexes list the new reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6055c75f2f78687a13b408cfc2a4883aa19ee12d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->