### PR TITLE
feat: support managed notification rules

### DIFF
--- a/docs/exec-plans/active/billing-credit-notifications.md
+++ b/docs/exec-plans/active/billing-credit-notifications.md
@@ -28,6 +28,13 @@
 - [x] 2026-06-21 17:05 CST: A config-tab follow-up extracted `dry-run` and template-sync state into dedicated frontend hooks so their errors stay local to the config area instead of reusing page-level state.
 - [x] 2026-08-31 17:58 CST: Template-management review remediation preserves Aliyun page request IDs, serializes manual library refreshes in the UI, adds provider-template workflow analytics, and completes the Thai detail label.
 - [x] 2026-08-31 18:56 CST: Closed template-management data-integrity gaps: binding relationships now report unavailable when notification config loading fails, and provider-fallback template lists return every synchronized local template instead of silently limiting results to 100.
+- [ ] 2026-08-31 19:35 CST: Replace the fixed three-row notification-type configuration with a managed notification-rule list. Operators create a named rule, select a supported trigger event, template, conditions, and enabled state; runtime continues to own the event sources and delivery protections.
+
+### Managed Notification Rules PR Split
+
+- **PR 1: rule runtime and API contract** stays on `feat/notification-rule-management`. It owns `rules[]` validation, legacy `types` compatibility, rule-aware template validation, multi-rule matching for `credit_granted`, `credit_expiring`, and `low_balance`, rule-scoped dedupe keys, notification-record rule snapshots, and focused backend regression coverage. It does not change the operator configuration UI.
+- **PR 2: operator rule management UI** starts only after PR 1 merges to `main`. It replaces the fixed notification-type editor with a rule list and create/edit/enable/delete interactions, while retaining the separate global delivery-protection controls. It includes i18n, analytics, and focused frontend coverage.
+- Keep each PR as one polished feature commit before pushing. Do not push intermediate implementation checkpoints.
 
 ## Surprises & Discoveries
 
@@ -53,6 +60,11 @@
 - Do not reuse `/api/user/send_sms_code`, `/api/user/console_send_sms_code`, or captcha templates.
 - softlimit is enforced on both frontend and backend: frontend disables teacher debug entry, backend debug/preview APIs validate `debug_allowed`.
 - hardlimit remains a billing admission/runtime boundary and is not controlled by notification policy.
+- Treat `credit_granted`, `credit_expiring`, and `low_balance` as fixed **trigger events**, not operator-defined notification types. Operators manage named **notification rules** that select one supported trigger event. A new arbitrary trigger event requires a separate backend implementation and must not be implied by the configuration UI.
+- Keep global delivery protections (frequency, quiet hours, blacklist, opt-out, and daily budget) in the shared notification policy. Per-rule configuration owns the channel, provider template, enabled state, and event-specific trigger conditions.
+- Store the initial managed rule list in `BILL_CREDIT_NOTIFICATION_SMS_CONFIG` as structured `rules[]` data. This is a runtime configuration change, not a schema migration. Give every rule a stable generated business ID and preserve the legacy `types` policy as a read-compatible source until existing values have been represented as rules.
+- Notification records must snapshot the matching rule ID and display name in `policy_snapshot_json`. Every notification dedupe key must include the rule ID so two enabled rules for the same source event can both be delivered without being mistaken for duplicates.
+- The domestic first release supports `sms` with approved Aliyun templates. The rule model must retain `channel` and provider/template references so the overseas email-template follow-up can reuse the same configuration and trigger model.
 
 ## Outcomes & Retrospective
 
@@ -174,6 +186,13 @@ Likely frontend surfaces:
    - requeue count
    - SMS cost estimate
 10. Update tests and keep this ExecPlan progress current as each step lands.
+11. Replace the fixed notification-type editor with a notification-rule list and rule editor:
+   - list columns: rule name, trigger event, channel/template, condition summary, enabled state, and actions
+   - create/edit fields: rule name, supported trigger event, approved template, enabled state, and event-specific conditions
+   - `credit_granted` has no operator-defined threshold; `credit_expiring` configures reminder windows; `low_balance` configures fixed or estimated-days thresholds
+   - retain a separate global delivery-protection section for frequency, quiet hours, blacklist, opt-out, and budget
+12. Change runtime matching so each enabled rule for a supported event can stage a notification independently. Preserve existing event hooks and scheduled tasks; only their policy lookup changes from a fixed type entry to matching rules.
+13. Add legacy-policy compatibility: configurations that only contain the existing `types` structure must continue to behave as today and be presented as the corresponding initial rules on the first managed-rule save. Do not silently discard existing enabled states, templates, expiry windows, or low-balance thresholds.
 
 ## Validation and Acceptance
 
@@ -223,3 +242,8 @@ Likely frontend surfaces:
   - billing ledger, wallet, and bucket accounting
   - existing auth SMS routes and captcha templates
   - existing hardlimit admission behavior
+- Managed-rule contract (first release):
+  - persisted under `BILL_CREDIT_NOTIFICATION_SMS_CONFIG.rules[]`, with a stable `rule_bid`, `name`, `trigger_event`, `channel`, `template_code`, `enabled`, and event-specific `conditions`
+  - supported `trigger_event` values remain `credit_granted`, `credit_expiring`, and `low_balance`
+  - rule-level conditions are restricted to the fields the corresponding runtime can evaluate; the operator UI must not expose free-form expressions or arbitrary event names
+  - no database schema migration is required for this configuration-model change; records retain rule provenance in the existing policy snapshot

--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -363,13 +363,83 @@ def _normalize_policy_list_group(
     }
 
 
-def _validate_policy_for_save(payload: dict[str, object]) -> dict[str, object]:
+def _normalize_notification_rules(app: Flask, value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        raise_param_error("rules")
+    rules: list[dict[str, object]] = []
+    for index, raw_rule in enumerate(value):
+        rule = _require_mapping(raw_rule, f"rules.{index}")
+        trigger_event = str(rule.get("trigger_event") or "").strip()
+        if trigger_event not in CREDIT_NOTIFICATION_TEMPLATE_PLACEHOLDERS:
+            raise_param_error(f"rules.{index}.trigger_event")
+        name = str(rule.get("name") or "").strip()
+        if not name or len(name) > 128:
+            raise_param_error(f"rules.{index}.name")
+        rule_bid = str(rule.get("rule_bid") or "").strip() or generate_id(app)
+        if len(rule_bid) > 64:
+            raise_param_error(f"rules.{index}.rule_bid")
+        legacy = bool(rule.get("legacy") and rule_bid == f"legacy-{trigger_event}")
+        channel = str(rule.get("channel") or CREDIT_NOTIFICATION_CHANNEL_SMS).strip()
+        if channel != CREDIT_NOTIFICATION_CHANNEL_SMS:
+            raise_param_error(f"rules.{index}.channel")
+        enabled = _coerce_bool(rule.get("enabled"))
+        template_code = str(rule.get("template_code") or "").strip()
+        if enabled and not template_code:
+            raise_param_error(f"rules.{index}.template_code")
+        conditions = _require_mapping(
+            rule.get("conditions") or {}, f"rules.{index}.conditions"
+        )
+        normalized_conditions: dict[str, object] = {}
+        if trigger_event == CREDIT_NOTIFICATION_TYPE_EXPIRING:
+            windows = _normalize_string_list(
+                conditions.get("windows", []), f"rules.{index}.conditions.windows"
+            )
+            if (not windows and not legacy) or any(
+                _parse_window_days(window) is None for window in windows
+            ):
+                raise_param_error(f"rules.{index}.conditions.windows")
+            normalized_conditions = {
+                "windows": windows,
+                "merge_same_creator": _coerce_bool(
+                    conditions.get("merge_same_creator", True)
+                ),
+            }
+        elif trigger_event == CREDIT_NOTIFICATION_TYPE_LOW_BALANCE:
+            thresholds = _normalize_low_balance_thresholds(
+                conditions.get("thresholds", []),
+                f"rules.{index}.conditions.thresholds",
+            )
+            if enabled and not thresholds:
+                raise_param_error(f"rules.{index}.conditions.thresholds")
+            normalized_conditions = {"thresholds": thresholds}
+        rules.append(
+            {
+                "rule_bid": rule_bid,
+                "name": name,
+                "trigger_event": trigger_event,
+                "channel": channel,
+                "template_code": template_code,
+                "enabled": enabled,
+                "conditions": normalized_conditions,
+                **({"legacy": True} if legacy else {}),
+            }
+        )
+    if len({str(rule["rule_bid"]) for rule in rules}) != len(rules):
+        raise_param_error("rules.rule_bid")
+    return rules
+
+
+def _validate_policy_for_save(
+    app: Flask, payload: dict[str, object]
+) -> dict[str, object]:
     policy = _deep_merge(DEFAULT_CREDIT_NOTIFICATION_SMS_CONFIG, payload)
     channel = str(policy.get("channel") or CREDIT_NOTIFICATION_CHANNEL_SMS).strip()
     if channel != CREDIT_NOTIFICATION_CHANNEL_SMS:
         raise_param_error("channel")
     policy["channel"] = CREDIT_NOTIFICATION_CHANNEL_SMS
     policy["enabled"] = _coerce_bool(policy.get("enabled"))
+    if "rules" in payload:
+        policy["rules"] = _normalize_notification_rules(app, payload["rules"])
 
     type_policies = _require_mapping(policy.get("types"), "types")
     for notification_type in (
@@ -483,6 +553,7 @@ def load_credit_notification_policy() -> dict[str, object]:
             type_policies[notification_type] = current
         current["enabled"] = _coerce_bool(current.get("enabled"))
         current["template_code"] = str(current.get("template_code") or "").strip()
+    policy["rules"] = _notification_rules(policy)
     return policy
 
 
@@ -603,7 +674,17 @@ def save_credit_notification_policy(
     """Persist credit notification policy."""
     if not isinstance(payload, dict):
         raise_param_error("policy")
-    policy = _validate_policy_for_save(payload)
+    if "rules" not in payload:
+        try:
+            existing_raw = get_config(
+                BILL_CONFIG_KEY_CREDIT_NOTIFICATION_SMS_CONFIG, ""
+            )
+            existing = json.loads(str(existing_raw)) if existing_raw else {}
+        except (KeyError, TypeError, ValueError):
+            existing = {}
+        if isinstance(existing, dict) and "rules" in existing:
+            payload = {**payload, "rules": existing["rules"]}
+    policy = _validate_policy_for_save(app, payload)
     if preserve_opt_out:
         existing_policy = load_credit_notification_policy()
         policy["opt_out"] = _normalize_policy_list_group(
@@ -643,11 +724,89 @@ def _type_policy(
     return item if isinstance(item, dict) else {}
 
 
+def _legacy_notification_rules(policy: dict[str, object]) -> list[dict[str, object]]:
+    """Expose the fixed legacy policy as managed rules without persisting it."""
+    rules: list[dict[str, object]] = []
+    for notification_type in (
+        CREDIT_NOTIFICATION_TYPE_EXPIRING,
+        CREDIT_NOTIFICATION_TYPE_GRANTED,
+        CREDIT_NOTIFICATION_TYPE_LOW_BALANCE,
+    ):
+        type_policy = _type_policy(policy, notification_type)
+        conditions: dict[str, object] = {}
+        if notification_type == CREDIT_NOTIFICATION_TYPE_EXPIRING:
+            conditions = {
+                "windows": list(type_policy.get("windows") or []),
+                "merge_same_creator": _coerce_bool(
+                    type_policy.get("merge_same_creator", True)
+                ),
+            }
+        elif notification_type == CREDIT_NOTIFICATION_TYPE_LOW_BALANCE:
+            conditions = {"thresholds": list(type_policy.get("thresholds") or [])}
+        rules.append(
+            {
+                "rule_bid": f"legacy-{notification_type}",
+                "name": notification_type,
+                "trigger_event": notification_type,
+                "channel": CREDIT_NOTIFICATION_CHANNEL_SMS,
+                "template_code": str(type_policy.get("template_code") or "").strip(),
+                "enabled": _coerce_bool(type_policy.get("enabled")),
+                "conditions": conditions,
+                "legacy": True,
+            }
+        )
+    return rules
+
+
+def _notification_rules(policy: dict[str, object]) -> list[dict[str, object]]:
+    """Return configured rules, falling back to the legacy fixed policy."""
+    configured_rules = policy.get("rules")
+    if isinstance(configured_rules, list):
+        return [item for item in configured_rules if isinstance(item, dict)]
+    return _legacy_notification_rules(policy)
+
+
+def _matching_notification_rules(
+    policy: dict[str, object], trigger_event: str
+) -> list[dict[str, object]]:
+    if not _coerce_bool(policy.get("enabled")):
+        return []
+    return [
+        rule
+        for rule in _notification_rules(policy)
+        if str(rule.get("trigger_event") or "").strip() == trigger_event
+        and _coerce_bool(rule.get("enabled"))
+    ]
+
+
+def _rule_dedupe_key(base_key: str, rule: dict[str, object]) -> str:
+    if _coerce_bool(rule.get("legacy")):
+        return base_key
+    return f"{base_key}:rule:{str(rule.get('rule_bid') or '').strip()}"
+
+
 def _notification_type_enabled(
     policy: dict[str, object], notification_type: str
 ) -> bool:
     return _coerce_bool(policy.get("enabled")) and _coerce_bool(
         _type_policy(policy, notification_type).get("enabled")
+    )
+
+
+def _notification_record_rule_enabled(
+    policy: dict[str, object], notification: NotificationRecord
+) -> bool:
+    if not _coerce_bool(policy.get("enabled")):
+        return False
+    snapshot = notification.policy_snapshot_json
+    matched_rule = snapshot.get("matched_rule") if isinstance(snapshot, dict) else None
+    if not isinstance(matched_rule, dict):
+        return _notification_type_enabled(policy, notification.notification_type)
+    rule_bid = str(matched_rule.get("rule_bid") or "").strip()
+    return any(
+        str(rule.get("rule_bid") or "").strip() == rule_bid
+        and _coerce_bool(rule.get("enabled"))
+        for rule in _notification_rules(policy)
     )
 
 
@@ -1187,14 +1346,11 @@ def _validate_credit_notification_policy_templates(
 ) -> None:
     if not _coerce_bool(policy.get("enabled")):
         return
-    for notification_type in (
-        CREDIT_NOTIFICATION_TYPE_EXPIRING,
-        CREDIT_NOTIFICATION_TYPE_GRANTED,
-        CREDIT_NOTIFICATION_TYPE_LOW_BALANCE,
-    ):
-        if not _notification_type_enabled(policy, notification_type):
+    for rule in _notification_rules(policy):
+        notification_type = str(rule.get("trigger_event") or "").strip()
+        if not _coerce_bool(rule.get("enabled")):
             continue
-        template_code = _template_code(policy, notification_type)
+        template_code = str(rule.get("template_code") or "").strip()
         if not template_code:
             continue
         result = _ensure_credit_notification_template_compatible(
@@ -1204,7 +1360,9 @@ def _validate_credit_notification_policy_templates(
         )
         if result.get("sync_status") != NOTIFICATION_TEMPLATE_SYNC_STATUS_SYNCED:
             error_code = str(result.get("error_code") or "sync_failed")
-            raise_param_error(f"types.{notification_type}.template_code:{error_code}")
+            raise_param_error(
+                f"rules.{rule.get('rule_bid')}.template_code:{error_code}"
+            )
         unsupported = [
             str(item or "").strip()
             for item in result.get("unsupported_placeholders", [])
@@ -1212,8 +1370,8 @@ def _validate_credit_notification_policy_templates(
         ]
         if unsupported:
             raise_param_error(
-                "types."
-                f"{notification_type}.template_code unsupported placeholders: "
+                "rules."
+                f"{rule.get('rule_bid')}.template_code unsupported placeholders: "
                 f"{','.join(sorted(unsupported))}"
             )
 
@@ -1405,6 +1563,7 @@ def _stage_notification_record(
     template_params: dict[str, object],
     metadata: dict[str, object] | None = None,
     policy: dict[str, object] | None = None,
+    rule: dict[str, object] | None = None,
 ) -> CreditNotificationStageResult:
     normalized_creator_bid = _normalize_bid(creator_bid)
     normalized_source_bid = _normalize_bid(source_bid)
@@ -1424,7 +1583,13 @@ def _stage_notification_record(
         )
 
     resolved_policy = policy or load_credit_notification_policy()
-    if not _notification_type_enabled(resolved_policy, notification_type):
+    resolved_rule = rule
+    if resolved_rule is None:
+        matching_rules = _matching_notification_rules(
+            resolved_policy, notification_type
+        )
+        resolved_rule = matching_rules[0] if matching_rules else None
+    if resolved_rule is None:
         return CreditNotificationStageResult(
             status="noop_disabled",
             notification_type=notification_type,
@@ -1501,11 +1666,11 @@ def _stage_notification_record(
         source_bid=normalized_source_bid,
         dedupe_key=normalized_dedupe_key,
         status=notification_status,
-        template_code=_template_code(resolved_policy, notification_type),
+        template_code=str(resolved_rule.get("template_code") or "").strip(),
         template_params_json={
             key: str(value or "").strip() for key, value in template_params.items()
         },
-        policy_snapshot_json=resolved_policy,
+        policy_snapshot_json={**resolved_policy, "matched_rule": resolved_rule},
         provider_response_json={},
         error_code=error_code,
         error_message=error_message,
@@ -1571,6 +1736,7 @@ def _stage_scan_notification_isolated(
     template_params: dict[str, object],
     metadata: dict[str, object] | None,
     policy: dict[str, object],
+    rule: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Stage one scan candidate in its own transaction.
 
@@ -1591,6 +1757,7 @@ def _stage_scan_notification_isolated(
                 template_params=template_params,
                 metadata=metadata,
                 policy=policy,
+                rule=rule,
             )
     except Exception:
         # exc_info carries the exception; keep provider error strings (which
@@ -1666,14 +1833,19 @@ def stage_credit_granted_notification(
         if ledger is None:
             return CreditNotificationStageResult(status="not_found").to_payload()
 
-        def _stage() -> CreditNotificationStageResult:
+        policy = load_credit_notification_policy()
+        rules = _matching_notification_rules(policy, CREDIT_NOTIFICATION_TYPE_GRANTED)
+
+        def _stage(rule: dict[str, object]) -> CreditNotificationStageResult:
             return _stage_notification_record(
                 app,
                 notification_type=CREDIT_NOTIFICATION_TYPE_GRANTED,
                 creator_bid=ledger.creator_bid,
                 source_type=SOURCE_TYPE_LEDGER,
                 source_bid=ledger.ledger_bid,
-                dedupe_key=build_credit_granted_dedupe_key(ledger.ledger_bid),
+                dedupe_key=_rule_dedupe_key(
+                    build_credit_granted_dedupe_key(ledger.ledger_bid), rule
+                ),
                 template_params={
                     "credits": _amount_text(ledger.amount),
                     "source": str(
@@ -1686,30 +1858,46 @@ def stage_credit_granted_notification(
                     "wallet_bucket_bid": ledger.wallet_bucket_bid,
                     "ledger_bid": ledger.ledger_bid,
                 },
+                policy=policy,
+                rule=rule,
             )
 
         if commit:
             # This call owns the transaction for the staged row.
             with unit_of_work():
-                result = _stage()
+                results = [_stage(rule) for rule in rules]
         else:
             # Legacy contract: with commit=False the CALLER owns the
             # transaction boundary. The staged row is only flushed here and
             # commits or rolls back with the caller's flow (renewal, trials,
             # paid_side_effects, and manual_plan_grants all pass commit=False
             # and persist it themselves).
-            result = _stage()
-        payload = result.to_payload()
+            results = [_stage(rule) for rule in rules]
+        if not results:
+            return CreditNotificationStageResult(
+                status="noop_disabled",
+                notification_type=CREDIT_NOTIFICATION_TYPE_GRANTED,
+                creator_bid=ledger.creator_bid,
+                source_type=SOURCE_TYPE_LEDGER,
+                source_bid=ledger.ledger_bid,
+            ).to_payload()
+        payload = results[0].to_payload()
+        payload["notifications"] = [result.to_payload() for result in results]
     if enqueue:
-        if payload.get("status") == CREDIT_NOTIFICATION_STATUS_PENDING:
-            notification_bid = str(payload.get("notification_bid") or "")
+        for result in payload.get("notifications", [payload]):
+            if result.get("status") != CREDIT_NOTIFICATION_STATUS_PENDING:
+                continue
+            notification_bid = str(result.get("notification_bid") or "")
 
-            def _dispatch() -> None:
+            def _dispatch(
+                notification_bid: str = notification_bid,
+                notification_payload: dict[str, object] = result,
+            ) -> None:
                 enqueue_result = enqueue_credit_notification(
                     app,
                     notification_bid=notification_bid,
                 )
-                payload["enqueued"] = bool(enqueue_result.get("enqueued"))
+                notification_payload["enqueued"] = bool(enqueue_result.get("enqueued"))
 
             # External celery dispatch. Outside any unit of work this runs
             # immediately, so the payload reports the real enqueue outcome
@@ -1717,8 +1905,9 @@ def stage_credit_granted_notification(
             # work it is deferred until the staged row is durable and dropped
             # on rollback (the payload then still reports enqueued=False).
             uow.on_commit(_dispatch)
-        else:
-            payload["enqueued"] = False
+        payload["enqueued"] = bool(
+            payload.get("notifications", [payload])[0].get("enqueued")
+        )
     return payload
 
 
@@ -1754,6 +1943,20 @@ def stage_credit_granted_notification_for_order(
         ledger_bid=ledger_bid,
         commit=commit,
         enqueue=enqueue,
+    )
+
+
+def pending_credit_notification_bids(payload: dict[str, object]) -> tuple[str, ...]:
+    """Return every pending notification bid from a staging result."""
+    candidates = payload.get("notifications")
+    if not isinstance(candidates, list):
+        candidates = [payload]
+    return tuple(
+        notification_bid
+        for item in candidates
+        if isinstance(item, dict)
+        and item.get("status") == CREDIT_NOTIFICATION_STATUS_PENDING
+        and (notification_bid := str(item.get("notification_bid") or "").strip())
     )
 
 
@@ -1871,13 +2074,19 @@ def scan_credit_expiring_notifications(
     now: datetime | None = None,
     creator_bid: str = "",
     dry_run: bool = False,
+    _rule: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Scan expiring credits and create or preview eligible notifications."""
     scan_now = now or now_utc()
     normalized_creator_bid = _normalize_bid(creator_bid)
     with _maybe_app_context(app):
         policy = load_credit_notification_policy()
-        if not _notification_type_enabled(policy, CREDIT_NOTIFICATION_TYPE_EXPIRING):
+        rules = (
+            [_rule]
+            if _rule is not None
+            else _matching_notification_rules(policy, CREDIT_NOTIFICATION_TYPE_EXPIRING)
+        )
+        if not rules:
             return {
                 "status": "noop_disabled",
                 "candidate_count": 0,
@@ -1886,7 +2095,52 @@ def scan_credit_expiring_notifications(
                 "dry_run": dry_run,
                 "notifications": [],
             }
-        type_policy = _type_policy(policy, CREDIT_NOTIFICATION_TYPE_EXPIRING)
+        if _rule is None and len(rules) > 1:
+            results = [
+                scan_credit_expiring_notifications(
+                    app,
+                    now=scan_now,
+                    creator_bid=normalized_creator_bid,
+                    dry_run=dry_run,
+                    _rule=rule,
+                )
+                for rule in rules
+            ]
+            notifications = [
+                item for result in results for item in result.get("notifications", [])
+            ]
+            candidate_count = sum(
+                int(result.get("candidate_count") or 0) for result in results
+            )
+            return {
+                "status": "created" if candidate_count else "noop",
+                "candidate_count": candidate_count,
+                "created_count": sum(
+                    int(result.get("created_count") or 0) for result in results
+                ),
+                "enqueued_count": sum(
+                    int(result.get("enqueued_count") or 0) for result in results
+                ),
+                "estimated_sms_cost": str(
+                    _quantize_credit_amount(
+                        sum(
+                            (
+                                _to_decimal(result.get("estimated_sms_cost"))
+                                for result in results
+                            ),
+                            start=_ZERO,
+                        )
+                    )
+                )
+                if dry_run
+                else "0",
+                "dry_run": dry_run,
+                "notifications": notifications,
+            }
+        rule = rules[0]
+        type_policy = rule.get("conditions")
+        if not isinstance(type_policy, dict):
+            type_policy = {}
         windows = type_policy.get("windows")
         if not isinstance(windows, list):
             windows = ["7d", "3d", "1d", "0d"]
@@ -1955,17 +2209,20 @@ def scan_credit_expiring_notifications(
                         group["wallet_bid"] = bucket.wallet_bid
 
                 for group in grouped.values():
-                    dedupe_key = build_credit_expiring_creator_dedupe_key(
-                        str(group.get("creator_bid") or ""),
-                        window,
-                        scan_now.date(),
+                    dedupe_key = _rule_dedupe_key(
+                        build_credit_expiring_creator_dedupe_key(
+                            str(group.get("creator_bid") or ""),
+                            window,
+                            scan_now.date(),
+                        ),
+                        rule,
                     )
                     existing = _find_credit_expiring_creator_window_record(
                         creator_bid=str(group.get("creator_bid") or ""),
                         window=window,
                         now=scan_now,
                     )
-                    if existing is not None:
+                    if existing is not None and _coerce_bool(rule.get("legacy")):
                         notifications.append(
                             _suppressed_duplicate_result(existing).to_payload()
                         )
@@ -2008,6 +2265,7 @@ def scan_credit_expiring_notifications(
                                 "window": window,
                             },
                             policy=policy,
+                            rule=rule,
                         )
                     )
                 continue
@@ -2018,9 +2276,12 @@ def scan_credit_expiring_notifications(
                     creator_eligibility_cache,
                 ):
                     continue
-                dedupe_key = build_credit_expiring_dedupe_key(
-                    bucket.wallet_bucket_bid,
-                    window,
+                dedupe_key = _rule_dedupe_key(
+                    build_credit_expiring_dedupe_key(
+                        bucket.wallet_bucket_bid,
+                        window,
+                    ),
+                    rule,
                 )
                 if dry_run:
                     notifications.append(
@@ -2052,6 +2313,7 @@ def scan_credit_expiring_notifications(
                             "window": window,
                         },
                         policy=policy,
+                        rule=rule,
                     )
                 )
     _dispatch_scan_notification_enqueues(app, notifications, dry_run=dry_run)
@@ -2238,13 +2500,21 @@ def scan_low_balance_notifications(
     now: datetime | None = None,
     creator_bid: str = "",
     dry_run: bool = False,
+    _rule: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Scan low balances and create or preview eligible notifications."""
     scan_now = now or now_utc()
     normalized_creator_bid = _normalize_bid(creator_bid)
     with _maybe_app_context(app):
         policy = load_credit_notification_policy()
-        if not _notification_type_enabled(policy, CREDIT_NOTIFICATION_TYPE_LOW_BALANCE):
+        rules = (
+            [_rule]
+            if _rule is not None
+            else _matching_notification_rules(
+                policy, CREDIT_NOTIFICATION_TYPE_LOW_BALANCE
+            )
+        )
+        if not rules:
             return {
                 "status": "noop_disabled",
                 "candidate_count": 0,
@@ -2253,7 +2523,55 @@ def scan_low_balance_notifications(
                 "dry_run": dry_run,
                 "notifications": [],
             }
-        thresholds = _load_low_balance_thresholds(policy)
+        if _rule is None and len(rules) > 1:
+            results = [
+                scan_low_balance_notifications(
+                    app,
+                    now=scan_now,
+                    creator_bid=normalized_creator_bid,
+                    dry_run=dry_run,
+                    _rule=rule,
+                )
+                for rule in rules
+            ]
+            notifications = [
+                item for result in results for item in result.get("notifications", [])
+            ]
+            candidate_count = sum(
+                int(result.get("candidate_count") or 0) for result in results
+            )
+            return {
+                "status": "created" if candidate_count else "noop",
+                "candidate_count": candidate_count,
+                "created_count": sum(
+                    int(result.get("created_count") or 0) for result in results
+                ),
+                "enqueued_count": sum(
+                    int(result.get("enqueued_count") or 0) for result in results
+                ),
+                "estimated_sms_cost": str(
+                    _quantize_credit_amount(
+                        sum(
+                            (
+                                _to_decimal(result.get("estimated_sms_cost"))
+                                for result in results
+                            ),
+                            start=_ZERO,
+                        )
+                    )
+                )
+                if dry_run
+                else "0",
+                "dry_run": dry_run,
+                "notifications": notifications,
+            }
+        rule = rules[0]
+        conditions = rule.get("conditions")
+        thresholds = (
+            conditions.get("thresholds") if isinstance(conditions, dict) else None
+        )
+        if not isinstance(thresholds, list):
+            thresholds = _load_low_balance_thresholds(policy)
         query = CreditWallet.query.filter(
             CreditWallet.deleted == 0,
             CreditWallet.creator_bid != "",
@@ -2487,11 +2805,9 @@ def scan_low_balance_notifications(
                 else:
                     continue
 
+                dedupe_key = _rule_dedupe_key(dedupe_key, rule)
                 missing_template_params = _missing_template_params(
-                    template_code=_template_code(
-                        policy,
-                        CREDIT_NOTIFICATION_TYPE_LOW_BALANCE,
-                    ),
+                    template_code=str(rule.get("template_code") or "").strip(),
                     template_params=template_params,
                 )
                 if missing_template_params:
@@ -2551,6 +2867,7 @@ def scan_low_balance_notifications(
                         template_params=template_params,
                         metadata=metadata,
                         policy=policy,
+                        rule=rule,
                     )
                 )
     _dispatch_scan_notification_enqueues(app, notifications, dry_run=dry_run)
@@ -2793,7 +3110,7 @@ def deliver_credit_notification(
 
         now = now_utc()
         policy = load_credit_notification_policy()
-        if not _notification_type_enabled(policy, notification.notification_type):
+        if not _notification_record_rule_enabled(policy, notification):
             _finalize_notification(
                 notification,
                 status=CREDIT_NOTIFICATION_STATUS_SKIPPED_OPT_OUT,

--- a/src/api/flaskr/service/billing/manual_plan_grants.py
+++ b/src/api/flaskr/service/billing/manual_plan_grants.py
@@ -23,6 +23,7 @@ from .consts import (
 )
 from .credit_notifications import (
     enqueue_credit_notification,
+    pending_credit_notification_bids,
     stage_credit_granted_notification_for_order,
 )
 from .models import BillingOrder, BillingProduct, BillingSubscription
@@ -222,7 +223,7 @@ def grant_manual_plan_to_user(
             now = now_utc()
             if existing_order is not None:
                 granted = grant_paid_order_credits(app, existing_order)
-                notification_bid = ""
+                notification_bids: tuple[str, ...] = ()
                 if granted:
                     grant_notification = stage_credit_granted_notification_for_order(
                         app,
@@ -231,10 +232,9 @@ def grant_manual_plan_to_user(
                         commit=False,
                         enqueue=False,
                     )
-                    if grant_notification.get("status") == "pending":
-                        notification_bid = str(
-                            grant_notification.get("notification_bid") or ""
-                        ).strip()
+                    notification_bids = pending_credit_notification_bids(
+                        grant_notification
+                    )
                 notification_status = _ensure_notification_extension_metadata(
                     existing_order,
                     requested_at=now,
@@ -243,7 +243,7 @@ def grant_manual_plan_to_user(
                 )
                 db.session.add(existing_order)
                 db.session.commit()
-                if notification_bid:
+                for notification_bid in notification_bids:
                     enqueue_credit_notification(app, notification_bid=notification_bid)
                 subscription = (
                     BillingSubscription.query.filter(
@@ -395,7 +395,7 @@ def grant_manual_plan_to_user(
             db.session.flush()
 
             granted = grant_paid_order_credits(app, order)
-            notification_bid = ""
+            notification_bids: tuple[str, ...] = ()
             if granted:
                 grant_notification = stage_credit_granted_notification_for_order(
                     app,
@@ -404,13 +404,10 @@ def grant_manual_plan_to_user(
                     commit=False,
                     enqueue=False,
                 )
-                if grant_notification.get("status") == "pending":
-                    notification_bid = str(
-                        grant_notification.get("notification_bid") or ""
-                    ).strip()
+                notification_bids = pending_credit_notification_bids(grant_notification)
 
             db.session.commit()
-            if notification_bid:
+            for notification_bid in notification_bids:
                 enqueue_credit_notification(app, notification_bid=notification_bid)
             return ManualPlanGrantResult(
                 user_bid=normalized_user_bid,

--- a/src/api/flaskr/service/billing/paid_side_effects.py
+++ b/src/api/flaskr/service/billing/paid_side_effects.py
@@ -10,6 +10,9 @@ from .credit_notifications import (
     enqueue_credit_notification as _enqueue_credit_notification,
 )
 from .credit_notifications import (
+    pending_credit_notification_bids as _pending_credit_notification_bids,
+)
+from .credit_notifications import (
     stage_credit_granted_notification_for_order as _stage_credit_granted_notification_for_order,
 )
 from .notifications import (
@@ -63,9 +66,9 @@ def stage_billing_paid_order_side_effects(
             commit=False,
             enqueue=False,
         )
-        notification_bid = str(grant_notification.get("notification_bid") or "").strip()
-        if grant_notification.get("status") == "pending" and notification_bid:
-            credit_notification_bids.append(notification_bid)
+        credit_notification_bids.extend(
+            _pending_credit_notification_bids(grant_notification)
+        )
     should_enqueue_subscription_purchase_sms = (
         _stage_subscription_purchase_sms_for_paid_order(
             order,

--- a/src/api/flaskr/service/billing/renewal.py
+++ b/src/api/flaskr/service/billing/renewal.py
@@ -33,10 +33,12 @@ from .consts import (
     BILLING_SUBSCRIPTION_STATUS_CANCELED,
     BILLING_SUBSCRIPTION_STATUS_EXPIRED,
     BILLING_SUBSCRIPTION_STATUS_LABELS,
-    CREDIT_NOTIFICATION_STATUS_PENDING,
 )
 from .credit_notifications import (
     enqueue_credit_notification as _enqueue_credit_notification,
+)
+from .credit_notifications import (
+    pending_credit_notification_bids as _pending_credit_notification_bids,
 )
 from .credit_notifications import (
     stage_credit_granted_notification_for_order as _stage_credit_granted_notification_for_order,
@@ -564,14 +566,17 @@ def _execute_expire_subscription(
                     now=now,
                     bill_order_bid=paid_renewal_order.bill_order_bid,
                 )
-            notification_bid = _stage_preorder_credit_release_notification(
+            notification_bids = _stage_preorder_credit_release_notification(
                 app,
                 paid_renewal_order,
             )
             # External dispatch fires only after the staged notification row
             # and the event transition are durable; dropped on rollback.
             uow.on_commit(
-                lambda: _enqueue_credit_release_notification(app, notification_bid)
+                lambda: [
+                    _enqueue_credit_release_notification(app, bid)
+                    for bid in notification_bids
+                ]
             )
             _complete_renewal_event(event, now=now)
             return _result_from_event(
@@ -647,14 +652,17 @@ def _execute_downgrade_effective(
                     now=now,
                     bill_order_bid=paid_renewal_order.bill_order_bid,
                 )
-            notification_bid = _stage_preorder_credit_release_notification(
+            notification_bids = _stage_preorder_credit_release_notification(
                 app,
                 paid_renewal_order,
             )
             # External dispatch fires only after the staged notification row
             # and the event transition are durable; dropped on rollback.
             uow.on_commit(
-                lambda: _enqueue_credit_release_notification(app, notification_bid)
+                lambda: [
+                    _enqueue_credit_release_notification(app, bid)
+                    for bid in notification_bids
+                ]
             )
             _complete_renewal_event(event, now=now)
             return _result_from_event(
@@ -682,9 +690,9 @@ def _execute_downgrade_effective(
 def _stage_preorder_credit_release_notification(
     app: Flask,
     order: BillingOrder,
-) -> str:
+) -> tuple[str, ...]:
     if not _is_preorder_order(order):
-        return ""
+        return ()
     stage_result = _stage_credit_granted_notification_for_order(
         app,
         creator_bid=order.creator_bid,
@@ -692,9 +700,7 @@ def _stage_preorder_credit_release_notification(
         commit=False,
         enqueue=False,
     )
-    if stage_result.get("status") != CREDIT_NOTIFICATION_STATUS_PENDING:
-        return ""
-    return str(stage_result.get("notification_bid") or "").strip()
+    return _pending_credit_notification_bids(stage_result)
 
 
 def _enqueue_credit_release_notification(app: Flask, notification_bid: str) -> None:

--- a/src/api/flaskr/service/billing/trials.py
+++ b/src/api/flaskr/service/billing/trials.py
@@ -35,6 +35,9 @@ from .credit_notifications import (
     enqueue_credit_notification as _enqueue_credit_notification,
 )
 from .credit_notifications import (
+    pending_credit_notification_bids as _pending_credit_notification_bids,
+)
+from .credit_notifications import (
     stage_credit_granted_notification_for_order as _stage_credit_granted_notification_for_order,
 )
 from .dtos import BillingTrialOfferDTO, BillingTrialWelcomeAckDTO
@@ -454,13 +457,12 @@ def _bootstrap_trial_subscription(
         commit=False,
         enqueue=False,
     )
-    if grant_notification.get("status") == "pending":
+    notification_bids = _pending_credit_notification_bids(grant_notification)
+    if notification_bids:
         order_metadata = (
-            order.metadata_json if isinstance(order.metadata_json, dict) else {}
+            dict(order.metadata_json) if isinstance(order.metadata_json, dict) else {}
         )
-        order_metadata["credit_granted_notification_bid"] = str(
-            grant_notification.get("notification_bid") or ""
-        ).strip()
+        order_metadata["credit_granted_notification_bids"] = list(notification_bids)
         order.metadata_json = order_metadata
         db.session.add(order)
 
@@ -481,13 +483,22 @@ def _enqueue_trial_credit_notification(app: Flask, creator_bid: str) -> None:
             .first()
         )
         metadata = order.metadata_json if order is not None else {}
-        notification_bid = (
-            str((metadata or {}).get("credit_granted_notification_bid") or "").strip()
+        notification_bids = (
+            tuple(
+                str(item or "").strip()
+                for item in (metadata or {}).get("credit_granted_notification_bids", [])
+                if str(item or "").strip()
+            )
             if isinstance(metadata, dict)
-            else ""
+            else ()
         )
-    if notification_bid:
-        _enqueue_credit_notification(app, notification_bid=notification_bid)
+        if not notification_bids and isinstance(metadata, dict):
+            notification_bids = (
+                str(metadata.get("credit_granted_notification_bid") or "").strip(),
+            )
+    for notification_bid in notification_bids:
+        if notification_bid:
+            _enqueue_credit_notification(app, notification_bid=notification_bid)
 
 
 def _resolve_trial_bootstrap_status(

--- a/src/api/flaskr/service/billing/trials.py
+++ b/src/api/flaskr/service/billing/trials.py
@@ -35,6 +35,9 @@ from .credit_notifications import (
     enqueue_credit_notification as _enqueue_credit_notification,
 )
 from .credit_notifications import (
+    pending_credit_notification_bids as _pending_credit_notification_bids,
+)
+from .credit_notifications import (
     stage_credit_granted_notification_for_order as _stage_credit_granted_notification_for_order,
 )
 from .dtos import BillingTrialOfferDTO, BillingTrialWelcomeAckDTO
@@ -454,13 +457,12 @@ def _bootstrap_trial_subscription(
         commit=False,
         enqueue=False,
     )
-    if grant_notification.get("status") == "pending":
+    notification_bids = _pending_credit_notification_bids(grant_notification)
+    if notification_bids:
         order_metadata = (
-            order.metadata_json if isinstance(order.metadata_json, dict) else {}
+            dict(order.metadata_json) if isinstance(order.metadata_json, dict) else {}
         )
-        order_metadata["credit_granted_notification_bid"] = str(
-            grant_notification.get("notification_bid") or ""
-        ).strip()
+        order_metadata["credit_granted_notification_bids"] = list(notification_bids)
         order.metadata_json = order_metadata
         db.session.add(order)
 
@@ -481,13 +483,27 @@ def _enqueue_trial_credit_notification(app: Flask, creator_bid: str) -> None:
             .first()
         )
         metadata = order.metadata_json if order is not None else {}
-        notification_bid = (
-            str((metadata or {}).get("credit_granted_notification_bid") or "").strip()
+        stored_notification_bids = (
+            metadata.get("credit_granted_notification_bids")
             if isinstance(metadata, dict)
-            else ""
+            else None
         )
-    if notification_bid:
-        _enqueue_credit_notification(app, notification_bid=notification_bid)
+        notification_bids = (
+            tuple(
+                str(item or "").strip()
+                for item in stored_notification_bids
+                if str(item or "").strip()
+            )
+            if isinstance(stored_notification_bids, list)
+            else ()
+        )
+        if not notification_bids and isinstance(metadata, dict):
+            notification_bids = (
+                str(metadata.get("credit_granted_notification_bid") or "").strip(),
+            )
+    for notification_bid in notification_bids:
+        if notification_bid:
+            _enqueue_credit_notification(app, notification_bid=notification_bid)
 
 
 def _resolve_trial_bootstrap_status(

--- a/src/api/tests/service/billing/test_billing_trial_credits.py
+++ b/src/api/tests/service/billing/test_billing_trial_credits.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 from flask import Flask, jsonify, request
 from flaskr import dao
+from flaskr.service.billing import trials
 from flaskr.service.billing.consts import (
     BILLING_LEGACY_NEW_CREATOR_TRIAL_PROGRAM_CODE,
     BILLING_ORDER_STATUS_PAID,
@@ -155,6 +156,44 @@ def test_billing_overview_returns_product_backed_eligible_trial_without_mutation
         assert (
             CreditLedgerEntry.query.filter_by(creator_bid="creator-trial").count() == 0
         )
+
+
+def test_trial_notification_enqueue_uses_legacy_bid_for_scalar_bid_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _OrderQuery:
+        def filter(self, *_args: object) -> _OrderQuery:
+            return self
+
+        def order_by(self, *_args: object) -> _OrderQuery:
+            return self
+
+        def first(self) -> SimpleNamespace:
+            return SimpleNamespace(
+                metadata_json={
+                    "credit_granted_notification_bids": "invalid-scalar-bids",
+                    "credit_granted_notification_bid": "legacy-notification-bid",
+                }
+            )
+
+    enqueued_bids: list[str] = []
+    app = Flask(__name__)
+    with app.app_context():
+        monkeypatch.setattr(
+            trials.BillingOrder,
+            "query",
+            _OrderQuery(),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            trials,
+            "_enqueue_credit_notification",
+            lambda _app, *, notification_bid: enqueued_bids.append(notification_bid),
+        )
+
+        trials._enqueue_trial_credit_notification(app, "creator-trial")
+
+    assert enqueued_bids == ["legacy-notification-bid"]
 
 
 def test_trial_bootstrap_creates_manual_order_subscription_and_expire_event_once(

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -336,6 +336,112 @@ def _seed_default_notification_templates(app: Flask) -> None:
     )
 
 
+def test_managed_rules_stage_each_matching_notification_once(
+    credit_notifications_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = credit_notifications_app
+    now = datetime(2026, 5, 21, 0, 0, 0)
+    _seed_creator(app)
+    _seed_default_notification_templates(app)
+    with app.app_context():
+        _seed_credit_ledger()
+        _seed_wallet(available_credits="1")
+        _seed_bucket(effective_to=now + timedelta(days=1, hours=2))
+        dao.db.session.commit()
+
+    save_credit_notification_policy(
+        app,
+        {
+            "enabled": True,
+            "frequency": {
+                "per_mobile_per_day": 0,
+                "per_creator_per_type_per_day": 0,
+            },
+            "rules": [
+                {
+                    "rule_bid": "grant-one",
+                    "name": "Grant one",
+                    "trigger_event": "credit_granted",
+                    "channel": "sms",
+                    "template_code": "TPL-GRANT",
+                    "enabled": True,
+                    "conditions": {},
+                },
+                {
+                    "rule_bid": "grant-two",
+                    "name": "Grant two",
+                    "trigger_event": "credit_granted",
+                    "channel": "sms",
+                    "template_code": "TPL-GRANT",
+                    "enabled": True,
+                    "conditions": {},
+                },
+                *[
+                    {
+                        "rule_bid": f"expiring-{index}",
+                        "name": f"Expiring {index}",
+                        "trigger_event": "credit_expiring",
+                        "channel": "sms",
+                        "template_code": "TPL-EXPIRING",
+                        "enabled": True,
+                        "conditions": {"windows": ["1d"]},
+                    }
+                    for index in ("one", "two")
+                ],
+                *[
+                    {
+                        "rule_bid": f"low-{index}",
+                        "name": f"Low {index}",
+                        "trigger_event": "low_balance",
+                        "channel": "sms",
+                        "template_code": "TPL-LOW",
+                        "enabled": True,
+                        "conditions": {"thresholds": [{"kind": "fixed", "value": "3"}]},
+                    }
+                    for index in ("one", "two")
+                ],
+            ],
+        },
+    )
+
+    granted = stage_credit_granted_notification(
+        app, ledger_bid="ledger-1", enqueue=False
+    )
+    expiring = scan_credit_expiring_notifications(app, now=now)
+    low_balance = scan_low_balance_notifications(app, now=now)
+
+    assert len(granted["notifications"]) == 2
+    assert expiring["created_count"] == 2
+    assert low_balance["created_count"] == 2
+    with app.app_context():
+        rows = NotificationRecord.query.order_by(NotificationRecord.id.asc()).all()
+        assert len(rows) == 6
+        assert len({row.dedupe_key for row in rows}) == 6
+        assert {
+            row.policy_snapshot_json["matched_rule"]["rule_bid"] for row in rows
+        } == {
+            "grant-one",
+            "grant-two",
+            "expiring-one",
+            "expiring-two",
+            "low-one",
+            "low-two",
+        }
+
+    monkeypatch.setattr(
+        "flaskr.service.billing.credit_notifications.send_sms_ali",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            body=SimpleNamespace(code="OK", message="", request_id="request-1")
+        ),
+    )
+    delivered = deliver_credit_notification(
+        app,
+        notification_bid=str(granted["notifications"][0]["notification_bid"]),
+    )
+    assert delivered["notification_status"] == CREDIT_NOTIFICATION_STATUS_SENT
+
+
 def test_credit_granted_notification_stages_once_and_delivers_sms(
     credit_notifications_app: Flask,
     monkeypatch: pytest.MonkeyPatch,

--- a/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
+++ b/src/api/tests/service/billing/test_renewal_uow_failure_paths.py
@@ -393,7 +393,7 @@ def test_expire_notification_fires_after_commit_and_drops_on_rollback(
     monkeypatch.setattr(
         billing_renewal,
         "_stage_preorder_credit_release_notification",
-        lambda *_args, **_kwargs: "notif-uow-1",
+        lambda *_args, **_kwargs: ("notif-uow-1",),
     )
     enqueued: list[str] = []
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- add validated managed notification rules while preserving legacy fixed policy compatibility
- match credit grant, expiring-credit, and low-balance notifications against every enabled rule
- include the matched rule in notification snapshots and rule IDs in non-legacy dedupe keys

## Database
- No schema or migration changes.

## Verification
- `cd src/api && pytest -q tests/service/billing/test_credit_notifications.py tests/service/billing/test_credit_notification_uow_failure_paths.py`
- `lefthook run pre-commit --all-files`
- `python scripts/check_architecture_boundaries.py`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing multiple notification rules for credit grants, expiring credits, and low balances.
  * Each matching rule can create a separate notification with its own template and delivery tracking.
  * Notification records identify the rule that triggered them.
  * Legacy notification configurations remain supported.
  * Billing, renewal, and trial workflows can enqueue multiple pending notifications.

* **Bug Fixes**
  * Improved deduplication and delivery handling when multiple rules match.
  * Ensured matching notifications are delivered consistently across billing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->