### PR TITLE
fix: keep listen mode follow-ups stable

### DIFF
--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
@@ -208,22 +208,6 @@
       flex: 1 1 auto;
       padding: 0 !important;
     }
-
-    &.listenModeWithPlayer {
-      .chatComponents {
-        :global(
-          .listen-reveal-wrapper.mobile .listen-slide-root .slide-stage__content
-        ) {
-          min-height: 100%;
-        }
-
-        :global(
-          .listen-reveal-wrapper.mobile .listen-slide-root .slide-stage__layer
-        ) {
-          padding-bottom: 0;
-        }
-      }
-    }
   }
 
   .chatComponents {

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.tsx
@@ -104,7 +104,6 @@ export const ChatUi = ({
   const isSlideMode = isListenMode || isClassroomMode;
   const showHeader = frameLayout !== FRAME_LAYOUT_MOBILE;
   const footerSeparator = String.fromCharCode(124);
-  const [isListenPlayerVisible, setIsListenPlayerVisible] = useState(false);
   const [showLessonUpdateNoticeInHeader, setShowLessonUpdateNoticeInHeader] =
     useState(false);
   const [lessonPdfDownloadAction, setLessonPdfDownloadAction] =
@@ -121,12 +120,6 @@ export const ChatUi = ({
     },
     [onLessonUpdateNoticeVisibilityChange],
   );
-
-  useEffect(() => {
-    if (!isSlideMode) {
-      setIsListenPlayerVisible(false);
-    }
-  }, [isSlideMode]);
 
   useEffect(() => {
     setShowLessonUpdateNoticeInHeader(false);
@@ -151,12 +144,6 @@ export const ChatUi = ({
           : '',
         isSlideMode ? styles.listenMode : '',
         isClassroomMode ? styles.classroomMode : '',
-        isListenMode && isListenPlayerVisible
-          ? styles.listenModeWithPlayer
-          : '',
-        isSlideMode && !isListenPlayerVisible
-          ? styles.listenModeWithoutPlayer
-          : '',
         hideMobileFooter ? styles.hideMobileFooter : '',
       )}
     >
@@ -241,7 +228,6 @@ export const ChatUi = ({
           getNextLessonId={getNextLessonId}
           isNavOpen={isNavOpen}
           onListenMobileViewModeChange={onListenMobileViewModeChange}
-          onListenPlayerVisibilityChange={setIsListenPlayerVisible}
           showGenerateBtn={showGenerateBtn}
           onLessonUpdateNoticeVisibilityChange={
             handleLessonUpdateNoticeVisibilityChange

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRenderer.scss
@@ -594,10 +594,6 @@
   );
 }
 
-.slide-ask-overlay--standalone {
-  bottom: var(--slide-player-bottom-offset);
-}
-
 .slide-player__ask-card {
   position: relative;
   overflow: hidden;
@@ -679,6 +675,16 @@
 .listen-reveal-wrapper.mobile {
   min-width: 0;
   max-width: 100%;
+
+  &.listen-reveal-wrapper--with-player {
+    .listen-slide-root .slide-stage__content {
+      min-height: 100%;
+    }
+
+    .listen-slide-root .slide-stage__layer {
+      padding-bottom: 0;
+    }
+  }
 
   .listen-slide-shell {
     display: flex;
@@ -794,13 +800,6 @@
     width: 44px !important;
     min-width: 44px;
     padding: 0;
-  }
-
-  .listen-slide-root .slide-ask-overlay--with-player {
-  }
-
-  .listen-slide-root .slide-ask-overlay--standalone {
-    bottom: 52px;
   }
 }
 

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRendererStyles.test.ts
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRendererStyles.test.ts
@@ -1,12 +1,12 @@
 import { readFileSync } from 'fs';
 import path from 'path';
 
+const readStylesheet = () =>
+  readFileSync(path.join(__dirname, 'ListenModeRenderer.scss'), 'utf8');
+
 describe('ListenModeRenderer styles', () => {
   it('keeps mobile landscape interaction overlays compatible with slide drag offsets', () => {
-    const stylesheet = readFileSync(
-      path.join(__dirname, 'ListenModeRenderer.scss'),
-      'utf8',
-    );
+    const stylesheet = readStylesheet();
     const ruleMatch = stylesheet.match(
       /\.listen-reveal-wrapper\.mobile\s+\.listen-slide-root--landscape\.slide--mobile-landscape\s+\.slide-interaction-overlay\s*\{([^}]+)\}/,
     );
@@ -16,5 +16,18 @@ describe('ListenModeRenderer styles', () => {
     expect(ruleBody).toContain('var(--slide-interaction-drag-x, 0px)');
     expect(ruleBody).toContain('var(--slide-interaction-drag-y, 0px)');
     expect(ruleBody).not.toContain('transform: none');
+  });
+
+  it('keeps host-managed ask and mobile layouts on reserved player space', () => {
+    const stylesheet = readStylesheet();
+    const askRuleMatch = stylesheet.match(
+      /\.slide-ask-overlay--with-player\s*\{([^}]+)\}/,
+    );
+    const askRuleBody = askRuleMatch?.[1];
+
+    expect(askRuleBody).toBeDefined();
+    expect(askRuleBody).toContain('var(--slide-player-height)');
+    expect(stylesheet).toContain('&.listen-reveal-wrapper--with-player');
+    expect(stylesheet).not.toContain('.slide-ask-overlay--standalone');
   });
 });

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -60,15 +60,16 @@ jest.mock('next/image', () => ({
 
 jest.mock('markdown-flow-ui/slide', () => {
   const ReactRuntime = jest.requireActual('react') as typeof React;
-  const slideCustomActionContext = {
-    currentElement: {
-      blockBid: 'content-1',
-      type: 'content',
-    },
-    currentIndex: 0,
-    isActive: false,
-    setActive: jest.fn(),
-    toggleActive: jest.fn(),
+  const slideCustomActionElement = {
+    blockBid: 'content-1',
+    type: 'content',
+  };
+  type SlideCustomActionContext = {
+    currentElement: typeof slideCustomActionElement;
+    currentIndex: number;
+    isActive: boolean;
+    setActive: (active: boolean) => void;
+    toggleActive: () => void;
   };
 
   return {
@@ -76,10 +77,25 @@ jest.mock('markdown-flow-ui/slide', () => {
       (props: {
         playerClassName?: string;
         fullscreenHeader?: { content?: React.ReactNode };
+        onPlayerVisibilityChange?: (visible: boolean) => void;
         playerCustomActions?:
           | React.ReactNode
-          | ((context: typeof slideCustomActionContext) => React.ReactNode);
+          | ((context: SlideCustomActionContext) => React.ReactNode);
       }) => {
+        const [isActive, setIsActive] = ReactRuntime.useState(false);
+        const toggleActive = ReactRuntime.useCallback(() => {
+          setIsActive(currentActive => !currentActive);
+        }, []);
+        const slideCustomActionContext = ReactRuntime.useMemo(
+          () => ({
+            currentElement: slideCustomActionElement,
+            currentIndex: 0,
+            isActive,
+            setActive: setIsActive,
+            toggleActive,
+          }),
+          [isActive, toggleActive],
+        );
         const mountId = ReactRuntime.useMemo(() => {
           mockSlideMountId += 1;
           return mockSlideMountId;
@@ -370,6 +386,104 @@ describe('ListenModeSlideRenderer', () => {
 
     expect(playerClassTokens).toContain('listen-slide-player');
     expect(playerClassTokens).not.toContain('classroom-slide-player');
+  });
+
+  it('keeps the desktop ask overlay above reserved player space when controls hide', async () => {
+    const onPlayerVisibilityChange = jest.fn();
+    const { container } = render(
+      <ListenModeSlideRenderer
+        items={[
+          {
+            type: 'content',
+            content: 'Hello',
+            element_bid: 'content-1',
+            is_speakable: true,
+          },
+        ]}
+        mobileStyle={false}
+        chatRef={createChatRef()}
+        onPlayerVisibilityChange={onPlayerVisibilityChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'module.chat.ask' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ask-block')).toHaveAttribute(
+        'data-expanded',
+        'true',
+      );
+    });
+
+    const askOverlay = container.querySelector('.slide-ask-overlay');
+    expect(askOverlay).toHaveClass('slide-ask-overlay--with-player');
+    expect(askOverlay).not.toHaveClass('slide-ask-overlay--standalone');
+
+    const slideCalls = getMockSlide().mock.calls;
+    const slideProps = slideCalls[slideCalls.length - 1]?.[0] as
+      | { onPlayerVisibilityChange?: (visible: boolean) => void }
+      | undefined;
+
+    act(() => {
+      slideProps?.onPlayerVisibilityChange?.(false);
+    });
+
+    expect(onPlayerVisibilityChange).toHaveBeenLastCalledWith(false);
+    expect(askOverlay).toHaveClass('slide-ask-overlay--with-player');
+    expect(askOverlay).not.toHaveClass('slide-ask-overlay--standalone');
+  });
+
+  it('keeps the mobile slide layout reserved when controls hide', () => {
+    const onPlayerVisibilityChange = jest.fn();
+    const { container } = render(
+      <ListenModeSlideRenderer
+        items={[
+          {
+            type: 'content',
+            content: 'Hello',
+            element_bid: 'content-1',
+            is_speakable: true,
+          },
+        ]}
+        mobileStyle={true}
+        chatRef={createChatRef()}
+        onPlayerVisibilityChange={onPlayerVisibilityChange}
+      />,
+    );
+
+    const revealWrapper = container.querySelector('.listen-reveal-wrapper');
+    expect(revealWrapper).toHaveClass('listen-reveal-wrapper--with-player');
+
+    const slideCalls = getMockSlide().mock.calls;
+    const slideProps = slideCalls[slideCalls.length - 1]?.[0] as
+      | { onPlayerVisibilityChange?: (visible: boolean) => void }
+      | undefined;
+
+    act(() => {
+      slideProps?.onPlayerVisibilityChange?.(false);
+    });
+
+    expect(onPlayerVisibilityChange).toHaveBeenLastCalledWith(false);
+    expect(revealWrapper).toHaveClass('listen-reveal-wrapper--with-player');
+  });
+
+  it('does not reserve player layout for an empty disabled slide', () => {
+    const { container } = render(
+      <ListenModeSlideRenderer
+        items={[]}
+        mobileStyle={false}
+        chatRef={createChatRef()}
+      />,
+    );
+
+    expect(container.querySelector('.listen-reveal-wrapper')).not.toHaveClass(
+      'listen-reveal-wrapper--with-player',
+    );
+
+    const slideProps = getMockSlide().mock.calls[0]?.[0] as
+      | { playerEnabled?: boolean }
+      | undefined;
+    expect(slideProps?.playerEnabled).toBe(false);
   });
 
   it('passes selected interaction user input to the slide during playback', () => {

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -800,7 +800,6 @@ const ListenModeSlideRenderer = ({
   const [isMobileAskOpen, setIsMobileAskOpen] = useState(false);
   const [isMobileAskPanelMounted, setIsMobileAskPanelMounted] = useState(false);
   const [mobileAskPanelElementBid, setMobileAskPanelElementBid] = useState('');
-  const [isPlayerVisible, setIsPlayerVisible] = useState(true);
   const [isClassroomFullscreenActive, setIsClassroomFullscreenActive] =
     useState(false);
   const [mobileViewMode, setMobileViewMode] = useState<MobileViewMode>(
@@ -1068,6 +1067,7 @@ const ListenModeSlideRenderer = ({
     !isLoading &&
     elementList.length === 1 &&
     elementList[0]?.blockBid === 'empty-ppt';
+  const playerLayoutReserved = !shouldRenderEmptyPpt;
 
   const fallbackAskElementBid = firstContentItem?.element_bid ?? '';
   const currentPlayerElementBid = useMemo(() => {
@@ -1299,14 +1299,6 @@ const ListenModeSlideRenderer = ({
     mobileStyle,
     playerCustomActionState.isActive,
   ]);
-
-  const handlePlayerVisibilityChange = useCallback(
-    (visible: boolean) => {
-      setIsPlayerVisible(visible);
-      onPlayerVisibilityChange?.(visible);
-    },
-    [onPlayerVisibilityChange],
-  );
 
   const requestClassroomFullscreen = useCallback(async () => {
     const slideShellElement = slideShellRef.current;
@@ -2094,12 +2086,7 @@ const ListenModeSlideRenderer = ({
 
   const desktopAskOverlay = shouldRenderDesktopAskOverlay ? (
     <div
-      className={cn(
-        'slide-ask-overlay',
-        isPlayerVisible
-          ? 'slide-ask-overlay--with-player'
-          : 'slide-ask-overlay--standalone',
-      )}
+      className='slide-ask-overlay slide-ask-overlay--with-player'
       aria-hidden={!playerCustomActionState.isActive}
       ref={customAskOverlayRef}
       style={playerCustomActionState.isActive ? undefined : { display: 'none' }}
@@ -2128,6 +2115,7 @@ const ListenModeSlideRenderer = ({
         'listen-reveal-wrapper',
         previewMode && !mobileStyle && 'listen-reveal-wrapper--preview',
         variant === 'classroom' && 'listen-reveal-wrapper--classroom',
+        playerLayoutReserved && 'listen-reveal-wrapper--with-player',
         mobileStyle ? 'mobile bg-white' : 'bg-[var(--color-slide-desktop-bg)]',
       )}
       ref={chatRef}
@@ -2205,7 +2193,7 @@ const ListenModeSlideRenderer = ({
           bufferingText={{
             waitingForAudio: t('module.chat.thinking'),
           }}
-          onPlayerVisibilityChange={handlePlayerVisibilityChange}
+          onPlayerVisibilityChange={onPlayerVisibilityChange}
           onStepChange={handleStepChange}
           interactionDefaultValueOptions={
             lessonFeedbackInteractionDefaultValueOptions

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -127,7 +127,6 @@ interface NewChatComponentsProps {
   getNextLessonId: NextLessonIdGetter;
   previewMode?: boolean;
   isNavOpen?: boolean;
-  onListenPlayerVisibilityChange?: (visible: boolean) => void;
   onListenMobileViewModeChange?: ListenMobileViewModeChangeHandler;
   showGenerateBtn?: boolean;
   onLessonUpdateNoticeVisibilityChange?: (visible: boolean) => void;
@@ -154,7 +153,6 @@ export const NewChatComponents = ({
   getNextLessonId,
   previewMode = false,
   isNavOpen = false,
-  onListenPlayerVisibilityChange,
   onListenMobileViewModeChange,
   showGenerateBtn = false,
   onLessonUpdateNoticeVisibilityChange,
@@ -761,13 +759,6 @@ export const NewChatComponents = ({
   }, [baseAskListByAnchorElementBid, hydrateAskListMap]);
 
   useEffect(() => {
-    if (isListenModeActive && !isLoading) {
-      return;
-    }
-    onListenPlayerVisibilityChange?.(false);
-  }, [isListenModeActive, isLoading, onListenPlayerVisibilityChange]);
-
-  useEffect(() => {
     if (isSlideMode) {
       setIsReadFeedbackAnchorVisible(false);
       setReadFeedbackTriggerElement(null);
@@ -1352,7 +1343,6 @@ export const NewChatComponents = ({
               variant={isClassroomMode ? 'classroom' : 'listen'}
               onMobileViewModeChange={onListenMobileViewModeChange}
               onSend={memoizedOnSend}
-              onPlayerVisibilityChange={onListenPlayerVisibilityChange}
               onLessonFeedbackPromptStateChange={setIsListenFeedbackReady}
               pausePlaybackWhen={reGenerateConfirm.open}
               disableInteractionEdits={isOutputInProgress}


### PR DESCRIPTION
Changed:
Kept AI-Shifu desktop follow-up overlays and mobile listen layouts tied to reserved player space instead of transient control visibility. Added regression coverage for desktop, mobile, and disabled-player states.

Benefit:
Follow-up controls and listen-mode content no longer jump when player controls hide or reappear.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only listen/classroom layout and styling changes with targeted tests; no auth, data, or API surface beyond removing an optional callback prop.
> 
> **Overview**
> **Listen-mode follow-up UI no longer shifts when slide player controls auto-hide.** Layout reservation is driven by whether real slide content exists (`playerLayoutReserved`), not transient `onPlayerVisibilityChange` callbacks.
> 
> Desktop **Ask** overlays always use `slide-ask-overlay--with-player`; the `standalone` variant and mobile-specific bottom overrides are removed. Mobile slide stage spacing moves to `listen-reveal-wrapper--with-player` in `ListenModeRenderer.scss` instead of `ChatUi` classes (`listenModeWithPlayer` / `listenModeWithoutPlayer`).
> 
> The **`onListenPlayerVisibilityChange` plumbing is removed** from `ChatUi` and `NewChatComp`; `ListenModeSlideRenderer` still forwards visibility to an optional parent callback but does not use it for CSS. Regression tests cover desktop ask overlay, mobile wrapper class, empty-slide disabled player, and SCSS invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a858c2e8fb75693c1e78124a36aec79d1484ccdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->