### PR TITLE
refactor: extract request-scoped TTS streams into strategies

### DIFF
--- a/docs/exec-plans/completed/tts-provider-capabilities.md
+++ b/docs/exec-plans/completed/tts-provider-capabilities.md
@@ -21,9 +21,11 @@ the four-tier rollout produced two follow-up incidents.
 - [x] 2026-09-03 18:00-18:40 CST (UTC+08:00): Verified the refactor on the
   dev01 and devus test environments; the TTS config payloads match the
   pre-refactor output on both.
-- [ ] Follow-up: extract the MiniMax HTTP and Volcengine timestamp
-  request-scoped finalize paths from `StreamingTTSProcessor` into strategy
-  objects selected through `request_scoped_stream`.
+- [x] 2026-09-04 10:30-12:00 CST (UTC+08:00): Extracted the MiniMax HTTP and
+  Volcengine timestamp request-scoped finalize paths from
+  `StreamingTTSProcessor` into `request_scoped_streams.py` strategy objects
+  selected through the capability-driven selectors; the processor keeps thin
+  compatibility entry points and the existing streaming suites pass unchanged.
 
 ## Surprises & Discoveries
 
@@ -45,16 +47,26 @@ the four-tier rollout produced two follow-up incidents.
   `_CONFIG_REQUIRES_*`, `SUPPORTED_TTS_PROVIDERS`, `PROVIDERS_REQUIRING_*`)
   remain as derived views for one release so external readers do not break.
   Runtime checks read the capabilities directly.
-- Request-scoped streams are named by string constants in `base.py`; the
-  strategy extraction itself is deferred to a separate change because it moves
-  two large generator methods and their subtitle bookkeeping.
+- Request-scoped streams are named by string constants in `base.py`. The
+  strategy extraction landed as a second change: `MinimaxHttpStreamStrategy`
+  and `VolcengineTimestampStreamStrategy` receive the processor and drive its
+  shared helpers, buffers, and usage context, so the processor no longer owns
+  provider-specific subtitle bookkeeping.
+- Strategies resolve `logger`, `time`, `MinimaxTTSProvider`, and the audio
+  duration/export helpers through the streaming module namespace at call time
+  so the existing suites, which patch those names there, keep working.
+- `StreamingTTSProcessor` keeps `_use_minimax_http_stream`,
+  `_use_volcengine_timestamp_stream`, and the two `_finalize_*` methods as
+  thin compatibility entry points that delegate to the strategies.
 
 ## Outcomes & Retrospective
 
 Provider behavior is declared next to the provider. `validation.py`,
 `streaming_tts.py`, `pipeline.py`, `minimax_run_tts.py`, and the registry no
-longer mention provider names. Existing behavior is unchanged, as proven by the
-golden-value parity test and the existing TTS suites.
+longer mention provider names, and `StreamingTTSProcessor` shrank from about
+2,100 to about 1,500 lines with the provider-specific request-scoped paths
+living in `request_scoped_streams.py`. Existing behavior is unchanged, as
+proven by the golden-value parity test and the existing TTS suites.
 
 ## Context and Orientation
 
@@ -82,6 +94,10 @@ capabilities, and lock behavior with a parity test.
 4. Switch `validation.py`, `streaming_tts.py`, `pipeline.py`, and
    `minimax_run_tts.py` to capability lookups.
 5. Add `tests/service/tts/test_provider_capabilities_parity.py`.
+6. Move the MiniMax HTTP and Volcengine timestamp finalize paths into
+   `request_scoped_streams.py`, select them from the capability-driven
+   selectors, keep compatibility entry points on the processor, and add
+   `tests/service/tts/test_request_scoped_streams.py`.
 
 ## Validation and Acceptance
 

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -30,7 +30,6 @@ Active and completed ExecPlans live here. The structure and required sections ar
 - [老带新邀请奖励实施计划](./active/referral-invitation-rewards.md)
 - [Rename The Cook Web Directory](./active/rename-cook-web-directory.md)
 - [Minimize the Explicit Ruff Policy](./active/ruff-rule-minimization.md)
-- [TTS Provider Capabilities](./active/tts-provider-capabilities.md)
 
 ## Completed
 
@@ -63,6 +62,7 @@ Active and completed ExecPlans live here. The structure and required sections ar
 - [Explain personalization before deferring profile setup](./completed/profile-onboarding-retention.md)
 - [Profile Onboarding Structural Simplification](./completed/profile-onboarding-structural-simplification.md)
 - [Runtime Harness Fast Value Gate](./completed/runtime-harness-fast-value-gate.md)
+- [TTS Provider Capabilities](./completed/tts-provider-capabilities.md)
 - [Remediate Cook Web Umami contracts](./completed/umami-contract-remediation.md)
 - [Correct the Umami remediation scope](./completed/umami-scope-correction.md)
 - [Unified Learner Profile Dialog](./completed/unified-learner-profile-dialog.md)

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -46,7 +46,6 @@
 | `docs/exec-plans/active/referral-invitation-rewards.md` | 老带新邀请奖励实施计划 | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/rename-cook-web-directory.md` | Rename The Cook Web Directory | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/ruff-rule-minimization.md` | Minimize the Explicit Ruff Policy | `exec-plan-active` | `active` | `repo` | `-` | `true` |
-| `docs/exec-plans/active/tts-provider-capabilities.md` | TTS Provider Capabilities | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/admin-orders-page-slimming.md` | Admin Orders Page Slimming | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/admin-rate-management-create.md` | Add arbitrary rate entries to Rate Management | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/agent-first-harness-migration.md` | Agent-First Harness Migration | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
@@ -76,6 +75,7 @@
 | `docs/exec-plans/completed/profile-onboarding-retention.md` | Explain personalization before deferring profile setup | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/profile-onboarding-structural-simplification.md` | Profile Onboarding Structural Simplification | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/runtime-harness-fast-value-gate.md` | Runtime Harness Fast Value Gate | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
+| `docs/exec-plans/completed/tts-provider-capabilities.md` | TTS Provider Capabilities | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/umami-contract-remediation.md` | Remediate Cook Web Umami contracts | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/umami-scope-correction.md` | Correct the Umami remediation scope | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |
 | `docs/exec-plans/completed/unified-learner-profile-dialog.md` | Unified Learner Profile Dialog | `exec-plan-completed` | `completed` | `repo` | `-` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -9,8 +9,8 @@ This generated report summarizes the repository harness control plane.
 - Design docs: `12`
 - Product specs: `10`
 - References: `4`
-- Active ExecPlans: `25`
-- Completed ExecPlans: `32`
+- Active ExecPlans: `24`
+- Completed ExecPlans: `33`
 
 ## Boundary Baseline
 

--- a/src/api/flaskr/service/tts/request_scoped_streams.py
+++ b/src/api/flaskr/service/tts/request_scoped_streams.py
@@ -1,0 +1,948 @@
+"""Request-scoped synthesis strategies for the streaming TTS processor.
+
+Some providers synthesize one whole mdflow text element per request instead
+of sentence-sized segments, either because the request itself streams audio
+(MiniMax HTTP streaming) or because the provider returns word timestamps that
+only line up for a single request (Volcengine bidirectional WebSocket). Those
+paths used to live inline in ``StreamingTTSProcessor``; they are now strategy
+objects selected through the provider's ``request_scoped_stream`` capability
+and handed the processor whose shared helpers, buffers, and usage context they
+drive.
+
+Collaborators such as ``logger``, ``time``, ``MinimaxTTSProvider``, and the
+audio duration/export helpers are resolved through the streaming module at
+call time because the existing test suites patch them there.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+from flaskr.service.tts import resolve_tts_billable_chars
+from flaskr.service.tts.subtitle_utils import normalize_subtitle_cues
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from types import ModuleType
+
+    from flaskr.api.tts.minimax_provider import MinimaxTTSProvider
+    from flaskr.service.learn.learn_dtos import RunMarkdownFlowDTO
+    from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
+
+_MINIMAX_HTTP_STREAM_SEGMENT_TARGET_MS = 1500
+_MINIMAX_HTTP_STREAM_MAX_CHARS = 9500
+
+
+def _streaming() -> ModuleType:
+    # Imported lazily: the streaming module imports this one, and the tests
+    # patch collaborators on the streaming module namespace.
+    from flaskr.service.tts import streaming_tts
+
+    return streaming_tts
+
+
+@dataclass
+class _MinimaxFallbackAudio:
+    audio_data: bytes
+    duration_ms: int
+    word_count: int
+    usage_characters: int
+    audio_format: str
+
+
+class RequestScopedSynthesisStrategy(Protocol):
+    """Synthesize one whole text element per request at processor finalize time."""
+
+    def finalize(
+        self,
+        processor: StreamingTTSProcessor,
+        *,
+        raw_text: str,
+        cleaned_text: str,
+        cleaned_text_length: int,
+        commit: bool,
+    ) -> Generator[RunMarkdownFlowDTO, None, None]:
+        """Yield audio events for the buffered element and complete the audio."""
+        ...
+
+
+class MinimaxHttpStreamStrategy:
+    """MiniMax HTTP streaming: chunked requests with provider subtitle cues."""
+
+    def _split_minimax_http_stream_text(
+        self, processor: StreamingTTSProcessor, text: str
+    ) -> list[str]:
+        parts: list[str] = []
+        current = ""
+        for unit in processor._sentence_units_for_tts(text):
+            if len(unit) > _MINIMAX_HTTP_STREAM_MAX_CHARS:
+                if current:
+                    parts.append(current)
+                    current = ""
+                for start in range(0, len(unit), _MINIMAX_HTTP_STREAM_MAX_CHARS):
+                    chunk = unit[start : start + _MINIMAX_HTTP_STREAM_MAX_CHARS].strip()
+                    if chunk:
+                        parts.append(chunk)
+                continue
+
+            candidate = f"{current}\n{unit}" if current else unit
+            if len(candidate) <= _MINIMAX_HTTP_STREAM_MAX_CHARS:
+                current = candidate
+                continue
+            if current:
+                parts.append(current)
+            current = unit
+
+        if current:
+            parts.append(current)
+        return parts
+
+    @staticmethod
+    def _minimax_subtitle_text(raw_item: dict[str, object]) -> str:
+        for key in ("text", "content", "sentence"):
+            text = str(raw_item.get(key, "") or "").strip()
+            if text:
+                return text
+        return ""
+
+    @staticmethod
+    def _minimax_subtitle_time_ms(
+        raw_item: dict[str, object],
+        keys: tuple[str, ...],
+        *,
+        default_ms: int = 0,
+    ) -> int:
+        for key in keys:
+            if key not in raw_item:
+                continue
+            raw_value = raw_item.get(key)
+            if raw_value is None or raw_value == "":
+                continue
+            try:
+                return round(float(raw_value))
+            except (TypeError, ValueError):
+                continue
+        return int(default_ms or 0)
+
+    @classmethod
+    def _minimax_raw_subtitle_key(cls, raw_item: dict[str, Any]) -> tuple[str, int]:
+        text = cls._minimax_subtitle_text(raw_item)
+        start_ms = cls._minimax_subtitle_time_ms(
+            raw_item,
+            ("time_begin", "start_ms", "start_time", "begin_time", "start", "begin"),
+        )
+        return text, start_ms
+
+    def _extend_unique_minimax_subtitles(
+        self,
+        processor: StreamingTTSProcessor,
+        target: list[dict[str, Any]],
+        incoming: list[dict[str, Any]],
+    ) -> None:
+        seen_indexes = {
+            self._minimax_raw_subtitle_key(item): index
+            for index, item in enumerate(target)
+        }
+        search_start = 0
+        for raw_item in incoming or []:
+            if not isinstance(raw_item, dict):
+                continue
+            key = self._minimax_raw_subtitle_key(raw_item)
+            if not key[0]:
+                continue
+            existing_index = seen_indexes.get(key)
+            if existing_index is not None:
+                target[existing_index] = raw_item
+                search_start = max(search_start, existing_index + 1)
+                continue
+            normalized_text = processor._normalize_subtitle_compare_text(key[0])
+            matching_index = None
+            for index in range(search_start, len(target)):
+                target_text = processor._normalize_subtitle_compare_text(
+                    self._minimax_subtitle_text(target[index])
+                )
+                if target_text == normalized_text:
+                    matching_index = index
+                    break
+            if matching_index is not None:
+                previous_key = self._minimax_raw_subtitle_key(target[matching_index])
+                if seen_indexes.get(previous_key) == matching_index:
+                    seen_indexes.pop(previous_key, None)
+                target[matching_index] = raw_item
+                seen_indexes[key] = matching_index
+                search_start = matching_index + 1
+                continue
+            target.append(raw_item)
+            seen_indexes[key] = len(target) - 1
+            search_start = len(target)
+
+    def _build_minimax_provider_subtitle_cues(
+        self,
+        processor: StreamingTTSProcessor,
+        *,
+        request_subtitles: list[dict[str, object]],
+        subtitle_offset_ms: int,
+    ) -> list[dict[str, object]]:
+        return normalize_subtitle_cues(
+            self._minimax_subtitles_to_cues(
+                processor,
+                request_subtitles,
+                offset_ms=subtitle_offset_ms,
+            )
+        )
+
+    def _minimax_subtitles_to_cues(
+        self,
+        processor: StreamingTTSProcessor,
+        subtitles: list[dict[str, Any]],
+        *,
+        offset_ms: int = 0,
+    ) -> list[dict[str, object]]:
+        cues: list[dict[str, Any]] = []
+        for raw_item in subtitles or []:
+            if not isinstance(raw_item, dict):
+                continue
+            text = self._minimax_subtitle_text(raw_item)
+            if not text:
+                continue
+            start_ms = self._minimax_subtitle_time_ms(
+                raw_item,
+                (
+                    "time_begin",
+                    "start_ms",
+                    "start_time",
+                    "begin_time",
+                    "start",
+                    "begin",
+                ),
+            )
+            end_ms = self._minimax_subtitle_time_ms(
+                raw_item,
+                ("time_end", "end_ms", "end_time", "finish_time", "end", "finish"),
+                default_ms=start_ms,
+            )
+            start_ms = max(start_ms + int(offset_ms or 0), 0)
+            end_ms = max(end_ms + int(offset_ms or 0), start_ms)
+            cues.append(
+                {
+                    "text": text,
+                    "start_ms": start_ms,
+                    "end_ms": end_ms,
+                    "segment_index": 0,
+                    "position": processor.position,
+                }
+            )
+        return cues
+
+    def _scale_minimax_cues_to_live_request(
+        self,
+        processor: StreamingTTSProcessor,
+        subtitle_cues: list[dict[str, Any]],
+        *,
+        provider_offset_ms: int,
+        live_offset_ms: int,
+        live_request_end_ms: int,
+    ) -> list[dict[str, object]]:
+        normalized_cues = normalize_subtitle_cues(subtitle_cues)
+        if not normalized_cues or live_request_end_ms <= 0:
+            return []
+
+        safe_provider_offset_ms = max(int(provider_offset_ms or 0), 0)
+        safe_live_offset_ms = max(int(live_offset_ms or 0), 0)
+        safe_live_request_end_ms = max(int(live_request_end_ms or 0), 0)
+        source_end_ms = max(
+            processor._subtitle_cues_end_ms(normalized_cues) - safe_provider_offset_ms,
+            0,
+        )
+        if source_end_ms <= 0:
+            source_end_ms = safe_live_request_end_ms
+        scale = safe_live_request_end_ms / source_end_ms if source_end_ms > 0 else 1.0
+
+        live_cues: list[dict[str, Any]] = []
+        for cue in normalized_cues:
+            text = processor._subtitle_cue_text(cue)
+            if not text:
+                continue
+            source_start_ms = max(
+                int(cue.get("start_ms", 0) or 0) - safe_provider_offset_ms,
+                0,
+            )
+            source_cue_end_ms = max(
+                int(cue.get("end_ms", source_start_ms) or source_start_ms)
+                - safe_provider_offset_ms,
+                source_start_ms,
+            )
+            start_ms = min(
+                round(source_start_ms * scale),
+                safe_live_request_end_ms,
+            )
+            end_ms = min(
+                round(source_cue_end_ms * scale),
+                safe_live_request_end_ms,
+            )
+            live_cues.append(
+                {
+                    "text": text,
+                    "start_ms": safe_live_offset_ms + max(start_ms, 0),
+                    "end_ms": safe_live_offset_ms + max(end_ms, start_ms),
+                    "segment_index": int(cue.get("segment_index", 0) or 0),
+                    "position": processor.position,
+                }
+            )
+        return live_cues
+
+    def _merge_minimax_live_request_cues(
+        self,
+        processor: StreamingTTSProcessor,
+        previous_live_cues: list[dict[str, Any]],
+        incoming_live_cues: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        previous = normalize_subtitle_cues(previous_live_cues)
+        incoming = normalize_subtitle_cues(incoming_live_cues)
+        if not previous:
+            return incoming
+        if not incoming:
+            return previous
+
+        frozen_prefix = [dict(cue) for cue in previous[:-1]]
+        previous_tail = dict(previous[-1])
+        incoming_tail_index: int | None = None
+
+        if len(incoming) >= len(previous):
+            candidate_index = len(previous) - 1
+            candidate = incoming[candidate_index]
+            if processor._subtitle_cue_text(candidate) == processor._subtitle_cue_text(
+                previous_tail
+            ):
+                incoming_tail_index = candidate_index
+
+        if incoming_tail_index is None:
+            for index in range(max(len(frozen_prefix), 0), len(incoming)):
+                candidate = incoming[index]
+                if processor._subtitle_cue_text(
+                    candidate
+                ) == processor._subtitle_cue_text(previous_tail):
+                    incoming_tail_index = index
+                    break
+
+        if incoming_tail_index is None:
+            previous_end_ms = int(previous_tail.get("end_ms", 0) or 0)
+            remaining = [
+                dict(cue)
+                for cue in incoming
+                if int(cue.get("end_ms", 0) or 0) > previous_end_ms
+            ]
+            return [dict(cue) for cue in previous] + remaining
+
+        tail_candidate = incoming[incoming_tail_index]
+        previous_tail["end_ms"] = max(
+            int(previous_tail.get("end_ms", 0) or 0),
+            int(tail_candidate.get("end_ms", 0) or 0),
+        )
+        remaining = [dict(cue) for cue in incoming[incoming_tail_index + 1 :]]
+        return [*frozen_prefix, previous_tail, *remaining]
+
+    def _normalize_minimax_live_request_cues(
+        self,
+        processor: StreamingTTSProcessor,
+        live_cues: list[dict[str, Any]],
+        *,
+        live_offset_ms: int,
+        live_request_end_ms: int,
+    ) -> list[dict[str, object]]:
+        normalized_cues = normalize_subtitle_cues(live_cues)
+        if not normalized_cues:
+            return []
+
+        timeline_start_ms = max(int(live_offset_ms or 0), 0)
+        timeline_end_ms = timeline_start_ms + max(int(live_request_end_ms or 0), 0)
+        if timeline_end_ms <= timeline_start_ms:
+            return []
+
+        bounded: list[dict[str, Any]] = []
+        last_end_ms = timeline_start_ms
+        for cue in normalized_cues:
+            text = processor._subtitle_cue_text(cue)
+            if not text:
+                continue
+            start_ms = max(int(cue.get("start_ms", 0) or 0), timeline_start_ms)
+            end_ms = max(int(cue.get("end_ms", start_ms) or start_ms), start_ms)
+            start_ms = max(start_ms, last_end_ms)
+            if start_ms >= timeline_end_ms:
+                continue
+            end_ms = min(max(end_ms, start_ms + 1), timeline_end_ms)
+            bounded.append(
+                {
+                    "text": text,
+                    "start_ms": start_ms,
+                    "end_ms": end_ms,
+                    "segment_index": int(cue.get("segment_index", 0) or 0),
+                    "position": processor.position,
+                }
+            )
+            last_end_ms = end_ms
+
+        if bounded:
+            bounded[-1]["start_ms"] = min(
+                int(bounded[-1].get("start_ms", 0) or 0),
+                max(timeline_end_ms - 1, timeline_start_ms),
+            )
+            bounded[-1]["end_ms"] = timeline_end_ms
+        return normalize_subtitle_cues(bounded)
+
+    def _build_minimax_live_request_subtitle_cues(
+        self,
+        processor: StreamingTTSProcessor,
+        subtitle_cues: list[dict[str, Any]],
+        *,
+        provider_offset_ms: int,
+        live_offset_ms: int,
+        live_request_end_ms: int,
+        previous_live_cues: list[dict[str, object]] | None = None,
+    ) -> list[dict[str, object]]:
+        incoming_live_cues = self._scale_minimax_cues_to_live_request(
+            processor,
+            subtitle_cues,
+            provider_offset_ms=provider_offset_ms,
+            live_offset_ms=live_offset_ms,
+            live_request_end_ms=live_request_end_ms,
+        )
+        merged_live_cues = self._merge_minimax_live_request_cues(
+            processor,
+            previous_live_cues or [],
+            incoming_live_cues,
+        )
+        return self._normalize_minimax_live_request_cues(
+            processor,
+            merged_live_cues,
+            live_offset_ms=live_offset_ms,
+            live_request_end_ms=live_request_end_ms,
+        )
+
+    def _synthesize_minimax_complete_fallback(
+        self,
+        processor: StreamingTTSProcessor,
+        provider: MinimaxTTSProvider,
+        *,
+        request_text: str,
+        request_format: str,
+        request_index: int,
+    ) -> _MinimaxFallbackAudio | None:
+        try:
+            result = provider.synthesize(
+                text=request_text,
+                voice_settings=processor.voice_settings,
+                audio_settings=processor.audio_settings,
+                model=processor.tts_model,
+            )
+        except Exception as exc:
+            _streaming().logger.warning(
+                "MiniMax complete synthesis fallback failed. request_index=%s, "
+                "text_length=%s, error=%s",
+                request_index,
+                len(request_text or ""),
+                exc,
+            )
+            _streaming().logger.debug(
+                "MiniMax complete synthesis fallback traceback", exc_info=True
+            )
+            return None
+
+        audio_data = result.audio_data or b""
+        audio_format = (
+            result.format or request_format or processor.audio_settings.format or "mp3"
+        )
+        decoded_duration_ms = _streaming().try_get_audio_duration_ms(
+            audio_data,
+            audio_format=audio_format,
+        )
+        if decoded_duration_ms is None or decoded_duration_ms <= 0:
+            _streaming().logger.warning(
+                "MiniMax complete synthesis fallback returned undecodable audio. "
+                "request_index=%s, bytes=%s, format=%s",
+                request_index,
+                len(audio_data),
+                audio_format,
+            )
+            return None
+
+        return _MinimaxFallbackAudio(
+            audio_data=audio_data,
+            duration_ms=int(result.duration_ms or decoded_duration_ms or 0),
+            word_count=int(result.word_count or 0),
+            usage_characters=int(getattr(result, "usage_characters", 0) or 0),
+            audio_format=audio_format,
+        )
+
+    def finalize(
+        self,
+        processor: StreamingTTSProcessor,
+        *,
+        raw_text: str,
+        cleaned_text: str,
+        cleaned_text_length: int,
+        commit: bool,
+    ) -> Generator[RunMarkdownFlowDTO, None, None]:
+        """Stream the element through chunked MiniMax HTTP requests."""
+        request_texts = self._split_minimax_http_stream_text(processor, cleaned_text)
+        if not processor._enabled or not request_texts:
+            return
+
+        provider = _streaming().MinimaxTTSProvider()
+        live_subtitle_cues: list[dict[str, Any]] = []
+        final_subtitle_cues: list[dict[str, Any]] = []
+        subtitle_offset_ms = 0
+        live_offset_ms = 0
+
+        from flaskr.service.tts.tts_usage_recorder import record_tts_segment_usage
+
+        for request_index, request_text in enumerate(request_texts):
+            if _streaming()._should_skip_non_speakable_tts_text(
+                request_text, processor.tts_provider
+            ):
+                _streaming()._log_skipped_non_speakable_tts_text(
+                    segment_index=request_index,
+                    text=request_text,
+                    tts_provider=processor.tts_provider,
+                    tts_model=processor.tts_model,
+                )
+                continue
+
+            request_started_at = _streaming().time.monotonic()
+            audio_chunks: list[bytes] = []
+            source_emitted_ms = 0
+            live_request_emitted_ms = 0
+            request_duration_ms = 0
+            request_word_count = 0
+            request_usage_characters = 0
+            request_format = processor.audio_settings.format or "mp3"
+            request_subtitles: list[dict[str, Any]] = []
+            request_final_subtitle_cues: list[dict[str, Any]] = []
+            request_final_subtitle_cues_are_provider = False
+            request_live_subtitle_cues: list[dict[str, Any]] = []
+
+            for chunk in provider.stream_synthesize(
+                text=request_text,
+                voice_settings=processor.voice_settings,
+                audio_settings=processor.audio_settings,
+                model=processor.tts_model,
+            ):
+                if chunk.audio_data:
+                    audio_chunks.append(chunk.audio_data)
+                if chunk.format:
+                    request_format = chunk.format
+                if chunk.is_final:
+                    request_duration_ms = int(chunk.duration_ms or request_duration_ms)
+                    request_word_count = int(chunk.word_count or request_word_count)
+                    request_usage_characters = int(
+                        getattr(chunk, "usage_characters", 0)
+                        or request_usage_characters
+                    )
+                if chunk.subtitles:
+                    self._extend_unique_minimax_subtitles(
+                        processor,
+                        request_subtitles,
+                        chunk.subtitles,
+                    )
+
+                accumulated_audio = b"".join(audio_chunks)
+                if not accumulated_audio:
+                    continue
+
+                progressive_request_subtitle_cues = (
+                    self._build_minimax_provider_subtitle_cues(
+                        processor,
+                        request_subtitles=request_subtitles,
+                        subtitle_offset_ms=subtitle_offset_ms,
+                    )
+                )
+                request_subtitle_coverage_end_ms = max(
+                    processor._subtitle_cues_end_ms(progressive_request_subtitle_cues)
+                    - int(subtitle_offset_ms or 0),
+                    0,
+                )
+
+                if chunk.is_final:
+                    if request_duration_ms <= 0:
+                        decoded_duration_ms = _streaming().try_get_audio_duration_ms(
+                            accumulated_audio,
+                            audio_format=request_format or "mp3",
+                        )
+                        if decoded_duration_ms is not None:
+                            request_duration_ms = int(decoded_duration_ms or 0)
+                    if progressive_request_subtitle_cues and (
+                        processor._subtitle_cues_cover_text(
+                            progressive_request_subtitle_cues,
+                            request_text,
+                        )
+                    ):
+                        request_final_subtitle_cues = progressive_request_subtitle_cues
+                        request_final_subtitle_cues_are_provider = True
+                        target_end_ms = max(
+                            request_subtitle_coverage_end_ms, source_emitted_ms
+                        )
+                    else:
+                        if progressive_request_subtitle_cues:
+                            _streaming().logger.debug(
+                                "MiniMax subtitles did not cover full request text; "
+                                "using fallback cues. request_index=%s, subtitles=%s",
+                                request_index,
+                                len(progressive_request_subtitle_cues),
+                            )
+                        request_final_subtitle_cues = (
+                            processor._build_minimax_fallback_subtitle_cues(
+                                request_text,
+                                duration_ms=int(
+                                    request_duration_ms
+                                    or source_emitted_ms
+                                    or live_request_emitted_ms
+                                    or 0
+                                ),
+                                offset_ms=subtitle_offset_ms,
+                            )
+                        )
+                        target_end_ms = max(
+                            int(request_duration_ms or 0), source_emitted_ms
+                        )
+                    event_request_subtitle_cues = request_final_subtitle_cues
+                else:
+                    if not progressive_request_subtitle_cues:
+                        continue
+                    target_end_ms = request_subtitle_coverage_end_ms
+                    event_request_subtitle_cues = progressive_request_subtitle_cues
+
+                if target_end_ms <= source_emitted_ms:
+                    continue
+
+                audio_piece = b""
+                piece_duration_ms = 0
+                audio_piece, piece_duration_ms = (
+                    _streaming().export_audio_range_best_effort(
+                        accumulated_audio,
+                        start_ms=source_emitted_ms,
+                        end_ms=target_end_ms,
+                        input_format=request_format or "mp3",
+                        output_format=processor.audio_settings.format or "mp3",
+                    )
+                )
+
+                if (
+                    not chunk.is_final
+                    and piece_duration_ms < _MINIMAX_HTTP_STREAM_SEGMENT_TARGET_MS
+                ):
+                    continue
+
+                if (
+                    not audio_piece
+                    and chunk.is_final
+                    and source_emitted_ms == 0
+                    and target_end_ms >= int(request_duration_ms or 0)
+                ):
+                    decoded_duration_ms = _streaming().try_get_audio_duration_ms(
+                        accumulated_audio,
+                        audio_format=request_format or "mp3",
+                    )
+                    if decoded_duration_ms is not None and decoded_duration_ms > 0:
+                        audio_piece = accumulated_audio
+                        piece_duration_ms = int(
+                            request_duration_ms or decoded_duration_ms
+                        )
+                    else:
+                        _streaming().logger.warning(
+                            "MiniMax HTTP stream produced undecodable final audio; "
+                            "will try complete synthesis fallback. request_index=%s, "
+                            "bytes=%s, format=%s, trace_id=%s",
+                            request_index,
+                            len(accumulated_audio or b""),
+                            request_format or "mp3",
+                            getattr(chunk, "trace_id", ""),
+                        )
+
+                if not audio_piece or piece_duration_ms <= 0:
+                    continue
+
+                source_emitted_ms = max(source_emitted_ms, int(target_end_ms or 0))
+                live_request_emitted_ms += int(piece_duration_ms or 0)
+                request_live_subtitle_cues = (
+                    self._build_minimax_live_request_subtitle_cues(
+                        processor,
+                        event_request_subtitle_cues,
+                        provider_offset_ms=subtitle_offset_ms,
+                        live_offset_ms=live_offset_ms,
+                        live_request_end_ms=live_request_emitted_ms,
+                        previous_live_cues=request_live_subtitle_cues,
+                    )
+                )
+                progressive_subtitle_cues = normalize_subtitle_cues(
+                    list(live_subtitle_cues or []) + request_live_subtitle_cues
+                )
+                _segment_index, event = processor._store_stream_audio_segment(
+                    audio_data=audio_piece,
+                    duration_ms=piece_duration_ms,
+                    text=request_text,
+                    subtitle_cues=progressive_subtitle_cues,
+                )
+                yield event
+
+            fallback_audio: _MinimaxFallbackAudio | None = None
+            if live_request_emitted_ms <= 0:
+                fallback_audio = self._synthesize_minimax_complete_fallback(
+                    processor,
+                    provider,
+                    request_text=request_text,
+                    request_format=request_format,
+                    request_index=request_index,
+                )
+                if fallback_audio is not None:
+                    request_duration_ms = int(fallback_audio.duration_ms or 0)
+                    if fallback_audio.word_count:
+                        request_word_count = int(fallback_audio.word_count or 0)
+                    if fallback_audio.usage_characters:
+                        request_usage_characters = int(
+                            fallback_audio.usage_characters or 0
+                        )
+
+            if request_duration_ms <= 0:
+                request_duration_ms = source_emitted_ms or live_request_emitted_ms
+            if request_word_count:
+                processor._word_count_total += request_word_count
+            processor._output_char_total += resolve_tts_billable_chars(
+                request_text,
+                request_usage_characters,
+            )
+            if not request_final_subtitle_cues:
+                request_subtitle_cues = self._minimax_subtitles_to_cues(
+                    processor,
+                    request_subtitles,
+                    offset_ms=subtitle_offset_ms,
+                )
+                if request_subtitle_cues and processor._subtitle_cues_cover_text(
+                    request_subtitle_cues,
+                    request_text,
+                ):
+                    request_final_subtitle_cues = request_subtitle_cues
+                    request_final_subtitle_cues_are_provider = True
+                else:
+                    if request_subtitle_cues:
+                        _streaming().logger.debug(
+                            "MiniMax subtitles did not cover full request text; "
+                            "using fallback cues. request_index=%s, subtitles=%s",
+                            request_index,
+                            len(request_subtitle_cues),
+                        )
+                    request_final_subtitle_cues = (
+                        processor._build_minimax_fallback_subtitle_cues(
+                            request_text,
+                            duration_ms=int(
+                                request_duration_ms
+                                or source_emitted_ms
+                                or live_request_emitted_ms
+                                or 0
+                            ),
+                            offset_ms=subtitle_offset_ms,
+                        )
+                    )
+            if (
+                fallback_audio is not None
+                and not request_final_subtitle_cues_are_provider
+            ):
+                request_final_subtitle_cues = (
+                    processor._build_minimax_fallback_subtitle_cues(
+                        request_text,
+                        duration_ms=int(fallback_audio.duration_ms or 0),
+                        offset_ms=subtitle_offset_ms,
+                    )
+                )
+            if fallback_audio is not None and live_request_emitted_ms <= 0:
+                live_request_emitted_ms = int(fallback_audio.duration_ms or 0)
+                request_live_subtitle_cues = (
+                    self._build_minimax_live_request_subtitle_cues(
+                        processor,
+                        request_final_subtitle_cues,
+                        provider_offset_ms=subtitle_offset_ms,
+                        live_offset_ms=live_offset_ms,
+                        live_request_end_ms=live_request_emitted_ms,
+                    )
+                )
+                progressive_subtitle_cues = normalize_subtitle_cues(
+                    list(live_subtitle_cues or []) + request_live_subtitle_cues
+                )
+                _segment_index, event = processor._store_stream_audio_segment(
+                    audio_data=fallback_audio.audio_data,
+                    duration_ms=fallback_audio.duration_ms,
+                    text=request_text,
+                    subtitle_cues=progressive_subtitle_cues,
+                )
+                yield event
+            final_subtitle_cues.extend(request_final_subtitle_cues)
+            if not request_live_subtitle_cues and live_request_emitted_ms > 0:
+                request_live_subtitle_cues = (
+                    self._build_minimax_live_request_subtitle_cues(
+                        processor,
+                        request_final_subtitle_cues,
+                        provider_offset_ms=subtitle_offset_ms,
+                        live_offset_ms=live_offset_ms,
+                        live_request_end_ms=live_request_emitted_ms,
+                    )
+                )
+            live_subtitle_cues = normalize_subtitle_cues(
+                list(live_subtitle_cues or []) + request_live_subtitle_cues
+            )
+            live_offset_ms += int(live_request_emitted_ms or 0)
+            request_subtitle_end_ms = processor._subtitle_cues_end_ms(
+                request_final_subtitle_cues
+            )
+            if request_subtitle_end_ms > subtitle_offset_ms:
+                subtitle_offset_ms = request_subtitle_end_ms
+            else:
+                subtitle_offset_ms += int(request_duration_ms or source_emitted_ms or 0)
+
+            record_tts_segment_usage(
+                app=processor.app,
+                usage_context=processor.usage_context,
+                provider=processor.tts_provider or "",
+                model=processor.tts_model or "",
+                segment_text=request_text,
+                word_count=request_word_count,
+                duration_ms=int(request_duration_ms or 0),
+                latency_ms=int(
+                    (_streaming().time.monotonic() - request_started_at) * 1000
+                ),
+                voice_settings=processor.voice_settings,
+                audio_settings=processor.audio_settings,
+                is_stream=True,
+                parent_usage_bid=processor._usage_parent_bid,
+                segment_index=request_index,
+                usage_characters=request_usage_characters,
+            )
+
+        with processor._lock:
+            all_segments = list(processor._all_audio_data)
+
+        yield from processor._yield_audio_complete_from_segments(
+            all_segments=all_segments,
+            raw_text=raw_text,
+            cleaned_text=cleaned_text,
+            cleaned_text_length=cleaned_text_length,
+            subtitle_cues=final_subtitle_cues,
+            event_subtitle_cues=live_subtitle_cues,
+            commit=commit,
+        )
+
+
+class VolcengineTimestampStreamStrategy:
+    """Volcengine WebSocket: one request whose word timestamps become subtitles."""
+
+    def finalize(
+        self,
+        processor: StreamingTTSProcessor,
+        *,
+        raw_text: str,
+        cleaned_text: str,
+        cleaned_text_length: int,
+        commit: bool,
+    ) -> Generator[RunMarkdownFlowDTO, None, None]:
+        """Synthesize the whole element in one request and reuse its timestamps."""
+        request_text = (cleaned_text or "").strip()
+        if not processor._enabled or not request_text:
+            return
+        if _streaming()._should_skip_non_speakable_tts_text(
+            request_text, processor.tts_provider
+        ):
+            _streaming()._log_skipped_non_speakable_tts_text(
+                segment_index=0,
+                text=request_text,
+                tts_provider=processor.tts_provider,
+                tts_model=processor.tts_model,
+            )
+            return
+
+        request_started_at = _streaming().time.monotonic()
+        result = processor._synthesize_text_with_retry(
+            text=request_text,
+            voice_settings=processor.voice_settings,
+            audio_settings=processor.audio_settings,
+            tts_model=processor.tts_model,
+            tts_provider=processor.tts_provider,
+            segment_index=0,
+        )
+        if not result.audio_data:
+            _streaming().logger.warning("Volcengine timestamp stream returned no audio")
+            return
+
+        request_duration_ms = int(result.duration_ms or 0)
+        if request_duration_ms <= 0:
+            request_duration_ms = _streaming().get_audio_duration_ms(
+                result.audio_data,
+                audio_format=result.format or processor.audio_settings.format or "mp3",
+            )
+        request_word_count = int(result.word_count or 0)
+        request_usage_characters = int(getattr(result, "usage_characters", 0) or 0)
+        if request_word_count:
+            processor._word_count_total += request_word_count
+        processor._output_char_total += resolve_tts_billable_chars(
+            request_text,
+            request_usage_characters,
+        )
+
+        provider_subtitle_cues = processor._apply_subtitle_context(
+            list(getattr(result, "subtitle_cues", []) or [])
+        )
+        if provider_subtitle_cues and processor._subtitle_cues_cover_text(
+            provider_subtitle_cues,
+            request_text,
+        ):
+            final_subtitle_cues = provider_subtitle_cues
+        else:
+            if provider_subtitle_cues:
+                _streaming().logger.debug(
+                    "Volcengine subtitles did not cover full request text; "
+                    "using fallback cues. subtitles=%s",
+                    len(provider_subtitle_cues),
+                )
+            final_subtitle_cues = processor._build_minimax_fallback_subtitle_cues(
+                request_text,
+                duration_ms=int(request_duration_ms or 0),
+            )
+            final_subtitle_cues = processor._apply_subtitle_context(final_subtitle_cues)
+
+        _segment_index, event = processor._store_stream_audio_segment(
+            audio_data=result.audio_data,
+            duration_ms=int(request_duration_ms or 0),
+            text=request_text,
+            subtitle_cues=final_subtitle_cues,
+        )
+        yield event
+
+        from flaskr.service.tts.tts_usage_recorder import record_tts_segment_usage
+
+        record_tts_segment_usage(
+            app=processor.app,
+            usage_context=processor.usage_context,
+            provider=processor.tts_provider or "",
+            model=processor.tts_model or "",
+            segment_text=request_text,
+            word_count=request_word_count,
+            duration_ms=int(request_duration_ms or 0),
+            latency_ms=int((_streaming().time.monotonic() - request_started_at) * 1000),
+            voice_settings=processor.voice_settings,
+            audio_settings=processor.audio_settings,
+            is_stream=True,
+            parent_usage_bid=processor._usage_parent_bid,
+            segment_index=0,
+            usage_characters=request_usage_characters,
+        )
+
+        with processor._lock:
+            all_segments = list(processor._all_audio_data)
+
+        yield from processor._yield_audio_complete_from_segments(
+            all_segments=all_segments,
+            raw_text=raw_text,
+            cleaned_text=cleaned_text,
+            cleaned_text_length=cleaned_text_length,
+            subtitle_cues=final_subtitle_cues,
+            event_subtitle_cues=final_subtitle_cues,
+            commit=commit,
+        )

--- a/src/api/flaskr/service/tts/request_scoped_streams.py
+++ b/src/api/flaskr/service/tts/request_scoped_streams.py
@@ -27,8 +27,10 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from flaskr.api.tts.minimax_provider import MinimaxTTSProvider
-    from flaskr.service.learn.learn_dtos import RunMarkdownFlowDTO
-    from flaskr.service.tts.streaming_tts import StreamingTTSProcessor
+    from flaskr.service.tts.streaming_tts import (
+        RunMarkdownFlowDTO,
+        StreamingTTSProcessor,
+    )
 
 _MINIMAX_HTTP_STREAM_SEGMENT_TARGET_MS = 1500
 _MINIMAX_HTTP_STREAM_MAX_CHARS = 9500

--- a/src/api/flaskr/service/tts/streaming_tts.py
+++ b/src/api/flaskr/service/tts/streaming_tts.py
@@ -29,7 +29,10 @@ from flaskr.api.tts import (
     synthesize_text,
 )
 from flaskr.api.tts.base import REQUEST_SCOPED_STREAM_VOLCENGINE_TIMESTAMP
-from flaskr.api.tts.minimax_provider import MinimaxTTSProvider
+
+# Resolved by the request-scoped strategies through this module namespace so
+# existing tests can keep patching ``streaming_tts.MinimaxTTSProvider``.
+from flaskr.api.tts.minimax_provider import MinimaxTTSProvider  # noqa: F401
 from flaskr.common.log import AppLoggerProxy
 from flaskr.dao import cleanup_session_after
 from flaskr.service.learn.learn_dtos import (
@@ -52,9 +55,9 @@ from flaskr.service.tts.audio_record_utils import (
 )
 from flaskr.service.tts.audio_utils import (
     concat_audio_best_effort,
-    export_audio_range_best_effort,
+    export_audio_range_best_effort,  # noqa: F401 - test seam used by request_scoped_streams
     get_audio_duration_ms,
-    try_get_audio_duration_ms,
+    try_get_audio_duration_ms,  # noqa: F401 - test seam used by request_scoped_streams
 )
 from flaskr.service.tts.boundary_strategies import find_boundary_end
 from flaskr.service.tts.minimax_run_tts import (
@@ -66,6 +69,11 @@ from flaskr.service.tts.patterns import (
 from flaskr.service.tts.pipeline import (
     _find_next_av_boundary,
     build_av_segmentation_contract,
+)
+from flaskr.service.tts.request_scoped_streams import (
+    MinimaxHttpStreamStrategy,
+    RequestScopedSynthesisStrategy,
+    VolcengineTimestampStreamStrategy,
 )
 from flaskr.service.tts.rpm_gate import TTSRpmQueueTimeoutError
 from flaskr.service.tts.subtitle_utils import (
@@ -214,6 +222,17 @@ def _should_use_volcengine_timestamp_stream(tts_provider: str) -> bool:
     )
 
 
+def _select_request_scoped_strategy(
+    tts_provider: str,
+) -> RequestScopedSynthesisStrategy | None:
+    """Pick the request-scoped strategy for a provider, or None for segments."""
+    if should_use_minimax_http_stream(tts_provider):
+        return MinimaxHttpStreamStrategy()
+    if _should_use_volcengine_timestamp_stream(tts_provider):
+        return VolcengineTimestampStreamStrategy()
+    return None
+
+
 _VISUAL_SKIP_KINDS = frozenset(
     {
         "fence",
@@ -232,8 +251,6 @@ _VISUAL_SKIP_KINDS = frozenset(
 # like `<div`, `<svg`, `![` or fenced code openers can span across chunks
 # without delaying speakable text submission more than necessary.
 _STREAM_BOUNDARY_GUARD_TAIL_CHARS = 12
-_MINIMAX_HTTP_STREAM_SEGMENT_TARGET_MS = 1500
-_MINIMAX_HTTP_STREAM_MAX_CHARS = 9500
 
 
 @dataclass
@@ -250,15 +267,6 @@ class TTSSegment:
     error: str | None = None
     is_ready: bool = False
     subtitle_cues: list[dict[str, Any]] = field(default_factory=list)
-
-
-@dataclass
-class _MinimaxFallbackAudio:
-    audio_data: bytes
-    duration_ms: int
-    word_count: int
-    usage_characters: int
-    audio_format: str
 
 
 class StreamingTTSProcessor:
@@ -322,10 +330,7 @@ class StreamingTTSProcessor:
         if emotion:
             self.voice_settings.emotion = emotion
         self.audio_settings = get_default_audio_settings(tts_provider)
-        self._use_minimax_http_stream = should_use_minimax_http_stream(tts_provider)
-        self._use_volcengine_timestamp_stream = _should_use_volcengine_timestamp_stream(
-            tts_provider
-        )
+        self._request_scoped_strategy = _select_request_scoped_strategy(tts_provider)
 
         # State
         self._buffer = ""
@@ -377,9 +382,9 @@ class StreamingTTSProcessor:
             return
 
         self._buffer += chunk
-        if self._use_minimax_http_stream or self._use_volcengine_timestamp_stream:
-            # Provider timestamp streams are request-scoped: send one request
-            # for the whole mdflow text element when this processor is finalized.
+        if self._request_scoped_strategy is not None:
+            # Request-scoped strategies send one request for the whole mdflow
+            # text element when this processor is finalized.
             return
 
         # Check if we should submit a new TTS task
@@ -908,110 +913,6 @@ class StreamingTTSProcessor:
             units.append(tail)
         return units or ([text.strip()] if (text or "").strip() else [])
 
-    def _split_minimax_http_stream_text(self, text: str) -> list[str]:
-        parts: list[str] = []
-        current = ""
-        for unit in self._sentence_units_for_tts(text):
-            if len(unit) > _MINIMAX_HTTP_STREAM_MAX_CHARS:
-                if current:
-                    parts.append(current)
-                    current = ""
-                for start in range(0, len(unit), _MINIMAX_HTTP_STREAM_MAX_CHARS):
-                    chunk = unit[start : start + _MINIMAX_HTTP_STREAM_MAX_CHARS].strip()
-                    if chunk:
-                        parts.append(chunk)
-                continue
-
-            candidate = f"{current}\n{unit}" if current else unit
-            if len(candidate) <= _MINIMAX_HTTP_STREAM_MAX_CHARS:
-                current = candidate
-                continue
-            if current:
-                parts.append(current)
-            current = unit
-
-        if current:
-            parts.append(current)
-        return parts
-
-    @staticmethod
-    def _minimax_subtitle_text(raw_item: dict[str, object]) -> str:
-        for key in ("text", "content", "sentence"):
-            text = str(raw_item.get(key, "") or "").strip()
-            if text:
-                return text
-        return ""
-
-    @staticmethod
-    def _minimax_subtitle_time_ms(
-        raw_item: dict[str, object],
-        keys: tuple[str, ...],
-        *,
-        default_ms: int = 0,
-    ) -> int:
-        for key in keys:
-            if key not in raw_item:
-                continue
-            raw_value = raw_item.get(key)
-            if raw_value is None or raw_value == "":
-                continue
-            try:
-                return round(float(raw_value))
-            except (TypeError, ValueError):
-                continue
-        return int(default_ms or 0)
-
-    @classmethod
-    def _minimax_raw_subtitle_key(cls, raw_item: dict[str, Any]) -> tuple[str, int]:
-        text = cls._minimax_subtitle_text(raw_item)
-        start_ms = cls._minimax_subtitle_time_ms(
-            raw_item,
-            ("time_begin", "start_ms", "start_time", "begin_time", "start", "begin"),
-        )
-        return text, start_ms
-
-    def _extend_unique_minimax_subtitles(
-        self,
-        target: list[dict[str, Any]],
-        incoming: list[dict[str, Any]],
-    ) -> None:
-        seen_indexes = {
-            self._minimax_raw_subtitle_key(item): index
-            for index, item in enumerate(target)
-        }
-        search_start = 0
-        for raw_item in incoming or []:
-            if not isinstance(raw_item, dict):
-                continue
-            key = self._minimax_raw_subtitle_key(raw_item)
-            if not key[0]:
-                continue
-            existing_index = seen_indexes.get(key)
-            if existing_index is not None:
-                target[existing_index] = raw_item
-                search_start = max(search_start, existing_index + 1)
-                continue
-            normalized_text = self._normalize_subtitle_compare_text(key[0])
-            matching_index = None
-            for index in range(search_start, len(target)):
-                target_text = self._normalize_subtitle_compare_text(
-                    self._minimax_subtitle_text(target[index])
-                )
-                if target_text == normalized_text:
-                    matching_index = index
-                    break
-            if matching_index is not None:
-                previous_key = self._minimax_raw_subtitle_key(target[matching_index])
-                if seen_indexes.get(previous_key) == matching_index:
-                    seen_indexes.pop(previous_key, None)
-                target[matching_index] = raw_item
-                seen_indexes[key] = matching_index
-                search_start = matching_index + 1
-                continue
-            target.append(raw_item)
-            seen_indexes[key] = len(target) - 1
-            search_start = len(target)
-
     @staticmethod
     def _normalize_subtitle_compare_text(text: str) -> str:
         return "".join(str(text or "").lower().split())
@@ -1090,242 +991,9 @@ class StreamingTTSProcessor:
             return 0
         return max(int(cue.get("end_ms", 0) or 0) for cue in normalized_cues)
 
-    def _build_minimax_provider_subtitle_cues(
-        self,
-        *,
-        request_subtitles: list[dict[str, object]],
-        subtitle_offset_ms: int,
-    ) -> list[dict[str, object]]:
-        return normalize_subtitle_cues(
-            self._minimax_subtitles_to_cues(
-                request_subtitles,
-                offset_ms=subtitle_offset_ms,
-            )
-        )
-
-    def _minimax_subtitles_to_cues(
-        self,
-        subtitles: list[dict[str, Any]],
-        *,
-        offset_ms: int = 0,
-    ) -> list[dict[str, object]]:
-        cues: list[dict[str, Any]] = []
-        for raw_item in subtitles or []:
-            if not isinstance(raw_item, dict):
-                continue
-            text = self._minimax_subtitle_text(raw_item)
-            if not text:
-                continue
-            start_ms = self._minimax_subtitle_time_ms(
-                raw_item,
-                (
-                    "time_begin",
-                    "start_ms",
-                    "start_time",
-                    "begin_time",
-                    "start",
-                    "begin",
-                ),
-            )
-            end_ms = self._minimax_subtitle_time_ms(
-                raw_item,
-                ("time_end", "end_ms", "end_time", "finish_time", "end", "finish"),
-                default_ms=start_ms,
-            )
-            start_ms = max(start_ms + int(offset_ms or 0), 0)
-            end_ms = max(end_ms + int(offset_ms or 0), start_ms)
-            cues.append(
-                {
-                    "text": text,
-                    "start_ms": start_ms,
-                    "end_ms": end_ms,
-                    "segment_index": 0,
-                    "position": self.position,
-                }
-            )
-        return cues
-
     @staticmethod
     def _subtitle_cue_text(cue: dict[str, object]) -> str:
         return str(cue.get("text", "") or "").strip()
-
-    def _scale_minimax_cues_to_live_request(
-        self,
-        subtitle_cues: list[dict[str, Any]],
-        *,
-        provider_offset_ms: int,
-        live_offset_ms: int,
-        live_request_end_ms: int,
-    ) -> list[dict[str, object]]:
-        normalized_cues = normalize_subtitle_cues(subtitle_cues)
-        if not normalized_cues or live_request_end_ms <= 0:
-            return []
-
-        safe_provider_offset_ms = max(int(provider_offset_ms or 0), 0)
-        safe_live_offset_ms = max(int(live_offset_ms or 0), 0)
-        safe_live_request_end_ms = max(int(live_request_end_ms or 0), 0)
-        source_end_ms = max(
-            self._subtitle_cues_end_ms(normalized_cues) - safe_provider_offset_ms,
-            0,
-        )
-        if source_end_ms <= 0:
-            source_end_ms = safe_live_request_end_ms
-        scale = safe_live_request_end_ms / source_end_ms if source_end_ms > 0 else 1.0
-
-        live_cues: list[dict[str, Any]] = []
-        for cue in normalized_cues:
-            text = self._subtitle_cue_text(cue)
-            if not text:
-                continue
-            source_start_ms = max(
-                int(cue.get("start_ms", 0) or 0) - safe_provider_offset_ms,
-                0,
-            )
-            source_cue_end_ms = max(
-                int(cue.get("end_ms", source_start_ms) or source_start_ms)
-                - safe_provider_offset_ms,
-                source_start_ms,
-            )
-            start_ms = min(
-                round(source_start_ms * scale),
-                safe_live_request_end_ms,
-            )
-            end_ms = min(
-                round(source_cue_end_ms * scale),
-                safe_live_request_end_ms,
-            )
-            live_cues.append(
-                {
-                    "text": text,
-                    "start_ms": safe_live_offset_ms + max(start_ms, 0),
-                    "end_ms": safe_live_offset_ms + max(end_ms, start_ms),
-                    "segment_index": int(cue.get("segment_index", 0) or 0),
-                    "position": self.position,
-                }
-            )
-        return live_cues
-
-    def _merge_minimax_live_request_cues(
-        self,
-        previous_live_cues: list[dict[str, Any]],
-        incoming_live_cues: list[dict[str, Any]],
-    ) -> list[dict[str, Any]]:
-        previous = normalize_subtitle_cues(previous_live_cues)
-        incoming = normalize_subtitle_cues(incoming_live_cues)
-        if not previous:
-            return incoming
-        if not incoming:
-            return previous
-
-        frozen_prefix = [dict(cue) for cue in previous[:-1]]
-        previous_tail = dict(previous[-1])
-        incoming_tail_index: int | None = None
-
-        if len(incoming) >= len(previous):
-            candidate_index = len(previous) - 1
-            candidate = incoming[candidate_index]
-            if self._subtitle_cue_text(candidate) == self._subtitle_cue_text(
-                previous_tail
-            ):
-                incoming_tail_index = candidate_index
-
-        if incoming_tail_index is None:
-            for index in range(max(len(frozen_prefix), 0), len(incoming)):
-                candidate = incoming[index]
-                if self._subtitle_cue_text(candidate) == self._subtitle_cue_text(
-                    previous_tail
-                ):
-                    incoming_tail_index = index
-                    break
-
-        if incoming_tail_index is None:
-            previous_end_ms = int(previous_tail.get("end_ms", 0) or 0)
-            remaining = [
-                dict(cue)
-                for cue in incoming
-                if int(cue.get("end_ms", 0) or 0) > previous_end_ms
-            ]
-            return [dict(cue) for cue in previous] + remaining
-
-        tail_candidate = incoming[incoming_tail_index]
-        previous_tail["end_ms"] = max(
-            int(previous_tail.get("end_ms", 0) or 0),
-            int(tail_candidate.get("end_ms", 0) or 0),
-        )
-        remaining = [dict(cue) for cue in incoming[incoming_tail_index + 1 :]]
-        return [*frozen_prefix, previous_tail, *remaining]
-
-    def _normalize_minimax_live_request_cues(
-        self,
-        live_cues: list[dict[str, Any]],
-        *,
-        live_offset_ms: int,
-        live_request_end_ms: int,
-    ) -> list[dict[str, object]]:
-        normalized_cues = normalize_subtitle_cues(live_cues)
-        if not normalized_cues:
-            return []
-
-        timeline_start_ms = max(int(live_offset_ms or 0), 0)
-        timeline_end_ms = timeline_start_ms + max(int(live_request_end_ms or 0), 0)
-        if timeline_end_ms <= timeline_start_ms:
-            return []
-
-        bounded: list[dict[str, Any]] = []
-        last_end_ms = timeline_start_ms
-        for cue in normalized_cues:
-            text = self._subtitle_cue_text(cue)
-            if not text:
-                continue
-            start_ms = max(int(cue.get("start_ms", 0) or 0), timeline_start_ms)
-            end_ms = max(int(cue.get("end_ms", start_ms) or start_ms), start_ms)
-            start_ms = max(start_ms, last_end_ms)
-            if start_ms >= timeline_end_ms:
-                continue
-            end_ms = min(max(end_ms, start_ms + 1), timeline_end_ms)
-            bounded.append(
-                {
-                    "text": text,
-                    "start_ms": start_ms,
-                    "end_ms": end_ms,
-                    "segment_index": int(cue.get("segment_index", 0) or 0),
-                    "position": self.position,
-                }
-            )
-            last_end_ms = end_ms
-
-        if bounded:
-            bounded[-1]["start_ms"] = min(
-                int(bounded[-1].get("start_ms", 0) or 0),
-                max(timeline_end_ms - 1, timeline_start_ms),
-            )
-            bounded[-1]["end_ms"] = timeline_end_ms
-        return normalize_subtitle_cues(bounded)
-
-    def _build_minimax_live_request_subtitle_cues(
-        self,
-        subtitle_cues: list[dict[str, Any]],
-        *,
-        provider_offset_ms: int,
-        live_offset_ms: int,
-        live_request_end_ms: int,
-        previous_live_cues: list[dict[str, object]] | None = None,
-    ) -> list[dict[str, object]]:
-        incoming_live_cues = self._scale_minimax_cues_to_live_request(
-            subtitle_cues,
-            provider_offset_ms=provider_offset_ms,
-            live_offset_ms=live_offset_ms,
-            live_request_end_ms=live_request_end_ms,
-        )
-        merged_live_cues = self._merge_minimax_live_request_cues(
-            previous_live_cues or [],
-            incoming_live_cues,
-        )
-        return self._normalize_minimax_live_request_cues(
-            merged_live_cues,
-            live_offset_ms=live_offset_ms,
-            live_request_end_ms=live_request_end_ms,
-        )
 
     def _store_stream_audio_segment(
         self,
@@ -1482,398 +1150,6 @@ class StreamingTTSProcessor:
             # connection instead of leaving it for the next statement.
             cleanup_session_after(e, source="streaming tts finalize")
 
-    def _synthesize_minimax_complete_fallback(
-        self,
-        provider: MinimaxTTSProvider,
-        *,
-        request_text: str,
-        request_format: str,
-        request_index: int,
-    ) -> _MinimaxFallbackAudio | None:
-        try:
-            result = provider.synthesize(
-                text=request_text,
-                voice_settings=self.voice_settings,
-                audio_settings=self.audio_settings,
-                model=self.tts_model,
-            )
-        except Exception as exc:
-            logger.warning(
-                "MiniMax complete synthesis fallback failed. request_index=%s, "
-                "text_length=%s, error=%s",
-                request_index,
-                len(request_text or ""),
-                exc,
-            )
-            logger.debug("MiniMax complete synthesis fallback traceback", exc_info=True)
-            return None
-
-        audio_data = result.audio_data or b""
-        audio_format = (
-            result.format or request_format or self.audio_settings.format or "mp3"
-        )
-        decoded_duration_ms = try_get_audio_duration_ms(
-            audio_data,
-            audio_format=audio_format,
-        )
-        if decoded_duration_ms is None or decoded_duration_ms <= 0:
-            logger.warning(
-                "MiniMax complete synthesis fallback returned undecodable audio. "
-                "request_index=%s, bytes=%s, format=%s",
-                request_index,
-                len(audio_data),
-                audio_format,
-            )
-            return None
-
-        return _MinimaxFallbackAudio(
-            audio_data=audio_data,
-            duration_ms=int(result.duration_ms or decoded_duration_ms or 0),
-            word_count=int(result.word_count or 0),
-            usage_characters=int(getattr(result, "usage_characters", 0) or 0),
-            audio_format=audio_format,
-        )
-
-    def _finalize_minimax_http_stream(
-        self,
-        *,
-        raw_text: str,
-        cleaned_text: str,
-        cleaned_text_length: int,
-        commit: bool,
-    ) -> Generator[RunMarkdownFlowDTO, None, None]:
-        request_texts = self._split_minimax_http_stream_text(cleaned_text)
-        if not self._enabled or not request_texts:
-            return
-
-        provider = MinimaxTTSProvider()
-        live_subtitle_cues: list[dict[str, Any]] = []
-        final_subtitle_cues: list[dict[str, Any]] = []
-        subtitle_offset_ms = 0
-        live_offset_ms = 0
-
-        from flaskr.service.tts.tts_usage_recorder import record_tts_segment_usage
-
-        for request_index, request_text in enumerate(request_texts):
-            if _should_skip_non_speakable_tts_text(request_text, self.tts_provider):
-                _log_skipped_non_speakable_tts_text(
-                    segment_index=request_index,
-                    text=request_text,
-                    tts_provider=self.tts_provider,
-                    tts_model=self.tts_model,
-                )
-                continue
-
-            request_started_at = time.monotonic()
-            audio_chunks: list[bytes] = []
-            source_emitted_ms = 0
-            live_request_emitted_ms = 0
-            request_duration_ms = 0
-            request_word_count = 0
-            request_usage_characters = 0
-            request_format = self.audio_settings.format or "mp3"
-            request_subtitles: list[dict[str, Any]] = []
-            request_final_subtitle_cues: list[dict[str, Any]] = []
-            request_final_subtitle_cues_are_provider = False
-            request_live_subtitle_cues: list[dict[str, Any]] = []
-
-            for chunk in provider.stream_synthesize(
-                text=request_text,
-                voice_settings=self.voice_settings,
-                audio_settings=self.audio_settings,
-                model=self.tts_model,
-            ):
-                if chunk.audio_data:
-                    audio_chunks.append(chunk.audio_data)
-                if chunk.format:
-                    request_format = chunk.format
-                if chunk.is_final:
-                    request_duration_ms = int(chunk.duration_ms or request_duration_ms)
-                    request_word_count = int(chunk.word_count or request_word_count)
-                    request_usage_characters = int(
-                        getattr(chunk, "usage_characters", 0)
-                        or request_usage_characters
-                    )
-                if chunk.subtitles:
-                    self._extend_unique_minimax_subtitles(
-                        request_subtitles,
-                        chunk.subtitles,
-                    )
-
-                accumulated_audio = b"".join(audio_chunks)
-                if not accumulated_audio:
-                    continue
-
-                progressive_request_subtitle_cues = (
-                    self._build_minimax_provider_subtitle_cues(
-                        request_subtitles=request_subtitles,
-                        subtitle_offset_ms=subtitle_offset_ms,
-                    )
-                )
-                request_subtitle_coverage_end_ms = max(
-                    self._subtitle_cues_end_ms(progressive_request_subtitle_cues)
-                    - int(subtitle_offset_ms or 0),
-                    0,
-                )
-
-                if chunk.is_final:
-                    if request_duration_ms <= 0:
-                        decoded_duration_ms = try_get_audio_duration_ms(
-                            accumulated_audio,
-                            audio_format=request_format or "mp3",
-                        )
-                        if decoded_duration_ms is not None:
-                            request_duration_ms = int(decoded_duration_ms or 0)
-                    if progressive_request_subtitle_cues and (
-                        self._subtitle_cues_cover_text(
-                            progressive_request_subtitle_cues,
-                            request_text,
-                        )
-                    ):
-                        request_final_subtitle_cues = progressive_request_subtitle_cues
-                        request_final_subtitle_cues_are_provider = True
-                        target_end_ms = max(
-                            request_subtitle_coverage_end_ms, source_emitted_ms
-                        )
-                    else:
-                        if progressive_request_subtitle_cues:
-                            logger.debug(
-                                "MiniMax subtitles did not cover full request text; "
-                                "using fallback cues. request_index=%s, subtitles=%s",
-                                request_index,
-                                len(progressive_request_subtitle_cues),
-                            )
-                        request_final_subtitle_cues = (
-                            self._build_minimax_fallback_subtitle_cues(
-                                request_text,
-                                duration_ms=int(
-                                    request_duration_ms
-                                    or source_emitted_ms
-                                    or live_request_emitted_ms
-                                    or 0
-                                ),
-                                offset_ms=subtitle_offset_ms,
-                            )
-                        )
-                        target_end_ms = max(
-                            int(request_duration_ms or 0), source_emitted_ms
-                        )
-                    event_request_subtitle_cues = request_final_subtitle_cues
-                else:
-                    if not progressive_request_subtitle_cues:
-                        continue
-                    target_end_ms = request_subtitle_coverage_end_ms
-                    event_request_subtitle_cues = progressive_request_subtitle_cues
-
-                if target_end_ms <= source_emitted_ms:
-                    continue
-
-                audio_piece = b""
-                piece_duration_ms = 0
-                audio_piece, piece_duration_ms = export_audio_range_best_effort(
-                    accumulated_audio,
-                    start_ms=source_emitted_ms,
-                    end_ms=target_end_ms,
-                    input_format=request_format or "mp3",
-                    output_format=self.audio_settings.format or "mp3",
-                )
-
-                if (
-                    not chunk.is_final
-                    and piece_duration_ms < _MINIMAX_HTTP_STREAM_SEGMENT_TARGET_MS
-                ):
-                    continue
-
-                if (
-                    not audio_piece
-                    and chunk.is_final
-                    and source_emitted_ms == 0
-                    and target_end_ms >= int(request_duration_ms or 0)
-                ):
-                    decoded_duration_ms = try_get_audio_duration_ms(
-                        accumulated_audio,
-                        audio_format=request_format or "mp3",
-                    )
-                    if decoded_duration_ms is not None and decoded_duration_ms > 0:
-                        audio_piece = accumulated_audio
-                        piece_duration_ms = int(
-                            request_duration_ms or decoded_duration_ms
-                        )
-                    else:
-                        logger.warning(
-                            "MiniMax HTTP stream produced undecodable final audio; "
-                            "will try complete synthesis fallback. request_index=%s, "
-                            "bytes=%s, format=%s, trace_id=%s",
-                            request_index,
-                            len(accumulated_audio or b""),
-                            request_format or "mp3",
-                            getattr(chunk, "trace_id", ""),
-                        )
-
-                if not audio_piece or piece_duration_ms <= 0:
-                    continue
-
-                source_emitted_ms = max(source_emitted_ms, int(target_end_ms or 0))
-                live_request_emitted_ms += int(piece_duration_ms or 0)
-                request_live_subtitle_cues = (
-                    self._build_minimax_live_request_subtitle_cues(
-                        event_request_subtitle_cues,
-                        provider_offset_ms=subtitle_offset_ms,
-                        live_offset_ms=live_offset_ms,
-                        live_request_end_ms=live_request_emitted_ms,
-                        previous_live_cues=request_live_subtitle_cues,
-                    )
-                )
-                progressive_subtitle_cues = normalize_subtitle_cues(
-                    list(live_subtitle_cues or []) + request_live_subtitle_cues
-                )
-                _segment_index, event = self._store_stream_audio_segment(
-                    audio_data=audio_piece,
-                    duration_ms=piece_duration_ms,
-                    text=request_text,
-                    subtitle_cues=progressive_subtitle_cues,
-                )
-                yield event
-
-            fallback_audio: _MinimaxFallbackAudio | None = None
-            if live_request_emitted_ms <= 0:
-                fallback_audio = self._synthesize_minimax_complete_fallback(
-                    provider,
-                    request_text=request_text,
-                    request_format=request_format,
-                    request_index=request_index,
-                )
-                if fallback_audio is not None:
-                    request_duration_ms = int(fallback_audio.duration_ms or 0)
-                    if fallback_audio.word_count:
-                        request_word_count = int(fallback_audio.word_count or 0)
-                    if fallback_audio.usage_characters:
-                        request_usage_characters = int(
-                            fallback_audio.usage_characters or 0
-                        )
-
-            if request_duration_ms <= 0:
-                request_duration_ms = source_emitted_ms or live_request_emitted_ms
-            if request_word_count:
-                self._word_count_total += request_word_count
-            self._output_char_total += resolve_tts_billable_chars(
-                request_text,
-                request_usage_characters,
-            )
-            if not request_final_subtitle_cues:
-                request_subtitle_cues = self._minimax_subtitles_to_cues(
-                    request_subtitles,
-                    offset_ms=subtitle_offset_ms,
-                )
-                if request_subtitle_cues and self._subtitle_cues_cover_text(
-                    request_subtitle_cues,
-                    request_text,
-                ):
-                    request_final_subtitle_cues = request_subtitle_cues
-                    request_final_subtitle_cues_are_provider = True
-                else:
-                    if request_subtitle_cues:
-                        logger.debug(
-                            "MiniMax subtitles did not cover full request text; "
-                            "using fallback cues. request_index=%s, subtitles=%s",
-                            request_index,
-                            len(request_subtitle_cues),
-                        )
-                    request_final_subtitle_cues = (
-                        self._build_minimax_fallback_subtitle_cues(
-                            request_text,
-                            duration_ms=int(
-                                request_duration_ms
-                                or source_emitted_ms
-                                or live_request_emitted_ms
-                                or 0
-                            ),
-                            offset_ms=subtitle_offset_ms,
-                        )
-                    )
-            if (
-                fallback_audio is not None
-                and not request_final_subtitle_cues_are_provider
-            ):
-                request_final_subtitle_cues = (
-                    self._build_minimax_fallback_subtitle_cues(
-                        request_text,
-                        duration_ms=int(fallback_audio.duration_ms or 0),
-                        offset_ms=subtitle_offset_ms,
-                    )
-                )
-            if fallback_audio is not None and live_request_emitted_ms <= 0:
-                live_request_emitted_ms = int(fallback_audio.duration_ms or 0)
-                request_live_subtitle_cues = (
-                    self._build_minimax_live_request_subtitle_cues(
-                        request_final_subtitle_cues,
-                        provider_offset_ms=subtitle_offset_ms,
-                        live_offset_ms=live_offset_ms,
-                        live_request_end_ms=live_request_emitted_ms,
-                    )
-                )
-                progressive_subtitle_cues = normalize_subtitle_cues(
-                    list(live_subtitle_cues or []) + request_live_subtitle_cues
-                )
-                _segment_index, event = self._store_stream_audio_segment(
-                    audio_data=fallback_audio.audio_data,
-                    duration_ms=fallback_audio.duration_ms,
-                    text=request_text,
-                    subtitle_cues=progressive_subtitle_cues,
-                )
-                yield event
-            final_subtitle_cues.extend(request_final_subtitle_cues)
-            if not request_live_subtitle_cues and live_request_emitted_ms > 0:
-                request_live_subtitle_cues = (
-                    self._build_minimax_live_request_subtitle_cues(
-                        request_final_subtitle_cues,
-                        provider_offset_ms=subtitle_offset_ms,
-                        live_offset_ms=live_offset_ms,
-                        live_request_end_ms=live_request_emitted_ms,
-                    )
-                )
-            live_subtitle_cues = normalize_subtitle_cues(
-                list(live_subtitle_cues or []) + request_live_subtitle_cues
-            )
-            live_offset_ms += int(live_request_emitted_ms or 0)
-            request_subtitle_end_ms = self._subtitle_cues_end_ms(
-                request_final_subtitle_cues
-            )
-            if request_subtitle_end_ms > subtitle_offset_ms:
-                subtitle_offset_ms = request_subtitle_end_ms
-            else:
-                subtitle_offset_ms += int(request_duration_ms or source_emitted_ms or 0)
-
-            record_tts_segment_usage(
-                app=self.app,
-                usage_context=self.usage_context,
-                provider=self.tts_provider or "",
-                model=self.tts_model or "",
-                segment_text=request_text,
-                word_count=request_word_count,
-                duration_ms=int(request_duration_ms or 0),
-                latency_ms=int((time.monotonic() - request_started_at) * 1000),
-                voice_settings=self.voice_settings,
-                audio_settings=self.audio_settings,
-                is_stream=True,
-                parent_usage_bid=self._usage_parent_bid,
-                segment_index=request_index,
-                usage_characters=request_usage_characters,
-            )
-
-        with self._lock:
-            all_segments = list(self._all_audio_data)
-
-        yield from self._yield_audio_complete_from_segments(
-            all_segments=all_segments,
-            raw_text=raw_text,
-            cleaned_text=cleaned_text,
-            cleaned_text_length=cleaned_text_length,
-            subtitle_cues=final_subtitle_cues,
-            event_subtitle_cues=live_subtitle_cues,
-            commit=commit,
-        )
-
     def _apply_subtitle_context(
         self, subtitle_cues: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
@@ -1885,6 +1161,34 @@ class StreamingTTSProcessor:
             contextualized.append(item)
         return normalize_subtitle_cues(contextualized)
 
+    @property
+    def _use_minimax_http_stream(self) -> bool:
+        return isinstance(self._request_scoped_strategy, MinimaxHttpStreamStrategy)
+
+    @property
+    def _use_volcengine_timestamp_stream(self) -> bool:
+        return isinstance(
+            self._request_scoped_strategy, VolcengineTimestampStreamStrategy
+        )
+
+    def _finalize_minimax_http_stream(
+        self,
+        *,
+        raw_text: str,
+        cleaned_text: str,
+        cleaned_text_length: int,
+        commit: bool,
+    ) -> Generator[RunMarkdownFlowDTO, None, None]:
+        # Explicit entry point for callers that drive the MiniMax request-scoped
+        # path directly, independent of how this processor was configured.
+        yield from MinimaxHttpStreamStrategy().finalize(
+            self,
+            raw_text=raw_text,
+            cleaned_text=cleaned_text,
+            cleaned_text_length=cleaned_text_length,
+            commit=commit,
+        )
+
     def _finalize_volcengine_timestamp_stream(
         self,
         *,
@@ -1893,104 +1197,13 @@ class StreamingTTSProcessor:
         cleaned_text_length: int,
         commit: bool,
     ) -> Generator[RunMarkdownFlowDTO, None, None]:
-        request_text = (cleaned_text or "").strip()
-        if not self._enabled or not request_text:
-            return
-        if _should_skip_non_speakable_tts_text(request_text, self.tts_provider):
-            _log_skipped_non_speakable_tts_text(
-                segment_index=0,
-                text=request_text,
-                tts_provider=self.tts_provider,
-                tts_model=self.tts_model,
-            )
-            return
-
-        request_started_at = time.monotonic()
-        result = self._synthesize_text_with_retry(
-            text=request_text,
-            voice_settings=self.voice_settings,
-            audio_settings=self.audio_settings,
-            tts_model=self.tts_model,
-            tts_provider=self.tts_provider,
-            segment_index=0,
-        )
-        if not result.audio_data:
-            logger.warning("Volcengine timestamp stream returned no audio")
-            return
-
-        request_duration_ms = int(result.duration_ms or 0)
-        if request_duration_ms <= 0:
-            request_duration_ms = get_audio_duration_ms(
-                result.audio_data,
-                audio_format=result.format or self.audio_settings.format or "mp3",
-            )
-        request_word_count = int(result.word_count or 0)
-        request_usage_characters = int(getattr(result, "usage_characters", 0) or 0)
-        if request_word_count:
-            self._word_count_total += request_word_count
-        self._output_char_total += resolve_tts_billable_chars(
-            request_text,
-            request_usage_characters,
-        )
-
-        provider_subtitle_cues = self._apply_subtitle_context(
-            list(getattr(result, "subtitle_cues", []) or [])
-        )
-        if provider_subtitle_cues and self._subtitle_cues_cover_text(
-            provider_subtitle_cues,
-            request_text,
-        ):
-            final_subtitle_cues = provider_subtitle_cues
-        else:
-            if provider_subtitle_cues:
-                logger.debug(
-                    "Volcengine subtitles did not cover full request text; "
-                    "using fallback cues. subtitles=%s",
-                    len(provider_subtitle_cues),
-                )
-            final_subtitle_cues = self._build_minimax_fallback_subtitle_cues(
-                request_text,
-                duration_ms=int(request_duration_ms or 0),
-            )
-            final_subtitle_cues = self._apply_subtitle_context(final_subtitle_cues)
-
-        _segment_index, event = self._store_stream_audio_segment(
-            audio_data=result.audio_data,
-            duration_ms=int(request_duration_ms or 0),
-            text=request_text,
-            subtitle_cues=final_subtitle_cues,
-        )
-        yield event
-
-        from flaskr.service.tts.tts_usage_recorder import record_tts_segment_usage
-
-        record_tts_segment_usage(
-            app=self.app,
-            usage_context=self.usage_context,
-            provider=self.tts_provider or "",
-            model=self.tts_model or "",
-            segment_text=request_text,
-            word_count=request_word_count,
-            duration_ms=int(request_duration_ms or 0),
-            latency_ms=int((time.monotonic() - request_started_at) * 1000),
-            voice_settings=self.voice_settings,
-            audio_settings=self.audio_settings,
-            is_stream=True,
-            parent_usage_bid=self._usage_parent_bid,
-            segment_index=0,
-            usage_characters=request_usage_characters,
-        )
-
-        with self._lock:
-            all_segments = list(self._all_audio_data)
-
-        yield from self._yield_audio_complete_from_segments(
-            all_segments=all_segments,
+        # Explicit entry point for callers that drive the Volcengine
+        # request-scoped path directly.
+        yield from VolcengineTimestampStreamStrategy().finalize(
+            self,
             raw_text=raw_text,
             cleaned_text=cleaned_text,
             cleaned_text_length=cleaned_text_length,
-            subtitle_cues=final_subtitle_cues,
-            event_subtitle_cues=final_subtitle_cues,
             commit=commit,
         )
 
@@ -2023,21 +1236,11 @@ class StreamingTTSProcessor:
             logger.debug("TTS finalize: TTS not enabled, returning early")
             return
 
-        if self._use_minimax_http_stream:
+        if self._request_scoped_strategy is not None:
             self._raw_offset = len(self._buffer)
             self._buffer = ""
-            yield from self._finalize_minimax_http_stream(
-                raw_text=raw_text,
-                cleaned_text=cleaned_text.strip(),
-                cleaned_text_length=cleaned_text_length,
-                commit=commit,
-            )
-            return
-
-        if self._use_volcengine_timestamp_stream:
-            self._raw_offset = len(self._buffer)
-            self._buffer = ""
-            yield from self._finalize_volcengine_timestamp_stream(
+            yield from self._request_scoped_strategy.finalize(
+                self,
                 raw_text=raw_text,
                 cleaned_text=cleaned_text.strip(),
                 cleaned_text_length=cleaned_text_length,

--- a/src/api/tests/service/tts/test_minimax_http_streaming.py
+++ b/src/api/tests/service/tts/test_minimax_http_streaming.py
@@ -934,10 +934,12 @@ def test_streaming_tts_minimax_http_stream_offsets_live_cues_by_emitted_audio(
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.MinimaxTTSProvider", _FakeMinimaxProvider
     )
+    from flaskr.service.tts.request_scoped_streams import MinimaxHttpStreamStrategy
+
     monkeypatch.setattr(
-        StreamingTTSProcessor,
+        MinimaxHttpStreamStrategy,
         "_split_minimax_http_stream_text",
-        lambda _self, _text: ["First sentence.", "Second sentence."],
+        lambda _self, _processor, _text: ["First sentence.", "Second sentence."],
     )
     monkeypatch.setattr(
         "flaskr.service.tts.streaming_tts.export_audio_range_best_effort",

--- a/src/api/tests/service/tts/test_request_scoped_streams.py
+++ b/src/api/tests/service/tts/test_request_scoped_streams.py
@@ -1,0 +1,132 @@
+"""Verify request-scoped strategy selection and dispatch in the TTS processor."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from flaskr.service.tts import streaming_tts
+from flaskr.service.tts.request_scoped_streams import (
+    MinimaxHttpStreamStrategy,
+    VolcengineTimestampStreamStrategy,
+)
+from flaskr.service.tts.streaming_tts import (
+    StreamingTTSProcessor,
+    _select_request_scoped_strategy,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _processor(tts_provider: str) -> StreamingTTSProcessor:
+    app = MagicMock()
+    with (
+        patch("flaskr.service.tts.streaming_tts.is_tts_configured", return_value=True),
+        patch("flaskr.service.tts.streaming_tts.generate_id", return_value="usage"),
+    ):
+        return StreamingTTSProcessor(
+            app=app,
+            generated_block_bid="block",
+            outline_bid="outline",
+            progress_record_bid="progress",
+            user_bid="user",
+            shifu_bid="shifu",
+            tts_provider=tts_provider,
+            tts_model="model",
+        )
+
+
+def test_selector_maps_capabilities_to_strategies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        streaming_tts, "should_use_minimax_http_stream", lambda name: name == "minimax"
+    )
+    assert isinstance(
+        _select_request_scoped_strategy("minimax"), MinimaxHttpStreamStrategy
+    )
+    assert isinstance(
+        _select_request_scoped_strategy("volcengine"), VolcengineTimestampStreamStrategy
+    )
+    for name in ("", "elevenlabs", "gemini", "tencent_texttovoice", "unknown"):
+        assert _select_request_scoped_strategy(name) is None
+
+
+def test_processor_exposes_compat_flags_from_selected_strategy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        streaming_tts, "should_use_minimax_http_stream", lambda name: name == "minimax"
+    )
+    minimax = _processor("minimax")
+    assert minimax._use_minimax_http_stream is True
+    assert minimax._use_volcengine_timestamp_stream is False
+
+    volcengine = _processor("volcengine")
+    assert volcengine._use_minimax_http_stream is False
+    assert volcengine._use_volcengine_timestamp_stream is True
+
+    segmented = _processor("gemini")
+    assert segmented._request_scoped_strategy is None
+    assert segmented._use_minimax_http_stream is False
+    assert segmented._use_volcengine_timestamp_stream is False
+
+
+def test_request_scoped_processor_buffers_chunks_and_delegates_finalize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        streaming_tts, "should_use_minimax_http_stream", lambda _n: False
+    )
+    processor = _processor("volcengine")
+    strategy = MagicMock()
+    strategy.finalize.return_value = iter(["event-1", "event-2"])
+    processor._request_scoped_strategy = strategy
+
+    assert list(processor.process_chunk("First sentence. ")) == []
+    assert list(processor.process_chunk("Second sentence.")) == []
+    assert processor._pending_futures == []
+    assert processor._buffer == "First sentence. Second sentence."
+
+    events = list(processor.finalize(commit=False))
+
+    assert events == ["event-1", "event-2"]
+    strategy.finalize.assert_called_once()
+    args, kwargs = strategy.finalize.call_args
+    assert args == (processor,)
+    assert kwargs["raw_text"] == "First sentence. Second sentence."
+    assert kwargs["cleaned_text"] == "First sentence. Second sentence."
+    assert kwargs["cleaned_text_length"] == len("First sentence. Second sentence.")
+    assert kwargs["commit"] is False
+    assert processor._buffer == ""
+
+
+def test_explicit_finalize_entry_points_use_matching_strategy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        streaming_tts, "should_use_minimax_http_stream", lambda _n: False
+    )
+    processor = _processor("gemini")
+    seen: list[tuple[str, object]] = []
+
+    def _fake_finalize(self: object, target: object, **_kwargs: object) -> object:
+        seen.append((type(self).__name__, target))
+        yield "done"
+
+    monkeypatch.setattr(MinimaxHttpStreamStrategy, "finalize", _fake_finalize)
+    monkeypatch.setattr(VolcengineTimestampStreamStrategy, "finalize", _fake_finalize)
+
+    kwargs = {
+        "raw_text": "x",
+        "cleaned_text": "x",
+        "cleaned_text_length": 1,
+        "commit": True,
+    }
+    assert list(processor._finalize_minimax_http_stream(**kwargs)) == ["done"]
+    assert list(processor._finalize_volcengine_timestamp_stream(**kwargs)) == ["done"]
+    assert seen == [
+        ("MinimaxHttpStreamStrategy", processor),
+        ("VolcengineTimestampStreamStrategy", processor),
+    ]


### PR DESCRIPTION
## Summary

Second half of the TTS decoupling that started in ai-shifu/ai-shifu#2754.

- New `flaskr/service/tts/request_scoped_streams.py` with `RequestScopedSynthesisStrategy` (Protocol), `MinimaxHttpStreamStrategy` (chunked MiniMax HTTP requests + the ~600 lines of provider subtitle bookkeeping and complete-synthesis fallback) and `VolcengineTimestampStreamStrategy` (one request whose word timestamps become subtitles).
- `StreamingTTSProcessor` selects a strategy via the capability-driven selectors (`should_use_minimax_http_stream`, `_should_use_volcengine_timestamp_stream`), buffers chunks while one is active, and delegates `finalize()` to it. It shrinks from ~2,100 to ~1,500 lines and no longer contains provider-specific synthesis code.
- Compatibility kept on purpose: `_use_minimax_http_stream` / `_use_volcengine_timestamp_stream` are now properties, and `_finalize_minimax_http_stream` / `_finalize_volcengine_timestamp_stream` remain as thin entry points that instantiate the matching strategy (a test drives them directly).
- Strategies resolve `logger`, `time`, `MinimaxTTSProvider`, `get_audio_duration_ms`, `export_audio_range_best_effort`, `try_get_audio_duration_ms` and the non-speakable helpers through the `streaming_tts` module namespace at call time, because the existing suites patch those names there. The two audio helpers stay imported in `streaming_tts` as test seams.
- The move was done mechanically from AST line ranges (`self.<processor state>` → `processor.<state>`, own helpers keep `self.`), then verified by the unchanged streaming suites.
- One test (`test_streaming_tts_minimax_http_stream_offsets_live_cues_by_emitted_audio`) patched the private splitter on the processor class; it now patches it on `MinimaxHttpStreamStrategy`.
- Archives the capabilities ExecPlan as completed with this step recorded.

## Test plan

- [x] New `tests/service/tts/test_request_scoped_streams.py` (selector mapping, compat flags, chunk buffering + finalize delegation, explicit entry points)
- [x] `tests/service/tts` + learn/shifu TTS suites: 418 passed, including the 12 MiniMax HTTP streaming tests and the AV-mode listen tests unchanged
- [x] `ruff check` / `ruff format --check`, `lefthook run pre-commit`, repo harness
- [x] Real streaming smoke on both test environments from inside the API containers (one `StreamingTTSProcessor` per provider, real provider calls, OSS upload):
  - dev01: MiniMax `speech-2.8-turbo` via `MinimaxHttpStreamStrategy` (3 segments, complete event, 3 cues, 6.9 s audio); Volcengine `seed-tts-2.0` via `VolcengineTimestampStreamStrategy` (1 request, 3 provider cues, 7.4 s); Tencent `large-model` on the segmented path (3 segments)
  - devus: Volcengine via the timestamp strategy (1 request, 3 cues) and Gemini 3.1 on the segmented path (3 segments, 8.3 s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved streaming text-to-speech processing for supported providers, including more consistent audio completion, subtitle timing, and usage tracking.
  - Added fallback handling when streamed audio cannot be decoded.
  - Preserved existing compatibility behavior for current streaming workflows.

- **Documentation**
  - Updated execution-plan documentation to reflect completion of the TTS provider capabilities work.

- **Tests**
  - Expanded coverage for provider selection, streaming finalization, delegation, and compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
