### PR TITLE
fix: make admin billing card navigation browser-native

### DIFF
--- a/docs/billing-subscription-design.md
+++ b/docs/billing-subscription-design.md
@@ -1242,7 +1242,7 @@ Feature-owned payload 固定为 `{}`。共享 `useTracking` 仍会自动添加�
 - 详情查看沿用现有订单页的 `Sheet` 交互，不使用新窗口跳转
 - 购买动作统一在 dialog 中确认，再调用 checkout API
 
-#### 7.5.3 API 接入与前端类型
+#### 7.5.4 API 接入与前端类型
 
 需要在 `src/cook-web/src/api/api.ts` 增加：
 
@@ -1278,7 +1278,7 @@ Feature-owned payload 固定为 `{}`。共享 `useTracking` 仍会自动添加�
 - `getBillingLedger` 在 `Details` tab 激活时懒加载；order sync / checkout 由 Stripe result、Pingxx polling 和 checkout dialog 按需触发
 - 写操作成功后只刷新受影响的 SWR key，不全页硬刷新
 
-#### 7.5.4 Stripe 支付回跳
+#### 7.5.5 Stripe 支付回跳
 
 当前现有 Stripe 回跳页 `src/cook-web/src/app/payment/stripe/result/page.tsx` 是学员购课专用，成功后会跳到课程页，不适合 creator billing 直接复用。
 
@@ -1293,7 +1293,7 @@ v1 前端方案：
   - 成功后跳回 `/admin/billing`
   - 待支付或失败时展示明确状态和重试入口
 
-#### 7.5.5 v1.1 前端扩展
+#### 7.5.6 v1.1 前端扩展
 
 v1.1 继续沿用 `/admin/billing`，在同一路由上增加扩展 tab：
 
@@ -1319,7 +1319,7 @@ v1.1 继续沿用 `/admin/billing`，在同一路由上增加扩展 tab：
 - admin `/admin/billing/admin`
   - 保留 `Subscriptions`、`Orders`、`Exceptions`、`Entitlements`、`Domains`、`Reports` 六个 ops tab
 
-#### 7.5.6 i18n 与状态展示
+#### 7.5.7 i18n 与状态展示
 
 前端新增文案统一使用 `module.billing.*` 命名空间，至少覆盖：
 

--- a/docs/billing-subscription-design.md
+++ b/docs/billing-subscription-design.md
@@ -1204,7 +1204,24 @@ v1 前端不新建全局 billing store，默认采用：
   - 展示 bucket 来源摘要、积分流水、来源类型、余额变化，以及最近 activity
   - usage 类明细通过右侧 detail sheet 展开
 
-#### 7.5.2 v1 组件拆分
+#### 7.5.2 侧边账务卡片导航埋点
+
+- Business question：管理后台侧边账务卡片是否是值得保留的套餐入口。
+- Metric definition：按滚动 7 天和 30 天统计被接受的套餐入口原始交互次数；当前没有曝光事件，因此不得将其解释为点击率，也不得和 checkout 事件组成精确漏斗。
+- Event name：`creator_billing_sidebar_packages_click`。
+- Actor and surface：账务能力开启时可看到卡片的已登录后台用户，固定为管理后台侧边账务卡片的套餐入口；运营管理员不额外排除。
+- Trigger：套餐主链接接收到一次有效的鼠标主键、键盘 Enter、带修饰键的主键或鼠标中键激活时，在浏览器执行原生导航前发送。通过浏览器上下文菜单打开新标签页无法被页面观察，明确排除。
+- Population：仅在账务卡片实际渲染时可触发；guest、登录状态未确认、账务能力关闭、卡片隐藏、用户菜单覆盖或没有发生用户激活时不发送。
+- Count unit：一次被接受的链接激活。后续重复的主动激活分别计数。
+- Deduplication：每个 DOM 激活最多发送一次；不跨点击、页面或会话去重。键盘路径只监听链接产生的 `click`，不额外监听 `keydown`，避免双计。
+- Correlation：无 feature-owned correlation ID，不与 checkout 做逐次关联；共享 helper 的既有 transport fields 不作为新 consumer 依赖。
+- Consumers：产品与账务团队的管理后台套餐入口原始流量趋势分析。
+- Compatibility：新增 v1 事件，不复用或改写既有 `creator_billing_checkout_click`。
+- Verification：聚焦组件测试覆盖普通点击、Enter、Space、Meta/Ctrl/Shift 修饰键、鼠标中键、非导航辅助点击、详情链接排除、精确空载荷，以及同步抛错和异步拒绝时原生链接仍可继续导航；布局测试覆盖账务能力关闭时不渲染入口。
+
+Feature-owned payload 固定为 `{}`。共享 `useTracking` 仍会自动添加既有的 `user_type`、`user_id`、`device` 和 `timeStamp` transport fields；这些字段不是本事件新增的契约字段，新 consumer 不得依赖它们。不得添加 URL、query、referrer、账务数据、用户输入、错误原文或关联 ID；埋点始终 fail-open，不得阻塞或改变导航。
+
+#### 7.5.3 v1 组件拆分
 
 当前 `src/cook-web/src/components/billing/` 的主要组件包括：
 

--- a/src/cook-web/src/app/admin/layout.test.tsx
+++ b/src/cook-web/src/app/admin/layout.test.tsx
@@ -991,6 +991,23 @@ describe('AdminLayout', () => {
     ).not.toBeInTheDocument();
   });
 
+  test('does not render the billing card when billing is disabled', () => {
+    mockEnvState.billingEnabled = 'false';
+
+    render(
+      <AdminLayout>
+        <div data-testid='child-content' />
+      </AdminLayout>,
+    );
+
+    expect(
+      screen.queryByTestId('admin-billing-sidebar-card'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('admin-billing-sidebar-primary-link'),
+    ).not.toBeInTheDocument();
+  });
+
   test('hides referral invite navigation when campaign is unavailable', async () => {
     mockGetReferralInviteProfile.mockResolvedValueOnce({
       available: false,

--- a/src/cook-web/src/app/admin/layout.test.tsx
+++ b/src/cook-web/src/app/admin/layout.test.tsx
@@ -971,15 +971,18 @@ describe('AdminLayout', () => {
       screen.getByText('module.billing.sidebar.nonMemberBalanceTitle'),
     ).toBeInTheDocument();
     expect(screen.getByText('12,500')).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', {
-        name: 'module.billing.sidebar.usageCta',
-      }),
-    ).toHaveAttribute('href', '/admin/billing?tab=details');
-    expect(screen.getByTestId('admin-billing-sidebar-card')).toHaveAttribute(
-      'data-href',
-      '/admin/billing?tab=packages',
-    );
+    const billingCard = screen.getByTestId('admin-billing-sidebar-card');
+    expect(billingCard).not.toHaveAttribute('role');
+    expect(billingCard).not.toHaveAttribute('tabindex');
+    const packagesLink = screen.getByRole('link', {
+      name: 'module.billing.sidebar.summaryTitle module.billing.sidebar.upgradeCta',
+    });
+    const detailsLink = screen.getByRole('link', {
+      name: 'module.billing.sidebar.usageCta',
+    });
+    expect(packagesLink).toHaveAttribute('href', '/admin/billing?tab=packages');
+    expect(packagesLink).not.toContainElement(detailsLink);
+    expect(detailsLink).toHaveAttribute('href', '/admin/billing?tab=details');
     expect(
       screen.queryByText('module.billing.sidebar.subscriptionStatusLabel'),
     ).not.toBeInTheDocument();
@@ -1044,10 +1047,11 @@ describe('AdminLayout', () => {
     expect(
       screen.getByText('module.billing.sidebar.nonMemberBalanceTitle'),
     ).toBeInTheDocument();
-    expect(screen.getByTestId('admin-billing-sidebar-card')).toHaveAttribute(
-      'data-href',
-      '/admin/billing?tab=packages',
-    );
+    expect(
+      screen.getByRole('link', {
+        name: 'module.billing.sidebar.summaryTitle module.billing.sidebar.upgradeCta',
+      }),
+    ).toHaveAttribute('href', '/admin/billing?tab=packages');
     expect(
       screen.getByTestId('admin-billing-sidebar-balance'),
     ).toHaveTextContent('0');

--- a/src/cook-web/src/components/billing/BillingSidebarCard.test.tsx
+++ b/src/cook-web/src/components/billing/BillingSidebarCard.test.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BillingSidebarCard } from './BillingSidebarCard';
+
+const mockTrackEvent = jest.fn();
+const mockNavigationContinuation = jest.fn();
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    onAuxClick,
+    onClick,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    children?: React.ReactNode;
+    href: string;
+  }) => (
+    <a
+      href={href}
+      onClick={event => {
+        onClick?.(event);
+        if (!event.defaultPrevented) {
+          mockNavigationContinuation(href);
+        }
+        event.preventDefault();
+      }}
+      onAuxClick={event => {
+        onAuxClick?.(event);
+        if (!event.defaultPrevented && event.button === 1) {
+          mockNavigationContinuation(href);
+        }
+        event.preventDefault();
+      }}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock('@/c-common/hooks/useTracking', () => ({
+  useTracking: () => ({
+    trackEvent: mockTrackEvent,
+  }),
+}));
+
+describe('BillingSidebarCard', () => {
+  beforeEach(() => {
+    mockTrackEvent.mockReset();
+    mockNavigationContinuation.mockReset();
+  });
+
+  const renderCard = () => {
+    render(<BillingSidebarCard />);
+    return screen.getByRole('link', {
+      name: 'module.billing.sidebar.summaryTitle module.billing.sidebar.upgradeCta',
+    });
+  };
+
+  test('tracks one privacy-safe event for a primary packages activation', () => {
+    const packagesLink = renderCard();
+
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+
+    fireEvent.click(packagesLink);
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      'creator_billing_sidebar_packages_click',
+      {},
+    );
+    expect(mockNavigationContinuation).toHaveBeenCalledWith(
+      '/admin/billing?tab=packages',
+    );
+  });
+
+  test('tracks keyboard, modifier, and middle-button new-tab activations once each', async () => {
+    const user = userEvent.setup();
+    const packagesLink = renderCard();
+
+    packagesLink.focus();
+    await user.keyboard('{Enter}');
+    fireEvent.click(packagesLink, { metaKey: true });
+    fireEvent.click(packagesLink, { ctrlKey: true });
+    fireEvent.click(packagesLink, { shiftKey: true });
+    fireEvent(
+      packagesLink,
+      new MouseEvent('auxclick', {
+        bubbles: true,
+        button: 1,
+        cancelable: true,
+      }),
+    );
+
+    expect(mockTrackEvent.mock.calls).toEqual(
+      Array.from({ length: 5 }, () => [
+        'creator_billing_sidebar_packages_click',
+        {},
+      ]),
+    );
+    expect(mockNavigationContinuation).toHaveBeenCalledTimes(5);
+    expect(mockNavigationContinuation).toHaveBeenCalledWith(
+      '/admin/billing?tab=packages',
+    );
+  });
+
+  test('does not track render, rerender, Space, or a right-button auxiliary click', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<BillingSidebarCard />);
+    const packagesLink = screen.getByRole('link', {
+      name: 'module.billing.sidebar.summaryTitle module.billing.sidebar.upgradeCta',
+    });
+
+    rerender(<BillingSidebarCard isLoading />);
+    packagesLink.focus();
+    await user.keyboard(' ');
+    fireEvent(
+      packagesLink,
+      new MouseEvent('auxclick', {
+        bubbles: true,
+        button: 2,
+        cancelable: true,
+      }),
+    );
+
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+    expect(mockNavigationContinuation).not.toHaveBeenCalled();
+  });
+
+  test('does not track the independent billing-details link', () => {
+    renderCard();
+
+    fireEvent.click(
+      screen.getByRole('link', {
+        name: 'module.billing.sidebar.usageCta',
+      }),
+    );
+
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+    expect(mockNavigationContinuation).toHaveBeenCalledWith(
+      '/admin/billing?tab=details',
+    );
+  });
+
+  test('keeps native link navigation available when tracking throws', () => {
+    mockTrackEvent.mockImplementationOnce(() => {
+      throw new Error('tracking unavailable');
+    });
+    const packagesLink = renderCard();
+
+    expect(() => fireEvent.click(packagesLink)).not.toThrow();
+    expect(mockNavigationContinuation).toHaveBeenCalledWith(
+      '/admin/billing?tab=packages',
+    );
+  });
+
+  test('keeps native link navigation available when tracking rejects', async () => {
+    mockTrackEvent.mockRejectedValueOnce(new Error('tracking unavailable'));
+    const packagesLink = renderCard();
+
+    fireEvent.click(packagesLink);
+    await Promise.resolve();
+
+    expect(mockNavigationContinuation).toHaveBeenCalledWith(
+      '/admin/billing?tab=packages',
+    );
+  });
+});

--- a/src/cook-web/src/components/billing/BillingSidebarCard.tsx
+++ b/src/cook-web/src/components/billing/BillingSidebarCard.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { ChevronRight, Crown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { useTracking } from '@/c-common/hooks/useTracking';
 import type { CreatorBillingOverview } from '@/types/billing';
 import {
   formatBillingCreditBalance,
@@ -20,11 +21,15 @@ type BillingSidebarCardProps = {
   isLoading?: boolean;
 };
 
+const BILLING_SIDEBAR_PACKAGES_CLICK_EVENT =
+  'creator_billing_sidebar_packages_click';
+
 export function BillingSidebarCard({
   overview,
   isLoading = false,
 }: BillingSidebarCardProps) {
   const { t } = useTranslation();
+  const { trackEvent } = useTracking();
   const availableCredits = overview?.wallet?.available_credits;
   const shouldShowCredits = !isLoading && availableCredits != null;
   const creditsValue = shouldShowCredits
@@ -37,6 +42,16 @@ export function BillingSidebarCard({
         overview?.subscription?.current_period_end_at,
       )
     : '';
+
+  const trackPackagesClick = () => {
+    try {
+      void Promise.resolve(
+        trackEvent(BILLING_SIDEBAR_PACKAGES_CLICK_EVENT, {}),
+      ).catch(() => {});
+    } catch {
+      // Billing navigation must remain available when analytics is unavailable.
+    }
+  };
 
   return (
     <div
@@ -51,6 +66,16 @@ export function BillingSidebarCard({
         )}`}
         className='absolute inset-0 z-0 rounded-[var(--border-radius-rounded-xl,14px)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400'
         data-testid='admin-billing-sidebar-primary-link'
+        onClick={event => {
+          if (event.button === 0) {
+            trackPackagesClick();
+          }
+        }}
+        onAuxClick={event => {
+          if (event.button === 1) {
+            trackPackagesClick();
+          }
+        }}
       />
       <div className='pointer-events-none relative z-10'>
         <div className='flex items-center justify-between gap-3 border-b border-[rgba(0,0,0,0.05)] pb-3 mr-1'>

--- a/src/cook-web/src/components/billing/BillingSidebarCard.tsx
+++ b/src/cook-web/src/components/billing/BillingSidebarCard.tsx
@@ -1,6 +1,4 @@
-import React from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { ChevronRight, Crown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { CreatorBillingOverview } from '@/types/billing';
@@ -27,7 +25,6 @@ export function BillingSidebarCard({
   isLoading = false,
 }: BillingSidebarCardProps) {
   const { t } = useTranslation();
-  const router = useRouter();
   const availableCredits = overview?.wallet?.available_credits;
   const shouldShowCredits = !isLoading && availableCredits != null;
   const creditsValue = shouldShowCredits
@@ -41,78 +38,72 @@ export function BillingSidebarCard({
       )
     : '';
 
-  const handleCardClick = React.useCallback(() => {
-    router.push(BILLING_PACKAGES_HREF);
-  }, [router]);
-
-  const handleCardKeyDown = React.useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === 'Enter' || event.key === ' ') {
-        event.preventDefault();
-        router.push(BILLING_PACKAGES_HREF);
-      }
-    },
-    [router],
-  );
-
   return (
     <div
-      role='link'
-      tabIndex={0}
-      data-href={BILLING_PACKAGES_HREF}
-      onClick={handleCardClick}
-      onKeyDown={handleCardKeyDown}
-      className='mt-4 block rounded-[var(--border-radius-rounded-xl,14px)] border border-[var(--base-border,#E5E5E5)] bg-[var(--base-card,#FFF)] py-[14px] pl-4 pr-3 shadow-[0_10px_24px_rgba(15,23,42,0.06)] transition-colors hover:border-[var(--base-border-hover,#D4D4D4)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400'
+      className='relative isolate mt-4 block rounded-[var(--border-radius-rounded-xl,14px)] border border-[var(--base-border,#E5E5E5)] bg-[var(--base-card,#FFF)] py-[14px] pl-4 pr-3 shadow-[0_10px_24px_rgba(15,23,42,0.06)] transition-colors hover:border-[var(--base-border-hover,#D4D4D4)]'
       data-testid='admin-billing-sidebar-card'
       {...buildOnboardingTargetProps(ONBOARDING_TARGET_IDS.billingCard)}
     >
-      <div className='flex items-center justify-between gap-3 border-b border-[rgba(0,0,0,0.05)] pb-3 mr-1'>
-        <div className='flex min-w-0 items-center gap-2.5'>
-          <div className='flex shrink-0 items-center justify-center text-slate-950'>
-            <Crown className='h-4 w-4' />
+      <Link
+        href={BILLING_PACKAGES_HREF}
+        aria-label={`${t('module.billing.sidebar.summaryTitle')} ${t(
+          'module.billing.sidebar.upgradeCta',
+        )}`}
+        className='absolute inset-0 z-0 rounded-[var(--border-radius-rounded-xl,14px)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400'
+        data-testid='admin-billing-sidebar-primary-link'
+      />
+      <div className='pointer-events-none relative z-10'>
+        <div className='flex items-center justify-between gap-3 border-b border-[rgba(0,0,0,0.05)] pb-3 mr-1'>
+          <div className='flex min-w-0 items-center gap-2.5'>
+            <div className='flex shrink-0 items-center justify-center text-slate-950'>
+              <Crown className='h-4 w-4' />
+            </div>
+            <p className='truncate text-sm font-extrabold leading-5 text-slate-950'>
+              {t('module.billing.sidebar.summaryTitle')}
+            </p>
           </div>
-          <p className='truncate text-sm font-extrabold leading-5 text-slate-950'>
-            {t('module.billing.sidebar.summaryTitle')}
-          </p>
-        </div>
-        <span
-          className='inline-flex h-6 min-h-6 shrink-0 items-center whitespace-nowrap rounded-full bg-slate-950 px-4 py-0 text-sm font-semibold leading-5 text-white'
-          {...buildOnboardingTargetProps(ONBOARDING_TARGET_IDS.billingUpgrade)}
-        >
-          {t('module.billing.sidebar.upgradeCta')}
-        </span>
-      </div>
-      <div className='pt-3'>
-        <div
-          className='flex min-w-0 items-center justify-between gap-3 text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-normal,400)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-card-foreground,#0A0A0A)]'
-          {...buildOnboardingTargetProps(ONBOARDING_TARGET_IDS.billingBalance)}
-        >
-          <span className='shrink-0'>
-            {t('module.billing.sidebar.nonMemberBalanceTitle')}
-          </span>
           <span
-            className='truncate pr-1'
-            data-testid='admin-billing-sidebar-balance'
+            className='inline-flex h-6 min-h-6 shrink-0 items-center whitespace-nowrap rounded-full bg-slate-950 px-4 py-0 text-sm font-semibold leading-5 text-white'
+            {...buildOnboardingTargetProps(
+              ONBOARDING_TARGET_IDS.billingUpgrade,
+            )}
           >
-            {creditsValue}
+            {t('module.billing.sidebar.upgradeCta')}
           </span>
         </div>
-        <div className='flex min-w-0 items-center justify-between gap-3 pt-2.5 text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-normal,400)] leading-[var(--text-sm-line-height,20px)] text-[rgba(10,10,10,0.45)]'>
-          <div className='min-w-0'>
-            {expiryCountdown ? (
-              <p className='truncate'>{expiryCountdown}</p>
-            ) : null}
-          </div>
-          <Link
-            href={BILLING_DETAILS_HREF}
-            onClick={event => event.stopPropagation()}
-            className='inline-flex shrink-0 items-center gap-1 leading-none transition-colors hover:text-[rgba(10,10,10,0.6)]'
+        <div className='pt-3'>
+          <div
+            className='flex min-w-0 items-center justify-between gap-3 text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-normal,400)] leading-[var(--text-sm-line-height,20px)] text-[var(--base-card-foreground,#0A0A0A)]'
+            {...buildOnboardingTargetProps(
+              ONBOARDING_TARGET_IDS.billingBalance,
+            )}
           >
-            <span className='leading-5'>
-              {t('module.billing.sidebar.usageCta')}
+            <span className='shrink-0'>
+              {t('module.billing.sidebar.nonMemberBalanceTitle')}
             </span>
-            <ChevronRight className='h-4 w-4 shrink-0 text-[rgba(10,10,10,0.45)]' />
-          </Link>
+            <span
+              className='truncate pr-1'
+              data-testid='admin-billing-sidebar-balance'
+            >
+              {creditsValue}
+            </span>
+          </div>
+          <div className='flex min-w-0 items-center justify-between gap-3 pt-2.5 text-[length:var(--text-sm-font-size,14px)] font-[var(--font-weight-normal,400)] leading-[var(--text-sm-line-height,20px)] text-[rgba(10,10,10,0.45)]'>
+            <div className='min-w-0'>
+              {expiryCountdown ? (
+                <p className='truncate'>{expiryCountdown}</p>
+              ) : null}
+            </div>
+            <Link
+              href={BILLING_DETAILS_HREF}
+              className='pointer-events-auto inline-flex shrink-0 items-center gap-1 leading-none transition-colors hover:text-[rgba(10,10,10,0.6)]'
+            >
+              <span className='leading-5'>
+                {t('module.billing.sidebar.usageCta')}
+              </span>
+              <ChevronRight className='h-4 w-4 shrink-0 text-[rgba(10,10,10,0.45)]' />
+            </Link>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- replace the simulated billing-card router navigation with a semantic packages link
- keep billing details as an independent sibling link while preserving the existing layout, onboarding targets, and destinations
- emit the fail-open `creator_billing_sidebar_packages_click` event for pointer, Enter, modifier-key, and middle-button activations
- document the event contract with an exact empty feature payload and explicit privacy, eligibility, deduplication, and consumer boundaries

## Context

Split from #2717 so billing navigation and its analytics contract can be reviewed independently from profile onboarding.

## Analytics contract

- metric: rolling 7-day and 30-day raw accepted package-entry activations; no exposure denominator and no exact checkout funnel
- eligible population: authenticated admin users when billing is enabled and the sidebar card is rendered
- payload: `{}` only; no URLs, queries, billing data, identifiers, content, locale, or raw errors
- exclusions: render/rerender, Space, right-click/context-menu paths, and the independent billing-details link
- delivery: fire-and-forget and fail-open; analytics can neither delay nor prevent native navigation

## Testing

- `cd src/cook-web && npm test -- --runInBand src/components/billing/BillingSidebarCard.test.tsx src/app/admin/layout.test.tsx` (2 suites, 30 passed)
- `cd src/cook-web && npm run type-check`
- `cd src/cook-web && npm run lint`
- `python3 scripts/check_dev_tools.py`
- `python3 scripts/check_architecture_boundaries.py`
- `python3 scripts/check_repo_harness.py`
- `lefthook run pre-commit --all-files`
- `lefthook run pre-commit` on the staged change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing sidebar navigation with reliable package and usage links.
  * Enhanced keyboard, pointer, and middle-click interactions for billing cards.
  * Billing details remain accessible independently from package navigation.
  * Billing sidebar content is correctly hidden when billing is disabled.

* **New Features**
  * Added privacy-safe tracking for package link interactions without interrupting navigation.

* **Documentation**
  * Documented billing sidebar navigation tracking behavior and verification rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only billing sidebar UX and analytics; navigation is more native and tracking is explicitly fail-open with no billing or auth backend changes.
> 
> **Overview**
> Replaces the admin billing sidebar card’s **programmatic** navigation (`router.push` on a faux `role="link"` div) with a **full-card overlay** `Link` to `/admin/billing?tab=packages`, so packages entry behaves like a real anchor (keyboard, modifiers, middle-click, open in new tab). The **usage/details** CTA stays a separate nested link to `?tab=details` with `pointer-events-auto` so it does not fire packages tracking.
> 
> Adds **fail-open** analytics: on accepted primary-link activations (left click, Enter-via-click, modifier clicks, middle button), the card emits `creator_billing_sidebar_packages_click` with an empty `{}` payload via `useTracking`, without blocking navigation if tracking throws or rejects.
> 
> **Documentation** adds section 7.5.2 defining the event contract (eligibility, deduplication, privacy, verification); later 7.5.x headings are renumbered.
> 
> **Tests** add `BillingSidebarCard.test.tsx` for tracking exclusions and navigation resilience, and update `layout.test.tsx` for the new link structure plus billing-disabled hiding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8d7dbd8b39acffa1c1bfae8c007d583f992224e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->