### PR TITLE
fix: keep listen mode overlays stable when controls hide

### DIFF
--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -49,7 +49,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "0.2.21",
+        "markdown-flow-ui": "0.2.22",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -3231,6 +3231,7 @@
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3270,6 +3271,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3290,6 +3292,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3310,6 +3313,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3330,6 +3334,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3350,6 +3355,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3370,6 +3376,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3390,6 +3397,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3410,6 +3418,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3430,6 +3439,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3450,6 +3460,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3470,6 +3481,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3490,6 +3502,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3510,6 +3523,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3525,6 +3539,7 @@
     },
     "node_modules/@parcel/watcher/node_modules/detect-libc": {
       "version": "1.0.3",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -7142,7 +7157,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -9807,7 +9822,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -10920,7 +10935,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10975,7 +10990,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -11005,7 +11020,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -13290,9 +13305,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.2.21",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.21.tgz",
-      "integrity": "sha512-jKtAeDt+QM81pkIDTpJZyRNwog5+b/jDnr+2PVsst5Nm5elzqFPfQdnKEK6llV9W8JNkTeFJXGr6UFjUBdPL4A==",
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.22.tgz",
+      "integrity": "sha512-r6qVlYu7wJprr69emSDxWmXGmDVN6iO14BEXJ+7oaPLW68lNIVGmBHsHTBBsseSibBCG2Ak6Xz2lp70UEGuS8g==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",
@@ -14730,7 +14745,7 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -15012,6 +15027,7 @@
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -15403,7 +15419,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -17563,7 +17579,7 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -3231,7 +3231,6 @@
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3271,7 +3270,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3292,7 +3290,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3313,7 +3310,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3334,7 +3330,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3355,7 +3350,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3376,7 +3370,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3397,7 +3390,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3418,7 +3410,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3439,7 +3430,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3460,7 +3450,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3481,7 +3470,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3502,7 +3490,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3523,7 +3510,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3539,7 +3525,6 @@
     },
     "node_modules/@parcel/watcher/node_modules/detect-libc": {
       "version": "1.0.3",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -7157,7 +7142,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -9822,7 +9807,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -10935,7 +10920,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10990,7 +10975,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -11020,7 +11005,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -14745,7 +14730,7 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -15027,7 +15012,6 @@
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -15419,7 +15403,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -17579,7 +17563,7 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -68,7 +68,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "0.2.21",
+    "markdown-flow-ui": "0.2.22",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",


### PR DESCRIPTION
Changed:
Pinned markdown-flow-ui from 0.2.21 to 0.2.22 and refreshed only the matching lockfile entries. Verified dependency installation, type checking, linting, and the focused listen-mode renderer tests.

Benefit:
Subtitles and built-in interaction overlays keep stable positions when player controls hide or reappear.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only patch bump with no local code changes; risk is limited to third-party listen-mode rendering behavior.
> 
> **Overview**
> **Bumps `markdown-flow-ui` from `0.2.21` to `0.2.22`** in `src/web/package.json` and the matching `package-lock.json` entries—no application code changes in this repo.
> 
> The upgrade pulls in upstream fixes so **listen-mode subtitles and built-in interaction overlays stay positioned** when player chrome hides or reappears, instead of jumping with the control bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b380b528875a6abc84e21cfbcdf573e5fd431763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Markdown rendering component to the latest available version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->