### PR TITLE
fix: allow long Google avatar URLs

### DIFF
--- a/src/api/flaskr/service/user/models.py
+++ b/src/api/flaskr/service/user/models.py
@@ -181,7 +181,7 @@ class UserInfo(db.Model):
         nullable=True,
         comment="Timestamp when the learner profile was last changed",
     )
-    avatar = Column(String(255), nullable=False, default="", comment="User avatar")
+    avatar = Column(Text, nullable=False, default="", comment="User avatar")
     birthday = Column(Date, nullable=True, comment="User birthday")
     language = Column(String(30), nullable=False, default="", comment="User language")
     state = Column(

--- a/src/api/migrations/versions/6d568133dd29_expand_user_avatar_url_storage.py
+++ b/src/api/migrations/versions/6d568133dd29_expand_user_avatar_url_storage.py
@@ -29,6 +29,25 @@ def upgrade():
 
 
 def downgrade():
+    bind = op.get_bind()
+    user_users = sa.table("user_users", sa.column("avatar", sa.Text()))
+    avatar_length = (
+        sa.func.char_length(user_users.c.avatar)
+        if bind.dialect.name == "mysql"
+        else sa.func.length(user_users.c.avatar)
+    )
+    oversized_avatar = bind.execute(
+        sa.select(sa.literal(1))
+        .select_from(user_users)
+        .where(avatar_length > 255)
+        .limit(1)
+    ).first()
+    if oversized_avatar is not None:
+        raise RuntimeError(
+            "Cannot downgrade user_users.avatar to VARCHAR(255): "
+            "at least one avatar exceeds 255 characters"
+        )
+
     with op.batch_alter_table("user_users", schema=None) as batch_op:
         batch_op.alter_column(
             "avatar",

--- a/src/api/migrations/versions/6d568133dd29_expand_user_avatar_url_storage.py
+++ b/src/api/migrations/versions/6d568133dd29_expand_user_avatar_url_storage.py
@@ -1,0 +1,39 @@
+"""Expand user avatar URL storage.
+
+Revision ID: 6d568133dd29
+Revises: a1b2c3d4e5f6
+Create Date: 2026-09-02 08:44:01.595336
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "6d568133dd29"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("user_users", schema=None) as batch_op:
+        batch_op.alter_column(
+            "avatar",
+            existing_type=sa.String(length=255),
+            type_=sa.Text(),
+            existing_nullable=False,
+            existing_comment="User avatar",
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("user_users", schema=None) as batch_op:
+        batch_op.alter_column(
+            "avatar",
+            existing_type=sa.Text(),
+            type_=sa.String(length=255),
+            existing_nullable=False,
+            existing_comment="User avatar",
+        )

--- a/src/api/tests/migrations/test_fresh_mysql_upgrade.py
+++ b/src/api/tests/migrations/test_fresh_mysql_upgrade.py
@@ -168,6 +168,9 @@ def test_fresh_mysql_upgrade_reaches_head() -> None:
             ).scalar_one()
         inspector = inspect(engine)
         tables = set(inspector.get_table_names())
+        user_columns = {
+            column["name"]: column for column in inspector.get_columns("user_users")
+        }
         provider_price_indexes = {
             index["name"]: tuple(index["column_names"])
             for index in inspector.get_indexes("bill_product_provider_prices")
@@ -188,6 +191,7 @@ def test_fresh_mysql_upgrade_reaches_head() -> None:
             "learn_lesson_feedbacks",
             "bill_product_provider_prices",
         }.issubset(tables)
+        assert str(user_columns["avatar"]["type"]).upper() == "TEXT"
         assert provider_price_indexes[
             "ix_bill_product_provider_prices_product_status"
         ] == ("product_bid", "status")

--- a/src/api/tests/migrations/test_user_avatar_migration.py
+++ b/src/api/tests/migrations/test_user_avatar_migration.py
@@ -1,0 +1,54 @@
+"""Verify the user-avatar storage migration."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+API_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_PATH = (
+    API_ROOT
+    / "migrations"
+    / "versions"
+    / "6d568133dd29_expand_user_avatar_url_storage.py"
+)
+
+
+def _load_migration_module() -> object:
+    spec = importlib.util.spec_from_file_location(
+        "test_user_avatar_migration_module",
+        MIGRATION_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_downgrade_rejects_oversized_avatar_without_changing_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    user_users = sa.Table(
+        "user_users",
+        metadata,
+        sa.Column("avatar", sa.Text(), nullable=False),
+    )
+    oversized_avatar = "a" * 256
+
+    with engine.begin() as connection:
+        metadata.create_all(connection)
+        connection.execute(user_users.insert().values(avatar=oversized_avatar))
+        monkeypatch.setattr(migration.op, "get_bind", lambda: connection)
+
+        with pytest.raises(RuntimeError, match="avatar exceeds 255 characters"):
+            migration.downgrade()
+
+        stored_avatar = connection.execute(sa.select(user_users.c.avatar)).scalar_one()
+        assert stored_avatar == oversized_avatar
+
+    engine.dispose()

--- a/src/api/tests/service/user/test_google_auth.py
+++ b/src/api/tests/service/user/test_google_auth.py
@@ -22,6 +22,7 @@ from flaskr.service.user.models import (
 from flaskr.service.user.models import (
     UserToken as UserTokenModel,
 )
+from sqlalchemy import Text
 
 
 def _reset_config_cache(*keys: str) -> None:
@@ -253,6 +254,48 @@ def test_google_existing_account_keeps_pre_profile_display_name_behavior(
             db.session.expire_all()
             stored = UserEntity.query.filter_by(user_bid=existing_user.user_bid).one()
             assert stored.nickname == "Current Google Name"
+        finally:
+            _reset_user_auth_tables()
+
+
+def test_google_existing_account_accepts_long_avatar_url(
+    app: object,
+    monkeypatch: object,
+) -> None:
+    email = f"{uuid.uuid4().hex[:10]}@example.com"
+    avatar_url = f"https://lh3.googleusercontent.com/a-/{'a' * 512}=s96-c"
+
+    assert len(avatar_url) > 255
+    assert isinstance(UserEntity.__table__.c.avatar.type, Text)
+
+    with app.app_context():
+        _reset_user_auth_tables()
+        try:
+            existing_user = UserEntity(
+                user_bid=uuid.uuid4().hex[:32],
+                user_identify=email,
+                nickname="Existing User",
+                avatar="",
+                language="en-US",
+                state=USER_STATE_UNREGISTERED,
+            )
+            db.session.add(existing_user)
+            db.session.commit()
+
+            result = _run_google_callback(
+                app,
+                monkeypatch,
+                {
+                    "sub": uuid.uuid4().hex,
+                    "email": email,
+                    "email_verified": True,
+                    "name": "Existing User",
+                    "picture": avatar_url,
+                },
+            )
+
+            stored = UserEntity.query.filter_by(user_bid=result.user.user_id).one()
+            assert stored.avatar == avatar_url
         finally:
             _reset_user_auth_tables()
 


### PR DESCRIPTION
## Summary

- expand `user_users.avatar` from `VARCHAR(255)` to `TEXT`
- add an Alembic migration for existing databases
- reject downgrade explicitly when oversized avatar values would prevent safe narrowing
- cover Google OAuth persistence and lossless rollback protection for avatar URLs longer than 255 characters
- assert the final avatar type in the fresh-MySQL migration smoke test

## Root cause

Google can return profile picture URLs longer than 255 characters. Persisting one for an existing user caused MySQL error 1406 during the OAuth callback and aborted sign-in.

## Verification

- `491 passed` — `tests/service/user/`
- `5 passed, 1 skipped` — `tests/migrations/`
- `10 passed, 1 skipped` — combined migration and focused Google OAuth tests after review follow-up
- Ruff check and format passed for all changed Python files
- pre-commit and commit-msg hooks passed

The skipped test is the opt-in fresh-MySQL smoke test, which requires `RUN_MYSQL_MIGRATION_SMOKE=1` and a MySQL admin DSN. Its schema assertion verifies that `user_users.avatar` resolves to `TEXT`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Avatar URLs longer than 255 characters can now be stored successfully during Google sign-in.
  * Expanded avatar storage capacity while preserving existing avatar settings and behavior.
  * Prevented database downgrades from proceeding when they would truncate existing avatar URLs.

* **Tests**
  * Added coverage for long avatar URLs and verified the updated database column type.
  * Added migration validation for fresh MySQL installations and downgrade safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->