### PR TITLE
feat: add Gemini TTS provider

### DIFF
--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -163,6 +163,36 @@ CAPTCHA_MAX_VERIFY_ATTEMPTS="5"
 # Type: int
 CAPTCHA_TICKET_EXPIRE_TIME="300"
 
+# Lifetime in seconds of a pending device authorization request
+# (Optional - default: 600)
+# Type: int
+DEVICE_AUTH_EXPIRE_TIME="600"
+
+# Window in seconds for counting device authorization requests
+# (Optional - default: 600)
+# Type: int
+DEVICE_AUTH_ISSUE_WINDOW="600"
+
+# Window in seconds for counting failed pairing-code lookups
+# (Optional - default: 600)
+# Type: int
+DEVICE_AUTH_LOOKUP_WINDOW="600"
+
+# Failed pairing-code lookups allowed per IP before refusing
+# (Optional - default: 10)
+# Type: int
+DEVICE_AUTH_MAX_LOOKUP_ATTEMPTS="10"
+
+# Device authorization requests allowed per IP per window
+# (Optional - default: 20)
+# Type: int
+DEVICE_AUTH_MAX_REQUESTS="20"
+
+# Seconds a device client should wait between polls
+# (Optional - default: 5)
+# Type: int
+DEVICE_AUTH_POLL_INTERVAL="5"
+
 # OAuth client ID issued by Google
 # (Optional - default: )
 GOOGLE_OAUTH_CLIENT_ID=""
@@ -1049,6 +1079,19 @@ ELEVENLABS_API_KEY=""
 # JSON array of approved ElevenLabs voices. Each item must contain non-empty value and label fields, e.g. [{"value":"voice_id","label":"Display name"}].
 # (Optional - default: )
 ELEVENLABS_TTS_VOICES_JSON=""
+
+# Base URL of the Gemini generateContent API used for speech synthesis. Independent of GEMINI_API_URL, which configures the LiteLLM chat endpoint.
+# (Optional - default: https://generativelanguage.googleapis.com/v1beta)
+GEMINI_TTS_API_URL="https://generativelanguage.googleapis.com/v1beta"
+
+# Expose Google Gemini as a TTS provider. Synthesis reuses GEMINI_API_KEY, so this explicit switch keeps deployments that only use Gemini for LLM calls from listing it as a voice option.
+# (Optional - default: False)
+# Type: bool
+GEMINI_TTS_ENABLED="False"
+
+# Optional JSON array narrowing or relabeling the built-in Gemini prebuilt voices. Each item must contain non-empty value and label fields, e.g. [{"value":"Kore","label":"Kore (Firm)"}]. The value must be a prebuilt voice name; empty exposes every built-in voice.
+# (Optional - default: )
+GEMINI_TTS_VOICES_JSON=""
 
 # Max concurrent block-audio TTS syntheses per (user, outline); 0 disables the concurrency cap
 # (Optional - default: 6)

--- a/docs/exec-plans/active/gemini-tts.md
+++ b/docs/exec-plans/active/gemini-tts.md
@@ -1,0 +1,133 @@
+# Gemini TTS Provider
+
+## Purpose / Big Picture
+
+Add Google Gemini as an application-side TTS provider so overseas deployments
+can offer Gemini voices next to Volcengine and ElevenLabs without changing the
+listen-mode streaming contract. Teachers select one of three Gemini TTS models
+and one of the thirty prebuilt voices; generated audio continues through the
+shared segmentation, SSE, caching, storage, and metering paths as MP3.
+
+## Progress
+
+- [x] 2026-09-03: Confirmed provider, validation, streaming, config, and test
+  ownership on the latest `origin/main`; researched the Gemini Developer API
+  speech contract (PCM-only output, no speed/pitch parameters, preview-only
+  models, streaming limited to 3.1).
+- [x] 2026-09-03: Extracted shared PCM helpers (`pcm_duration_ms`,
+  `export_pcm_to_mp3`) into `flaskr/service/tts/audio_utils.py` and made the
+  Tencent SSE provider delegate to them.
+- [x] 2026-09-03: Implemented `GeminiTTSProvider`, the shared voice allowlist
+  parser, registry wiring, strict validation, shared retry/skip integration,
+  and environment declarations.
+- [x] 2026-09-03: Added focused provider tests plus audio-utility and
+  streaming regression coverage; regenerated the Docker env example.
+- [ ] Credentialed smoke test against the live API from a test environment.
+
+## Surprises & Discoveries
+
+- Gemini's `generateContent` speech responses carry raw 16-bit PCM inside
+  `inlineData` (`audio/L16;codec=pcm;rate=24000`). The SSE audio contract has
+  no format field and the web player decodes each segment independently, so
+  the provider must transcode to MP3 itself.
+- `GEMINI_API_URL` is a LiteLLM chat override that the LLM layer discards
+  when it points at the official Gemini host. The TTS endpoint therefore has
+  its own `GEMINI_TTS_API_URL` instead of reusing that value.
+- Preview TTS models report overload as HTTP 503. The shared streaming retry
+  matches on a "rate limit" marker in the error text, so 503 is reported the
+  same way as 429 to opt into the staggered retry.
+- Gemini exposes neither speed nor pitch. Locking both ranges to a single
+  value keeps the generic editor working because strict validation uses
+  inclusive bounds and the editor clamps into the advertised range.
+
+## Decision Log
+
+- Use the Gemini Developer API with `GEMINI_API_KEY`; the Cloud
+  Text-to-Speech transport (GA models, direct MP3, GCP OAuth) is documented as
+  a possible follow-up but not implemented.
+- Gate exposure behind `GEMINI_TTS_ENABLED` because many deployments set
+  `GEMINI_API_KEY` for LLM calls only and must not gain a voice option by
+  accident.
+- Expose exactly `gemini-3.1-flash-tts-preview`,
+  `gemini-2.5-flash-preview-tts`, and `gemini-2.5-pro-preview-tts`.
+- Ship the thirty prebuilt voices as the built-in catalog; the optional
+  `GEMINI_TTS_VOICES_JSON` allowlist narrows or relabels them and falls back
+  to the built-in catalog when invalid.
+- Keep the provider explicit-only (not auto-detected) and hide it from the
+  config payload unless it is configured and allowlisted, matching ElevenLabs.
+- Send each sentence-sized segment as one unary request; provider-native
+  streaming for the 3.1 model is intentionally out of scope.
+- Do not map `emotion` to a style prompt in this version; the text is sent
+  unchanged through a single hook where a prefix could be added later.
+
+## Outcomes & Retrospective
+
+Gemini is available as an explicit, fail-closed provider with three models and
+thirty deployment-filterable voices. Existing frontend, database, SSE,
+storage, and metering contracts were reused unchanged. Transcoding reuses the
+same pydub/ffmpeg path already required by the Tencent SSE provider.
+
+## Context and Orientation
+
+Provider adapters live under `src/api/flaskr/api/tts/`. Registry and picker
+payload construction live in that package's `__init__.py`. Strict course
+settings are checked in `src/api/flaskr/service/tts/validation.py`, while the
+generic listen-mode synthesis and retry behavior live in
+`src/api/flaskr/service/tts/streaming_tts.py`. Shared audio helpers live in
+`src/api/flaskr/service/tts/audio_utils.py`.
+
+## Plan of Work
+
+Implement a REST adapter that validates its deployment configuration, calls
+`generateContent` with `responseModalities=["AUDIO"]`, transcodes the PCM
+reply to MP3, and returns the existing `TTSResult`. Register it for explicit
+selection, add strict model/voice checks, opt it into shared empty-audio and
+rate-limit behavior, declare its environment variables, and cover the
+integration with focused tests.
+
+## Concrete Steps
+
+1. Add `pcm_duration_ms` and `export_pcm_to_mp3` to `audio_utils.py`; make
+   the Tencent provider delegate to them.
+2. Add `voice_config.parse_voice_list_json` for deployment voice allowlists.
+3. Add `GeminiTTSProvider` with its model catalog, voice catalog, request
+   builder, response validation, and PCM-to-MP3 transcoding.
+4. Register `gemini` without changing auto-detection; add it to the strict
+   validation sets and the shared empty-audio and non-speakable skip sets.
+5. Declare `GEMINI_TTS_ENABLED`, `GEMINI_TTS_API_URL`, and
+   `GEMINI_TTS_VOICES_JSON`; regenerate `docker/.env.example.full`.
+6. Add provider, audio-utility, validation, and streaming regression tests.
+
+## Validation and Acceptance
+
+With `GEMINI_TTS_ENABLED=true`, a Gemini API key, and matching
+`TTS_ALLOWED_MODELS`, the TTS config payload exposes the Gemini models and
+voices with locked speed and pitch ranges. Synthesis sends the expected
+authenticated request and returns playable MP3 bytes whose duration matches
+the PCM length. Missing or disabled configuration hides the provider, and
+invalid course settings fail before an external request.
+
+Run:
+
+```bash
+cd src/api
+python -m pytest tests/service/tts -q
+ruff check flaskr/api/tts flaskr/service/tts tests/service/tts
+```
+
+## Idempotence and Recovery
+
+Environment example generation is deterministic. Tests use mocked HTTP and a
+mocked transcoder and do not require credentials or ffmpeg. If configuration
+is invalid, unsetting `GEMINI_TTS_ENABLED` restores the previous provider set
+without data migration.
+
+## Interfaces and Dependencies
+
+- New environment variables: `GEMINI_TTS_ENABLED`, `GEMINI_TTS_API_URL`, and
+  `GEMINI_TTS_VOICES_JSON`; synthesis reuses `GEMINI_API_KEY`.
+- Existing dependencies: `requests`, `pydub` with ffmpeg (already required by
+  the Tencent SSE provider and audio concatenation).
+- No database, public HTTP DTO, frontend, or deployment repository changes.
+  Deployments must add `credit_usage_rates` rows for the Gemini models so the
+  picker shows a credit multiplier.

--- a/docs/exec-plans/active/gemini-tts.md
+++ b/docs/exec-plans/active/gemini-tts.md
@@ -22,7 +22,13 @@ shared segmentation, SSE, caching, storage, and metering paths as MP3.
   and environment declarations.
 - [x] 2026-09-03: Added focused provider tests plus audio-utility and
   streaming regression coverage; regenerated the Docker env example.
-- [ ] Credentialed smoke test against the live API from a test environment.
+- [x] 2026-09-03: Credentialed smoke tests. From the US dev pod (direct
+  Google access) both `gemini-3.1-flash-tts-preview` and
+  `gemini-2.5-flash-preview-tts` returned MP3 in about 3 seconds for a
+  43-character sentence, with `duration_ms` matching the decoded MP3 length.
+  From the China test host Google is unreachable, so `GEMINI_TTS_API_URL`
+  points at the internal Google AI proxy (`.../googleai/v1beta`), which
+  returned the same PCM payload in about 9 seconds.
 
 ## Surprises & Discoveries
 
@@ -36,6 +42,10 @@ shared segmentation, SSE, caching, storage, and metering paths as MP3.
 - Preview TTS models report overload as HTTP 503. The shared streaming retry
   matches on a "rate limit" marker in the error text, so 503 is reported the
   same way as 429 to opt into the staggered retry.
+- Hosts in mainland China cannot reach `generativelanguage.googleapis.com`.
+  The dedicated `GEMINI_TTS_API_URL` lets those deployments route the TTS
+  call through the existing Google AI proxy while keeping the default for
+  overseas clusters.
 - Gemini exposes neither speed nor pitch. Locking both ranges to a single
   value keeps the generic editor working because strict validation uses
   inclusive bounds and the editor clamps into the advertised range.

--- a/docs/exec-plans/active/gemini-tts.md
+++ b/docs/exec-plans/active/gemini-tts.md
@@ -61,8 +61,16 @@ shared segmentation, SSE, caching, storage, and metering paths as MP3.
 - Expose exactly `gemini-3.1-flash-tts-preview`,
   `gemini-2.5-flash-preview-tts`, and `gemini-2.5-pro-preview-tts`.
 - Ship the thirty prebuilt voices as the built-in catalog; the optional
-  `GEMINI_TTS_VOICES_JSON` allowlist narrows or relabels them and falls back
-  to the built-in catalog when invalid.
+  `GEMINI_TTS_VOICES_JSON` allowlist narrows or relabels them. A configured
+  allowlist is fail-closed: invalid JSON or no built-in voice left makes the
+  provider unavailable instead of silently widening voice access (review
+  feedback on the first revision).
+- Require an `https://` value for `GEMINI_TTS_API_URL` because the API key is
+  sent in a request header; the shared key is still sent to whatever trusted
+  endpoint the deployment configures, matching how the other provider base
+  URLs in this repository are treated.
+- Reject fractional pitch values both in the provider and in strict
+  validation instead of truncating them to the locked integer.
 - Keep the provider explicit-only (not auto-detected) and hide it from the
   config payload unless it is configured and allowlisted, matching ElevenLabs.
 - Send each sentence-sized segment as one unary request; provider-native

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -20,6 +20,7 @@ Active and completed ExecPlans live here. The structure and required sections ar
 - [Creator Dashboard Learners SQL Optimization](./active/creator-dashboard-learners-sql-optimization.md)
 - [Creator Dashboard Ratings SQL Optimization](./active/creator-dashboard-ratings-sql-optimization.md)
 - [Creator Dashboard Request Splitting](./active/creator-dashboard-request-splitting.md)
+- [Gemini TTS Provider](./active/gemini-tts.md)
 - [Notification Channel Foundation](./active/notification-channel-foundation.md)
 - [Observability Artifacts, Consistency Probes, and Frontend Trace IDs](./active/observability-artifacts-consistency-frontend-trace.md)
 - [Existing Creator Onboarding Rollout](./active/onboarding-existing-creator-rollout.md)

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -36,6 +36,7 @@
 | `docs/exec-plans/active/creator-dashboard-learners-sql-optimization.md` | Creator Dashboard Learners SQL Optimization | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/creator-dashboard-ratings-sql-optimization.md` | Creator Dashboard Ratings SQL Optimization | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/creator-dashboard-request-splitting.md` | Creator Dashboard Request Splitting | `exec-plan-active` | `active` | `repo` | `-` | `true` |
+| `docs/exec-plans/active/gemini-tts.md` | Gemini TTS Provider | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/notification-channel-foundation.md` | Notification Channel Foundation | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/observability-artifacts-consistency-frontend-trace.md` | Observability Artifacts, Consistency Probes, and Frontend Trace IDs | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/onboarding-existing-creator-rollout.md` | Existing Creator Onboarding Rollout | `exec-plan-active` | `active` | `repo` | `-` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -9,7 +9,7 @@ This generated report summarizes the repository harness control plane.
 - Design docs: `12`
 - Product specs: `10`
 - References: `4`
-- Active ExecPlans: `23`
+- Active ExecPlans: `24`
 - Completed ExecPlans: `32`
 
 ## Boundary Baseline

--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -8,6 +8,7 @@ This module provides integration with multiple Text-to-Speech providers:
 - Tencent (TRTC conversational SSE API)
 - Tencent TextToVoice (standard Tencent Cloud TTS API)
 - ElevenLabs (create-speech REST API)
+- Gemini (generateContent speech API)
 
 The provider can be selected per-Shifu configuration.
 """
@@ -41,6 +42,7 @@ from flaskr.api.tts.base import (
     VoiceSettings as VoiceSettings,
 )
 from flaskr.api.tts.elevenlabs_provider import ElevenLabsTTSProvider
+from flaskr.api.tts.gemini_provider import GeminiTTSProvider
 from flaskr.api.tts.minimax_provider import MinimaxTTSProvider
 from flaskr.api.tts.tencent_provider import TencentTTSProvider
 from flaskr.api.tts.tencent_texttovoice_provider import TencentTextToVoiceProvider
@@ -67,6 +69,7 @@ _PROVIDER_REGISTRY = {
     "tencent": TencentTTSProvider,
     "tencent_texttovoice": TencentTextToVoiceProvider,
     "elevenlabs": ElevenLabsTTSProvider,
+    "gemini": GeminiTTSProvider,
 }
 _PROVIDER_PRIORITY = (
     "minimax",
@@ -77,6 +80,7 @@ _PROVIDER_PRIORITY = (
     "tencent",
     "tencent_texttovoice",
     "elevenlabs",
+    "gemini",
 )
 _AUTO_DETECT_PROVIDER_PRIORITY = (
     "minimax",
@@ -85,8 +89,8 @@ _AUTO_DETECT_PROVIDER_PRIORITY = (
     "baidu",
     "aliyun",
 )
-_CONFIG_REQUIRES_CONFIGURED_PROVIDER = {"elevenlabs"}
-_CONFIG_REQUIRES_ALLOWED_MODEL = {"elevenlabs"}
+_CONFIG_REQUIRES_CONFIGURED_PROVIDER = {"elevenlabs", "gemini"}
+_CONFIG_REQUIRES_ALLOWED_MODEL = {"elevenlabs", "gemini"}
 
 # Provider instances (lazy initialized)
 _provider_instances: dict = {}
@@ -142,8 +146,9 @@ def get_tts_provider(provider_name: str = "") -> BaseTTSProvider:
     """Get a TTS provider instance.
 
     Args:
-        provider_name: Provider name ("minimax", "volcengine", "volcengine_http", "baidu", "aliyun", "tencent").
-                      If empty, auto-detects.
+        provider_name: Provider name ("minimax", "volcengine", "volcengine_http",
+                      "baidu", "aliyun", "tencent", "tencent_texttovoice",
+                      "elevenlabs", "gemini"). If empty, auto-detects.
 
     Returns:
         TTS provider instance

--- a/src/api/flaskr/api/tts/base.py
+++ b/src/api/flaskr/api/tts/base.py
@@ -22,6 +22,7 @@ class TTSProvider(StrEnum):
     TENCENT = "tencent"
     TENCENT_TEXTTOVOICE = "tencent_texttovoice"
     ELEVENLABS = "elevenlabs"
+    GEMINI = "gemini"
 
 
 @dataclass

--- a/src/api/flaskr/api/tts/gemini_provider.py
+++ b/src/api/flaskr/api/tts/gemini_provider.py
@@ -1,0 +1,461 @@
+"""Google Gemini text-to-speech provider.
+
+Synthesis goes through the Gemini Developer API ``generateContent`` endpoint
+with ``responseModalities=["AUDIO"]``. Gemini only returns raw 16-bit PCM, so
+the provider transcodes every response to MP3 before handing it to the shared
+streaming, storage, and playback paths, which all assume MP3.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+import math
+import re
+from typing import Any
+from urllib.parse import quote
+
+import requests
+from requests import Response
+
+from flaskr.api.tts.base import (
+    AudioSettings,
+    BaseTTSProvider,
+    ParamRange,
+    ProviderConfig,
+    TTSResult,
+    VoiceSettings,
+)
+from flaskr.api.tts.voice_config import parse_voice_list_json
+from flaskr.common.config import get_config
+from flaskr.common.log import AppLoggerProxy
+from flaskr.service.tts.audio_utils import export_pcm_to_mp3, pcm_duration_ms
+
+logger = AppLoggerProxy(logging.getLogger(__name__))
+
+GEMINI_TTS_DEFAULT_API_URL = "https://generativelanguage.googleapis.com/v1beta"
+GEMINI_TTS_REQUEST_TIMEOUT = (10, 90)
+# The TTS models accept 8k input tokens; CJK text runs at roughly one token
+# per character, so this cap stays far inside the limit while still catching
+# misuse. Callers normally send sentence-sized segments (TTS_MAX_SEGMENT_CHARS).
+GEMINI_TTS_MAX_INPUT_CHARS = 4000
+GEMINI_TTS_DEFAULT_SAMPLE_RATE = 24000
+GEMINI_TTS_DEFAULT_VOICE = "Kore"
+GEMINI_TTS_DEFAULT_MODEL = "gemini-2.5-flash-preview-tts"
+GEMINI_TTS_MODELS = [
+    {"value": "gemini-3.1-flash-tts-preview", "label": "Gemini 3.1 Flash TTS"},
+    {"value": "gemini-2.5-flash-preview-tts", "label": "Gemini 2.5 Flash TTS"},
+    {"value": "gemini-2.5-pro-preview-tts", "label": "Gemini 2.5 Pro TTS"},
+]
+_GEMINI_TTS_MODEL_IDS = {item["value"] for item in GEMINI_TTS_MODELS}
+# Prebuilt voices published by Google, with the official character adjectives.
+GEMINI_TTS_VOICES = [
+    {"value": "Zephyr", "label": "Zephyr (Bright)"},
+    {"value": "Puck", "label": "Puck (Upbeat)"},
+    {"value": "Charon", "label": "Charon (Informative)"},
+    {"value": "Kore", "label": "Kore (Firm)"},
+    {"value": "Fenrir", "label": "Fenrir (Excitable)"},
+    {"value": "Leda", "label": "Leda (Youthful)"},
+    {"value": "Orus", "label": "Orus (Firm)"},
+    {"value": "Aoede", "label": "Aoede (Breezy)"},
+    {"value": "Callirrhoe", "label": "Callirrhoe (Easy-going)"},
+    {"value": "Autonoe", "label": "Autonoe (Bright)"},
+    {"value": "Enceladus", "label": "Enceladus (Breathy)"},
+    {"value": "Iapetus", "label": "Iapetus (Clear)"},
+    {"value": "Umbriel", "label": "Umbriel (Easy-going)"},
+    {"value": "Algieba", "label": "Algieba (Smooth)"},
+    {"value": "Despina", "label": "Despina (Smooth)"},
+    {"value": "Erinome", "label": "Erinome (Clear)"},
+    {"value": "Algenib", "label": "Algenib (Gravelly)"},
+    {"value": "Rasalgethi", "label": "Rasalgethi (Informative)"},
+    {"value": "Laomedeia", "label": "Laomedeia (Upbeat)"},
+    {"value": "Achernar", "label": "Achernar (Soft)"},
+    {"value": "Alnilam", "label": "Alnilam (Firm)"},
+    {"value": "Schedar", "label": "Schedar (Even)"},
+    {"value": "Gacrux", "label": "Gacrux (Mature)"},
+    {"value": "Pulcherrima", "label": "Pulcherrima (Forward)"},
+    {"value": "Achird", "label": "Achird (Friendly)"},
+    {"value": "Zubenelgenubi", "label": "Zubenelgenubi (Casual)"},
+    {"value": "Vindemiatrix", "label": "Vindemiatrix (Gentle)"},
+    {"value": "Sadachbia", "label": "Sadachbia (Lively)"},
+    {"value": "Sadaltager", "label": "Sadaltager (Knowledgeable)"},
+    {"value": "Sulafat", "label": "Sulafat (Warm)"},
+]
+_GEMINI_TTS_VOICE_IDS = {item["value"] for item in GEMINI_TTS_VOICES}
+_BLOCKING_FINISH_REASONS = frozenset(
+    {"SAFETY", "RECITATION", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII"}
+)
+_EMPTY_AUDIO_MESSAGE = "No audio data received from Gemini TTS"
+_ERROR_DETAIL_LIMIT = 500
+_PCM_RATE_PATTERN = re.compile(r"rate=(\d+)")
+_HTTP_OK = 200
+_HTTP_TOO_MANY_REQUESTS = 429
+_HTTP_SERVICE_UNAVAILABLE = 503
+
+
+def _load_gemini_voices() -> list[dict[str, str]]:
+    """Return the selectable voices, narrowed by the optional deployment allowlist."""
+    raw = get_config("GEMINI_TTS_VOICES_JSON")
+    if raw in (None, "") or (isinstance(raw, str) and not raw.strip()):
+        return [dict(item) for item in GEMINI_TTS_VOICES]
+
+    try:
+        configured = parse_voice_list_json(raw, env_name="GEMINI_TTS_VOICES_JSON")
+    except (TypeError, ValueError) as exc:
+        logger.warning(
+            "Ignoring invalid GEMINI_TTS_VOICES_JSON, using built-in voices: %s",
+            exc,
+        )
+        return [dict(item) for item in GEMINI_TTS_VOICES]
+
+    voices: list[dict[str, str]] = []
+    for item in configured:
+        if item["value"] not in _GEMINI_TTS_VOICE_IDS:
+            logger.warning(
+                "Ignoring unknown Gemini TTS voice in GEMINI_TTS_VOICES_JSON: %s",
+                item["value"],
+            )
+            continue
+        voices.append(item)
+    if not voices:
+        logger.warning(
+            "GEMINI_TTS_VOICES_JSON has no built-in voices, using built-in voices"
+        )
+        return [dict(item) for item in GEMINI_TTS_VOICES]
+    return voices
+
+
+def _resolve_api_base_url() -> str:
+    configured = str(get_config("GEMINI_TTS_API_URL") or "").strip()
+    return (configured or GEMINI_TTS_DEFAULT_API_URL).rstrip("/")
+
+
+def _parse_audio_mime_type(mime_type: str) -> tuple[bool, int]:
+    """Return ``(is_pcm, sample_rate)`` for a Gemini inline audio mime type.
+
+    Gemini reports raw audio as ``audio/L16;codec=pcm;rate=24000``. The rate is
+    read from the mime parameters so a future default change does not desync
+    the transcoder.
+    """
+    normalized = str(mime_type or "").strip().lower()
+    is_pcm = normalized.startswith("audio/l16") or "pcm" in normalized
+    match = _PCM_RATE_PATTERN.search(normalized)
+    sample_rate = GEMINI_TTS_DEFAULT_SAMPLE_RATE
+    if match:
+        try:
+            sample_rate = int(match.group(1)) or GEMINI_TTS_DEFAULT_SAMPLE_RATE
+        except ValueError:
+            sample_rate = GEMINI_TTS_DEFAULT_SAMPLE_RATE
+    return is_pcm, sample_rate
+
+
+def _extract_safe_error_detail(response: Response, request_text: str) -> str:
+    detail: Any = ""
+    try:
+        payload = response.json()
+    except (TypeError, ValueError):
+        payload = None
+
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            detail = error.get("message") or error.get("status") or ""
+        else:
+            detail = payload.get("message") or error or ""
+    if not detail:
+        detail = getattr(response, "reason", "") or ""
+    safe_detail = str(detail).strip()
+    if request_text:
+        safe_detail = safe_detail.replace(request_text, "[redacted]")
+    return safe_detail[:_ERROR_DETAIL_LIMIT]
+
+
+def _extract_request_id(response: Response) -> str:
+    for key, value in (response.headers or {}).items():
+        if key.lower() in {"request-id", "x-request-id"}:
+            return str(value or "").strip()
+    return ""
+
+
+def _find_inline_audio(candidate: dict[str, Any]) -> tuple[str, str]:
+    """Return ``(base64_audio, mime_type)`` from the first inline audio part."""
+    content = candidate.get("content")
+    if not isinstance(content, dict):
+        return "", ""
+    parts = content.get("parts")
+    if not isinstance(parts, list):
+        return "", ""
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        inline = part.get("inlineData")
+        if not isinstance(inline, dict):
+            inline = part.get("inline_data")
+        if not isinstance(inline, dict):
+            continue
+        data = str(inline.get("data") or "").strip()
+        mime_type = str(inline.get("mimeType") or inline.get("mime_type") or "")
+        if data:
+            return data, mime_type
+    return "", ""
+
+
+def _coerce_finite_float(value: object, field_name: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        message = f"Invalid Gemini TTS {field_name}: {value!r}"
+        raise ValueError(message) from exc
+    if not math.isfinite(number):
+        message = f"Invalid Gemini TTS {field_name}: {value!r}"
+        raise ValueError(message)
+    return number
+
+
+class GeminiTTSProvider(BaseTTSProvider):
+    """TTS provider using the Gemini Developer API generateContent endpoint."""
+
+    @property
+    def provider_name(self) -> str:
+        """Return the provider's stable configuration name."""
+        return "gemini"
+
+    def is_configured(self) -> bool:
+        """Return whether the provider is switched on and has an API key."""
+        if not get_config("GEMINI_TTS_ENABLED"):
+            return False
+        return bool(str(get_config("GEMINI_API_KEY") or "").strip())
+
+    def get_default_voice_settings(self) -> VoiceSettings:
+        """Return a provider-level fallback using the first selectable voice."""
+        voices = _load_gemini_voices()
+        return VoiceSettings(
+            voice_id=voices[0]["value"] if voices else GEMINI_TTS_DEFAULT_VOICE,
+            speed=1.0,
+            pitch=0,
+            emotion="",
+            volume=1.0,
+        )
+
+    def get_default_audio_settings(self) -> AudioSettings:
+        """Return the MP3 settings produced after transcoding Gemini PCM."""
+        return AudioSettings(
+            format="mp3",
+            sample_rate=GEMINI_TTS_DEFAULT_SAMPLE_RATE,
+            bitrate=128000,
+            channel=1,
+        )
+
+    def get_supported_voices(self) -> list[dict[str, str]]:
+        """Return the built-in voices, narrowed by deployment configuration."""
+        return _load_gemini_voices()
+
+    def _build_prompt_text(self, text: str, emotion: str) -> str:
+        # Gemini steers delivery through natural-language instructions in the
+        # text itself. Emotion is not exposed in v1, so the text is sent as-is;
+        # this hook is where a style prefix would be added later.
+        del emotion
+        return text
+
+    def synthesize(
+        self,
+        text: str,
+        voice_settings: VoiceSettings | None = None,
+        audio_settings: AudioSettings | None = None,
+        model: str | None = None,
+    ) -> TTSResult:
+        """Synthesize speech through generateContent and return MP3 bytes."""
+        del audio_settings  # Output is fixed to MP3 for the shared audio pipeline.
+
+        if not text or not text.strip():
+            message = "Text cannot be empty"
+            raise ValueError(message)
+        if len(text) > GEMINI_TTS_MAX_INPUT_CHARS:
+            message = (
+                f"Text exceeds Gemini TTS limit: {len(text)} > "
+                f"{GEMINI_TTS_MAX_INPUT_CHARS} characters"
+            )
+            raise ValueError(message)
+        if not get_config("GEMINI_TTS_ENABLED"):
+            message = "GEMINI_TTS_ENABLED is not set"
+            raise ValueError(message)
+        api_key = str(get_config("GEMINI_API_KEY") or "").strip()
+        if not api_key:
+            message = "GEMINI_API_KEY is not configured"
+            raise ValueError(message)
+
+        settings = voice_settings or self.get_default_voice_settings()
+        voice_id = str(settings.voice_id or "").strip() or GEMINI_TTS_DEFAULT_VOICE
+        approved_voice_ids = {voice["value"] for voice in self.get_supported_voices()}
+        if voice_id not in approved_voice_ids:
+            message = f"Gemini TTS voice is not approved: {voice_id}"
+            raise ValueError(message)
+
+        model_id = str(model or "").strip() or GEMINI_TTS_DEFAULT_MODEL
+        if model_id not in _GEMINI_TTS_MODEL_IDS:
+            message = f"Unsupported Gemini TTS model: {model_id}"
+            raise ValueError(message)
+
+        speed = _coerce_finite_float(settings.speed, "speed")
+        if not math.isclose(speed, 1.0, abs_tol=1e-9):
+            message = f"Gemini TTS speed is fixed at 1.0: {speed}"
+            raise ValueError(message)
+        pitch = int(_coerce_finite_float(settings.pitch or 0, "pitch"))
+        if pitch != 0:
+            message = f"Gemini TTS pitch is fixed at 0: {pitch}"
+            raise ValueError(message)
+
+        url = f"{_resolve_api_base_url()}/models/{quote(model_id, safe='')}:generateContent"
+        headers = {
+            "x-goog-api-key": api_key,
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "contents": [
+                {"parts": [{"text": self._build_prompt_text(text, settings.emotion)}]}
+            ],
+            "generationConfig": {
+                "responseModalities": ["AUDIO"],
+                "speechConfig": {
+                    "voiceConfig": {"prebuiltVoiceConfig": {"voiceName": voice_id}}
+                },
+            },
+        }
+
+        try:
+            response = requests.post(
+                url,
+                headers=headers,
+                json=payload,
+                timeout=GEMINI_TTS_REQUEST_TIMEOUT,
+                allow_redirects=False,
+            )
+        except requests.RequestException as exc:
+            logger.warning(
+                "Gemini TTS request failed: model=%s voice=%s text_len=%s error_type=%s",
+                model_id,
+                voice_id,
+                len(text),
+                type(exc).__name__,
+            )
+            message = f"Gemini TTS request failed: {exc}"
+            raise ValueError(message) from exc
+
+        if response.status_code != _HTTP_OK:
+            request_id = _extract_request_id(response)
+            detail = _extract_safe_error_detail(response, text)
+            logger.error(
+                "Gemini TTS HTTP error: status=%s request_id=%s model=%s voice=%s text_len=%s detail=%s",
+                response.status_code,
+                request_id or "-",
+                model_id,
+                voice_id,
+                len(text),
+                detail or "-",
+            )
+            if response.status_code == _HTTP_TOO_MANY_REQUESTS:
+                message = "Gemini TTS HTTP 429 rate limit"
+            elif response.status_code == _HTTP_SERVICE_UNAVAILABLE:
+                # Preview models answer overload with 503 UNAVAILABLE. The
+                # shared streaming retry keys off the "rate limit" marker, so
+                # overload is reported the same way as quota exhaustion.
+                message = "Gemini TTS HTTP 503 overloaded (rate limit)"
+            else:
+                message = f"Gemini TTS HTTP {response.status_code}"
+            if detail:
+                message = f"{message}: {detail}"
+            raise ValueError(message)
+
+        try:
+            body = response.json()
+        except (TypeError, ValueError) as exc:
+            message = "Gemini TTS returned a non-JSON response"
+            raise ValueError(message) from exc
+        if not isinstance(body, dict):
+            message = "Gemini TTS returned an unexpected response payload"
+            raise TypeError(message)
+
+        prompt_feedback = body.get("promptFeedback")
+        block_reason = ""
+        if isinstance(prompt_feedback, dict):
+            block_reason = str(prompt_feedback.get("blockReason") or "").strip()
+        if block_reason:
+            message = f"Gemini TTS request blocked: {block_reason}"
+            raise ValueError(message)
+
+        candidates = body.get("candidates") or []
+        candidate: dict[str, Any] = {}
+        if (
+            isinstance(candidates, list)
+            and candidates
+            and isinstance(candidates[0], dict)
+        ):
+            candidate = candidates[0]
+        finish_reason = str(candidate.get("finishReason") or "").strip().upper()
+        if finish_reason in _BLOCKING_FINISH_REASONS:
+            message = f"Gemini TTS content blocked: {finish_reason}"
+            raise ValueError(message)
+
+        encoded_audio, mime_type = _find_inline_audio(candidate)
+        if not encoded_audio:
+            raise ValueError(_EMPTY_AUDIO_MESSAGE)
+        try:
+            pcm_audio = base64.b64decode(encoded_audio, validate=False)
+        except (binascii.Error, ValueError) as exc:
+            message = "Gemini TTS returned undecodable audio payload"
+            raise ValueError(message) from exc
+        if not pcm_audio:
+            raise ValueError(_EMPTY_AUDIO_MESSAGE)
+
+        is_pcm, sample_rate = _parse_audio_mime_type(mime_type)
+        if not is_pcm:
+            message = (
+                f"Unsupported Gemini TTS audio mime type: {mime_type or '<empty>'}"
+            )
+            raise ValueError(message)
+
+        mp3_audio = export_pcm_to_mp3(pcm_audio, sample_rate=sample_rate)
+        if not mp3_audio:
+            message = "No decodable audio data received from Gemini TTS"
+            raise ValueError(message)
+        duration_ms = pcm_duration_ms(pcm_audio, sample_rate=sample_rate)
+
+        usage = body.get("usageMetadata")
+        audio_tokens = (
+            usage.get("candidatesTokenCount") if isinstance(usage, dict) else None
+        )
+        logger.info(
+            "Gemini TTS synthesis completed: model=%s voice=%s duration_ms=%s pcm_bytes=%s mp3_bytes=%s text_len=%s audio_tokens=%s finish_reason=%s",
+            model_id,
+            voice_id,
+            duration_ms,
+            len(pcm_audio),
+            len(mp3_audio),
+            len(text),
+            audio_tokens if audio_tokens is not None else "-",
+            finish_reason or "-",
+        )
+        return TTSResult(
+            audio_data=mp3_audio,
+            duration_ms=duration_ms,
+            sample_rate=sample_rate,
+            format="mp3",
+            word_count=len(text),
+            usage_characters=len(text),
+        )
+
+    def get_provider_config(self) -> ProviderConfig:
+        """Return Gemini settings consumed by the generic editor UI."""
+        return ProviderConfig(
+            name="gemini",
+            label="Gemini",
+            speed=ParamRange(min=1.0, max=1.0, step=0.1, default=1.0),
+            pitch=ParamRange(min=0, max=0, step=1, default=0),
+            supports_emotion=False,
+            models=GEMINI_TTS_MODELS,
+            voices=self.get_supported_voices(),
+            emotions=[],
+            supports_custom_voice_id=False,
+            supports_voice_cloning=False,
+        )

--- a/src/api/flaskr/api/tts/gemini_provider.py
+++ b/src/api/flaskr/api/tts/gemini_provider.py
@@ -14,7 +14,7 @@ import logging
 import math
 import re
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import requests
 from requests import Response
@@ -95,7 +95,13 @@ _HTTP_SERVICE_UNAVAILABLE = 503
 
 
 def _load_gemini_voices() -> list[dict[str, str]]:
-    """Return the selectable voices, narrowed by the optional deployment allowlist."""
+    """Return the selectable voices, narrowed by the optional deployment allowlist.
+
+    An unset or blank ``GEMINI_TTS_VOICES_JSON`` exposes every built-in
+    prebuilt voice. A configured allowlist is fail-closed: invalid JSON or an
+    allowlist without a single built-in voice yields no voices, which marks the
+    provider as not configured instead of silently widening voice access.
+    """
     raw = get_config("GEMINI_TTS_VOICES_JSON")
     if raw in (None, "") or (isinstance(raw, str) and not raw.strip()):
         return [dict(item) for item in GEMINI_TTS_VOICES]
@@ -103,11 +109,8 @@ def _load_gemini_voices() -> list[dict[str, str]]:
     try:
         configured = parse_voice_list_json(raw, env_name="GEMINI_TTS_VOICES_JSON")
     except (TypeError, ValueError) as exc:
-        logger.warning(
-            "Ignoring invalid GEMINI_TTS_VOICES_JSON, using built-in voices: %s",
-            exc,
-        )
-        return [dict(item) for item in GEMINI_TTS_VOICES]
+        logger.warning("Ignoring invalid GEMINI_TTS_VOICES_JSON: %s", exc)
+        return []
 
     voices: list[dict[str, str]] = []
     for item in configured:
@@ -120,15 +123,34 @@ def _load_gemini_voices() -> list[dict[str, str]]:
         voices.append(item)
     if not voices:
         logger.warning(
-            "GEMINI_TTS_VOICES_JSON has no built-in voices, using built-in voices"
+            "GEMINI_TTS_VOICES_JSON contains no built-in Gemini voices; "
+            "the Gemini TTS provider is unavailable"
         )
-        return [dict(item) for item in GEMINI_TTS_VOICES]
     return voices
 
 
 def _resolve_api_base_url() -> str:
+    """Return the HTTPS base URL for the Gemini API.
+
+    The API key travels in a request header, so a cleartext endpoint is
+    rejected outright rather than leaking the key over ``http://``.
+    """
     configured = str(get_config("GEMINI_TTS_API_URL") or "").strip()
-    return (configured or GEMINI_TTS_DEFAULT_API_URL).rstrip("/")
+    base_url = (configured or GEMINI_TTS_DEFAULT_API_URL).rstrip("/")
+    parsed = urlparse(base_url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        message = "GEMINI_TTS_API_URL must be an https:// URL"
+        raise ValueError(message)
+    return base_url
+
+
+def _is_api_base_url_valid() -> bool:
+    try:
+        _resolve_api_base_url()
+    except ValueError as exc:
+        logger.warning("Ignoring invalid GEMINI_TTS_API_URL: %s", exc)
+        return False
+    return True
 
 
 def _parse_audio_mime_type(mime_type: str) -> tuple[bool, int]:
@@ -222,10 +244,14 @@ class GeminiTTSProvider(BaseTTSProvider):
         return "gemini"
 
     def is_configured(self) -> bool:
-        """Return whether the provider is switched on and has an API key."""
+        """Return whether the switch, API key, endpoint, and voices are all valid."""
         if not get_config("GEMINI_TTS_ENABLED"):
             return False
-        return bool(str(get_config("GEMINI_API_KEY") or "").strip())
+        if not str(get_config("GEMINI_API_KEY") or "").strip():
+            return False
+        if not _is_api_base_url_valid():
+            return False
+        return bool(_load_gemini_voices())
 
     def get_default_voice_settings(self) -> VoiceSettings:
         """Return a provider-level fallback using the first selectable voice."""
@@ -288,6 +314,9 @@ class GeminiTTSProvider(BaseTTSProvider):
         settings = voice_settings or self.get_default_voice_settings()
         voice_id = str(settings.voice_id or "").strip() or GEMINI_TTS_DEFAULT_VOICE
         approved_voice_ids = {voice["value"] for voice in self.get_supported_voices()}
+        if not approved_voice_ids:
+            message = "GEMINI_TTS_VOICES_JSON has no valid built-in voices"
+            raise ValueError(message)
         if voice_id not in approved_voice_ids:
             message = f"Gemini TTS voice is not approved: {voice_id}"
             raise ValueError(message)
@@ -301,9 +330,10 @@ class GeminiTTSProvider(BaseTTSProvider):
         if not math.isclose(speed, 1.0, abs_tol=1e-9):
             message = f"Gemini TTS speed is fixed at 1.0: {speed}"
             raise ValueError(message)
-        pitch = int(_coerce_finite_float(settings.pitch or 0, "pitch"))
-        if pitch != 0:
-            message = f"Gemini TTS pitch is fixed at 0: {pitch}"
+        pitch = _coerce_finite_float(settings.pitch or 0, "pitch")
+        # Compare before any integer conversion so 0.5 cannot truncate to 0.
+        if not math.isclose(pitch, 0.0, abs_tol=1e-9):
+            message = f"Gemini TTS pitch is fixed at 0: {settings.pitch!r}"
             raise ValueError(message)
 
         url = f"{_resolve_api_base_url()}/models/{quote(model_id, safe='')}:generateContent"

--- a/src/api/flaskr/api/tts/tencent_provider.py
+++ b/src/api/flaskr/api/tts/tencent_provider.py
@@ -10,7 +10,6 @@ import base64
 import datetime as dt
 import hashlib
 import hmac
-import io
 import json
 import logging
 import time
@@ -22,11 +21,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 import requests
-
-try:
-    from pydub import AudioSegment as PydubAudioSegment
-except ImportError:  # pragma: no cover - exercised only in minimal deployments
-    PydubAudioSegment = None
 
 from flaskr.api.tts.base import (
     AudioSettings,
@@ -41,6 +35,8 @@ from flaskr.common.log import AppLoggerProxy
 from flaskr.service.tts import resolve_tts_billable_chars
 from flaskr.service.tts.audio_utils import (
     concat_audio_best_effort,
+    export_pcm_to_mp3,
+    pcm_duration_ms,
     try_get_audio_duration_ms,
 )
 from flaskr.service.tts.subtitle_utils import normalize_subtitle_cues
@@ -290,28 +286,17 @@ def _concat_tencent_audio_segments(
 
 
 def _tencent_pcm_duration_ms(audio_data: bytes, *, sample_rate: int) -> int:
-    if not audio_data:
-        return 0
-    bytes_per_second = max(int(sample_rate or TENCENT_DEFAULT_SAMPLE_RATE), 1) * 2
-    return round(len(audio_data) * 1000 / bytes_per_second)
+    return pcm_duration_ms(
+        audio_data,
+        sample_rate=int(sample_rate or TENCENT_DEFAULT_SAMPLE_RATE),
+    )
 
 
 def _export_tencent_pcm_to_mp3(audio_data: bytes, *, sample_rate: int) -> bytes:
-    if not audio_data:
-        return b""
-    if PydubAudioSegment is None:
-        message = "pydub is required to convert Tencent TTS PCM audio to MP3"
-        raise ValueError(message)
-
-    segment = PydubAudioSegment(
-        data=audio_data,
-        sample_width=2,
-        frame_rate=int(sample_rate or TENCENT_DEFAULT_SAMPLE_RATE),
-        channels=1,
+    return export_pcm_to_mp3(
+        audio_data,
+        sample_rate=int(sample_rate or TENCENT_DEFAULT_SAMPLE_RATE),
     )
-    output = io.BytesIO()
-    segment.export(output, format=TENCENT_DEFAULT_CODEC, bitrate="128k")
-    return output.getvalue()
 
 
 def _coerce_app_id(app_id: object) -> int:

--- a/src/api/flaskr/api/tts/voice_config.py
+++ b/src/api/flaskr/api/tts/voice_config.py
@@ -1,0 +1,52 @@
+"""Shared parsing for deployment-owned TTS voice allowlists."""
+
+from __future__ import annotations
+
+import json
+
+
+def parse_voice_list_json(value: object, *, env_name: str) -> list[dict[str, str]]:
+    """Parse and normalize a JSON voice allowlist from deployment configuration.
+
+    The value must be a JSON array (or an already-decoded list) of objects with
+    non-empty ``value`` and ``label`` fields. Whitespace is stripped, duplicate
+    voice ids are rejected, and ``env_name`` is used in error messages so the
+    operator knows which variable to fix.
+    """
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return []
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            message = f"{env_name} must be valid JSON"
+            raise ValueError(message) from exc
+    else:
+        payload = value
+
+    if payload in (None, ""):
+        return []
+    if not isinstance(payload, list):
+        message = f"{env_name} must be a JSON array"
+        raise TypeError(message)
+
+    voices: list[dict[str, str]] = []
+    seen_ids: set[str] = set()
+    for index, item in enumerate(payload):
+        if not isinstance(item, dict):
+            message = f"{env_name} voice at index {index} must be an object"
+            raise TypeError(message)
+        voice_id = str(item.get("value") or "").strip()
+        label = str(item.get("label") or "").strip()
+        if not voice_id or not label:
+            message = (
+                f"{env_name} voice at index {index} requires non-empty value and label"
+            )
+            raise ValueError(message)
+        if voice_id in seen_ids:
+            message = f"Duplicate {env_name} voice id: {voice_id}"
+            raise ValueError(message)
+        seen_ids.add(voice_id)
+        voices.append({"value": voice_id, "label": label})
+    return voices

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1585,6 +1585,39 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         group="tts",
         required=False,
     ),
+    "GEMINI_TTS_ENABLED": EnvVar(
+        name="GEMINI_TTS_ENABLED",
+        default=False,
+        type=bool,
+        description=(
+            "Expose Google Gemini as a TTS provider. Synthesis reuses "
+            "GEMINI_API_KEY, so this explicit switch keeps deployments that "
+            "only use Gemini for LLM calls from listing it as a voice option."
+        ),
+        group="tts",
+    ),
+    "GEMINI_TTS_API_URL": EnvVar(
+        name="GEMINI_TTS_API_URL",
+        default="https://generativelanguage.googleapis.com/v1beta",
+        description=(
+            "Base URL of the Gemini generateContent API used for speech "
+            "synthesis. Independent of GEMINI_API_URL, which configures the "
+            "LiteLLM chat endpoint."
+        ),
+        group="tts",
+    ),
+    "GEMINI_TTS_VOICES_JSON": EnvVar(
+        name="GEMINI_TTS_VOICES_JSON",
+        default="",
+        description=(
+            "Optional JSON array narrowing or relabeling the built-in Gemini "
+            "prebuilt voices. Each item must contain non-empty value and label "
+            'fields, e.g. [{"value":"Kore","label":"Kore (Firm)"}]. The value '
+            "must be a prebuilt voice name; empty exposes every built-in voice."
+        ),
+        group="tts",
+        required=False,
+    ),
     "TTS_MAX_SEGMENT_CHARS": EnvVar(
         name="TTS_MAX_SEGMENT_CHARS",
         default=300,

--- a/src/api/flaskr/service/tts/audio_utils.py
+++ b/src/api/flaskr/service/tts/audio_utils.py
@@ -30,6 +30,58 @@ def is_audio_processing_available() -> bool:
     return PYDUB_AVAILABLE
 
 
+def pcm_duration_ms(
+    audio_data: bytes,
+    *,
+    sample_rate: int,
+    channels: int = 1,
+    sample_width: int = 2,
+) -> int:
+    """Return the duration of raw PCM bytes in milliseconds.
+
+    The duration is derived purely from the byte length and the sample
+    geometry, so it never needs ffmpeg and is exact for uncompressed audio.
+    """
+    if not audio_data:
+        return 0
+    bytes_per_second = (
+        max(int(sample_rate or 0), 1)
+        * max(int(channels or 1), 1)
+        * max(int(sample_width or 1), 1)
+    )
+    return round(len(audio_data) * 1000 / bytes_per_second)
+
+
+def export_pcm_to_mp3(
+    audio_data: bytes,
+    *,
+    sample_rate: int,
+    channels: int = 1,
+    sample_width: int = 2,
+    bitrate: str = "128k",
+) -> bytes:
+    """Encode raw signed little-endian PCM bytes as MP3 through pydub/ffmpeg.
+
+    Providers that only return PCM use this so the shared streaming, storage,
+    and playback paths keep receiving MP3.
+    """
+    if not audio_data:
+        return b""
+    if not PYDUB_AVAILABLE:
+        message = "pydub is required to convert PCM audio to MP3"
+        raise ValueError(message)
+
+    segment = AudioSegment(
+        data=audio_data,
+        sample_width=int(sample_width),
+        frame_rate=int(sample_rate),
+        channels=int(channels),
+    )
+    output = io.BytesIO()
+    segment.export(output, format="mp3", bitrate=bitrate)
+    return output.getvalue()
+
+
 def _estimated_duration_ms(audio_data: bytes) -> int:
     # Rough estimate based on bitrate (128kbps for MP3):
     # 128kbps = 16KB/s, so duration = size_bytes / 16000 * 1000.

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -115,6 +115,7 @@ _EMPTY_AUDIO_ERROR_MESSAGE = "No audio data received"
 _EMPTY_AUDIO_RETRY_PROVIDERS = {
     "",
     "elevenlabs",
+    "gemini",
     "tencent",
     "tencent_texttovoice",
     "volcengine",
@@ -143,6 +144,7 @@ _TTS_ERROR_TEXT_PREVIEW_CHARS = 300
 _VOLCENGINE_TIMESTAMP_PROVIDERS = {"volcengine"}
 _NON_SPEAKABLE_TTS_SKIP_PROVIDERS = {
     "elevenlabs",
+    "gemini",
     "minimax",
     "tencent",
     "tencent_texttovoice",

--- a/src/api/flaskr/service/tts/validation.py
+++ b/src/api/flaskr/service/tts/validation.py
@@ -25,14 +25,16 @@ SUPPORTED_TTS_PROVIDERS = {
     "tencent",
     "tencent_texttovoice",
     "elevenlabs",
+    "gemini",
 }
 PROVIDERS_REQUIRING_MODEL = {
     "minimax",
     "volcengine",
     "tencent_texttovoice",
     "elevenlabs",
+    "gemini",
 }
-PROVIDERS_REQUIRING_LISTED_VOICE = {"elevenlabs"}
+PROVIDERS_REQUIRING_LISTED_VOICE = {"elevenlabs", "gemini"}
 
 
 @dataclass(frozen=True)

--- a/src/api/flaskr/service/tts/validation.py
+++ b/src/api/flaskr/service/tts/validation.py
@@ -62,9 +62,14 @@ def _to_float(value: object, field_name: str) -> float:
 
 def _to_int(value: object, field_name: str) -> int:
     try:
-        return int(value)
+        number = float(value)
     except (TypeError, ValueError):
         _raise_param_error(f"Invalid {field_name}: {value!r}")
+    # Reject fractional values instead of silently truncating them: 0.5 must
+    # not pass as 0 for providers whose pitch is locked to a whole number.
+    if not math.isfinite(number) or not number.is_integer():
+        _raise_param_error(f"Invalid {field_name}: {value!r}")
+    return int(number)
 
 
 def validate_tts_settings_strict(

--- a/src/api/tests/service/tts/test_audio_utils.py
+++ b/src/api/tests/service/tts/test_audio_utils.py
@@ -190,3 +190,41 @@ def test_export_audio_range_does_not_return_invalid_bytes_after_decode_failure(
 
     assert output == b""
     assert duration_ms == 0
+
+
+def test_pcm_duration_ms_uses_sample_geometry() -> None:
+    assert audio_utils.pcm_duration_ms(b"", sample_rate=24000) == 0
+    # 16-bit mono at 24 kHz is 48000 bytes per second.
+    assert audio_utils.pcm_duration_ms(b"\x00" * 48000, sample_rate=24000) == 1000
+    assert audio_utils.pcm_duration_ms(b"\x00" * 48000, sample_rate=16000) == 1500
+    assert (
+        audio_utils.pcm_duration_ms(b"\x00" * 48000, sample_rate=24000, channels=2)
+        == 500
+    )
+
+
+def test_export_pcm_to_mp3_returns_empty_for_empty_input() -> None:
+    assert audio_utils.export_pcm_to_mp3(b"", sample_rate=24000) == b""
+
+
+def test_export_pcm_to_mp3_requires_pydub(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(audio_utils, "PYDUB_AVAILABLE", False)
+    with pytest.raises(ValueError, match="pydub is required"):
+        audio_utils.export_pcm_to_mp3(b"\x00\x00", sample_rate=24000)
+
+
+def test_export_pcm_to_mp3_produces_decodable_mp3() -> None:
+    if not audio_utils.PYDUB_AVAILABLE:
+        pytest.skip("pydub/ffmpeg not available")
+    from pydub.utils import which
+
+    if not which("ffmpeg"):
+        pytest.skip("ffmpeg not available")
+
+    pcm = b"\x00\x00" * 24000  # one second of silence, 16-bit mono
+    mp3 = audio_utils.export_pcm_to_mp3(pcm, sample_rate=24000)
+
+    assert mp3
+    duration = audio_utils.try_get_audio_duration_ms(mp3, audio_format="mp3")
+    assert duration is not None
+    assert 900 <= duration <= 1100

--- a/src/api/tests/service/tts/test_gemini_provider.py
+++ b/src/api/tests/service/tts/test_gemini_provider.py
@@ -1,0 +1,662 @@
+"""Verify Gemini TTS provider configuration, requests, and validation."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import ClassVar
+
+import pytest
+import requests
+from flaskr.api.tts import gemini_provider as module
+from flaskr.api.tts.base import VoiceSettings
+from flaskr.service.common.models import AppError
+from flaskr.service.tts.validation import validate_tts_settings_strict
+
+_ONE_SECOND_PCM = b"\x00\x00" * 24000  # 16-bit mono at 24 kHz
+_FAKE_MP3 = b"ID3fake-mp3"
+
+
+def _patch_config(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    enabled: object = True,
+    api_key: str = "test-gemini-key",
+    voices: object = "",
+    api_url: str = "",
+) -> None:
+    values = {
+        "GEMINI_TTS_ENABLED": enabled,
+        "GEMINI_API_KEY": api_key,
+        "GEMINI_TTS_VOICES_JSON": voices,
+        "GEMINI_TTS_API_URL": api_url,
+    }
+    monkeypatch.setattr(module, "get_config", lambda key, *_args: values.get(key, ""))
+
+
+def _patch_transcoder(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    calls: list[dict[str, object]] = []
+
+    def _fake_export(pcm: bytes, *, sample_rate: int, **kwargs: object) -> bytes:
+        calls.append({"pcm": pcm, "sample_rate": sample_rate, **kwargs})
+        return _FAKE_MP3 if pcm else b""
+
+    monkeypatch.setattr(module, "export_pcm_to_mp3", _fake_export)
+    return calls
+
+
+def _audio_response(
+    pcm: bytes = _ONE_SECOND_PCM,
+    *,
+    mime_type: str = "audio/L16;codec=pcm;rate=24000",
+    finish_reason: str = "STOP",
+    extra_parts: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    parts: list[dict[str, object]] = list(extra_parts or [])
+    parts.append(
+        {
+            "inlineData": {
+                "mimeType": mime_type,
+                "data": base64.b64encode(pcm).decode("ascii"),
+            }
+        }
+    )
+    return {
+        "candidates": [
+            {
+                "content": {"parts": parts, "role": "model"},
+                "finishReason": finish_reason,
+            }
+        ],
+        "usageMetadata": {"promptTokenCount": 5, "candidatesTokenCount": 25},
+    }
+
+
+class _JsonResponse:
+    reason = "OK"
+    headers: ClassVar[dict[str, str]] = {"x-request-id": "req-1"}
+
+    def __init__(self, payload: object, status_code: int = 200) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.content = json.dumps(payload).encode("utf-8")
+
+    def json(self) -> object:
+        return self._payload
+
+
+def test_builtin_voice_catalog_has_thirty_unique_prebuilt_voices() -> None:
+    values = [item["value"] for item in module.GEMINI_TTS_VOICES]
+
+    assert len(values) == 30
+    assert len(set(values)) == 30
+    assert "Kore" in values
+    assert all(
+        item["label"].startswith(item["value"]) for item in module.GEMINI_TTS_VOICES
+    )
+
+
+def test_load_voices_defaults_to_builtin_when_allowlist_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config(monkeypatch, voices="")
+    assert module._load_gemini_voices() == module.GEMINI_TTS_VOICES
+
+    _patch_config(monkeypatch, voices="   ")
+    assert module._load_gemini_voices() == module.GEMINI_TTS_VOICES
+
+
+def test_load_voices_filters_allowlist_to_builtin_and_applies_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config(
+        monkeypatch,
+        voices=json.dumps(
+            [
+                {"value": " Puck ", "label": "Narrator"},
+                {"value": "Kore", "label": "Teacher"},
+            ]
+        ),
+    )
+
+    assert module._load_gemini_voices() == [
+        {"value": "Puck", "label": "Narrator"},
+        {"value": "Kore", "label": "Teacher"},
+    ]
+
+
+def test_load_voices_drops_unknown_names_and_falls_back_when_none_remain(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _patch_config(
+        monkeypatch,
+        voices=json.dumps(
+            [{"value": "NotAVoice", "label": "Nope"}, {"value": "Kore", "label": "K"}]
+        ),
+    )
+    with caplog.at_level("WARNING"):
+        assert module._load_gemini_voices() == [{"value": "Kore", "label": "K"}]
+    assert "NotAVoice" in caplog.text
+
+    _patch_config(monkeypatch, voices=json.dumps([{"value": "Nope", "label": "N"}]))
+    assert module._load_gemini_voices() == module.GEMINI_TTS_VOICES
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "not-json",
+        json.dumps({"value": "Kore"}),
+        json.dumps(["Kore"]),
+        json.dumps([{"value": "", "label": "Voice"}]),
+        json.dumps([{"value": "Kore", "label": "A"}, {"value": "Kore", "label": "B"}]),
+    ],
+)
+def test_load_voices_ignores_invalid_json(
+    monkeypatch: pytest.MonkeyPatch, value: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    _patch_config(monkeypatch, voices=value)
+    with caplog.at_level("WARNING"):
+        assert module._load_gemini_voices() == module.GEMINI_TTS_VOICES
+    assert "GEMINI_TTS_VOICES_JSON" in caplog.text
+
+
+def test_provider_requires_enabled_flag_and_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = module.GeminiTTSProvider()
+
+    _patch_config(monkeypatch, enabled=False, api_key="key")
+    assert provider.is_configured() is False
+
+    _patch_config(monkeypatch, enabled=True, api_key="")
+    assert provider.is_configured() is False
+
+    _patch_config(monkeypatch, enabled=True, api_key="key")
+    assert provider.is_configured() is True
+
+
+def test_provider_config_exposes_models_locked_ranges_and_voices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config(monkeypatch)
+    provider = module.GeminiTTSProvider()
+
+    config = provider.get_provider_config()
+
+    assert provider.provider_name == "gemini"
+    assert config.name == "gemini"
+    assert config.label == "Gemini"
+    assert [item["value"] for item in config.models or []] == [
+        "gemini-3.1-flash-tts-preview",
+        "gemini-2.5-flash-preview-tts",
+        "gemini-2.5-pro-preview-tts",
+    ]
+    assert config.voices == module.GEMINI_TTS_VOICES
+    assert config.speed.to_dict() == {
+        "min": 1.0,
+        "max": 1.0,
+        "step": 0.1,
+        "default": 1.0,
+    }
+    assert config.pitch.min == config.pitch.max == config.pitch.default == 0
+    assert config.supports_emotion is False
+    assert config.supports_custom_voice_id is False
+    assert config.supports_voice_cloning is False
+    assert provider.get_default_voice_settings().voice_id == "Zephyr"
+    assert provider.get_default_audio_settings().format == "mp3"
+
+
+def test_provider_is_registered_for_explicit_selection_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import flaskr.api.tts as tts_api
+
+    _patch_config(monkeypatch)
+    tts_api._provider_instances.clear()
+
+    assert tts_api.TTSProvider.GEMINI == "gemini"
+    assert tts_api.get_tts_provider("gemini").provider_name == "gemini"
+    assert "gemini" in tts_api._PROVIDER_PRIORITY
+    assert "gemini" not in tts_api._AUTO_DETECT_PROVIDER_PRIORITY
+    assert "gemini" in tts_api._CONFIG_REQUIRES_CONFIGURED_PROVIDER
+    assert "gemini" in tts_api._CONFIG_REQUIRES_ALLOWED_MODEL
+
+
+def test_synthesize_sends_generate_content_request_and_returns_mp3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config(monkeypatch, api_url="https://example.test/v1beta/")
+    transcodes = _patch_transcoder(monkeypatch)
+    captured: dict[str, object] = {}
+
+    def fake_post(url: str, **kwargs: object) -> object:
+        captured["url"] = url
+        captured.update(kwargs)
+        return _JsonResponse(_audio_response())
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    result = module.GeminiTTSProvider().synthesize(
+        "Hello there.",
+        voice_settings=VoiceSettings(voice_id="Puck", speed=1.0, pitch=0),
+        model="gemini-2.5-pro-preview-tts",
+    )
+
+    assert captured["url"] == (
+        "https://example.test/v1beta/models/gemini-2.5-pro-preview-tts:generateContent"
+    )
+    assert captured["headers"] == {
+        "x-goog-api-key": "test-gemini-key",
+        "Content-Type": "application/json",
+    }
+    assert captured["json"] == {
+        "contents": [{"parts": [{"text": "Hello there."}]}],
+        "generationConfig": {
+            "responseModalities": ["AUDIO"],
+            "speechConfig": {
+                "voiceConfig": {"prebuiltVoiceConfig": {"voiceName": "Puck"}}
+            },
+        },
+    }
+    assert captured["timeout"] == (10, 90)
+    assert captured["allow_redirects"] is False
+    assert transcodes == [{"pcm": _ONE_SECOND_PCM, "sample_rate": 24000}]
+    assert result.audio_data == _FAKE_MP3
+    assert result.format == "mp3"
+    assert result.sample_rate == 24000
+    assert result.duration_ms == 1000
+    assert result.word_count == len("Hello there.")
+    assert result.usage_characters == len("Hello there.")
+    assert result.subtitle_cues == []
+
+
+def test_synthesize_defaults_model_and_voice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config(monkeypatch, voices=json.dumps([{"value": "Kore", "label": "K"}]))
+    _patch_transcoder(monkeypatch)
+    captured: dict[str, object] = {}
+
+    def fake_post(url: str, **kwargs: object) -> object:
+        captured["url"] = url
+        captured.update(kwargs)
+        return _JsonResponse(_audio_response())
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    module.GeminiTTSProvider().synthesize("Hello")
+
+    assert str(captured["url"]).endswith(
+        f"/models/{module.GEMINI_TTS_DEFAULT_MODEL}:generateContent"
+    )
+    speech_config = captured["json"]["generationConfig"]["speechConfig"]  # type: ignore[index]
+    assert speech_config["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Kore"
+
+
+def test_synthesize_honours_sample_rate_from_mime_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config(monkeypatch)
+    transcodes = _patch_transcoder(monkeypatch)
+    monkeypatch.setattr(
+        module.requests,
+        "post",
+        lambda *_args, **_kwargs: _JsonResponse(
+            _audio_response(
+                mime_type="audio/L16;codec=pcm;rate=16000",
+                extra_parts=[{"text": "ignored transcript"}],
+            )
+        ),
+    )
+
+    result = module.GeminiTTSProvider().synthesize("Hello")
+
+    assert transcodes[0]["sample_rate"] == 16000
+    assert result.sample_rate == 16000
+    assert result.duration_ms == 1500
+
+
+def test_synthesize_rejects_non_pcm_mime_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config(monkeypatch)
+    _patch_transcoder(monkeypatch)
+    monkeypatch.setattr(
+        module.requests,
+        "post",
+        lambda *_args, **_kwargs: _JsonResponse(
+            _audio_response(mime_type="audio/mpeg")
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Unsupported Gemini TTS audio mime type"):
+        module.GeminiTTSProvider().synthesize("Hello")
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [
+        (400, "Gemini TTS HTTP 400"),
+        (401, "Gemini TTS HTTP 401"),
+        (404, "Gemini TTS HTTP 404"),
+        (429, "rate limit"),
+        (500, "Gemini TTS HTTP 500"),
+        (503, "rate limit"),
+    ],
+)
+def test_synthesize_reports_safe_http_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
+    expected: str,
+) -> None:
+    _patch_config(monkeypatch)
+    payload = {
+        "error": {
+            "code": status_code,
+            "message": "request denied for Hello",
+            "status": "FAILED",
+        }
+    }
+    monkeypatch.setattr(
+        module.requests,
+        "post",
+        lambda *_args, **_kwargs: _JsonResponse(payload, status_code=status_code),
+    )
+
+    with pytest.raises(ValueError, match=expected) as exc_info:
+        module.GeminiTTSProvider().synthesize("Hello")
+
+    assert "test-gemini-key" not in str(exc_info.value)
+    assert "Hello" not in str(exc_info.value)
+    assert "[redacted]" in str(exc_info.value)
+
+
+def test_synthesize_rejects_redirect_without_following(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config(monkeypatch)
+    captured: dict[str, object] = {}
+
+    def fake_post(*_args: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return _JsonResponse({"error": {"message": "moved"}}, status_code=302)
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    with pytest.raises(ValueError, match="Gemini TTS HTTP 302"):
+        module.GeminiTTSProvider().synthesize("Hello")
+    assert captured["allow_redirects"] is False
+
+
+def test_synthesize_converts_network_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config(monkeypatch)
+
+    def timeout(*_args: object, **_kwargs: object) -> object:
+        message = "connection timed out"
+        raise requests.Timeout(message)
+
+    monkeypatch.setattr(module.requests, "post", timeout)
+    with pytest.raises(ValueError, match="request failed"):
+        module.GeminiTTSProvider().synthesize("Hello")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"candidates": []},
+        {"candidates": [{"content": {"parts": [{"text": "no audio"}]}}]},
+        {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [{"inlineData": {"mimeType": "audio/L16", "data": ""}}]
+                    }
+                }
+            ]
+        },
+        _audio_response(pcm=b""),
+    ],
+)
+def test_synthesize_raises_empty_audio_marker(
+    monkeypatch: pytest.MonkeyPatch, payload: dict[str, object]
+) -> None:
+    _patch_config(monkeypatch)
+    _patch_transcoder(monkeypatch)
+    monkeypatch.setattr(
+        module.requests, "post", lambda *_args, **_kwargs: _JsonResponse(payload)
+    )
+
+    with pytest.raises(ValueError, match="No audio data received"):
+        module.GeminiTTSProvider().synthesize("Hello")
+
+
+def test_synthesize_reports_prompt_block_and_safety_finish_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config(monkeypatch)
+    _patch_transcoder(monkeypatch)
+
+    monkeypatch.setattr(
+        module.requests,
+        "post",
+        lambda *_args, **_kwargs: _JsonResponse(
+            {"promptFeedback": {"blockReason": "PROHIBITED_CONTENT"}, "candidates": []}
+        ),
+    )
+    with pytest.raises(ValueError, match="blocked: PROHIBITED_CONTENT") as exc_info:
+        module.GeminiTTSProvider().synthesize("Hello")
+    assert "No audio data received" not in str(exc_info.value)
+
+    monkeypatch.setattr(
+        module.requests,
+        "post",
+        lambda *_args, **_kwargs: _JsonResponse(
+            {"candidates": [{"finishReason": "SAFETY", "content": {"parts": []}}]}
+        ),
+    )
+    with pytest.raises(ValueError, match="content blocked: SAFETY") as exc_info:
+        module.GeminiTTSProvider().synthesize("Hello")
+    assert "No audio data received" not in str(exc_info.value)
+
+
+def test_synthesize_rejects_non_json_and_non_object_bodies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_config(monkeypatch)
+
+    class BadJsonResponse(_JsonResponse):
+        def json(self) -> object:
+            message = "not json"
+            raise ValueError(message)
+
+    monkeypatch.setattr(
+        module.requests, "post", lambda *_args, **_kwargs: BadJsonResponse({})
+    )
+    with pytest.raises(ValueError, match="non-JSON"):
+        module.GeminiTTSProvider().synthesize("Hello")
+
+    monkeypatch.setattr(
+        module.requests, "post", lambda *_args, **_kwargs: _JsonResponse(["nope"])
+    )
+    with pytest.raises(TypeError, match="unexpected response payload"):
+        module.GeminiTTSProvider().synthesize("Hello")
+
+
+@pytest.mark.parametrize(
+    ("text", "voice_id", "model", "speed", "pitch", "message"),
+    [
+        (
+            "Hello",
+            "Unknown",
+            "gemini-2.5-flash-preview-tts",
+            1.0,
+            0,
+            "voice is not approved",
+        ),
+        ("Hello", "Kore", "unknown-model", 1.0, 0, "Unsupported Gemini TTS model"),
+        (
+            "Hello",
+            "Kore",
+            "gemini-2.5-flash-preview-tts",
+            1.2,
+            0,
+            "speed is fixed at 1.0",
+        ),
+        (
+            "Hello",
+            "Kore",
+            "gemini-2.5-flash-preview-tts",
+            1.0,
+            1,
+            "pitch is fixed at 0",
+        ),
+        (
+            "Hello",
+            "Kore",
+            "gemini-2.5-flash-preview-tts",
+            float("nan"),
+            0,
+            "Invalid Gemini TTS speed",
+        ),
+        (
+            "x" * 4001,
+            "Kore",
+            "gemini-2.5-flash-preview-tts",
+            1.0,
+            0,
+            "exceeds Gemini TTS limit",
+        ),
+        ("   ", "Kore", "gemini-2.5-flash-preview-tts", 1.0, 0, "Text cannot be empty"),
+    ],
+)
+def test_synthesize_rejects_invalid_direct_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    text: str,
+    voice_id: str,
+    model: str,
+    speed: float,
+    pitch: int,
+    message: str,
+) -> None:
+    _patch_config(monkeypatch)
+    monkeypatch.setattr(
+        module.requests,
+        "post",
+        lambda *_args, **_kwargs: pytest.fail("provider must reject before requesting"),
+    )
+    with pytest.raises(ValueError, match=message):
+        module.GeminiTTSProvider().synthesize(
+            text,
+            voice_settings=VoiceSettings(voice_id=voice_id, speed=speed, pitch=pitch),
+            model=model,
+        )
+
+
+def test_synthesize_requires_switch_and_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        module.requests,
+        "post",
+        lambda *_args, **_kwargs: pytest.fail("provider must reject before requesting"),
+    )
+
+    _patch_config(monkeypatch, enabled=False)
+    with pytest.raises(ValueError, match="GEMINI_TTS_ENABLED"):
+        module.GeminiTTSProvider().synthesize("Hello")
+
+    _patch_config(monkeypatch, api_key="")
+    with pytest.raises(ValueError, match="GEMINI_API_KEY"):
+        module.GeminiTTSProvider().synthesize("Hello")
+
+
+def test_strict_validation_accepts_locked_settings_and_rejects_others(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import flaskr.api.tts as tts_api
+
+    _patch_config(monkeypatch)
+    tts_api._provider_instances.clear()
+
+    settings = validate_tts_settings_strict(
+        provider="gemini",
+        model="gemini-3.1-flash-tts-preview",
+        voice_id="Kore",
+        speed=1.0,
+        pitch=0,
+        emotion="",
+    )
+    assert settings.provider == "gemini"
+    assert settings.model == "gemini-3.1-flash-tts-preview"
+    assert settings.voice_id == "Kore"
+
+    valid = {
+        "model": "gemini-3.1-flash-tts-preview",
+        "voice_id": "Kore",
+        "speed": 1.0,
+        "pitch": 0,
+        "emotion": "",
+    }
+    invalid_settings = [
+        {**valid, "model": ""},
+        {**valid, "model": "unknown"},
+        {**valid, "voice_id": "Unknown"},
+        {**valid, "speed": 0.9},
+        {**valid, "speed": float("inf")},
+        {**valid, "pitch": 1},
+        {**valid, "emotion": "happy"},
+    ]
+    for values in invalid_settings:
+        with pytest.raises(AppError):
+            validate_tts_settings_strict(provider="gemini", **values)
+
+
+def test_config_endpoint_hides_disabled_provider_and_exposes_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import flaskr.api.tts as tts_api
+
+    monkeypatch.setattr(
+        tts_api,
+        "_PROVIDER_REGISTRY",
+        {"gemini": module.GeminiTTSProvider},
+    )
+    monkeypatch.setattr(tts_api, "_PROVIDER_PRIORITY", ("gemini",))
+    monkeypatch.setattr(
+        tts_api, "_resolve_credit_multiplier_label", lambda *_args: None
+    )
+
+    _patch_config(monkeypatch, enabled=False)
+    assert tts_api.get_all_provider_configs() == {"providers": [], "model_options": []}
+
+    _patch_config(monkeypatch)
+    monkeypatch.setattr(
+        tts_api,
+        "get_config",
+        lambda key, default=None: (
+            "volcengine/seed-tts-2.0" if key == "TTS_ALLOWED_MODELS" else default
+        ),
+    )
+    assert tts_api.get_all_provider_configs() == {"providers": [], "model_options": []}
+
+    subset_config = {
+        "TTS_ALLOWED_MODELS": "gemini/gemini-2.5-flash-preview-tts",
+        "TTS_DEFAULT_MODEL": "gemini/gemini-2.5-flash-preview-tts",
+        "TTS_ALLOWED_MODEL_DISPLAY_NAMES_JSON": "",
+    }
+    monkeypatch.setattr(
+        tts_api, "get_config", lambda key, default=None: subset_config.get(key, default)
+    )
+    subset = tts_api.get_all_provider_configs()
+
+    assert [model["value"] for model in subset["providers"][0]["models"]] == [
+        "gemini-2.5-flash-preview-tts"
+    ]
+    assert len(subset["providers"][0]["voices"]) == 30
+    assert [item["value"] for item in subset["model_options"]] == [
+        "gemini/gemini-2.5-flash-preview-tts"
+    ]
+    assert subset["model_options"][0]["is_default"] is True

--- a/src/api/tests/service/tts/test_gemini_provider.py
+++ b/src/api/tests/service/tts/test_gemini_provider.py
@@ -125,7 +125,7 @@ def test_load_voices_filters_allowlist_to_builtin_and_applies_labels(
     ]
 
 
-def test_load_voices_drops_unknown_names_and_falls_back_when_none_remain(
+def test_load_voices_drops_unknown_names_and_fails_closed_when_none_remain(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     _patch_config(
@@ -139,7 +139,8 @@ def test_load_voices_drops_unknown_names_and_falls_back_when_none_remain(
     assert "NotAVoice" in caplog.text
 
     _patch_config(monkeypatch, voices=json.dumps([{"value": "Nope", "label": "N"}]))
-    assert module._load_gemini_voices() == module.GEMINI_TTS_VOICES
+    assert module._load_gemini_voices() == []
+    assert module.GeminiTTSProvider().is_configured() is False
 
 
 @pytest.mark.parametrize(
@@ -152,13 +153,16 @@ def test_load_voices_drops_unknown_names_and_falls_back_when_none_remain(
         json.dumps([{"value": "Kore", "label": "A"}, {"value": "Kore", "label": "B"}]),
     ],
 )
-def test_load_voices_ignores_invalid_json(
+def test_load_voices_fails_closed_on_invalid_json(
     monkeypatch: pytest.MonkeyPatch, value: str, caplog: pytest.LogCaptureFixture
 ) -> None:
     _patch_config(monkeypatch, voices=value)
     with caplog.at_level("WARNING"):
-        assert module._load_gemini_voices() == module.GEMINI_TTS_VOICES
+        assert module._load_gemini_voices() == []
     assert "GEMINI_TTS_VOICES_JSON" in caplog.text
+    assert module.GeminiTTSProvider().is_configured() is False
+    with pytest.raises(ValueError, match="no valid built-in voices"):
+        module.GeminiTTSProvider().synthesize("Hello")
 
 
 def test_provider_requires_enabled_flag_and_api_key(
@@ -174,6 +178,29 @@ def test_provider_requires_enabled_flag_and_api_key(
 
     _patch_config(monkeypatch, enabled=True, api_key="key")
     assert provider.is_configured() is True
+
+    _patch_config(monkeypatch, api_url="http://proxy.internal/v1beta")
+    assert provider.is_configured() is False
+
+    _patch_config(monkeypatch, api_url="https://proxy.internal/v1beta")
+    assert provider.is_configured() is True
+
+
+@pytest.mark.parametrize(
+    "api_url",
+    ["http://proxy.internal/v1beta", "proxy.internal/v1beta", "https://"],
+)
+def test_synthesize_rejects_non_https_endpoint_before_sending_key(
+    monkeypatch: pytest.MonkeyPatch, api_url: str
+) -> None:
+    _patch_config(monkeypatch, api_url=api_url)
+    monkeypatch.setattr(
+        module.requests,
+        "post",
+        lambda *_args, **_kwargs: pytest.fail("provider must reject before requesting"),
+    )
+    with pytest.raises(ValueError, match="https://"):
+        module.GeminiTTSProvider().synthesize("Hello")
 
 
 def test_provider_config_exposes_models_locked_ranges_and_voices(
@@ -517,6 +544,22 @@ def test_synthesize_rejects_non_json_and_non_object_bodies(
             "Hello",
             "Kore",
             "gemini-2.5-flash-preview-tts",
+            1.0,
+            0.5,
+            "pitch is fixed at 0",
+        ),
+        (
+            "Hello",
+            "Kore",
+            "gemini-2.5-flash-preview-tts",
+            1.0,
+            -0.5,
+            "pitch is fixed at 0",
+        ),
+        (
+            "Hello",
+            "Kore",
+            "gemini-2.5-flash-preview-tts",
             float("nan"),
             0,
             "Invalid Gemini TTS speed",
@@ -538,7 +581,7 @@ def test_synthesize_rejects_invalid_direct_settings(
     voice_id: str,
     model: str,
     speed: float,
-    pitch: int,
+    pitch: float,
     message: str,
 ) -> None:
     _patch_config(monkeypatch)
@@ -607,11 +650,22 @@ def test_strict_validation_accepts_locked_settings_and_rejects_others(
         {**valid, "speed": 0.9},
         {**valid, "speed": float("inf")},
         {**valid, "pitch": 1},
+        {**valid, "pitch": 0.5},
+        {**valid, "pitch": -0.5},
+        {**valid, "pitch": "0.5"},
         {**valid, "emotion": "happy"},
     ]
     for values in invalid_settings:
         with pytest.raises(AppError):
             validate_tts_settings_strict(provider="gemini", **values)
+
+    for integral_pitch in (0, 0.0, "0"):
+        assert (
+            validate_tts_settings_strict(
+                provider="gemini", **{**valid, "pitch": integral_pitch}
+            ).pitch
+            == 0
+        )
 
 
 def test_config_endpoint_hides_disabled_provider_and_exposes_allowlist(
@@ -630,6 +684,9 @@ def test_config_endpoint_hides_disabled_provider_and_exposes_allowlist(
     )
 
     _patch_config(monkeypatch, enabled=False)
+    assert tts_api.get_all_provider_configs() == {"providers": [], "model_options": []}
+
+    _patch_config(monkeypatch, voices="not-json")
     assert tts_api.get_all_provider_configs() == {"providers": [], "model_options": []}
 
     _patch_config(monkeypatch)

--- a/src/api/tests/service/tts/test_streaming_tts_empty_audio_retry.py
+++ b/src/api/tests/service/tts/test_streaming_tts_empty_audio_retry.py
@@ -6,7 +6,7 @@ from flaskr.service.tts.streaming_tts import _is_retryable_empty_audio_error
 
 @pytest.mark.parametrize(
     "provider",
-    ["", "elevenlabs", "tencent", "tencent_texttovoice", "volcengine"],
+    ["", "elevenlabs", "gemini", "tencent", "tencent_texttovoice", "volcengine"],
 )
 def test_empty_audio_is_retryable_for_all_tts_providers(provider: object) -> None:
     error = ValueError(f"No audio data received from provider {provider or 'auto'}")

--- a/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
+++ b/src/api/tests/service/tts/test_streaming_tts_finalize_segmentation.py
@@ -367,7 +367,14 @@ class TestStreamingSynthesisRetries:
     @patch("flaskr.service.tts.streaming_tts.is_tts_configured")
     @pytest.mark.parametrize(
         "tts_provider",
-        ["elevenlabs", "tencent", "tencent_texttovoice", "volcengine", "minimax"],
+        [
+            "elevenlabs",
+            "gemini",
+            "tencent",
+            "tencent_texttovoice",
+            "volcengine",
+            "minimax",
+        ],
     )
     def test_non_speakable_segment_skips_configured_provider_call(
         self,

--- a/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
+++ b/src/api/tests/service/tts/test_streaming_tts_rate_limit_retry.py
@@ -126,3 +126,25 @@ def test_elevenlabs_http_429_uses_shared_retry(monkeypatch: object) -> None:
     assert result is success
     assert len(calls) == 2
     assert len(sleeps) == 1
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Gemini TTS HTTP 429 rate limit: quota exceeded",
+        "Gemini TTS HTTP 503 overloaded (rate limit): The model is overloaded",
+    ],
+)
+def test_gemini_http_429_and_503_use_shared_retry(
+    monkeypatch: object, message: str
+) -> None:
+    success = types.SimpleNamespace(audio_data=b"ok")
+    result, calls, sleeps = _run_retry(
+        monkeypatch,
+        [ValueError(message), success],
+        tts_provider="gemini",
+    )
+
+    assert result is success
+    assert len(calls) == 2
+    assert len(sleeps) == 1


### PR DESCRIPTION
## Summary

- Add a `gemini` TTS provider backed by the Gemini Developer API `generateContent` endpoint (`responseModalities=["AUDIO"]`), exposing `gemini-3.1-flash-tts-preview`, `gemini-2.5-flash-preview-tts`, and `gemini-2.5-pro-preview-tts` with the thirty prebuilt voices.
- Gemini only returns raw 16-bit PCM, so the provider transcodes to MP3 through new shared helpers (`pcm_duration_ms`, `export_pcm_to_mp3`) in `audio_utils.py`; the Tencent SSE provider now delegates to the same helpers.
- Exposure is gated by a new explicit `GEMINI_TTS_ENABLED` switch (synthesis reuses `GEMINI_API_KEY`), with `GEMINI_TTS_API_URL` and an optional `GEMINI_TTS_VOICES_JSON` allowlist. The provider is explicit-only (not auto-detected) and hidden from `/tts/config` unless configured and allowlisted, matching ElevenLabs.
- Speed and pitch are locked (Gemini has no such parameters); HTTP 429/503 and empty audio opt into the shared streaming retries.
- No frontend, database, SSE, or deploy-config changes. Deployments need `credit_usage_rates` rows for the Gemini models so the picker shows a credit multiplier.

ExecPlan: `docs/exec-plans/active/gemini-tts.md`.

## Test plan

- [x] `python -m pytest tests/service/tts -q` — 292 passed (48 new)
- [x] `ruff check` / `ruff format --check` on `flaskr/api/tts`, `flaskr/service/tts`, `tests/service/tts`
- [x] `lefthook run pre-commit` on staged files (all checks green)
- [x] `python scripts/generate_env_examples.py`, `build_repo_knowledge_index.py`, `check_repo_harness.py`
- [ ] Credentialed smoke test on dev01 / devus (pushed to both test branches)

Note: running `tests/service/tts` together with the `tests/service/learn` TTS files reports the same 5 failures / 63 errors on a clean `origin/main` (a cross-file `litellm` stub leak); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Gemini as a text-to-speech provider.
  * Supports configurable models, voices, API endpoints, and enablement settings.
  * Added voice allowlisting and provider configuration for supported models and audio controls.
  * Added retry handling for rate limits, temporary service overloads, and empty audio responses.

* **Improvements**
  * Improved PCM audio duration and MP3 conversion support across TTS providers.
  * Added secure HTTPS endpoint validation and fail-closed voice allowlist handling.
  * Added configuration examples and documentation for Gemini TTS and device authorization settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->