### PR TITLE
chore: upgrade LiteLLM to latest stable

### DIFF
--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -750,8 +750,8 @@ def _reload_ark_params(model_id: str, temperature: float) -> dict[str, object]:
     return {
         "temperature": temperature,
         "thinking": {"type": "disabled"},
-        # The follow-up flow relies on JSON mode, but LiteLLM 1.95 omits this
-        # supported Volcengine parameter from its adapter metadata.
+        # The follow-up flow relies on JSON mode; explicitly allow this
+        # Volcengine parameter through the shared adapter boundary.
         "allowed_openai_params": ["response_format"],
     }
 
@@ -802,9 +802,8 @@ def _reload_glm_params(model_id: str, temperature: float) -> dict[str, object]:
     }
     if model_id.lower().startswith(_GLM_THINKING_MODEL_PREFIXES):
         params["allowed_openai_params"].append("thinking")
-        # ZAI still sends chat completions through the OpenAI SDK in LiteLLM
-        # 1.95.0. Keep thinking in extra_body so the SDK forwards it instead
-        # of rejecting the vendor-specific argument before the request is sent.
+        # Keep thinking in extra_body so the OpenAI-compatible SDK forwards the
+        # vendor-specific argument instead of rejecting it before the request.
         params["extra_body"] = {"thinking": {"type": "disabled"}}
     return params
 

--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -110,7 +110,7 @@ sympy==1.13.1
 tenacity==8.5.0
 tqdm==4.66.4
 typing-inspect==0.9.0
-typing_extensions==4.12.2
+typing_extensions==4.16.0
 tzdata==2025.2
 ujson==5.13.0
 urllib3==2.7.0

--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -66,7 +66,7 @@ mistune==3.2.1
 mpmath==1.3.0
 mypy-extensions==1.0.0
 nodeenv==1.9.1
-litellm==1.95.0
+litellm==1.98.0
 openpyxl==3.1.5
 opentelemetry-api==1.36.0
 opentelemetry-exporter-otlp-proto-http==1.36.0
@@ -84,7 +84,7 @@ protobuf==6.33.5
 pycryptodome==3.20.0
 pycryptodomex==3.20.0
 pydantic==2.10.6
-pydantic-settings==2.6.1
+pydantic-settings==2.15.0
 pydantic_core==2.27.2
 PyJWT==2.13.0
 PyMySQL==1.1.1

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -996,7 +996,7 @@ def test_provider_thinking_policy_preserves_caller_extra_body_fields() -> None:
     }
 
 
-LITELLM_CONTRACT_VERSION = "1.95.0"
+LITELLM_CONTRACT_VERSION = "1.98.0"
 
 
 def _installed_litellm_version() -> str | None:
@@ -1015,7 +1015,7 @@ def _installed_litellm_version() -> str | None:
         "install requirements.txt to run it"
     ),
 )
-def test_litellm_195_native_adapter_contracts() -> None:
+def test_litellm_198_native_adapter_contracts() -> None:
     script = textwrap.dedent(
         """
         import importlib.metadata
@@ -1218,7 +1218,7 @@ def test_litellm_195_native_adapter_contracts() -> None:
 
     assert completed.returncode == 0, completed.stdout + completed.stderr
     contracts = json.loads(completed.stdout.strip().splitlines()[-1])
-    assert contracts["version"] == "1.95.0"
+    assert contracts["version"] == "1.98.0"
 
     expected_urls = {
         "deepseek": "https://api.deepseek.com/chat/completions",
@@ -1263,8 +1263,8 @@ def test_litellm_195_native_adapter_contracts() -> None:
     assert contracts["max_tokens"] == {
         "gpt-5.6-luna": 128000,
         "gemini-3.6-flash": 65536,
-        "deepseek-v4-pro": 8192,
-        "deepseek-v4-flash": 8192,
+        "deepseek-v4-pro": 393216,
+        "deepseek-v4-flash": 393216,
     }
 
 


### PR DESCRIPTION
## Summary

- Upgrade LiteLLM from 1.95.0 to 1.98.0.
- Align pydantic-settings with LiteLLM 1.98.0 requirements.
- Pin typing_extensions 4.16.0 so LiteLLM's PEP 728 TypedDict definitions import on Python 3.11.
- Refresh the native adapter contract for the updated DeepSeek v4 token metadata.

## Verification

- `pytest tests/test_openai.py tests/test_llm.py -q --disable-warnings` — 65 passed.
- Application LLM module import verified on Python 3.11 with LiteLLM 1.98.0.
- `python scripts/check_dev_tools.py` — core toolchain passed.
- Commit hooks — architecture, translation, Ruff, formatting, and commit validation passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency upgrade touches all LLM routing via LiteLLM; contract tests mitigate adapter regressions, but production behavior can still shift with provider adapters and token limits.
> 
> **Overview**
> Bumps **LiteLLM** from `1.95.0` to `1.98.0` and pulls in **`pydantic-settings` 2.15.0** and **`typing_extensions` 4.16.0** so the stack installs cleanly on Python 3.11 (PEP 728 TypedDict support for LiteLLM).
> 
> Provider reload helpers for **Volcengine (ark)** and **GLM (ZAI)** keep the same behavior (`allowed_openai_params` for JSON mode, `extra_body` for disabled thinking); only inline comments are updated to describe the adapter boundary without pinning to 1.95.
> 
> The **native adapter contract test** is retargeted to 1.98.0 and now expects LiteLLM’s bundled **DeepSeek v4** `max_output_tokens` metadata at **393216** (was 8192), so CI catches adapter/request-shape drift on upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b9440bb78bce91cbf5bbae86152bf3d9fb4dbfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->