### PR TITLE
fix: prevent concurrent template sync failures

### DIFF
--- a/src/api/flaskr/service/billing/credit_notifications.py
+++ b/src/api/flaskr/service/billing/credit_notifications.py
@@ -923,16 +923,28 @@ def _format_operator_datetime(app: Flask, value: datetime | None) -> str:
     return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
-def _load_notification_template(template_code: str) -> NotificationTemplate | None:
-    return (
-        NotificationTemplate.query.filter(
-            NotificationTemplate.deleted == 0,
-            NotificationTemplate.channel == CREDIT_NOTIFICATION_CHANNEL_SMS,
-            NotificationTemplate.provider == NOTIFICATION_TEMPLATE_PROVIDER_ALIYUN,
-            NotificationTemplate.template_code == template_code,
-        )
-        .order_by(NotificationTemplate.id.desc())
-        .first()
+def _load_notification_template(
+    template_code: str,
+    *,
+    for_update: bool = False,
+) -> NotificationTemplate | None:
+    query = NotificationTemplate.query.filter(
+        NotificationTemplate.deleted == 0,
+        NotificationTemplate.channel == CREDIT_NOTIFICATION_CHANNEL_SMS,
+        NotificationTemplate.provider == NOTIFICATION_TEMPLATE_PROVIDER_ALIYUN,
+        NotificationTemplate.template_code == template_code,
+    )
+    if for_update:
+        query = query.with_for_update()
+    return query.order_by(NotificationTemplate.id.desc()).first()
+
+
+def _is_notification_template_unique_constraint_error(exc: IntegrityError) -> bool:
+    error_message = str(getattr(exc, "orig", exc)).lower()
+    return "uq_notification_templates_channel_provider_code" in error_message or (
+        "notification_templates.channel" in error_message
+        and "notification_templates.provider" in error_message
+        and "notification_templates.template_code" in error_message
     )
 
 
@@ -945,7 +957,22 @@ def _get_or_create_notification_template(
     template = _load_notification_template(template_code)
     if template is not None:
         return template
-    return _create_notification_template(app, template_code=template_code, now=now)
+    try:
+        with db.session.begin_nested():
+            template = _create_notification_template(
+                app,
+                template_code=template_code,
+                now=now,
+            )
+            db.session.flush()
+            return template
+    except IntegrityError as exc:
+        if not _is_notification_template_unique_constraint_error(exc):
+            raise
+        template = _load_notification_template(template_code, for_update=True)
+        if template is not None:
+            return template
+        raise
 
 
 def _create_notification_template(
@@ -1284,7 +1311,7 @@ def list_credit_notification_templates(app: Flask) -> dict[str, object]:
                 continue
             template = existing_templates.get(template_code)
             if template is None:
-                template = _create_notification_template(
+                template = _get_or_create_notification_template(
                     app,
                     template_code=template_code,
                     now=now,

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -348,13 +348,14 @@ def test_get_or_create_notification_template_recovers_from_unique_conflict(
     _seed_notification_template(app, template_code="TPL-CONCURRENT")
 
     with app.app_context():
-        existing = NotificationTemplate.query.filter_by(
+        expected = NotificationTemplate.query.filter_by(
             channel="sms",
             provider="aliyun",
             template_code="TPL-CONCURRENT",
             deleted=0,
         ).one()
         load_calls: list[bool] = []
+        original_load_template = credit_notifications._load_notification_template
 
         def load_template(
             template_code: str,
@@ -363,7 +364,9 @@ def test_get_or_create_notification_template_recovers_from_unique_conflict(
         ) -> NotificationTemplate | None:
             assert template_code == "TPL-CONCURRENT"
             load_calls.append(for_update)
-            return existing if for_update else None
+            if len(load_calls) == 1:
+                return None
+            return original_load_template(template_code, for_update=for_update)
 
         monkeypatch.setattr(
             credit_notifications,
@@ -377,7 +380,7 @@ def test_get_or_create_notification_template_recovers_from_unique_conflict(
             now=now_utc(),
         )
 
-    assert actual is existing
+    assert actual is expected
     assert load_calls == [False, True]
 
 

--- a/src/api/tests/service/billing/test_credit_notifications.py
+++ b/src/api/tests/service/billing/test_credit_notifications.py
@@ -15,6 +15,7 @@ import pytest
 from flask import Flask
 from flaskr import dao
 from flaskr.i18n import load_translations
+from flaskr.service.billing import credit_notifications
 from flaskr.service.billing.consts import (
     CREDIT_BUCKET_CATEGORY_TOPUP,
     CREDIT_BUCKET_STATUS_ACTIVE,
@@ -337,6 +338,47 @@ def _seed_default_notification_templates(app: Flask) -> None:
         template_code="TPL-LOW",
         placeholders=["available_credits"],
     )
+
+
+def test_get_or_create_notification_template_recovers_from_unique_conflict(
+    credit_notifications_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = credit_notifications_app
+    _seed_notification_template(app, template_code="TPL-CONCURRENT")
+
+    with app.app_context():
+        existing = NotificationTemplate.query.filter_by(
+            channel="sms",
+            provider="aliyun",
+            template_code="TPL-CONCURRENT",
+            deleted=0,
+        ).one()
+        load_calls: list[bool] = []
+
+        def load_template(
+            template_code: str,
+            *,
+            for_update: bool = False,
+        ) -> NotificationTemplate | None:
+            assert template_code == "TPL-CONCURRENT"
+            load_calls.append(for_update)
+            return existing if for_update else None
+
+        monkeypatch.setattr(
+            credit_notifications,
+            "_load_notification_template",
+            load_template,
+        )
+
+        actual = credit_notifications._get_or_create_notification_template(
+            app,
+            template_code="TPL-CONCURRENT",
+            now=now_utc(),
+        )
+
+    assert actual is existing
+    assert load_calls == [False, True]
 
 
 def test_managed_rules_stage_each_matching_notification_once(


### PR DESCRIPTION
## Summary
Prevent concurrent Aliyun SMS template synchronization from failing on the existing template uniqueness constraint.

## Change
- Create missing local templates inside a savepoint and flush immediately.
- Reload the winning template with a lock after the target unique-key conflict.
- Reuse the protected helper for single-template and paginated template synchronization.
- Add a regression test covering unique-key conflict recovery.

## Benefit
Concurrent operator refreshes of the same template complete successfully instead of returning a server error.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when notification templates are created concurrently.
  * Prevented duplicate-template errors by safely reusing an existing template when one is created simultaneously.

* **Tests**
  * Added coverage for concurrent notification-template creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->