### PR TITLE
fix: keep trailing zeros in whole-number credit multiplier labels

### DIFF
--- a/src/api/flaskr/api/tts/__init__.py
+++ b/src/api/flaskr/api/tts/__init__.py
@@ -453,7 +453,11 @@ def _load_usage_rate_unit_cost(
 
 def _format_credit_multiplier_label(value: Decimal) -> str:
     rounded = value.quantize(Decimal("0.01"))
-    text = format(rounded.normalize(), "f").rstrip("0").rstrip(".")
+    if rounded == rounded.to_integral_value():
+        # Whole numbers must not lose trailing zeros: stripping "30" to "3".
+        text = str(int(rounded))
+    else:
+        text = format(rounded.normalize(), "f").rstrip("0").rstrip(".")
     return f"{text or '0'}x"
 
 

--- a/src/api/flaskr/service/billing/charges.py
+++ b/src/api/flaskr/service/billing/charges.py
@@ -382,7 +382,11 @@ def _rate_unit_cost(rate: CreditUsageRate | None) -> Decimal:
 
 def _format_multiplier(value: Decimal) -> str:
     rounded = value.quantize(Decimal("0.01"))
-    text = format(rounded.normalize(), "f").rstrip("0").rstrip(".")
+    if rounded == rounded.to_integral_value():
+        # Whole numbers must not lose trailing zeros: stripping "30" to "3".
+        text = str(int(rounded))
+    else:
+        text = format(rounded.normalize(), "f").rstrip("0").rstrip(".")
     return f"{text or '0'}x"
 
 

--- a/src/api/flaskr/service/billing/rate_references.py
+++ b/src/api/flaskr/service/billing/rate_references.py
@@ -29,7 +29,11 @@ def format_credit_multiplier(value: Decimal | None) -> str | None:
     if value is None or value <= 0:
         return None
     rounded = value.quantize(Decimal("0.01"))
-    text = format(rounded.normalize(), "f").rstrip("0").rstrip(".")
+    if rounded == rounded.to_integral_value():
+        # Whole numbers must not lose trailing zeros: stripping "30" to "3".
+        text = str(int(rounded))
+    else:
+        text = format(rounded.normalize(), "f").rstrip("0").rstrip(".")
     return f"{text or '0'}x"
 
 

--- a/src/api/tests/service/billing/test_credit_multiplier_label_format.py
+++ b/src/api/tests/service/billing/test_credit_multiplier_label_format.py
@@ -1,0 +1,41 @@
+"""Verify credit multiplier labels keep the trailing zeros of whole numbers."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from flaskr.api.tts import _format_credit_multiplier_label
+from flaskr.service.billing.charges import _format_multiplier
+from flaskr.service.billing.rate_references import format_credit_multiplier
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (Decimal(30), "30x"),
+        (Decimal("30.00"), "30x"),
+        (Decimal(10), "10x"),
+        (Decimal(100), "100x"),
+        (Decimal(1), "1x"),
+        (Decimal(15), "15x"),
+        (Decimal("2.50"), "2.5x"),
+        (Decimal("10.5"), "10.5x"),
+        (Decimal("0.5"), "0.5x"),
+        (Decimal("33.004"), "33x"),
+        (Decimal("0.001"), "0x"),
+    ],
+)
+def test_multiplier_formatters_agree_and_keep_whole_number_zeros(
+    value: Decimal, expected: str
+) -> None:
+    assert _format_credit_multiplier_label(value) == expected
+    assert _format_multiplier(value) == expected
+    if value > 0:
+        assert format_credit_multiplier(value) == expected
+
+
+def test_public_formatter_returns_none_for_missing_or_non_positive_values() -> None:
+    assert format_credit_multiplier(None) is None
+    assert format_credit_multiplier(Decimal(0)) is None
+    assert format_credit_multiplier(Decimal(-1)) is None


### PR DESCRIPTION
## Summary

`format(Decimal("30").normalize(), "f").rstrip("0")` yields `"3"`, so every credit multiplier that is a whole multiple of ten (10x, 20x, 30x, 100x) has been rendered as 1x, 2x, 3x, 1x in the TTS picker, the billing charge labels, and the shared rate reference helper. Found while wiring a 30x Gemini TTS tier (ai-shifu/ai-shifu#2751): the DB row was right, the label said `3x`.

- Whole-number multipliers now format from the integer value; fractional ones keep the existing trimmed rendering.
- Same two-line change in `flaskr/api/tts/__init__.py`, `flaskr/service/billing/charges.py`, and `flaskr/service/billing/rate_references.py` (they are three copies of the same helper; consolidating them is left for a follow-up).
- The credit-amount formatters in checkout/notifications/provider_catalog already guard the integer case and are unaffected.

## Test plan

- [x] New `tests/service/billing/test_credit_multiplier_label_format.py` (parametrized over all three formatters)
- [x] `tests/service/billing/test_usage_settlement.py`, `tests/service/tts/test_tts_config_options.py`, `tests/service/shifu/test_admin_course_detail.py` — 115 passed
- [x] `lefthook run pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->