### PR TITLE
fix: move listen mode controls lower

### DIFF
--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ChatUi.module.scss
@@ -1,6 +1,6 @@
 .ChatUi {
   --chat-footer-height: 40px;
-  --listen-player-footer-gap: 12px;
+  --listen-player-footer-gap: 0px;
 
   position: relative;
   flex: 1;

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRendererStyles.test.ts
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRendererStyles.test.ts
@@ -7,6 +7,9 @@ const readStylesheet = () =>
 const readChatUiStylesheet = () =>
   readFileSync(path.join(__dirname, 'ChatUi.module.scss'), 'utf8');
 
+const normalizeStylesheet = (stylesheet: string) =>
+  stylesheet.replace(/\s+/g, ' ');
+
 describe('ListenModeRenderer styles', () => {
   it('keeps mobile landscape interaction overlays compatible with slide drag offsets', () => {
     const stylesheet = readStylesheet();
@@ -37,21 +40,27 @@ describe('ListenModeRenderer styles', () => {
   it('aligns desktop listen controls to the footer through one shared offset', () => {
     const stylesheet = readStylesheet();
     const chatUiStylesheet = readChatUiStylesheet();
+    const normalizedStylesheet = normalizeStylesheet(stylesheet);
+    const desktopWrapperSelector =
+      '.listen-reveal-wrapper:not(.mobile):not(.listen-reveal-wrapper--classroom)';
+    const browserFullscreenExcludedSelector =
+      '.listen-slide-root:not(.slide--browser-fullscreen)';
 
     expect(chatUiStylesheet).toContain('--listen-player-footer-gap: 0px');
-    expect(stylesheet).toMatch(
-      /\.listen-slide-player\s*\{\s*bottom:\s*var\(--listen-slide-player-bottom-offset\)/,
+    expect(normalizedStylesheet).toContain(
+      `${desktopWrapperSelector} ${browserFullscreenExcludedSelector} .listen-slide-player { bottom: var(--listen-slide-player-bottom-offset);`,
     );
-    expect(stylesheet).toMatch(
-      /\.slide-ask-overlay,[\s\S]*?\.slide-interaction-overlay\s*\{\s*--slide-player-bottom-offset:\s*var\(--listen-slide-player-bottom-offset\)/,
+    expect(normalizedStylesheet).toContain(
+      [
+        `${desktopWrapperSelector} .listen-slide-shell > .slide-ask-overlay`,
+        `${desktopWrapperSelector} ${browserFullscreenExcludedSelector} .slide-ask-overlay`,
+        `${desktopWrapperSelector} ${browserFullscreenExcludedSelector} .slide-interaction-overlay`,
+      ].join(', ') +
+        ' { --slide-player-bottom-offset: var(--listen-slide-player-bottom-offset);',
     );
-    expect(stylesheet).toMatch(
-      /\.slide-subtitle-overlay\s*\{\s*--slide-player-bottom-offset:\s*var\(--listen-slide-player-bottom-offset\)/,
+    expect(normalizedStylesheet).toContain(
+      `${desktopWrapperSelector} ${browserFullscreenExcludedSelector} .slide-subtitle-overlay { --slide-player-bottom-offset: var(--listen-slide-player-bottom-offset);`,
     );
-    expect(stylesheet).toContain(
-      ':not(.mobile):not(.listen-reveal-wrapper--classroom)',
-    );
-    expect(stylesheet).toContain(':not(.slide--browser-fullscreen)');
   });
 
   it('lets Slide size the mobile player grid from its rendered actions', () => {

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRendererStyles.test.ts
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeRendererStyles.test.ts
@@ -4,6 +4,9 @@ import path from 'path';
 const readStylesheet = () =>
   readFileSync(path.join(__dirname, 'ListenModeRenderer.scss'), 'utf8');
 
+const readChatUiStylesheet = () =>
+  readFileSync(path.join(__dirname, 'ChatUi.module.scss'), 'utf8');
+
 describe('ListenModeRenderer styles', () => {
   it('keeps mobile landscape interaction overlays compatible with slide drag offsets', () => {
     const stylesheet = readStylesheet();
@@ -29,6 +32,26 @@ describe('ListenModeRenderer styles', () => {
     expect(askRuleBody).toContain('var(--slide-player-height)');
     expect(stylesheet).toContain('&.listen-reveal-wrapper--with-player');
     expect(stylesheet).not.toContain('.slide-ask-overlay--standalone');
+  });
+
+  it('aligns desktop listen controls to the footer through one shared offset', () => {
+    const stylesheet = readStylesheet();
+    const chatUiStylesheet = readChatUiStylesheet();
+
+    expect(chatUiStylesheet).toContain('--listen-player-footer-gap: 0px');
+    expect(stylesheet).toMatch(
+      /\.listen-slide-player\s*\{\s*bottom:\s*var\(--listen-slide-player-bottom-offset\)/,
+    );
+    expect(stylesheet).toMatch(
+      /\.slide-ask-overlay,[\s\S]*?\.slide-interaction-overlay\s*\{\s*--slide-player-bottom-offset:\s*var\(--listen-slide-player-bottom-offset\)/,
+    );
+    expect(stylesheet).toMatch(
+      /\.slide-subtitle-overlay\s*\{\s*--slide-player-bottom-offset:\s*var\(--listen-slide-player-bottom-offset\)/,
+    );
+    expect(stylesheet).toContain(
+      ':not(.mobile):not(.listen-reveal-wrapper--classroom)',
+    );
+    expect(stylesheet).toContain(':not(.slide--browser-fullscreen)');
   });
 
   it('lets Slide size the mobile player grid from its rendered actions', () => {


### PR DESCRIPTION
## Summary

Move the desktop listen-mode player, subtitle, interaction, and follow-up controls 12px closer to the chat footer while keeping mobile, browser fullscreen, and classroom layouts unchanged.

## Changes

- Set the host-side desktop listen-player footer gap from 12px to 0px so all four controls continue to share one vertical anchor.
- Add a style regression test covering the shared offset and excluded responsive modes.

## Verification

- Focused Jest: 4 tests passed.
- `npm run format:check:changed` passed.
- `python3 scripts/check_dev_tools.py` passed.
- `lefthook run pre-commit --all-files` passed.

Manual course-level visual verification was not available because the local learner route requires an authenticated course session.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual spacing-only change on desktop listen mode; mobile, classroom, and browser fullscreen paths are unchanged and guarded by tests.
> 
> **Overview**
> Desktop listen mode controls sit **12px lower** by changing the shared `--listen-player-footer-gap` on **ChatUi** from `12px` to **`0px`**. That gap feeds into `--listen-slide-player-bottom-offset`, so the player, subtitles, interaction overlays, and ask overlay still share one vertical anchor—just flush with the footer spacing instead of inset.
> 
> A new stylesheet regression test locks in **`0px`** on the host and asserts desktop (non-mobile, non-classroom, non-browser-fullscreen) rules still wire overlays and the player through **`var(--listen-slide-player-bottom-offset)`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a04d888a5afb76ffd2ad01637499b6e789a9f49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->