### PR TITLE
chore: keep AI reviews within pull request scope

### DIFF
--- a/.cursor/rules/repository-ai-collab.mdc
+++ b/.cursor/rules/repository-ai-collab.mdc
@@ -42,6 +42,18 @@ alwaysApply: true
   sync with the latest code changes so they accurately describe the current
   implementation and verification state.
 
+- Keep every pull request focused on one clearly defined problem. Include all
+  code, tests, docs, migrations, and compatibility work required to solve that
+  problem, but move unrelated fixes, cleanup, and follow-up work to separate
+  pull requests.
+
+- During code review, evaluate only whether the pull request solves its stated
+  problem correctly, safely, completely, and with adequate tests, including
+  regressions or contract effects introduced by the change.
+
+- Do not raise review findings about unrelated or pre-existing problems
+  outside the current pull request's responsibility boundary.
+
 - For git commit message title, body, and classification requirements, read
   `AGENTS.md#git-commit-message-requirements`; keep agent-specific rule files
   from duplicating the detailed commit-message policy.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,6 +37,18 @@
   sync with the latest code changes so they accurately describe the current
   implementation and verification state.
 
+- Keep every pull request focused on one clearly defined problem. Include all
+  code, tests, docs, migrations, and compatibility work required to solve that
+  problem, but move unrelated fixes, cleanup, and follow-up work to separate
+  pull requests.
+
+- During code review, evaluate only whether the pull request solves its stated
+  problem correctly, safely, completely, and with adequate tests, including
+  regressions or contract effects introduced by the change.
+
+- Do not raise review findings about unrelated or pre-existing problems
+  outside the current pull request's responsibility boundary.
+
 - For git commit message title, body, and classification requirements, read
   `AGENTS.md#git-commit-message-requirements`; keep agent-specific rule files
   from duplicating the detailed commit-message policy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,13 @@ to.
 - When a branch already has an open PR, keep the PR title and description in
   sync with the latest code changes so they accurately describe the current
   implementation and verification state.
+- Keep every pull request focused on one clearly defined problem. Include all
+  code, tests, docs, migrations, and compatibility work required to solve that
+  problem, but move unrelated fixes, cleanup, and follow-up work to separate
+  pull requests.
+- During code review, evaluate only whether the pull request solves its stated
+  problem correctly, safely, completely, and with adequate tests, including
+  regressions or contract effects introduced by the change.
 - Keep shared instruction surfaces aligned. When shared rules move, update the
   touched `AGENTS.md`, `CLAUDE.md`, generated `.cursor` rules, and generated
   `.github` instructions in the same change.
@@ -96,6 +103,8 @@ to.
   discoverable from versioned files.
 - Do not start modifying code from guesswork when the local implementation and
   neighboring tests have not been inspected.
+- Do not raise review findings about unrelated or pre-existing problems
+  outside the current pull request's responsibility boundary.
 - Do not hardcode user-facing strings, secrets, or environment-specific URLs.
 - Do not add free-form or user-authored text, prompts or model output, names,
   contact details, profile content, titles or descriptions, coupon codes,

--- a/scripts/check_repo_harness.py
+++ b/scripts/check_repo_harness.py
@@ -38,6 +38,8 @@ MANUAL_AGENTS = {
         "docs/exec-plans/active/",
         "docs/references/frontend-product-analytics.md",
         "Umami",
+        "one clearly defined problem",
+        "responsibility boundary",
         "product analytics as a completion requirement",
         "best-effort",
         "python scripts/check_repo_harness.py",

--- a/scripts/check_repo_harness.py
+++ b/scripts/check_repo_harness.py
@@ -30,6 +30,13 @@ from generate_ai_collab_docs import (
 ROOT = Path(__file__).resolve().parents[1]
 BOUNDARY_BASELINE = DOCS_ROOT / "generated" / "architecture-boundary-baseline.json"
 HARNESS_HEALTH = DOCS_ROOT / "generated" / "harness-health.md"
+PR_REVIEW_SCOPE_MARKERS = (
+    "one clearly defined problem",
+    "correctly, safely, completely, and with adequate tests",
+    "responsibility boundary",
+)
+CURSOR_REPOSITORY_AI_RULE = ROOT / ".cursor" / "rules" / "repository-ai-collab.mdc"
+COPILOT_REPOSITORY_AI_INSTRUCTIONS = ROOT / ".github" / "copilot-instructions.md"
 MANUAL_AGENTS = {
     ROOT / "AGENTS.md": (
         "ARCHITECTURE.md",
@@ -38,9 +45,7 @@ MANUAL_AGENTS = {
         "docs/exec-plans/active/",
         "docs/references/frontend-product-analytics.md",
         "Umami",
-        "one clearly defined problem",
-        "correctly, safely, completely, and with adequate tests",
-        "responsibility boundary",
+        *PR_REVIEW_SCOPE_MARKERS,
         "product analytics as a completion requirement",
         "best-effort",
         "python scripts/check_repo_harness.py",
@@ -63,6 +68,10 @@ MANUAL_AGENTS = {
         "src/lib/request.ts",
         "npm run test:e2e",
     ),
+}
+GENERATED_AI_DOC_MARKERS = {
+    CURSOR_REPOSITORY_AI_RULE: PR_REVIEW_SCOPE_MARKERS,
+    COPILOT_REPOSITORY_AI_INSTRUCTIONS: PR_REVIEW_SCOPE_MARKERS,
 }
 REQUIRED_ROOT_DOCS = (
     ROOT / "ARCHITECTURE.md",
@@ -135,6 +144,16 @@ def check_ordered_headings(path: Path, text: str, errors: list[str]) -> None:
 def check_generated_ai_docs(errors: list[str]) -> None:
     """Check generated AI docs."""
     expected_docs = build_documents()
+    for path, markers in GENERATED_AI_DOC_MARKERS.items():
+        expected = expected_docs.get(path)
+        if expected is None:
+            errors.append(f"Missing generated AI doc definition: {path}")
+            continue
+        errors.extend(
+            f"Missing marker '{marker}' in generated AI doc definition: {path}"
+            for marker in markers
+            if marker not in expected
+        )
     for path, expected in sorted(expected_docs.items()):
         if not path.exists():
             errors.append(f"Missing generated AI doc: {path}")

--- a/scripts/check_repo_harness.py
+++ b/scripts/check_repo_harness.py
@@ -39,6 +39,7 @@ MANUAL_AGENTS = {
         "docs/references/frontend-product-analytics.md",
         "Umami",
         "one clearly defined problem",
+        "correctly, safely, completely, and with adequate tests",
         "responsibility boundary",
         "product analytics as a completion requirement",
         "best-effort",

--- a/scripts/generate_ai_collab_docs.py
+++ b/scripts/generate_ai_collab_docs.py
@@ -1610,6 +1610,17 @@ def build_documents() -> dict[Path, str]:
                 "description in sync with the latest code changes so they "
                 "accurately describe the current implementation and "
                 "verification state.",
+                "Keep every pull request focused on one clearly defined problem. "
+                "Include all code, tests, docs, migrations, and compatibility "
+                "work required to solve that problem, but move unrelated fixes, "
+                "cleanup, and follow-up work to separate pull requests.",
+                "During code review, evaluate only whether the pull request "
+                "solves its stated problem correctly, safely, completely, and "
+                "with adequate tests, including regressions or contract effects "
+                "introduced by the change.",
+                "Do not raise review findings about unrelated or pre-existing "
+                "problems outside the current pull request's responsibility "
+                "boundary.",
                 "For git commit message title, body, and classification "
                 "requirements, read "
                 "`AGENTS.md#git-commit-message-requirements`; keep "
@@ -1843,6 +1854,17 @@ def build_documents() -> dict[Path, str]:
                 "description in sync with the latest code changes so they "
                 "accurately describe the current implementation and "
                 "verification state.",
+                "Keep every pull request focused on one clearly defined problem. "
+                "Include all code, tests, docs, migrations, and compatibility "
+                "work required to solve that problem, but move unrelated fixes, "
+                "cleanup, and follow-up work to separate pull requests.",
+                "During code review, evaluate only whether the pull request "
+                "solves its stated problem correctly, safely, completely, and "
+                "with adequate tests, including regressions or contract effects "
+                "introduced by the change.",
+                "Do not raise review findings about unrelated or pre-existing "
+                "problems outside the current pull request's responsibility "
+                "boundary.",
                 "For git commit message title, body, and classification "
                 "requirements, read "
                 "`AGENTS.md#git-commit-message-requirements`; keep "


### PR DESCRIPTION
## Summary

- Require each pull request to solve one clearly defined problem.
- Keep AI review findings within the pull request responsibility boundary while covering regressions and contract effects introduced by the change.
- Sync the generated Cursor and Copilot guidance.
- Protect the root rule and both generated mirrors with explicit repository harness markers.

## Verification

- `python3 scripts/generate_ai_collab_docs.py`
- `python3 scripts/check_repo_harness.py`
- `ruff check scripts/check_repo_harness.py`
- `ruff format --check scripts/check_repo_harness.py`
- Generated review marker negative checks: 8 cases
- `git diff --check`
- Lefthook pre-commit and commit message checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and harness validation only; no runtime product or security logic changes.
> 
> **Overview**
> Adds **repository-wide collaboration rules** so pull requests stay tied to one problem and reviews (including AI) stay within that boundary.
> 
> **`AGENTS.md`** now requires each PR to include everything needed for one defined problem and to split unrelated work. Reviewers should judge correctness, safety, completeness, tests, and regressions from the change—not unrelated or pre-existing issues. The **Avoid** section explicitly bans out-of-scope review findings.
> 
> The same three policy bullets are wired into **`scripts/generate_ai_collab_docs.py`**, which regenerates **`.cursor/rules/repository-ai-collab.mdc`** and **`.github/copilot-instructions.md`** so Cursor and Copilot see identical guidance.
> 
> **`scripts/check_repo_harness.py`** enforces the text with `PR_REVIEW_SCOPE_MARKERS` on root `AGENTS.md` and checks that generated AI doc definitions include those markers before comparing file contents to expected output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 516ebf00f067e9a6bcf18362ecc3c479a187445f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->