### PR TITLE
fix: use low reasoning for GLM 5.3 and Gemini 3.7 Flash

### DIFF
--- a/docs/exec-plans/completed/llm-provider-parameter-policies.md
+++ b/docs/exec-plans/completed/llm-provider-parameter-policies.md
@@ -1,0 +1,242 @@
+# LiteLLM-First Minimum-Thinking Parameters
+
+## Purpose / Big Picture
+
+AI-Shifu applies a product-wide rule that model reasoning should be disabled or
+set to the lowest supported level. The earlier implementation encoded this rule
+in provider callbacks and then proposed a custom policy language. That made the
+application duplicate behavior already supplied by LiteLLM and made each new
+exception harder to reason about.
+
+This change makes LiteLLM 1.98.0 the default source of adapter capabilities and
+reasoning mappings. One request-preparation function serves both streaming entry
+points. A small, version-labelled, flat compatibility table contains only
+confirmed LiteLLM 1.98.0 gaps, so a future exception normally requires one table
+row and one contract assertion rather than a new callback or merge framework.
+
+## Progress
+
+- [x] 2026-09-01 07:20 CST: Rebased the two focused model fixes onto current
+  `origin/main` and removed the previous policy-DSL refactor commit.
+- [x] 2026-09-01 08:00 CST: Replaced provider reload callbacks with one
+  LiteLLM-first request preparation function and a flat compatibility table.
+- [x] 2026-09-01 08:07 CST: Added capability, precedence, conflict, temperature,
+  adapter-wire, strict-error, and both-entry-point tests; 69 focused tests pass
+  with LiteLLM 1.98.0.
+- [x] 2026-09-01 08:36 CST: Re-ran the complete backend suite after the final
+  OpenAI Responses conflict fix; 3601 tests pass and 17 are skipped.
+- [x] 2026-09-01 08:36 CST: Repository harness, architecture-boundary, and
+  development-tool checks pass; final formatting, diff, and pre-commit gates
+  are run after this archival move regenerates repository documentation.
+- [x] 2026-09-01 08:36 CST: Archived this implementation plan for the single
+  replacement refactor commit. Exact force-with-lease push and live CI/review
+  convergence are recorded on PR #2733 after the commit exists.
+- [x] 2026-09-01 09:00 CST: Addressed a live review finding that the ZAI
+  provider-wide patch reached legacy GLM-4 models. Kept provider-wide
+  `response_format`, enumerated the 13 LiteLLM 1.98/current-contract thinking
+  models as exact rows, and added legacy no-thinking wire coverage.
+
+## Surprises & Discoveries
+
+- LiteLLM 1.98.0 already maps `reasoning_effort=none` to native minimums for
+  Gemini and DeepSeek, and maps standard `thinking={"type":"disabled"}` for
+  Volcengine. Provider-specific reload functions duplicated these mappings.
+- Gemini 3 model metadata leaves the individual effort flags unset, but its
+  adapter supports `reasoning_effort`; `none` therefore correctly delegates to
+  the adapter's native minimum. Gemini 3.7 Flash is the exact exception because
+  Google documents `low`, not `minimal`, as its minimum.
+- DashScope does not list `reasoning_effort` for the ZHIPU GLM-5.3 IDs. Passing
+  the standard field through `allowed_openai_params` produces the required
+  `reasoning_effort=low` wire shape without `enable_thinking=true`.
+- ZAI's top-level `thinking` support is incomplete in LiteLLM 1.98.0: it reaches
+  the OpenAI SDK as an unsupported keyword. Keeping `thinking.disabled` in
+  `extra_body` works.
+- ZAI's adapter gap is not provider-wide. Legacy models such as `glm-4-flash`
+  do not accept `thinking`, while LiteLLM 1.98 also omits the capability for
+  several GLM-4.5 variants and `glm-5.2` that do accept it. The provider row
+  must therefore contain only `response_format`; supported current IDs need
+  explicit exact rows, and unknown future IDs must not match implicitly.
+- A flat `additional_drop_params` entry also removes an `extra_body` field with
+  the same name for OpenAI-compatible adapters. Provider patches that own a
+  nested `thinking` or `enable_thinking` field therefore set the caller's
+  top-level copy to `None`, shallow-merge the patch value, and reserve precise
+  drop paths for other conflicts.
+- Caller-supplied drop paths can name a compatibility patch's whole ancestor
+  object, the exact protected path, or one of its descendants. Filtering all
+  three overlap forms is necessary; otherwise a broad `extra_body` drop can
+  erase a provider-owned minimum-thinking control.
+- Volcengine is a special case of that overlap rule: LiteLLM maps the standard
+  root `thinking` control to `extra_body.thinking` before its own drop filter
+  runs. Ark request preparation must therefore protect and sanitize both paths
+  even though the application policy remains the standard root field.
+- The OpenAI completion-to-Responses bridge has the inverse hazard: a caller's
+  root or `extra_body.reasoning` object is promoted to the final Responses API
+  `reasoning` object and takes precedence over `reasoning_effort`. Both exact
+  paths must be dropped so a caller cannot raise a Pro model above the product
+  minimum; unrelated `extra_body` values remain intact.
+- LiteLLM 1.98.0 incorrectly reports `minimal` support for GPT-5 Pro, GPT-5.2
+  Pro, and GPT-5.4 Pro. Its GPT-5.5 Pro flags correctly reject the three lower
+  levels but do not explicitly identify `medium`. Exact compatibility rows are
+  required for the documented minimums.
+- The existing automatic `temperature=0.3` overrides Gemini 3's adapter default
+  and is invalid for OpenAI reasoning efforts above `none`. Omitting an
+  application default preserves native behavior while leaving explicit caller
+  values available for strict validation.
+
+## Decision Log
+
+- Decision: ask `litellm.get_supported_openai_params()` first and use
+  `get_model_info()` only to select among explicitly declared effort levels.
+  Rationale: LiteLLM owns provider mapping; model flags only refine the minimum.
+- Decision: select explicit `none`, then `minimal`, then `low`; select `medium`
+  only when all three lower flags are explicitly false; otherwise use `none`
+  when the adapter supports the field. Rationale: `None` means metadata is
+  missing, not unsupported.
+- Decision: use one `_LITELLM_198_COMPATIBILITY_PATCHES` mapping keyed by
+  `(provider, None)` or `(provider, exact_casefold_model_id)`. Rationale: this
+  provides provider-wide then exact-model precedence without prefix matching,
+  dataclass rules, recursive merge, sentinels, or dynamic builders.
+- Decision: merge scalar parameters shallowly, union allow/drop lists in stable
+  order, and merge only the first level of `extra_body`, with later patches
+  winning. Rationale: the behavior is easy to inspect and matches LiteLLM's
+  request boundary.
+- Decision: do not enable `drop_params=True`. Use only targeted
+  `additional_drop_params` generated for conflicting thinking controls.
+  Rationale: unrelated invalid `stop`, `top_p`, reasoning, and structured-output
+  parameters must continue to fail loudly.
+- Decision: reject caller drop paths that overlap a compatibility-owned control
+  at the ancestor, exact, or descendant level, including LiteLLM's mapped
+  `extra_body.thinking` target for standard Ark thinking. Rationale: conflict
+  cleanup may remove caller values, but callers may not remove the forced
+  product minimum itself.
+- Decision: include both `reasoning` and `extra_body.reasoning` in the targeted
+  conflict list whenever a minimum-thinking control is active. Rationale:
+  LiteLLM 1.98's Responses bridge otherwise promotes the caller object and lets
+  it override the selected `reasoning_effort`.
+- Decision: keep explicit incompatible temperature values unchanged, but omit
+  the automatic default for Gemini 3 and OpenAI non-`none` reasoning requests.
+  Rationale: callers retain strict provider feedback and ordinary requests use
+  native defaults.
+- Decision: enumerate the LiteLLM 1.98.0 OpenAI Pro base IDs and known snapshots
+  as exact rows. Rationale: the first version deliberately avoids a prefix DSL;
+  new aliases must be added explicitly.
+- Decision: enumerate the 13 confirmed ZAI thinking IDs as exact rows sharing
+  one literal disabled-thinking patch, while leaving legacy and unknown IDs on
+  the capability-only path. Rationale: this preserves LiteLLM-first behavior
+  and the no-prefix contract without sending an unsupported vendor field to
+  older endpoints.
+
+## Outcomes & Retrospective
+
+The implementation now delegates ordinary minimum-thinking selection to
+LiteLLM 1.98.0 and limits application exceptions to one flat, versioned table.
+Both public invocation paths share the same preparation function; provider
+callbacks and the proposed policy DSL are gone.
+
+The final local behavior evidence is 70 focused LiteLLM 1.98.0 tests and 3602
+passing backend tests with 17 skips. The wire contracts cover native provider
+mappings, exact compatibility rows, strict unsupported parameters, Ark's mapped
+thinking field, legacy ZAI exclusion, and the OpenAI completion-to-Responses
+reasoning conflict. Independent and live reviews found the broad-drop,
+Responses-bridge, and legacy-ZAI bypasses; all were fixed and re-reviewed.
+
+The remaining operational follow-through is to publish the replacement commit
+with an exact force-with-lease, update the PR description, and wait for checks
+and review threads on that immutable head. Those live results belong to the PR
+rather than a commit that must already exist before CI can run.
+
+## Context and Orientation
+
+`src/api/flaskr/api/llm/__init__.py` registers model providers, resolves display
+IDs to actual provider model IDs, prepares LiteLLM arguments, and implements
+`invoke_llm()` plus `chat_llm()`. Both entry points previously received a
+`reload_params` callback through `ProviderConfig` and `ProviderState`.
+
+`src/api/tests/test_llm.py` contains request-preparation unit tests, both complete
+invocation paths, and a subprocess contract pinned to the installed LiteLLM
+1.98.0 distribution. The subprocess uses mock HTTP transports to inspect final
+provider request bodies without external API calls.
+
+## Plan of Work
+
+Remove the callback field from provider config/state and delete all provider
+reload functions. Resolve the provider adapter from the registered config, ask
+LiteLLM for supported standard controls, and calculate the lowest effort from
+explicit model metadata. Merge the versioned provider and exact-model patches
+after that baseline. Determine the final control, discard superseded controls,
+and attach targeted drop paths so caller conflicts cannot defeat the product
+minimum while unrelated arguments remain strict.
+
+Apply this single preparation function in `invoke_llm()` and `chat_llm()` after
+their messages and stream options are prepared. Preserve their public function
+signatures, routing, token limits, streaming, billing, and observability.
+
+Replace callback-oriented tests with capability and patch matrices. Verify the
+actual LiteLLM 1.98.0 mapping for DeepSeek, DashScope, Volcengine, ZAI, Gemini,
+and OpenAI Pro models. Complete full repository validation, then replace only
+the old third PR commit and converge the live PR state.
+
+## Concrete Steps
+
+1. Remove `reload_params` from `ProviderConfig`, `ProviderState`, initialization,
+   and all provider registrations.
+2. Add the LiteLLM capability resolver, shallow patch merger, conflict-drop
+   builder, temperature decision, and versioned compatibility table.
+3. Route both LLM invocation functions through the shared preparation helper.
+4. Rewrite focused tests around capabilities, exact/provider precedence,
+   casefold matching, list/extra-body merges, caller conflict handling, native
+   wire shapes, and strict unsupported-parameter errors.
+5. Run the focused and complete backend suites, Ruff, diff checks, harness
+   checks, and repository pre-commit hooks.
+6. Move this file to `docs/exec-plans/completed/`, regenerate repository
+   knowledge docs, commit, push with an exact force-with-lease, update the PR
+   description, and wait for all checks and review threads on the new head.
+
+## Validation and Acceptance
+
+- Models with standard LiteLLM `reasoning_effort` or `thinking` support require
+  no compatibility table entry.
+- Capability flags `True`, `False`, and `None`, plus missing model metadata, map
+  to the documented minimum-selection behavior.
+- Provider rows apply before exact rows with case-insensitive exact model IDs.
+- Qwen GLM-5.3 and GLM-5.3-Flash send only `reasoning_effort=low`; ordinary
+  Qwen and SiliconFlow send `enable_thinking=false`.
+- DeepSeek and Ark use LiteLLM native disabled-thinking mappings. ZAI sends
+  nested `thinking.disabled` and still permits `response_format`.
+- Gemini 3.7 Flash maps to `thinkingLevel=low`; Gemini 2.5 Pro maps to its
+  128-token minimum budget.
+- GPT-5 Pro maps to `high`; GPT-5.2/5.4/5.5 Pro and their known snapshots map to
+  `medium`, with no automatic sampling temperature.
+- Caller conflicts cannot override the minimum. Unrelated `extra_body` fields
+  and parameters remain, and no global `drop_params=True` is introduced.
+- Removing the DashScope or Gemini exact row exposes LiteLLM 1.98.0's original
+  unsupported request or wrong minimum wire shape.
+- Focused and complete backend tests, Ruff, `git diff --check`, repository
+  harness checks, and all pre-commit hooks pass.
+- PR #2733 ends CLEAN/MERGEABLE with all current-head checks terminal and no
+  unresolved actionable review thread.
+
+## Idempotence and Recovery
+
+Request preparation creates fresh dictionaries and does not mutate the
+compatibility table. Repeated calls therefore cannot accumulate parameters.
+Focused tests use mock transports and do not contact providers.
+
+The replacement refactor will remain one commit above the two preserved model
+fix commits. Before push, re-fetch the remote branch and use an exact
+`--force-with-lease` value. If the refactor must be rolled back after merge,
+revert that single commit; model routing, configuration, credentials, and the
+two focused fixes remain unchanged.
+
+## Interfaces and Dependencies
+
+The implementation depends on LiteLLM 1.98.0 APIs
+`get_supported_openai_params`, `get_model_info`, `allowed_openai_params`, and
+`additional_drop_params`. It does not change the signatures of `invoke_llm()`
+or `chat_llm()`, environment variables, Kubernetes configuration, model IDs,
+token limits, streaming responses, billing, or database schemas.
+
+The compatibility values follow the provider documentation for
+[Gemini 3.7 Flash](https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash),
+[GPT-5 Pro](https://developers.openai.com/api/docs/models/gpt-5-pro), and
+[GPT-5.4 Pro](https://developers.openai.com/api/docs/models/gpt-5.4-pro).

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -44,6 +44,7 @@ Active and completed ExecPlans live here. The structure and required sections ar
 - [ExecPlan: Learn /run Chain Decomposition (B6)](./completed/learn-run-decomposition.md)
 - [Learner Profile Dialog](./completed/learner-profile-dialog-redesign.md)
 - [Learner Profile Foundation](./completed/learner-profile-foundation.md)
+- [LiteLLM-First Minimum-Thinking Parameters](./completed/llm-provider-parameter-policies.md)
 - [MarkdownFlow Scroll Controls](./completed/markdown-flow-scroll-controls.md)
 - [Mobile Learner Personalization Dialog](./completed/mobile-personalization-dialog.md)
 - [Operator Course B Optimization](./completed/operator-course-b-optimization.md)

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -57,6 +57,7 @@
 | `docs/exec-plans/completed/learn-run-decomposition.md` | ExecPlan: Learn /run Chain Decomposition (B6) | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/learner-profile-dialog-redesign.md` | Learner Profile Dialog | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/learner-profile-foundation.md` | Learner Profile Foundation | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
+| `docs/exec-plans/completed/llm-provider-parameter-policies.md` | LiteLLM-First Minimum-Thinking Parameters | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/markdown-flow-scroll-controls.md` | MarkdownFlow Scroll Controls | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/mobile-personalization-dialog.md` | Mobile Learner Personalization Dialog | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/operator-course-b-optimization.md` | Operator Course B Optimization | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -10,7 +10,7 @@ This generated report summarizes the repository harness control plane.
 - Product specs: `10`
 - References: `4`
 - Active ExecPlans: `22`
-- Completed ExecPlans: `31`
+- Completed ExecPlans: `32`
 
 ## Boundary Baseline
 

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -107,7 +107,6 @@ class ProviderConfig:
         ]
         | None
     ) = None
-    reload_params: Callable[[str, float], dict[str, Any]] | None = None
 
 
 @dataclass
@@ -119,7 +118,6 @@ class ProviderState:
     models: list[str]
     prefix: str = ""
     wildcard_prefixes: tuple[str, ...] = ()
-    reload_params: Callable[[str, float], dict[str, Any]] | None = None
 
 
 MODEL_ALIAS_MAP: dict[str, tuple[str, str]] = {}
@@ -369,7 +367,6 @@ def _init_litellm_provider(config: ProviderConfig) -> ProviderState:
             models=[],
             prefix=config.prefix,
             wildcard_prefixes=config.wildcard_prefixes,
-            reload_params=config.reload_params,
         )
     base_url = None
     if config.base_url_env:
@@ -410,7 +407,6 @@ def _init_litellm_provider(config: ProviderConfig) -> ProviderState:
         models=display_models,
         prefix=config.prefix,
         wildcard_prefixes=config.wildcard_prefixes,
-        reload_params=config.reload_params,
     )
 
 
@@ -656,233 +652,322 @@ DEEPSEEK_FALLBACK_MODELS = [
 ]
 
 
-def _reload_openai_params(model_id: str, temperature: float) -> dict[str, object]:
-    if model_id.startswith("gpt-5"):
-        try:
-            model_info = litellm.get_model_info(
-                model=model_id,
-                custom_llm_provider="openai",
-            )
-        except Exception as exc:
-            # Keep the existing prefix-based behavior for model aliases that
-            # have not reached LiteLLM's bundled model map yet.
-            logger.debug(
-                "LiteLLM model info unavailable for %s: %s",
-                model_id,
-                exc,
-            )
-        else:
-            if model_info.get("supports_none_reasoning_effort") is True:
-                return {
-                    "reasoning_effort": "none",
-                    "temperature": temperature,
-                }
-            if model_info.get("supports_minimal_reasoning_effort") is True:
-                reasoning_effort = "minimal"
-            elif model_info.get("supports_low_reasoning_effort") is True:
-                reasoning_effort = "low"
-            elif all(
-                model_info.get(key) is False
-                for key in (
-                    "supports_none_reasoning_effort",
-                    "supports_minimal_reasoning_effort",
-                    "supports_low_reasoning_effort",
-                )
-            ):
-                reasoning_effort = "medium"
-            else:
-                reasoning_effort = None
-            if reasoning_effort is not None:
-                return {
-                    "reasoning_effort": reasoning_effort,
-                    "temperature": 1,
-                }
-
-    if model_id.startswith("gpt-5.2"):
-        return {
-            "reasoning_effort": "none",
-            "temperature": temperature,
-        }
-    if model_id.startswith("gpt-5.1"):
-        return {
-            "reasoning_effort": "none",
-            "temperature": 1,
-        }
-    if model_id.startswith("gpt-5-pro"):
-        return {
-            "reasoning_effort": "none",
-        }
-
-    if model_id.startswith("gpt-5"):
-        return {
-            "reasoning_effort": "minimal",
-            "temperature": 1,
-        }
-    return {
-        "temperature": temperature,
-    }
-
-
-_GEMINI_LOW_REASONING_MODELS = frozenset({"gemini-3.7-flash"})
-_QWEN_REQUIRED_THINKING_MODELS = frozenset(
-    {
-        "zhipu/glm-5.3",
-        "zhipu/glm-5.3-flash",
-    }
+_REASONING_EFFORT_CAPABILITIES = (
+    ("none", "supports_none_reasoning_effort"),
+    ("minimal", "supports_minimal_reasoning_effort"),
+    ("low", "supports_low_reasoning_effort"),
 )
-
-
-def _reload_gemini_params(model_id: str, temperature: float) -> dict[str, object]:
-    # Gemini thinking is controlled via LiteLLM's reasoning_effort mapping. Some
-    # Gemini model ids are not included in LiteLLM's supported-params table yet,
-    # so explicitly allow reasoning_effort for Gemini requests.
-    params: dict[str, Any] = {
-        "temperature": temperature,
-        "allowed_openai_params": ["reasoning_effort"],
-    }
-    normalized_model_id = model_id.casefold()
-    if normalized_model_id in _GEMINI_LOW_REASONING_MODELS:
-        # Gemini 3.7 Flash does not support minimal thinking. Low is its
-        # lowest supported thinking level.
-        params["reasoning_effort"] = "low"
-    elif normalized_model_id.startswith("gemini-3"):
-        # Gemini 3 cannot fully disable thinking. LiteLLM maps none to the
-        # model's lowest supported level and suppresses thought output.
-        params["reasoning_effort"] = "none"
-    elif normalized_model_id.startswith("gemini-2.5-pro"):
-        # Gemini 2.5 Pro cannot disable thinking; LiteLLM maps minimal to its
-        # minimum supported 128-token thinking budget.
-        params["reasoning_effort"] = "minimal"
-    elif normalized_model_id.startswith("gemini"):
-        # Older Gemini models can use the cost-optimized no-thinking mapping.
-        params["reasoning_effort"] = "none"
-    return params
-
-
-def _reload_ark_params(model_id: str, temperature: float) -> dict[str, object]:
-    _ = model_id
-    return {
-        "temperature": temperature,
-        "thinking": {"type": "disabled"},
-        # The follow-up flow relies on JSON mode; explicitly allow this
-        # Volcengine parameter through the shared adapter boundary.
-        "allowed_openai_params": ["response_format"],
-    }
-
-
-def _reload_silicon_params(model_id: str, temperature: float) -> dict[str, object]:
-    _ = model_id
-    return {
-        "temperature": temperature,
-        "extra_body": {"enable_thinking": False},
-    }
-
-
-def _reload_qwen_params(model_id: str, temperature: float) -> dict[str, object]:
-    if model_id.casefold() in _QWEN_REQUIRED_THINKING_MODELS:
-        # DashScope's ZHIPU GLM-5.3 models always think and default to enabled.
-        # Only set their lowest supported thinking level; the provider-policy
-        # merge removes any conflicting enable_thinking value from callers.
-        return {
-            "temperature": temperature,
-            "extra_body": {
-                "reasoning_effort": "low",
-            },
-        }
-    return {
-        "temperature": temperature,
-        "extra_body": {"enable_thinking": False},
-    }
-
-
-def _reload_deepseek_params(model_id: str, temperature: float) -> dict[str, object]:
-    _ = model_id
-    return {
-        "temperature": temperature,
-        "reasoning_effort": "none",
-    }
-
-
-_GLM_THINKING_MODEL_PREFIXES = ("glm-4.5", "glm-4.6", "glm-4.7", "glm-5")
-_THINKING_CONTROL_KEYS = (
+_THINKING_CONTROL_KEYS = ("reasoning_effort", "thinking", "enable_thinking")
+_LIST_PATCH_KEYS = frozenset({"allowed_openai_params", "additional_drop_params"})
+_THINKING_CONFLICT_PATHS = (
     "reasoning_effort",
+    "reasoning",
     "thinking",
     "enable_thinking",
     "thinkingConfig",
     "thinking_config",
+    "extra_body.reasoning_effort",
+    "extra_body.reasoning",
+    "extra_body.thinking",
+    "extra_body.enable_thinking",
+    "extra_body.thinkingConfig",
+    "extra_body.thinking_config",
+    "generationConfig.thinkingConfig",
+    "generationConfig.thinking_config",
+    "generation_config.thinkingConfig",
+    "generation_config.thinking_config",
+    "extra_body.generationConfig.thinkingConfig",
+    "extra_body.generationConfig.thinking_config",
+    "extra_body.generation_config.thinkingConfig",
+    "extra_body.generation_config.thinking_config",
 )
-_GEMINI_GENERATION_CONFIG_KEYS = ("generation_config", "generationConfig")
-_GEMINI_THINKING_CONFIG_KEYS = ("thinkingConfig", "thinking_config")
+
+# These entries cover confirmed gaps in LiteLLM 1.98.0. The normal path is
+# capability-driven; upgrading LiteLLM should make individual rows removable
+# when their contract tests start passing without the row.
+_ZAI_DISABLED_THINKING_PATCH: dict[str, object] = {
+    # LiteLLM 1.98 sends top-level thinking to the OpenAI SDK for ZAI, where it
+    # is rejected. extra_body reaches the provider wire format.
+    "extra_body": {"thinking": {"type": "disabled"}},
+}
+_LITELLM_198_COMPATIBILITY_PATCHES: dict[tuple[str, str | None], dict[str, object]] = {
+    ("qwen", None): {"extra_body": {"enable_thinking": False}},
+    ("silicon", None): {"extra_body": {"enable_thinking": False}},
+    ("ark", None): {"allowed_openai_params": ["response_format"]},
+    ("glm", None): {"allowed_openai_params": ["response_format"]},
+    ("glm", "glm-4.5"): _ZAI_DISABLED_THINKING_PATCH,
+    ("glm", "glm-4.5v"): _ZAI_DISABLED_THINKING_PATCH,
+    ("glm", "glm-4.5-air"): _ZAI_DISABLED_THINKING_PATCH,
+    ("glm", "glm-4.5-x"): _ZAI_DISABLED_THINKING_PATCH,
+    ("glm", "glm-4.5-airx"): _ZAI_DISABLED_THINKING_PATCH,
+    ("glm", "glm-4.5-flash"): _ZAI_DISABLED_THINKING_PATCH,
+    ("glm", "glm-4.6"): _ZAI_DISABLED_THINKING_PATCH,
+    ("glm", "glm-4.7"): _ZAI_DISABLED_THINKING_PATCH,
+    ("glm", "glm-4.7-flash"): _ZAI_DISABLED_THINKING_PATCH,
+    ("glm", "glm-5"): _ZAI_DISABLED_THINKING_PATCH,
+    ("glm", "glm-5.1"): _ZAI_DISABLED_THINKING_PATCH,
+    ("glm", "glm-5-code"): _ZAI_DISABLED_THINKING_PATCH,
+    ("glm", "glm-5.2"): _ZAI_DISABLED_THINKING_PATCH,
+    ("qwen", "zhipu/glm-5.3"): {
+        "reasoning_effort": "low",
+        "allowed_openai_params": ["reasoning_effort"],
+        "additional_drop_params": ["enable_thinking"],
+    },
+    ("qwen", "zhipu/glm-5.3-flash"): {
+        "reasoning_effort": "low",
+        "allowed_openai_params": ["reasoning_effort"],
+        "additional_drop_params": ["enable_thinking"],
+    },
+    ("gemini", "gemini-3.7-flash"): {"reasoning_effort": "low"},
+    ("gemini", "gemini-2.5-pro"): {"reasoning_effort": "minimal"},
+    ("openai", "gpt-5-pro"): {"reasoning_effort": "high"},
+    ("openai", "gpt-5-pro-2025-10-06"): {"reasoning_effort": "high"},
+    ("openai", "gpt-5.2-pro"): {"reasoning_effort": "medium"},
+    ("openai", "gpt-5.2-pro-2025-12-11"): {"reasoning_effort": "medium"},
+    ("openai", "gpt-5.4-pro"): {"reasoning_effort": "medium"},
+    ("openai", "gpt-5.4-pro-2026-03-05"): {"reasoning_effort": "medium"},
+    ("openai", "gpt-5.5-pro"): {"reasoning_effort": "medium"},
+    ("openai", "gpt-5.5-pro-2026-04-23"): {"reasoning_effort": "medium"},
+}
 
 
-def _reload_glm_params(model_id: str, temperature: float) -> dict[str, object]:
-    params: dict[str, Any] = {
-        "temperature": temperature,
-        # LiteLLM's ZAI adapter currently gates thinking on model metadata and
-        # omits response_format from its supported list. Keep JSON output
-        # compatible without allowing thinking on legacy GLM models.
-        "allowed_openai_params": ["response_format"],
-    }
-    if model_id.lower().startswith(_GLM_THINKING_MODEL_PREFIXES):
-        params["allowed_openai_params"].append("thinking")
-        # Keep thinking in extra_body so the OpenAI-compatible SDK forwards the
-        # vendor-specific argument instead of rejecting it before the request.
-        params["extra_body"] = {"thinking": {"type": "disabled"}}
-    return params
+def _ordered_param_union(*values: object) -> list[object]:
+    merged: list[object] = []
+    for value in values:
+        if not isinstance(value, (list, tuple)):
+            continue
+        for item in value:
+            if item not in merged:
+                merged.append(item)
+    return merged
 
 
-def _apply_provider_params(
-    kwargs: dict[str, object], provider_params: dict[str, object]
-) -> None:
-    provider_extra_body = provider_params.get("extra_body")
-    has_thinking_policy = any(
-        key in provider_params for key in _THINKING_CONTROL_KEYS
-    ) or (
-        isinstance(provider_extra_body, dict)
-        and any(key in provider_extra_body for key in _THINKING_CONTROL_KEYS)
-    )
-    if has_thinking_policy:
-        for key in _THINKING_CONTROL_KEYS:
-            kwargs.pop(key, None)
-        caller_extra_body = kwargs.get("extra_body")
-        if isinstance(caller_extra_body, dict):
-            sanitized_extra_body = {
-                key: value
-                for key, value in caller_extra_body.items()
-                if key not in _THINKING_CONTROL_KEYS
+def _merge_litellm_param_patch(
+    base: dict[str, object], patch: dict[str, object]
+) -> dict[str, object]:
+    """Shallow-merge one request patch without inventing a policy language."""
+    merged = dict(base)
+    for key, value in patch.items():
+        if key in _LIST_PATCH_KEYS:
+            merged[key] = _ordered_param_union(merged.get(key), value)
+        elif key == "extra_body" and isinstance(value, dict):
+            current = merged.get(key)
+            merged[key] = {
+                **(current if isinstance(current, dict) else {}),
+                **value,
             }
-            # Gemini merges these native blocks after mapping reasoning_effort,
-            # so a caller-supplied thinking config would otherwise win.
-            normalized_generation_config: dict[str, Any] = {}
-            for generation_config_key in _GEMINI_GENERATION_CONFIG_KEYS:
-                generation_config = sanitized_extra_body.pop(
-                    generation_config_key,
-                    None,
-                )
-                if not isinstance(generation_config, dict):
-                    continue
-                normalized_generation_config.update(
-                    {
-                        key: value
-                        for key, value in generation_config.items()
-                        if key not in _GEMINI_THINKING_CONFIG_KEYS
-                    }
-                )
-            if normalized_generation_config:
-                sanitized_extra_body["generationConfig"] = normalized_generation_config
-            if sanitized_extra_body:
-                kwargs["extra_body"] = sanitized_extra_body
-            else:
-                kwargs.pop("extra_body", None)
+        elif isinstance(value, dict):
+            merged[key] = dict(value)
+        elif isinstance(value, list):
+            merged[key] = list(value)
+        else:
+            merged[key] = value
+    return merged
 
-    applied_params = dict(provider_params)
-    if isinstance(provider_extra_body, dict):
-        caller_extra_body = kwargs.get("extra_body")
-        applied_params["extra_body"] = {
-            **(caller_extra_body if isinstance(caller_extra_body, dict) else {}),
-            **provider_extra_body,
-        }
-    kwargs.update(applied_params)
+
+def _litellm_provider_name(provider_key: str, provider_params: dict[str, str]) -> str:
+    configured_provider = provider_params.get("custom_llm_provider")
+    if configured_provider:
+        return configured_provider
+    for config in LITELLM_PROVIDER_CONFIGS:
+        if config.key == provider_key and config.custom_llm_provider:
+            return config.custom_llm_provider
+    return provider_key
+
+
+def _litellm_minimum_thinking_params(
+    model_id: str, custom_llm_provider: str
+) -> dict[str, object]:
+    """Use LiteLLM's declared adapter capabilities for the product minimum."""
+    try:
+        supported_params = litellm.get_supported_openai_params(
+            model=model_id,
+            custom_llm_provider=custom_llm_provider,
+        )
+    except Exception as exc:
+        logger.debug(
+            "LiteLLM supported params unavailable for %s/%s: %s",
+            custom_llm_provider,
+            model_id,
+            exc,
+        )
+        supported_params = None
+
+    if supported_params and "reasoning_effort" in supported_params:
+        try:
+            model_info = litellm.get_model_info(
+                model=model_id,
+                custom_llm_provider=custom_llm_provider,
+            )
+        except Exception as exc:
+            logger.debug(
+                "LiteLLM model info unavailable for %s/%s: %s",
+                custom_llm_provider,
+                model_id,
+                exc,
+            )
+            model_info = {}
+
+        for effort, capability in _REASONING_EFFORT_CAPABILITIES:
+            if model_info.get(capability) is True:
+                return {"reasoning_effort": effort}
+        if all(
+            model_info.get(capability) is False
+            for _effort, capability in _REASONING_EFFORT_CAPABILITIES
+        ):
+            return {"reasoning_effort": "medium"}
+        # The adapter supports the standard parameter but the model metadata is
+        # incomplete. LiteLLM maps none to each provider's native minimum.
+        return {"reasoning_effort": "none"}
+
+    if supported_params and "thinking" in supported_params:
+        return {"thinking": {"type": "disabled"}}
+    return {}
+
+
+def _find_thinking_control(
+    params: dict[str, object],
+) -> tuple[str, str] | None:
+    for key in _THINKING_CONTROL_KEYS:
+        if key in params:
+            return "root", key
+    extra_body = params.get("extra_body")
+    if isinstance(extra_body, dict):
+        for key in _THINKING_CONTROL_KEYS:
+            if key in extra_body:
+                return "extra_body", key
+    return None
+
+
+def _keep_primary_thinking_control(
+    params: dict[str, object], primary: tuple[str, str] | None
+) -> dict[str, object]:
+    if primary is None:
+        return params
+    kept = dict(params)
+    for key in _THINKING_CONTROL_KEYS:
+        if primary != ("root", key):
+            kept.pop(key, None)
+    extra_body = kept.get("extra_body")
+    if isinstance(extra_body, dict):
+        kept_extra_body = dict(extra_body)
+        for key in _THINKING_CONTROL_KEYS:
+            if primary != ("extra_body", key):
+                kept_extra_body.pop(key, None)
+        if kept_extra_body:
+            kept["extra_body"] = kept_extra_body
+        else:
+            kept.pop("extra_body", None)
+    return kept
+
+
+def _thinking_conflict_drop_params(primary: tuple[str, str]) -> list[object]:
+    if primary[0] == "root":
+        protected_paths = {primary[1]}
+        if primary[1] == "thinking":
+            # OpenAI-compatible adapters can map standard thinking into
+            # extra_body, so dropping that path would remove the policy value.
+            protected_paths.add("extra_body.thinking")
+    else:
+        # A flat drop also removes an extra_body field with the same name.
+        protected_paths = {primary[1], f"extra_body.{primary[1]}"}
+    return [path for path in _THINKING_CONFLICT_PATHS if path not in protected_paths]
+
+
+def _drop_path_overlaps_primary(path: object, primary: tuple[str, str]) -> bool:
+    if not isinstance(path, str):
+        return False
+    target_path = primary[1] if primary[0] == "root" else f"extra_body.{primary[1]}"
+    protected_paths = {target_path}
+    if primary == ("root", "thinking"):
+        protected_paths.add("extra_body.thinking")
+    if primary[0] == "extra_body":
+        # LiteLLM also treats the flat field name as an extra_body filter.
+        protected_paths.add(primary[1])
+    return any(
+        path == protected
+        or path.startswith(f"{protected}.")
+        or protected.startswith(f"{path}.")
+        for protected in protected_paths
+    )
+
+
+def _should_inject_default_temperature(
+    provider_key: str,
+    model_id: str,
+    primary: tuple[str, str] | None,
+    policy_params: dict[str, object],
+) -> bool:
+    normalized_model = model_id.casefold()
+    if provider_key == "gemini" and normalized_model.startswith("gemini-3"):
+        return False
+    return not (
+        provider_key == "openai"
+        and primary == ("root", "reasoning_effort")
+        and policy_params.get("reasoning_effort") != "none"
+    )
+
+
+def _prepare_litellm_request_kwargs(
+    provider_key: str,
+    model_id: str,
+    provider_params: dict[str, str],
+    kwargs: dict[str, object],
+) -> dict[str, object]:
+    """Resolve minimum thinking controls once for both invocation paths."""
+    provider_key = provider_key.casefold()
+    custom_llm_provider = _litellm_provider_name(provider_key, provider_params)
+    stages = [
+        _litellm_minimum_thinking_params(model_id, custom_llm_provider),
+        _LITELLM_198_COMPATIBILITY_PATCHES.get((provider_key, None), {}),
+        _LITELLM_198_COMPATIBILITY_PATCHES.get((provider_key, model_id.casefold()), {}),
+    ]
+    primary = None
+    policy_params: dict[str, object] = {}
+    for stage in stages:
+        policy_params = _merge_litellm_param_patch(policy_params, stage)
+        stage_control = _find_thinking_control(stage)
+        if stage_control is not None:
+            primary = stage_control
+    policy_params = _keep_primary_thinking_control(policy_params, primary)
+
+    prepared = dict(kwargs)
+    if "temperature" in prepared:
+        prepared["temperature"] = float(prepared["temperature"])
+    elif _should_inject_default_temperature(
+        provider_key, model_id, primary, policy_params
+    ):
+        prepared["temperature"] = 0.3
+
+    if primary is not None:
+        if primary == ("root", "thinking"):
+            caller_extra_body = prepared.get("extra_body")
+            if isinstance(caller_extra_body, dict):
+                sanitized_extra_body = dict(caller_extra_body)
+                sanitized_extra_body.pop("thinking", None)
+                if sanitized_extra_body:
+                    prepared["extra_body"] = sanitized_extra_body
+                else:
+                    prepared.pop("extra_body", None)
+        if primary[0] == "extra_body":
+            # None prevents the caller's top-level vendor field from
+            # overwriting the patch when LiteLLM builds extra_body.
+            prepared[primary[1]] = None
+        caller_drop_params = prepared.get("additional_drop_params")
+        if isinstance(caller_drop_params, (list, tuple)):
+            prepared["additional_drop_params"] = [
+                path
+                for path in caller_drop_params
+                if not _drop_path_overlaps_primary(path, primary)
+            ]
+        policy_params = _merge_litellm_param_patch(
+            policy_params,
+            {
+                "additional_drop_params": _thinking_conflict_drop_params(primary),
+            },
+        )
+
+    return _merge_litellm_param_patch(prepared, policy_params)
 
 
 LITELLM_PROVIDER_CONFIGS: list[ProviderConfig] = [
@@ -895,7 +980,6 @@ LITELLM_PROVIDER_CONFIGS: list[ProviderConfig] = [
         wildcard_prefixes=("gpt",),
         config_hint="OPENAI_API_KEY,OPENAI_BASE_URL",
         custom_llm_provider="openai",
-        reload_params=_reload_openai_params,
     ),
     ProviderConfig(
         key="qwen",
@@ -907,7 +991,6 @@ LITELLM_PROVIDER_CONFIGS: list[ProviderConfig] = [
         wildcard_prefixes=(QWEN_PREFIX,),
         config_hint="QWEN_API_KEY,QWEN_API_URL",
         custom_llm_provider="dashscope",
-        reload_params=_reload_qwen_params,
     ),
     ProviderConfig(
         key="ernie_v2",
@@ -925,7 +1008,6 @@ LITELLM_PROVIDER_CONFIGS: list[ProviderConfig] = [
         config_hint="DEEPSEEK_API_KEY,DEEPSEEK_API_URL",
         custom_llm_provider="deepseek",
         model_loader=_load_deepseek_models,
-        reload_params=_reload_deepseek_params,
     ),
     ProviderConfig(
         key="gemini",
@@ -938,7 +1020,6 @@ LITELLM_PROVIDER_CONFIGS: list[ProviderConfig] = [
         config_hint="GEMINI_API_KEY,GEMINI_API_URL",
         custom_llm_provider="gemini",
         model_loader=_load_gemini_models,
-        reload_params=_reload_gemini_params,
     ),
     ProviderConfig(
         key="glm",
@@ -947,7 +1028,6 @@ LITELLM_PROVIDER_CONFIGS: list[ProviderConfig] = [
         prefix=GLM_PREFIX,
         config_hint="BIGMODEL_API_KEY",
         custom_llm_provider="zai",
-        reload_params=_reload_glm_params,
     ),
     ProviderConfig(
         key="silicon",
@@ -956,7 +1036,6 @@ LITELLM_PROVIDER_CONFIGS: list[ProviderConfig] = [
         prefix=SILICON_PREFIX,
         config_hint="SILICON_API_KEY,SILICON_API_URL",
         custom_llm_provider="openai",
-        reload_params=_reload_silicon_params,
     ),
     ProviderConfig(
         key="ark",
@@ -965,7 +1044,6 @@ LITELLM_PROVIDER_CONFIGS: list[ProviderConfig] = [
         prefix="ark/",
         config_hint="ARK_API_KEY",
         custom_llm_provider="volcengine",
-        reload_params=_reload_ark_params,
     ),
 ]
 
@@ -1024,15 +1102,14 @@ def get_litellm_params_and_model(
 ) -> tuple[
     dict[str, str] | None,
     str,
-    Callable[[str, float], dict[str, Any]] | None,
+    str | None,
 ]:
-    """Return litellm params and model."""
+    """Return LiteLLM params, actual model, and application provider key."""
     requested_model = model
     provider_key, invoke_model = _resolve_provider_for_model(model)
     if provider_key:
         state = PROVIDER_STATES.get(provider_key)
         params = state.params if state else None
-        reload_params = state.reload_params if state else None
         if not params:
             raise_error_with_args(
                 "server.llm.specifiedLlmNotConfigured",
@@ -1041,7 +1118,7 @@ def get_litellm_params_and_model(
                     provider_key, provider_key.upper()
                 ),
             )
-        return params, invoke_model, reload_params
+        return params, invoke_model, provider_key
     return None, model, None
 
 
@@ -1098,10 +1175,9 @@ def invoke_llm(
     input_cache_tokens = 0
     provider_name = ""
     start_time = time.monotonic()
-    params, invoke_model, reload_params = get_litellm_params_and_model(model)
+    params, invoke_model, provider_key = get_litellm_params_and_model(model)
     start_completion_time = None
     if params:
-        provider_key, _normalized = _resolve_provider_for_model(model)
         provider_name = provider_key or ""
         messages = []
         if system:
@@ -1110,17 +1186,12 @@ def invoke_llm(
         if json:
             kwargs["response_format"] = {"type": "json_object"}
         kwargs["stream_options"] = {"include_usage": True}
-        if reload_params:
-            _apply_provider_params(
-                kwargs,
-                reload_params(invoke_model, float(kwargs.get("temperature", 0.3))),
-            )
-        else:
-            kwargs.update(
-                {
-                    "temperature": float(kwargs.get("temperature", 0.3)),
-                }
-            )
+        kwargs = _prepare_litellm_request_kwargs(
+            provider_name,
+            invoke_model,
+            params,
+            kwargs,
+        )
         response = _iter_stream_with_precontent_retry(
             app,
             model,
@@ -1287,22 +1358,16 @@ def chat_llm(
     provider_name = ""
     start_time = time.monotonic()
     start_completion_time = None
-    params, invoke_model, reload_params = get_litellm_params_and_model(model)
+    params, invoke_model, provider_key = get_litellm_params_and_model(model)
     if params:
-        provider_key, _normalized = _resolve_provider_for_model(model)
         provider_name = provider_key or ""
-        if reload_params:
-            _apply_provider_params(
-                kwargs,
-                reload_params(invoke_model, float(kwargs.get("temperature", 0.3))),
-            )
-        else:
-            kwargs.update(
-                {
-                    "temperature": float(kwargs.get("temperature", 0.3)),
-                }
-            )
         kwargs["stream_options"] = {"include_usage": True}
+        kwargs = _prepare_litellm_request_kwargs(
+            provider_name,
+            invoke_model,
+            params,
+            kwargs,
+        )
         response = _iter_stream_with_precontent_retry(
             app,
             model,

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -723,6 +723,15 @@ def _reload_openai_params(model_id: str, temperature: float) -> dict[str, object
     }
 
 
+_GEMINI_LOW_REASONING_MODELS = frozenset({"gemini-3.7-flash"})
+_QWEN_REQUIRED_THINKING_MODELS = frozenset(
+    {
+        "zhipu/glm-5.3",
+        "zhipu/glm-5.3-flash",
+    }
+)
+
+
 def _reload_gemini_params(model_id: str, temperature: float) -> dict[str, object]:
     # Gemini thinking is controlled via LiteLLM's reasoning_effort mapping. Some
     # Gemini model ids are not included in LiteLLM's supported-params table yet,
@@ -731,15 +740,20 @@ def _reload_gemini_params(model_id: str, temperature: float) -> dict[str, object
         "temperature": temperature,
         "allowed_openai_params": ["reasoning_effort"],
     }
-    if model_id.startswith("gemini-3"):
+    normalized_model_id = model_id.casefold()
+    if normalized_model_id in _GEMINI_LOW_REASONING_MODELS:
+        # Gemini 3.7 Flash does not support minimal thinking. Low is its
+        # lowest supported thinking level.
+        params["reasoning_effort"] = "low"
+    elif normalized_model_id.startswith("gemini-3"):
         # Gemini 3 cannot fully disable thinking. LiteLLM maps none to the
         # model's lowest supported level and suppresses thought output.
         params["reasoning_effort"] = "none"
-    elif model_id.startswith("gemini-2.5-pro"):
+    elif normalized_model_id.startswith("gemini-2.5-pro"):
         # Gemini 2.5 Pro cannot disable thinking; LiteLLM maps minimal to its
         # minimum supported 128-token thinking budget.
         params["reasoning_effort"] = "minimal"
-    elif model_id.startswith("gemini"):
+    elif normalized_model_id.startswith("gemini"):
         # Older Gemini models can use the cost-optimized no-thinking mapping.
         params["reasoning_effort"] = "none"
     return params
@@ -765,7 +779,16 @@ def _reload_silicon_params(model_id: str, temperature: float) -> dict[str, objec
 
 
 def _reload_qwen_params(model_id: str, temperature: float) -> dict[str, object]:
-    _ = model_id
+    if model_id.casefold() in _QWEN_REQUIRED_THINKING_MODELS:
+        # DashScope's ZHIPU GLM-5.3 models always think. Disabling thinking
+        # returns HTTP 400, while low is their lowest supported thinking level.
+        return {
+            "temperature": temperature,
+            "extra_body": {
+                "enable_thinking": True,
+                "reasoning_effort": "low",
+            },
+        }
     return {
         "temperature": temperature,
         "extra_body": {"enable_thinking": False},

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -780,12 +780,12 @@ def _reload_silicon_params(model_id: str, temperature: float) -> dict[str, objec
 
 def _reload_qwen_params(model_id: str, temperature: float) -> dict[str, object]:
     if model_id.casefold() in _QWEN_REQUIRED_THINKING_MODELS:
-        # DashScope's ZHIPU GLM-5.3 models always think. Disabling thinking
-        # returns HTTP 400, while low is their lowest supported thinking level.
+        # DashScope's ZHIPU GLM-5.3 models always think and default to enabled.
+        # Only set their lowest supported thinking level; the provider-policy
+        # merge removes any conflicting enable_thinking value from callers.
         return {
             "temperature": temperature,
             "extra_body": {
-                "enable_thinking": True,
                 "reasoning_effort": "low",
             },
         }

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -516,17 +516,16 @@ def test_qwen_prefixed_model_routes_without_fetched_alias(
 
     monkeypatch.setattr(llm.litellm, "completion", fake_completion)
 
-    def reload_qwen_params(model_id: object, temperature: object) -> object:
-        captured["reload_model"] = model_id
-        return llm._reload_qwen_params(model_id, temperature)
-
     provider_state = llm.ProviderState(
         enabled=True,
-        params={"api_key": "test-key", "api_base": "https://example.com"},
+        params={
+            "api_key": "test-key",
+            "api_base": "https://example.com",
+            "custom_llm_provider": "dashscope",
+        },
         models=[],
         prefix=llm.QWEN_PREFIX,
         wildcard_prefixes=(llm.QWEN_PREFIX,),
-        reload_params=reload_qwen_params,
     )
     monkeypatch.setattr(llm, "PROVIDER_STATES", {"qwen": provider_state})
     monkeypatch.setattr(llm, "MODEL_ALIAS_MAP", {})
@@ -555,9 +554,10 @@ def test_qwen_prefixed_model_routes_without_fetched_alias(
 
     assert [resp.result for resp in responses] == ["ok"]
     assert captured["model"] == "deepseek-v4-flash"
-    assert captured["reload_model"] == "deepseek-v4-flash"
     assert captured["kwargs"]["temperature"] == 0.7
     assert captured["kwargs"]["extra_body"] == {"enable_thinking": False}
+    assert captured["kwargs"]["enable_thinking"] is None
+    assert "drop_params" not in captured["kwargs"]
     assert captured["kwargs"]["max_tokens"] == 393216
 
 
@@ -739,16 +739,15 @@ def test_provider_configs_use_expected_litellm_adapters(
 
 
 @pytest.mark.parametrize(
-    ("model_info", "expected_effort", "expected_temperature"),
+    ("model_info", "expected_effort"),
     [
-        ({"supports_none_reasoning_effort": True}, "none", 0.4),
+        ({"supports_none_reasoning_effort": True}, "none"),
         (
             {
                 "supports_none_reasoning_effort": False,
                 "supports_minimal_reasoning_effort": True,
             },
             "minimal",
-            1,
         ),
         (
             {
@@ -757,7 +756,6 @@ def test_provider_configs_use_expected_litellm_adapters(
                 "supports_low_reasoning_effort": True,
             },
             "low",
-            1,
         ),
         (
             {
@@ -766,15 +764,15 @@ def test_provider_configs_use_expected_litellm_adapters(
                 "supports_low_reasoning_effort": False,
             },
             "medium",
-            1,
         ),
+        ({"supports_none_reasoning_effort": None}, "none"),
+        ({}, "none"),
     ],
 )
-def test_openai_params_use_litellm_reasoning_capabilities(
+def test_minimum_thinking_uses_litellm_reasoning_capabilities(
     monkeypatch: object,
     model_info: object,
     expected_effort: object,
-    expected_temperature: object,
 ) -> None:
     captured = {}
 
@@ -783,23 +781,31 @@ def test_openai_params_use_litellm_reasoning_capabilities(
         captured["custom_llm_provider"] = custom_llm_provider
         return model_info
 
+    monkeypatch.setattr(
+        llm.litellm,
+        "get_supported_openai_params",
+        lambda **_kwargs: ["reasoning_effort"],
+    )
     monkeypatch.setattr(llm.litellm, "get_model_info", fake_get_model_info)
 
-    params = llm._reload_openai_params("gpt-5.6-luna", 0.4)
+    params = llm._litellm_minimum_thinking_params("future-model", "provider")
 
-    assert params == {
-        "reasoning_effort": expected_effort,
-        "temperature": expected_temperature,
-    }
+    assert params == {"reasoning_effort": expected_effort}
     assert captured == {
-        "model": "gpt-5.6-luna",
-        "custom_llm_provider": "openai",
+        "model": "future-model",
+        "custom_llm_provider": "provider",
     }
 
 
-def test_openai_params_fall_back_to_existing_policy_for_unknown_model(
+def test_minimum_thinking_uses_none_when_model_metadata_is_missing(
     monkeypatch: object,
 ) -> None:
+    monkeypatch.setattr(
+        llm.litellm,
+        "get_supported_openai_params",
+        lambda **_kwargs: ["reasoning_effort"],
+    )
+
     def raise_unknown(*args: object, **kwargs: object) -> None:
         _ = args, kwargs
         message = "unknown model"
@@ -807,230 +813,396 @@ def test_openai_params_fall_back_to_existing_policy_for_unknown_model(
 
     monkeypatch.setattr(llm.litellm, "get_model_info", raise_unknown)
 
-    assert llm._reload_openai_params("gpt-5-custom", 0.4) == {
-        "reasoning_effort": "minimal",
-        "temperature": 1,
+    assert llm._litellm_minimum_thinking_params("future-model", "provider") == {
+        "reasoning_effort": "none"
     }
 
 
-def test_openai_params_fall_back_when_capability_metadata_is_partial(
+def test_minimum_thinking_falls_back_to_standard_thinking(
     monkeypatch: object,
 ) -> None:
     monkeypatch.setattr(
         llm.litellm,
-        "get_model_info",
-        lambda *_args, **_kwargs: {"supports_none_reasoning_effort": False},
+        "get_supported_openai_params",
+        lambda **_kwargs: ["thinking"],
     )
 
-    assert llm._reload_openai_params("gpt-5.2-custom", 0.4) == {
-        "reasoning_effort": "none",
-        "temperature": 0.4,
+    assert llm._litellm_minimum_thinking_params("future-model", "provider") == {
+        "thinking": {"type": "disabled"}
     }
 
 
-@pytest.mark.parametrize(
-    "model_id",
-    ["glm-4.5", "glm-4.6-air", "glm-4.7-flash", "glm-5.2"],
-)
-def test_glm_params_disable_thinking_for_supported_models(model_id: object) -> None:
-    params = llm._reload_glm_params(model_id, 0.4)
+def test_minimum_thinking_leaves_non_reasoning_models_unchanged(
+    monkeypatch: object,
+) -> None:
+    monkeypatch.setattr(
+        llm.litellm,
+        "get_supported_openai_params",
+        lambda **_kwargs: ["temperature", "stream"],
+    )
 
-    assert params == {
-        "temperature": 0.4,
-        "allowed_openai_params": ["response_format", "thinking"],
-        "extra_body": {"thinking": {"type": "disabled"}},
-    }
+    assert llm._litellm_minimum_thinking_params("plain-model", "provider") == {}
 
 
-def test_glm_params_leave_legacy_models_unchanged() -> None:
-    params = llm._reload_glm_params("glm-4-plus", 0.4)
+def test_request_patch_merge_is_shallow_and_deduplicates_lists() -> None:
+    merged = llm._merge_litellm_param_patch(
+        {
+            "allowed_openai_params": ["response_format", "tools"],
+            "additional_drop_params": ["thinking"],
+            "extra_body": {
+                "custom": "keep",
+                "nested": {"caller": True},
+            },
+        },
+        {
+            "allowed_openai_params": ["tools", "reasoning_effort"],
+            "additional_drop_params": ["thinking", "enable_thinking"],
+            "extra_body": {
+                "nested": {"patch": True},
+                "enable_thinking": False,
+            },
+        },
+    )
 
-    assert params == {
-        "temperature": 0.4,
-        "allowed_openai_params": ["response_format"],
-    }
-
-
-def test_provider_specific_thinking_params_remain_compatible() -> None:
-    assert llm._reload_qwen_params("qwen-max", 0.4)["extra_body"] == {
-        "enable_thinking": False
-    }
-    assert llm._reload_silicon_params("deepseek-ai/DeepSeek-V3", 0.4)["extra_body"] == {
-        "enable_thinking": False
-    }
-    assert llm._reload_ark_params("doubao-seed", 0.4)["thinking"] == {
-        "type": "disabled"
-    }
-    assert llm._reload_ark_params("doubao-seed", 0.4)["allowed_openai_params"] == [
-        "response_format"
-    ]
-
-
-@pytest.mark.parametrize(
-    "model_id",
-    ["ZHIPU/GLM-5.3", "ZHIPU/GLM-5.3-Flash"],
-)
-def test_qwen_glm_53_params_use_lowest_supported_reasoning(model_id: object) -> None:
-    assert llm._reload_qwen_params(model_id, 0.4) == {
-        "temperature": 0.4,
+    assert merged == {
+        "allowed_openai_params": [
+            "response_format",
+            "tools",
+            "reasoning_effort",
+        ],
+        "additional_drop_params": ["thinking", "enable_thinking"],
         "extra_body": {
-            "reasoning_effort": "low",
+            "custom": "keep",
+            "nested": {"patch": True},
+            "enable_thinking": False,
         },
     }
 
 
-def test_provider_thinking_policy_removes_caller_conflicts() -> None:
-    kwargs = {
-        "reasoning_effort": "high",
-        "thinking": {"type": "enabled"},
-        "enable_thinking": True,
-        "extra_body": {
+@pytest.mark.parametrize("provider_key", ["QWEN", "Silicon"])
+def test_provider_patch_disables_thinking_and_preserves_extra_body(
+    monkeypatch: object, provider_key: object
+) -> None:
+    monkeypatch.setattr(
+        llm,
+        "_litellm_minimum_thinking_params",
+        lambda *_args, **_kwargs: {},
+    )
+
+    prepared = llm._prepare_litellm_request_kwargs(
+        str(provider_key),
+        "ordinary-model",
+        {"custom_llm_provider": "openai"},
+        {
+            "enable_thinking": True,
+            "additional_drop_params": [
+                "extra_body",
+                "extra_body.enable_thinking.type",
+                "caller_only",
+            ],
+            "extra_body": {
+                "enable_thinking": True,
+                "custom_field": "keep",
+            },
+        },
+    )
+
+    assert prepared["enable_thinking"] is None
+    assert prepared["extra_body"] == {
+        "enable_thinking": False,
+        "custom_field": "keep",
+    }
+    assert "enable_thinking" not in prepared["additional_drop_params"]
+    assert "extra_body" not in prepared["additional_drop_params"]
+    assert prepared["additional_drop_params"][0] == "caller_only"
+    assert "drop_params" not in prepared
+
+
+def test_zai_patch_keeps_thinking_in_extra_body(monkeypatch: object) -> None:
+    adapter_supported_models = {
+        "glm-4.6",
+        "glm-4.7",
+        "glm-4.7-flash",
+        "glm-5",
+        "glm-5.1",
+        "glm-5-code",
+    }
+    monkeypatch.setattr(
+        llm,
+        "_litellm_minimum_thinking_params",
+        lambda model_id, *_args, **_kwargs: (
+            {"thinking": {"type": "disabled"}}
+            if model_id.casefold() in adapter_supported_models
+            else {}
+        ),
+    )
+
+    patched_model_ids = (
+        "glm-4.5",
+        "glm-4.5v",
+        "glm-4.5-air",
+        "glm-4.5-x",
+        "glm-4.5-airx",
+        "glm-4.5-flash",
+        "glm-4.6",
+        "GLM-4.7",
+        "glm-4.7-flash",
+        "glm-5",
+        "glm-5.1",
+        "glm-5-code",
+        "glm-5.2",
+    )
+    assert {
+        model_id
+        for provider, model_id in llm._LITELLM_198_COMPATIBILITY_PATCHES
+        if provider == "glm" and model_id is not None
+    } == {model_id.casefold() for model_id in patched_model_ids}
+
+    for model_id in patched_model_ids:
+        prepared = llm._prepare_litellm_request_kwargs(
+            "glm",
+            model_id,
+            {"custom_llm_provider": "zai"},
+            {
+                "thinking": {"type": "enabled"},
+                "allowed_openai_params": ["tools"],
+                "extra_body": {
+                    "thinking": {"type": "enabled"},
+                    "custom_field": "keep",
+                },
+            },
+        )
+
+        assert prepared["thinking"] is None, model_id
+        assert prepared["extra_body"] == {
+            "thinking": {"type": "disabled"},
+            "custom_field": "keep",
+        }, model_id
+        assert prepared["allowed_openai_params"] == [
+            "tools",
+            "response_format",
+        ], model_id
+        assert "thinking" not in prepared["additional_drop_params"], model_id
+
+
+def test_zai_provider_patch_does_not_inject_thinking_for_legacy_models(
+    monkeypatch: object,
+) -> None:
+    monkeypatch.setattr(
+        llm,
+        "_litellm_minimum_thinking_params",
+        lambda *_args, **_kwargs: {},
+    )
+
+    for model_id in ("glm-4-flash", "GLM-4-FLASH-250414", "glm-5-future"):
+        prepared = llm._prepare_litellm_request_kwargs(
+            "glm",
+            model_id,
+            {"custom_llm_provider": "zai"},
+            {"response_format": {"type": "json_object"}},
+        )
+
+        assert "thinking" not in prepared, model_id
+        assert "extra_body" not in prepared, model_id
+        assert "additional_drop_params" not in prepared, model_id
+        assert prepared["allowed_openai_params"] == ["response_format"], model_id
+
+
+def test_ark_uses_litellm_thinking_and_provider_response_format_patch(
+    monkeypatch: object,
+) -> None:
+    monkeypatch.setattr(
+        llm,
+        "_litellm_minimum_thinking_params",
+        lambda *_args, **_kwargs: {"thinking": {"type": "disabled"}},
+    )
+
+    prepared = llm._prepare_litellm_request_kwargs(
+        "ark",
+        "doubao-seed",
+        {"custom_llm_provider": "volcengine"},
+        {
+            "thinking": {"type": "enabled"},
+            "additional_drop_params": ["extra_body", "caller_only"],
+            "extra_body": {
+                "thinking": {"type": "enabled"},
+                "custom_field": "keep",
+            },
+        },
+    )
+
+    assert prepared["thinking"] == {"type": "disabled"}
+    assert prepared["allowed_openai_params"] == ["response_format"]
+    assert prepared["extra_body"] == {"custom_field": "keep"}
+    assert "extra_body" not in prepared["additional_drop_params"]
+    assert "extra_body.thinking" not in prepared["additional_drop_params"]
+
+
+@pytest.mark.parametrize("model_id", ["ZHIPU/GLM-5.3", "zhipu/glm-5.3-FLASH"])
+def test_qwen_glm_exact_patch_wins_and_marks_conflicts_for_litellm(
+    monkeypatch: object, model_id: object
+) -> None:
+    monkeypatch.setattr(
+        llm,
+        "_litellm_minimum_thinking_params",
+        lambda *_args, **_kwargs: {"thinking": {"type": "disabled"}},
+    )
+
+    prepared = llm._prepare_litellm_request_kwargs(
+        "qwen",
+        str(model_id),
+        {"custom_llm_provider": "dashscope"},
+        {
+            "reasoning_effort": "high",
             "thinking": {"type": "enabled"},
             "enable_thinking": True,
-            "custom_field": "keep",
+            "allowed_openai_params": ["response_format"],
+            "additional_drop_params": ["caller_only"],
+            "extra_body": {
+                "enable_thinking": True,
+                "reasoning_effort": "max",
+                "custom_field": "keep",
+            },
         },
-    }
-
-    llm._apply_provider_params(
-        kwargs,
-        {"reasoning_effort": "none", "temperature": 0.4},
     )
 
-    assert kwargs == {
-        "reasoning_effort": "none",
-        "temperature": 0.4,
-        "extra_body": {"custom_field": "keep"},
-    }
+    assert prepared["reasoning_effort"] == "low"
+    assert prepared["temperature"] == 0.3
+    assert prepared["allowed_openai_params"] == [
+        "response_format",
+        "reasoning_effort",
+    ]
+    assert prepared["additional_drop_params"][:4] == [
+        "caller_only",
+        "enable_thinking",
+        "reasoning",
+        "thinking",
+    ]
+    assert "extra_body.reasoning_effort" in prepared["additional_drop_params"]
+    assert prepared["extra_body"]["custom_field"] == "keep"
+    assert "drop_params" not in prepared
+
+
+def test_gemini_uses_native_mapping_and_does_not_override_temperature(
+    monkeypatch: object,
+) -> None:
+    monkeypatch.setattr(
+        llm,
+        "_litellm_minimum_thinking_params",
+        lambda *_args, **_kwargs: {"reasoning_effort": "none"},
+    )
+
+    prepared = llm._prepare_litellm_request_kwargs(
+        "gemini",
+        "gemini-3.6-flash",
+        {"custom_llm_provider": "gemini"},
+        {
+            "reasoning_effort": "high",
+            "thinking": {"type": "enabled"},
+            "extra_body": {
+                "generationConfig": {
+                    "thinkingConfig": {"thinkingLevel": "high"},
+                    "topK": 8,
+                },
+                "custom_field": "keep",
+            },
+        },
+    )
+
+    assert prepared["reasoning_effort"] == "none"
+    assert "temperature" not in prepared
+    assert "thinking" in prepared["additional_drop_params"]
+    assert (
+        "extra_body.generationConfig.thinkingConfig"
+        in prepared["additional_drop_params"]
+    )
+    assert prepared["extra_body"]["custom_field"] == "keep"
 
 
 @pytest.mark.parametrize(
-    ("generation_config_key", "thinking_config_key", "top_k_key"),
+    ("model_id", "expected_effort", "expects_temperature"),
     [
-        ("generationConfig", "thinkingConfig", "topK"),
-        ("generation_config", "thinking_config", "top_k"),
+        ("gemini-3.7-flash", "low", False),
+        ("GEMINI-3.7-FLASH", "low", False),
+        ("gemini-2.5-pro", "minimal", True),
     ],
 )
-def test_gemini_thinking_policy_removes_nested_caller_override(
-    generation_config_key: object,
-    thinking_config_key: object,
-    top_k_key: object,
+def test_gemini_exact_minimum_patches(
+    monkeypatch: object,
+    model_id: object,
+    expected_effort: object,
+    expects_temperature: object,
 ) -> None:
-    kwargs = {
-        "extra_body": {
-            generation_config_key: {
-                thinking_config_key: {"thinkingLevel": "high"},
-                top_k_key: 8,
-            },
-            "custom_field": "keep",
-        },
-    }
-
-    llm._apply_provider_params(
-        kwargs,
-        llm._reload_gemini_params("gemini-3.6-flash", 0.4),
+    monkeypatch.setattr(
+        llm,
+        "_litellm_minimum_thinking_params",
+        lambda *_args, **_kwargs: {"reasoning_effort": "none"},
     )
 
-    assert kwargs == {
-        "temperature": 0.4,
-        "reasoning_effort": "none",
-        "allowed_openai_params": ["reasoning_effort"],
-        "extra_body": {
-            "generationConfig": {top_k_key: 8},
-            "custom_field": "keep",
-        },
-    }
+    prepared = llm._prepare_litellm_request_kwargs(
+        "gemini",
+        str(model_id),
+        {"custom_llm_provider": "gemini"},
+        {},
+    )
+
+    assert prepared["reasoning_effort"] == expected_effort
+    assert ("temperature" in prepared) is expects_temperature
+    assert "allowed_openai_params" not in prepared
 
 
-@pytest.mark.parametrize("generation_config_key", llm._GEMINI_GENERATION_CONFIG_KEYS)
-def test_gemini_thinking_policy_removes_invalid_native_config(
-    generation_config_key: object,
+@pytest.mark.parametrize(
+    ("model_id", "expected_effort"),
+    [
+        ("gpt-5-pro", "high"),
+        ("gpt-5-pro-2025-10-06", "high"),
+        ("gpt-5.2-pro", "medium"),
+        ("gpt-5.2-pro-2025-12-11", "medium"),
+        ("gpt-5.4-pro", "medium"),
+        ("gpt-5.4-pro-2026-03-05", "medium"),
+        ("gpt-5.5-pro", "medium"),
+        ("gpt-5.5-pro-2026-04-23", "medium"),
+    ],
+)
+def test_openai_pro_patches_correct_litellm_198_metadata(
+    monkeypatch: object, model_id: object, expected_effort: object
 ) -> None:
-    kwargs = {
-        "extra_body": {
-            generation_config_key: None,
-            "custom_field": "keep",
-        },
-    }
-
-    llm._apply_provider_params(
-        kwargs,
-        llm._reload_gemini_params("gemini-3.6-flash", 0.4),
+    monkeypatch.setattr(
+        llm,
+        "_litellm_minimum_thinking_params",
+        lambda *_args, **_kwargs: {"reasoning_effort": "minimal"},
     )
 
-    assert kwargs["extra_body"] == {"custom_field": "keep"}
-
-
-def test_gemini_thinking_policy_normalizes_generation_config_aliases() -> None:
-    kwargs = {
-        "extra_body": {
-            "generation_config": {
-                "thinking_config": {"thinking_level": "high"},
-                "top_k": 4,
-            },
-            "generationConfig": {
-                "thinkingConfig": {"thinkingLevel": "high"},
-                "topK": 8,
-            },
-        },
-    }
-
-    llm._apply_provider_params(
-        kwargs,
-        llm._reload_gemini_params("gemini-3.6-flash", 0.4),
+    prepared = llm._prepare_litellm_request_kwargs(
+        "openai",
+        str(model_id),
+        {"custom_llm_provider": "openai"},
+        {},
     )
 
-    assert kwargs["extra_body"] == {
-        "generationConfig": {
-            "top_k": 4,
-            "topK": 8,
-        },
-    }
+    assert prepared["reasoning_effort"] == expected_effort
+    assert "temperature" not in prepared
 
 
-def test_provider_thinking_policy_preserves_caller_extra_body_fields() -> None:
-    kwargs = {
-        "extra_body": {
-            "enable_thinking": True,
-            "custom_field": "keep",
-        },
-    }
-
-    llm._apply_provider_params(
-        kwargs,
-        llm._reload_qwen_params("qwen-max", 0.4),
+def test_explicit_temperature_is_preserved_for_strict_provider_validation(
+    monkeypatch: object,
+) -> None:
+    monkeypatch.setattr(
+        llm,
+        "_litellm_minimum_thinking_params",
+        lambda *_args, **_kwargs: {"reasoning_effort": "minimal"},
     )
 
-    assert kwargs == {
-        "temperature": 0.4,
-        "extra_body": {
-            "enable_thinking": False,
-            "custom_field": "keep",
-        },
-    }
-
-
-def test_qwen_glm_53_thinking_policy_removes_caller_conflicts() -> None:
-    kwargs = {
-        "reasoning_effort": "high",
-        "extra_body": {
-            "enable_thinking": False,
-            "reasoning_effort": "max",
-            "custom_field": "keep",
-        },
-    }
-
-    llm._apply_provider_params(
-        kwargs,
-        llm._reload_qwen_params("ZHIPU/GLM-5.3-Flash", 0.4),
+    prepared = llm._prepare_litellm_request_kwargs(
+        "openai",
+        "gpt-5-future",
+        {"custom_llm_provider": "openai"},
+        {"temperature": "0.3", "stop": ["done"]},
     )
 
-    assert kwargs == {
-        "temperature": 0.4,
-        "extra_body": {
-            "custom_field": "keep",
-            "reasoning_effort": "low",
-        },
-    }
+    assert prepared["temperature"] == 0.3
+    assert prepared["stop"] == ["done"]
+    assert "drop_params" not in prepared
 
 
 LITELLM_CONTRACT_VERSION = "1.98.0"
@@ -1055,13 +1227,17 @@ def _installed_litellm_version() -> str | None:
 def test_litellm_198_native_adapter_contracts() -> None:
     script = textwrap.dedent(
         """
+        import copy
         import importlib.metadata
         import json
 
         import httpx
         import litellm
+        from flaskr.api import llm as app_llm
+        from litellm.completion_extras.litellm_responses_transformation.transformation import LiteLLMResponsesTransformationHandler
         from openai import OpenAI
         from litellm.llms.custom_httpx.http_handler import HTTPHandler
+        from litellm.types.llms.openai import ResponsesAPIOptionalRequestParams
 
         messages = [{"role": "user", "content": "hello"}]
         sse_events = [
@@ -1151,7 +1327,6 @@ def test_litellm_198_native_adapter_contracts() -> None:
                     messages=messages,
                     stream=True,
                     stream_options={"include_usage": True},
-                    temperature=0.4,
                     **provider_kwargs,
                 )
             )
@@ -1177,73 +1352,213 @@ def test_litellm_198_native_adapter_contracts() -> None:
                 },
             }
 
+        def optional_params_error(**kwargs):
+            try:
+                litellm.get_optional_params(**kwargs)
+            except Exception as exc:
+                return type(exc).__name__
+            return None
+
+        def prepared(provider_key, provider, model, kwargs=None):
+            return app_llm._prepare_litellm_request_kwargs(
+                provider_key,
+                model,
+                {"custom_llm_provider": provider},
+                kwargs or {},
+            )
+
+        def openai_responses_reasoning_contract():
+            prepared_kwargs = prepared(
+                "openai",
+                "openai",
+                "gpt-5.2-pro",
+                {
+                    "reasoning": {"effort": "max"},
+                    "extra_body": {
+                        "reasoning": {"effort": "high"},
+                        "custom": "keep",
+                    },
+                },
+            )
+            optional_params = litellm.get_optional_params(
+                model="gpt-5.2-pro",
+                custom_llm_provider="openai",
+                **prepared_kwargs,
+            )
+            handler = LiteLLMResponsesTransformationHandler()
+            extracted = handler._extract_extra_body_params(
+                copy.deepcopy(optional_params)
+            )
+            request = ResponsesAPIOptionalRequestParams()
+            handler._map_optional_params_to_responses_api_request(extracted, request)
+            return {
+                "prepared": prepared_kwargs,
+                "optional": optional_params,
+                "request": request,
+            }
+
         contracts = {
             "version": importlib.metadata.version("litellm"),
             "deepseek": adapter_contract(
                 "deepseek",
                 "deepseek-v4-pro",
                 "https://api.deepseek.com",
-                {"reasoning_effort": "none"},
+                prepared("deepseek", "deepseek", "deepseek-v4-pro"),
             ),
             "dashscope": adapter_contract(
                 "dashscope",
                 "deepseek-v3",
                 "https://dashscope.aliyuncs.com/compatible-mode/v1",
-                {"extra_body": {"enable_thinking": False}},
+                prepared("qwen", "dashscope", "deepseek-v3"),
             ),
             "dashscope_glm_53": adapter_contract(
                 "dashscope",
                 "ZHIPU/GLM-5.3-Flash",
                 "https://dashscope.aliyuncs.com/compatible-mode/v1",
-                {
-                    "extra_body": {
-                        "reasoning_effort": "low",
-                    }
-                },
+                prepared(
+                    "qwen",
+                    "dashscope",
+                    "ZHIPU/GLM-5.3-Flash",
+                    {
+                        "reasoning_effort": "high",
+                        "enable_thinking": True,
+                        "extra_body": {
+                            "enable_thinking": True,
+                            "reasoning_effort": "max",
+                        },
+                    },
+                ),
             ),
             "volcengine": adapter_contract(
                 "volcengine",
                 "doubao-seed-2-0-lite-260428",
                 "https://ark.cn-beijing.volces.com/api/v3",
-                {
-                    "thinking": {"type": "disabled"},
-                    "allowed_openai_params": ["response_format"],
-                    "response_format": {"type": "json_object"},
-                },
+                prepared(
+                    "ark",
+                    "volcengine",
+                    "doubao-seed-2-0-lite-260428",
+                    {
+                        "thinking": {"type": "enabled"},
+                        "response_format": {"type": "json_object"},
+                        "additional_drop_params": ["extra_body"],
+                        "extra_body": {"thinking": {"type": "enabled"}},
+                    },
+                ),
             ),
             "zai": adapter_contract(
                 "zai",
                 "glm-5.2",
                 "https://open.bigmodel.cn/api/paas/v4",
-                {
-                    "extra_body": {"thinking": {"type": "disabled"}},
-                    "allowed_openai_params": ["thinking", "response_format"],
-                    "response_format": {"type": "json_object"},
-                },
+                prepared(
+                    "glm",
+                    "zai",
+                    "glm-5.2",
+                    {
+                        "thinking": {"type": "enabled"},
+                        "response_format": {"type": "json_object"},
+                        "additional_drop_params": ["extra_body"],
+                        "extra_body": {"thinking": {"type": "enabled"}},
+                    },
+                ),
             ),
+            "zai_native_thinking": adapter_contract(
+                "zai",
+                "glm-4.6",
+                "https://open.bigmodel.cn/api/paas/v4",
+                prepared(
+                    "glm",
+                    "zai",
+                    "glm-4.6",
+                    {
+                        "thinking": {"type": "enabled"},
+                        "extra_body": {"thinking": {"type": "enabled"}},
+                    },
+                ),
+            ),
+            "zai_legacy": adapter_contract(
+                "zai",
+                "glm-4-flash",
+                "https://open.bigmodel.cn/api/paas/v4",
+                prepared(
+                    "glm",
+                    "zai",
+                    "glm-4-flash",
+                    {"response_format": {"type": "json_object"}},
+                ),
+            ),
+            "zai_198_supported_params": {
+                model: litellm.get_supported_openai_params(
+                    model=model,
+                    custom_llm_provider="zai",
+                )
+                for model in ("glm-4.5", "glm-4.6", "glm-5.2")
+            },
             "gemini_3": litellm.get_optional_params(
                 model="gemini-3.6-flash",
                 custom_llm_provider="gemini",
-                reasoning_effort="none",
-                allowed_openai_params=["reasoning_effort"],
+                **prepared("gemini", "gemini", "gemini-3.6-flash"),
             ),
             "gemini_37_flash": litellm.get_optional_params(
                 model="gemini-3.7-flash",
                 custom_llm_provider="gemini",
-                reasoning_effort="low",
-                allowed_openai_params=["reasoning_effort"],
+                **prepared("gemini", "gemini", "gemini-3.7-flash"),
+            ),
+            "unpatched_gemini_37_flash": litellm.get_optional_params(
+                model="gemini-3.7-flash",
+                custom_llm_provider="gemini",
+                reasoning_effort="none",
             ),
             "gemini_25_pro": litellm.get_optional_params(
                 model="gemini-2.5-pro",
                 custom_llm_provider="gemini",
-                reasoning_effort="minimal",
-                allowed_openai_params=["reasoning_effort"],
+                **prepared("gemini", "gemini", "gemini-2.5-pro"),
             ),
             "gemini_25_flash": litellm.get_optional_params(
                 model="gemini-2.5-flash",
                 custom_llm_provider="gemini",
-                reasoning_effort="none",
-                allowed_openai_params=["reasoning_effort"],
+                **prepared("gemini", "gemini", "gemini-2.5-flash"),
+            ),
+            "unpatched_dashscope_glm_error": optional_params_error(
+                model="ZHIPU/GLM-5.3-Flash",
+                custom_llm_provider="dashscope",
+                reasoning_effort="low",
+            ),
+            "strict_openai_errors": {
+                name: optional_params_error(
+                    model="gpt-5-pro",
+                    custom_llm_provider="openai",
+                    reasoning_effort="high",
+                    **{name: value},
+                )
+                for name, value in {
+                    "temperature": 0.3,
+                    "stop": ["done"],
+                    "top_p": 0.9,
+                }.items()
+            },
+            "targeted_drop_still_strict": optional_params_error(
+                model="gpt-5-pro",
+                custom_llm_provider="openai",
+                reasoning_effort="high",
+                temperature=0.3,
+                stop=["done"],
+                additional_drop_params=["temperature"],
+            ),
+            "openai_pro": {
+                model: litellm.get_optional_params(
+                    model=model,
+                    custom_llm_provider="openai",
+                    **prepared("openai", "openai", model),
+                )
+                for model in (
+                    "gpt-5-pro",
+                    "gpt-5.2-pro",
+                    "gpt-5.4-pro",
+                    "gpt-5.5-pro",
+                )
+            },
+            "openai_responses_reasoning_conflict": (
+                openai_responses_reasoning_contract()
             ),
             "max_tokens": {
                 model: litellm.get_max_tokens(model)
@@ -1283,6 +1598,10 @@ def test_litellm_198_native_adapter_contracts() -> None:
         ),
         "volcengine": ("https://ark.cn-beijing.volces.com/api/v3/chat/completions"),
         "zai": "https://open.bigmodel.cn/api/paas/v4/chat/completions",
+        "zai_native_thinking": (
+            "https://open.bigmodel.cn/api/paas/v4/chat/completions"
+        ),
+        "zai_legacy": "https://open.bigmodel.cn/api/paas/v4/chat/completions",
     }
     for provider, expected_url in expected_urls.items():
         body = contracts[provider]["body"]
@@ -1305,6 +1624,12 @@ def test_litellm_198_native_adapter_contracts() -> None:
     assert contracts["volcengine"]["body"]["response_format"] == {"type": "json_object"}
     assert contracts["zai"]["body"]["thinking"] == {"type": "disabled"}
     assert contracts["zai"]["body"]["response_format"] == {"type": "json_object"}
+    assert contracts["zai_native_thinking"]["body"]["thinking"] == {"type": "disabled"}
+    assert "thinking" not in contracts["zai_legacy"]["body"]
+    assert contracts["zai_legacy"]["body"]["response_format"] == {"type": "json_object"}
+    assert "thinking" not in contracts["zai_198_supported_params"]["glm-4.5"]
+    assert "thinking" in contracts["zai_198_supported_params"]["glm-4.6"]
+    assert "thinking" not in contracts["zai_198_supported_params"]["glm-5.2"]
 
     assert contracts["gemini_3"]["thinkingConfig"] == {
         "thinkingLevel": "minimal",
@@ -1314,6 +1639,10 @@ def test_litellm_198_native_adapter_contracts() -> None:
         "thinkingLevel": "low",
         "includeThoughts": True,
     }
+    assert contracts["unpatched_gemini_37_flash"]["thinkingConfig"] == {
+        "thinkingLevel": "minimal",
+        "includeThoughts": False,
+    }
     assert contracts["gemini_25_pro"]["thinkingConfig"] == {
         "thinkingBudget": 128,
         "includeThoughts": True,
@@ -1322,6 +1651,33 @@ def test_litellm_198_native_adapter_contracts() -> None:
         "thinkingBudget": 0,
         "includeThoughts": False,
     }
+    assert contracts["unpatched_dashscope_glm_error"] == "UnsupportedParamsError"
+    assert contracts["strict_openai_errors"] == {
+        "temperature": "UnsupportedParamsError",
+        "stop": "UnsupportedParamsError",
+        "top_p": "UnsupportedParamsError",
+    }
+    assert contracts["targeted_drop_still_strict"] == "UnsupportedParamsError"
+    assert {
+        model: params["reasoning_effort"]
+        for model, params in contracts["openai_pro"].items()
+    } == {
+        "gpt-5-pro": "high",
+        "gpt-5.2-pro": "medium",
+        "gpt-5.4-pro": "medium",
+        "gpt-5.5-pro": "medium",
+    }
+    assert all(
+        "temperature" not in params for params in contracts["openai_pro"].values()
+    )
+    responses_contract = contracts["openai_responses_reasoning_conflict"]
+    assert responses_contract["request"]["reasoning"] == {"effort": "medium"}
+    assert responses_contract["optional"]["extra_body"] == {"custom": "keep"}
+    assert "reasoning" in responses_contract["prepared"]["additional_drop_params"]
+    assert (
+        "extra_body.reasoning"
+        in responses_contract["prepared"]["additional_drop_params"]
+    )
     assert contracts["max_tokens"] == {
         "gpt-5.6-luna": 128000,
         "gemini-3.6-flash": 65536,
@@ -1330,7 +1686,9 @@ def test_litellm_198_native_adapter_contracts() -> None:
     }
 
 
-def test_chat_llm_disables_deepseek_thinking(monkeypatch: object, app: object) -> None:
+def test_chat_llm_uses_shared_minimum_thinking_preparation(
+    monkeypatch: object, app: object
+) -> None:
     captured_kwargs = {}
 
     def fake_completion(*args: object, **kwargs: object) -> object:
@@ -1339,13 +1697,21 @@ def test_chat_llm_disables_deepseek_thinking(monkeypatch: object, app: object) -
         return iter([FakeResponse("chunk-1", content="Hi", finish_reason="stop")])
 
     monkeypatch.setattr(llm.litellm, "completion", fake_completion)
+    monkeypatch.setattr(
+        llm,
+        "_litellm_minimum_thinking_params",
+        lambda *_args, **_kwargs: {"reasoning_effort": "none"},
+    )
     provider_state = llm.ProviderState(
         enabled=True,
-        params={"api_key": "test-key", "api_base": "https://api.deepseek.com"},
+        params={
+            "api_key": "test-key",
+            "api_base": "https://api.deepseek.com",
+            "custom_llm_provider": "deepseek",
+        },
         models=["deepseek-v4-pro"],
         prefix="",
         wildcard_prefixes=(),
-        reload_params=llm._reload_deepseek_params,
     )
     monkeypatch.setattr(llm, "PROVIDER_STATES", {"deepseek": provider_state})
     monkeypatch.setattr(
@@ -1379,35 +1745,9 @@ def test_chat_llm_disables_deepseek_thinking(monkeypatch: object, app: object) -
 
     assert captured_kwargs["kwargs"]["temperature"] == 0.7
     assert captured_kwargs["kwargs"]["reasoning_effort"] == "none"
-    assert "thinking" not in captured_kwargs["kwargs"]
-    assert captured_kwargs["kwargs"]["extra_body"] == {"custom_field": "keep"}
-
-
-def test_gemini_3_params_use_none_with_explicit_allowlist() -> None:
-    params = llm._reload_gemini_params("gemini-3.1-flash-lite", 0.3)
-
-    assert params == {
-        "temperature": 0.3,
-        "allowed_openai_params": ["reasoning_effort"],
-        "reasoning_effort": "none",
-    }
-
-
-def test_gemini_37_flash_params_use_lowest_supported_reasoning() -> None:
-    params = llm._reload_gemini_params("gemini-3.7-flash", 0.3)
-
-    assert params == {
-        "temperature": 0.3,
-        "allowed_openai_params": ["reasoning_effort"],
-        "reasoning_effort": "low",
-    }
-
-
-def test_gemini_25_pro_params_use_lowest_supported_reasoning() -> None:
-    params = llm._reload_gemini_params("gemini-2.5-pro", 0.3)
-
-    assert params["allowed_openai_params"] == ["reasoning_effort"]
-    assert params["reasoning_effort"] == "minimal"
+    assert "thinking" in captured_kwargs["kwargs"]["additional_drop_params"]
+    assert "extra_body.thinking" in captured_kwargs["kwargs"]["additional_drop_params"]
+    assert captured_kwargs["kwargs"]["extra_body"]["custom_field"] == "keep"
 
 
 def test_invoke_llm_uses_actual_model_for_provider_params(
@@ -1415,9 +1755,10 @@ def test_invoke_llm_uses_actual_model_for_provider_params(
 ) -> None:
     captured = {}
 
-    def reload_params(model_id: object, temperature: object) -> object:
-        captured["reload_model"] = model_id
-        return {"temperature": temperature}
+    def minimum_thinking_params(model_id: object, provider: object) -> object:
+        captured["prepared_model"] = model_id
+        captured["prepared_provider"] = provider
+        return {}
 
     def fake_completion(model: object, *args: object, **kwargs: object) -> object:
         _ = args
@@ -1426,6 +1767,11 @@ def test_invoke_llm_uses_actual_model_for_provider_params(
         return iter([FakeResponse("chunk-1", content="ok", finish_reason="stop")])
 
     monkeypatch.setattr(llm.litellm, "completion", fake_completion)
+    monkeypatch.setattr(
+        llm,
+        "_litellm_minimum_thinking_params",
+        minimum_thinking_params,
+    )
     monkeypatch.setattr(llm, "record_llm_usage", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         llm,
@@ -1433,9 +1779,11 @@ def test_invoke_llm_uses_actual_model_for_provider_params(
         {
             "test": llm.ProviderState(
                 enabled=True,
-                params={"api_key": "test-key"},
+                params={
+                    "api_key": "test-key",
+                    "custom_llm_provider": "test-adapter",
+                },
                 models=["display-model"],
-                reload_params=reload_params,
             )
         },
     )
@@ -1459,7 +1807,8 @@ def test_invoke_llm_uses_actual_model_for_provider_params(
     )
 
     assert [response.result for response in responses] == ["ok"]
-    assert captured["reload_model"] == "actual-model"
+    assert captured["prepared_model"] == "actual-model"
+    assert captured["prepared_provider"] == "test-adapter"
     assert captured["completion_model"] == "actual-model"
     assert captured["completion_kwargs"]["temperature"] == 0.4
 

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -874,7 +874,6 @@ def test_qwen_glm_53_params_use_lowest_supported_reasoning(model_id: object) -> 
     assert llm._reload_qwen_params(model_id, 0.4) == {
         "temperature": 0.4,
         "extra_body": {
-            "enable_thinking": True,
             "reasoning_effort": "low",
         },
     }
@@ -1029,7 +1028,6 @@ def test_qwen_glm_53_thinking_policy_removes_caller_conflicts() -> None:
         "temperature": 0.4,
         "extra_body": {
             "custom_field": "keep",
-            "enable_thinking": True,
             "reasoning_effort": "low",
         },
     }
@@ -1199,7 +1197,6 @@ def test_litellm_198_native_adapter_contracts() -> None:
                 "https://dashscope.aliyuncs.com/compatible-mode/v1",
                 {
                     "extra_body": {
-                        "enable_thinking": True,
                         "reasoning_effort": "low",
                     }
                 },
@@ -1302,7 +1299,7 @@ def test_litellm_198_native_adapter_contracts() -> None:
 
     assert contracts["deepseek"]["body"]["thinking"] == {"type": "disabled"}
     assert contracts["dashscope"]["body"]["enable_thinking"] is False
-    assert contracts["dashscope_glm_53"]["body"]["enable_thinking"] is True
+    assert "enable_thinking" not in contracts["dashscope_glm_53"]["body"]
     assert contracts["dashscope_glm_53"]["body"]["reasoning_effort"] == "low"
     assert contracts["volcengine"]["body"]["thinking"] == {"type": "disabled"}
     assert contracts["volcengine"]["body"]["response_format"] == {"type": "json_object"}

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -866,6 +866,20 @@ def test_provider_specific_thinking_params_remain_compatible() -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    "model_id",
+    ["ZHIPU/GLM-5.3", "ZHIPU/GLM-5.3-Flash"],
+)
+def test_qwen_glm_53_params_use_lowest_supported_reasoning(model_id: object) -> None:
+    assert llm._reload_qwen_params(model_id, 0.4) == {
+        "temperature": 0.4,
+        "extra_body": {
+            "enable_thinking": True,
+            "reasoning_effort": "low",
+        },
+    }
+
+
 def test_provider_thinking_policy_removes_caller_conflicts() -> None:
     kwargs = {
         "reasoning_effort": "high",
@@ -992,6 +1006,31 @@ def test_provider_thinking_policy_preserves_caller_extra_body_fields() -> None:
         "extra_body": {
             "enable_thinking": False,
             "custom_field": "keep",
+        },
+    }
+
+
+def test_qwen_glm_53_thinking_policy_removes_caller_conflicts() -> None:
+    kwargs = {
+        "reasoning_effort": "high",
+        "extra_body": {
+            "enable_thinking": False,
+            "reasoning_effort": "max",
+            "custom_field": "keep",
+        },
+    }
+
+    llm._apply_provider_params(
+        kwargs,
+        llm._reload_qwen_params("ZHIPU/GLM-5.3-Flash", 0.4),
+    )
+
+    assert kwargs == {
+        "temperature": 0.4,
+        "extra_body": {
+            "custom_field": "keep",
+            "enable_thinking": True,
+            "reasoning_effort": "low",
         },
     }
 
@@ -1154,6 +1193,17 @@ def test_litellm_198_native_adapter_contracts() -> None:
                 "https://dashscope.aliyuncs.com/compatible-mode/v1",
                 {"extra_body": {"enable_thinking": False}},
             ),
+            "dashscope_glm_53": adapter_contract(
+                "dashscope",
+                "ZHIPU/GLM-5.3-Flash",
+                "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                {
+                    "extra_body": {
+                        "enable_thinking": True,
+                        "reasoning_effort": "low",
+                    }
+                },
+            ),
             "volcengine": adapter_contract(
                 "volcengine",
                 "doubao-seed-2-0-lite-260428",
@@ -1178,6 +1228,12 @@ def test_litellm_198_native_adapter_contracts() -> None:
                 model="gemini-3.6-flash",
                 custom_llm_provider="gemini",
                 reasoning_effort="none",
+                allowed_openai_params=["reasoning_effort"],
+            ),
+            "gemini_37_flash": litellm.get_optional_params(
+                model="gemini-3.7-flash",
+                custom_llm_provider="gemini",
+                reasoning_effort="low",
                 allowed_openai_params=["reasoning_effort"],
             ),
             "gemini_25_pro": litellm.get_optional_params(
@@ -1225,6 +1281,9 @@ def test_litellm_198_native_adapter_contracts() -> None:
         "dashscope": (
             "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
         ),
+        "dashscope_glm_53": (
+            "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+        ),
         "volcengine": ("https://ark.cn-beijing.volces.com/api/v3/chat/completions"),
         "zai": "https://open.bigmodel.cn/api/paas/v4/chat/completions",
     }
@@ -1243,6 +1302,8 @@ def test_litellm_198_native_adapter_contracts() -> None:
 
     assert contracts["deepseek"]["body"]["thinking"] == {"type": "disabled"}
     assert contracts["dashscope"]["body"]["enable_thinking"] is False
+    assert contracts["dashscope_glm_53"]["body"]["enable_thinking"] is True
+    assert contracts["dashscope_glm_53"]["body"]["reasoning_effort"] == "low"
     assert contracts["volcengine"]["body"]["thinking"] == {"type": "disabled"}
     assert contracts["volcengine"]["body"]["response_format"] == {"type": "json_object"}
     assert contracts["zai"]["body"]["thinking"] == {"type": "disabled"}
@@ -1251,6 +1312,10 @@ def test_litellm_198_native_adapter_contracts() -> None:
     assert contracts["gemini_3"]["thinkingConfig"] == {
         "thinkingLevel": "minimal",
         "includeThoughts": False,
+    }
+    assert contracts["gemini_37_flash"]["thinkingConfig"] == {
+        "thinkingLevel": "low",
+        "includeThoughts": True,
     }
     assert contracts["gemini_25_pro"]["thinkingConfig"] == {
         "thinkingBudget": 128,
@@ -1328,6 +1393,16 @@ def test_gemini_3_params_use_none_with_explicit_allowlist() -> None:
         "temperature": 0.3,
         "allowed_openai_params": ["reasoning_effort"],
         "reasoning_effort": "none",
+    }
+
+
+def test_gemini_37_flash_params_use_lowest_supported_reasoning() -> None:
+    params = llm._reload_gemini_params("gemini-3.7-flash", 0.3)
+
+    assert params == {
+        "temperature": 0.3,
+        "allowed_openai_params": ["reasoning_effort"],
+        "reasoning_effort": "low",
     }
 
 


### PR DESCRIPTION
## Summary

- replace provider `reload_params` callbacks and the proposed policy DSL with one `_prepare_litellm_request_kwargs()` path shared by `invoke_llm()` and `chat_llm()`
- use LiteLLM 1.98.0 capabilities and native `reasoning_effort` / `thinking` mappings for the normal path; keep only confirmed gaps in a flat, versioned provider-wide then exact-model table
- enforce the product minimum against caller `reasoning`, `thinking`, and vendor-control conflicts with targeted `additional_drop_params`, without enabling global `drop_params=True`
- keep DashScope `ZHIPU/GLM-5.3(-Flash)` and exact `gemini-3.7-flash` at `reasoning_effort=low`, without hard-setting `enable_thinking=true` for GLM
- limit ZAI's `thinking.disabled` compatibility fix to the 13 exact GLM-4.5+ model IDs that support that request field, leaving legacy, snapshot, and future IDs untouched

## Why

LiteLLM already owns provider capability detection and most native request mappings. Keeping parallel provider callbacks—or a custom selector/merge DSL—duplicates that behavior and makes future exceptions harder to remove.

Most models now need no application patch. Confirmed LiteLLM 1.98.0 gaps are concentrated in `_LITELLM_198_COMPATIBILITY_PATCHES`, keyed only by provider default or case-insensitive exact model ID. Scalar values merge shallowly, allow/drop lists use stable ordered union, and `extra_body` merges one level with patch values winning.

The compatibility table covers ordinary Qwen/SiliconFlow, Ark, ZAI, Qwen-hosted GLM-5.3, Gemini 3.7 Flash and 2.5 Pro, plus documented OpenAI Pro minimum efforts. Automatic `temperature=0.3` is omitted for Gemini 3 and OpenAI reasoning models that reject sampling temperature; explicit incompatible values remain strict provider errors.

- [Gemini 3.7 Flash](https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash)
- [GPT-5 Pro](https://developers.openai.com/api/docs/models/gpt-5-pro)
- [GPT-5.4 Pro](https://developers.openai.com/api/docs/models/gpt-5.4-pro)

## Tests

- `tests/test_llm.py` against LiteLLM 1.98.0 — 70 passed
- full backend suite — 3602 passed, 17 skipped
- real adapter/wire contracts for DashScope GLM, Gemini, DeepSeek, Ark, ZAI, OpenAI Pro, and the completion-to-Responses reasoning bridge
- `ruff check .` and `ruff format --check .`
- `lefthook run pre-commit --all-files`
- `python3 scripts/check_repo_harness.py`
- `python3 scripts/check_architecture_boundaries.py` — 133 baseline, 0 new violations
- `python3 scripts/check_dev_tools.py`
- `git diff --check`

## Rollback

Revert `3666f973e` to restore the provider-specific reload implementation while retaining the two focused GLM/Gemini fixes. Revert the full PR to restore the prior minimum-thinking behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every routed LLM request sets reasoning/thinking and sampling defaults across providers; regressions would affect model behavior or billing-adjacent invocations, though public APIs are unchanged and coverage is extensive.
> 
> **Overview**
> Replaces per-provider **`reload_params`** callbacks with a single **`_prepare_litellm_request_kwargs`** path used by **`invoke_llm`** and **`chat_llm`**. Minimum reasoning/thinking now comes from LiteLLM 1.98.0 capabilities (`get_supported_openai_params`, `get_model_info`), with a flat **`_LITELLM_198_COMPATIBILITY_PATCHES`** table only for confirmed adapter gaps (Qwen/Silicon `enable_thinking`, ZAI `extra_body.thinking`, DashScope GLM-5.3 `reasoning_effort=low`, Gemini 3.7 Flash / 2.5 Pro, OpenAI Pro documented minimums).
> 
> Caller overrides are blocked via targeted **`additional_drop_params`** (including OpenAI Responses **`reasoning`** promotion), without global **`drop_params=True`**. Default **`temperature=0.3`** is skipped for Gemini 3 and OpenAI non-`none` reasoning so native defaults and strict validation stay intact.
> 
> **`test_llm.py`** is reworked around capability matrices, conflict/drop overlap rules, and a subprocess contract pinned to LiteLLM **1.98.0**. Documentation adds the completed exec plan and regenerates harness inventory counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e82a3bc73cc1b20eb1f9f30af30bc4b2621b1a3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added low reasoning-effort support for Gemini 3.7 Flash.
  * Added optimized reasoning configuration for ZHIPU GLM-5.3 and GLM-5.3 Flash.
  * Added consistent minimum-thinking behavior across supported providers and models.
* **Bug Fixes**
  * Improved capitalization-independent model matching.
  * Prevented conflicting reasoning parameters from being sent to providers.
  * Ensured appropriate default temperature handling across supported models.
* **Tests**
  * Expanded coverage for model configurations, request payloads, and reasoning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
