### PR TITLE
chore: upgrade markdown-flow-ui to 0.2.21

### DIFF
--- a/src/cook-web/package-lock.json
+++ b/src/cook-web/package-lock.json
@@ -49,7 +49,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "0.2.20",
+        "markdown-flow-ui": "0.2.21",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -13290,9 +13290,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.20.tgz",
-      "integrity": "sha512-eqP5Dz7ZWcOBB6GmfPwrYbPqx68nPm/AZG2KMN9IXJxPvgqii3+udYvZL6oCovFYsu6suEgFynN3NC/oWvtbXA==",
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.21.tgz",
+      "integrity": "sha512-jKtAeDt+QM81pkIDTpJZyRNwog5+b/jDnr+2PVsst5Nm5elzqFPfQdnKEK6llV9W8JNkTeFJXGr6UFjUBdPL4A==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",

--- a/src/cook-web/package.json
+++ b/src/cook-web/package.json
@@ -67,7 +67,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "0.2.20",
+    "markdown-flow-ui": "0.2.21",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",


### PR DESCRIPTION
Picks up [markdown-flow-ui#224](https://github.com/ai-shifu/markdown-flow-ui/pull/224), which stops the published stylesheet from carrying its KaTeX fonts as inlined base64.

## Why this matters here

`src/app/layout.tsx` imports `markdown-flow-ui/dist/markdown-flow-ui.css` in the **root layout**, so the file is a render-blocking download on the first load of every page. At 1.5 MB that was long enough to show unstyled content before the stylesheet arrived, which cleared on refresh once the file was cached.

The fonts are now emitted as files, so the browser fetches only the `woff2` listed first in each `@font-face` instead of receiving woff2, woff and truetype inline.

## Measured

Built twice on the same commit, changing only the dependency:

| | 0.2.20 | 0.2.21 |
| --- | ---: | ---: |
| stylesheet from the root layout | 1,521,579 B | **88,362 B** |
| all CSS emitted by the build | 1,844,974 B | **411,757 B** |
| inlined `data:font` URIs | 60 | **0** |

First-load CSS drops by 1,433,217 B (−78%).

Re-verified against the published package rather than a local build: `npm ci` and `npm run build` both succeed on 0.2.21, the installed stylesheet is 87,812 B, and the build emits 411,381 B of CSS with zero inlined fonts.

## Scope

Dependency bump only — `package.json` and `package-lock.json`. No source changes.

This keeps importing the same stylesheet as before. The sibling `markdown-flow-ui-lib.css` is still not used: the comment at `layout.tsx:15` records that it regresses the dark-mode logo colour, so the fix was made to the file already in use.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Markdown rendering component to the latest available version, bringing in maintenance updates and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->