### PR TITLE
feat: adapt learner input shortcuts

### DIFF
--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -22,6 +22,8 @@ Implementation and architecture decisions that shape repository behavior live he
   - Status: `implemented` | Owner: `shared` | Last reviewed: `2026-07-12` | Canonical: `true`
 - [Langfuse Trace Association](../design-docs/langfuse-trace-association.md)
   - Status: `implemented` | Owner: `backend` | Last reviewed: `2026-08-17` | Canonical: `true`
+- [Learner follow-up input shortcuts](../design-docs/learner-follow-up-input-shortcuts.md)
+  - Status: `implemented` | Owner: `learner-web` | Last reviewed: `2026-09-04` | Canonical: `true`
 - [MiniMax Voice Cloning](../design-docs/minimax-voice-cloning.md)
   - Status: `proposed` | Owner: `shared` | Last reviewed: `2026-06-18` | Canonical: `true`
 - [Primary Surface Rules Completion](../design-docs/primary-surface-rules.md)

--- a/docs/design-docs/learner-follow-up-input-shortcuts.md
+++ b/docs/design-docs/learner-follow-up-input-shortcuts.md
@@ -1,0 +1,44 @@
+---
+title: Learner follow-up input shortcuts
+status: implemented
+owner_surface: learner-web
+last_reviewed: 2026-09-04
+canonical: true
+---
+
+# Learner follow-up input shortcuts
+
+Desktop learners submit a follow-up with Enter and add a line with
+Shift+Enter. Mobile learners keep Enter for a line break and use the visible
+send button. IME composition never submits a follow-up.
+
+## Product analytics contract
+
+### Learner follow-up submission
+
+- Business question: which supported learner surface and submission method
+  learners use to start a valid follow-up request.
+- Metric definition: count accepted submissions by `surface` and
+  `submission_method` over a reporting window. This is an accepted-use metric,
+  not a request-success metric.
+- Event name: `learner_follow_up_submit`.
+- Actor and surface: learners and eligible course owners in learner preview;
+  guests are included when the follow-up input is available. Empty inputs,
+  credit-ineligible users, and submissions rejected because a follow-up is
+  already streaming are excluded.
+- Trigger: immediately after local eligibility and non-empty validation accept
+  a submission, before starting the follow-up request.
+- Count unit and deduplication: one accepted deliberate submission; no
+  cross-session deduplication. The streaming guard prevents concurrent
+  re-entry from adding events.
+- Consumers: product analytics uses the grouped counts to compare keyboard
+  adoption on desktop with the mobile send-button path.
+- Compatibility: new event family; no backfill.
+- Verification: focused component tests assert keyboard and button payloads,
+  prohibit question/course fields, and prove tracking failure does not block
+  the request.
+
+| Field               | Type   | Allowed values                      | Cardinality | Privacy class     | Why required                        |
+| ------------------- | ------ | ----------------------------------- | ----------- | ----------------- | ----------------------------------- |
+| `surface`           | string | `learner_desktop`, `learner_mobile` | low         | non-personal enum | Compare supported learner surfaces. |
+| `submission_method` | string | `keyboard`, `button`                | low         | non-personal enum | Measure shortcut adoption.          |

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -18,6 +18,7 @@
 | `docs/design-docs/billing-subscription-preorder.md` | Billing Subscription Preorder | `design-doc` | `proposed` | `backend` | `2026-05-25` | `true` |
 | `docs/design-docs/creator-brand-domain-payments.md` | Creator Brand Domain And Payments | `design-doc` | `implemented` | `shared` | `2026-07-12` | `true` |
 | `docs/design-docs/langfuse-trace-association.md` | Langfuse Trace Association | `design-doc` | `implemented` | `backend` | `2026-08-17` | `true` |
+| `docs/design-docs/learner-follow-up-input-shortcuts.md` | Learner follow-up input shortcuts | `design-doc` | `implemented` | `learner-web` | `2026-09-04` | `true` |
 | `docs/design-docs/minimax-voice-cloning.md` | MiniMax Voice Cloning | `design-doc` | `proposed` | `shared` | `2026-06-18` | `true` |
 | `docs/design-docs/primary-surface-rules.md` | Primary Surface Rules Completion | `design-doc` | `implemented` | `repo` | `2026-04-17` | `true` |
 | `docs/design-docs/referral-invitation-rewards.md` | 老带新邀请奖励 | `design-doc` | `implemented` | `shared` | `2026-06-11` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -6,7 +6,7 @@ This generated report summarizes the repository harness control plane.
 
 ## Knowledge System
 
-- Design docs: `12`
+- Design docs: `13`
 - Product specs: `10`
 - References: `4`
 - Active ExecPlans: `24`

--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -49,7 +49,7 @@
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
-        "markdown-flow-ui": "0.2.23",
+        "markdown-flow-ui": "0.2.24",
         "next": "15.5.19",
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
@@ -3231,6 +3231,7 @@
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3270,6 +3271,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3290,6 +3292,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3310,6 +3313,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3330,6 +3334,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3350,6 +3355,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3370,6 +3376,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3390,6 +3397,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3410,6 +3418,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3430,6 +3439,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3450,6 +3460,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3470,6 +3481,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3490,6 +3502,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3510,6 +3523,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3525,6 +3539,7 @@
     },
     "node_modules/@parcel/watcher/node_modules/detect-libc": {
       "version": "1.0.3",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -7142,7 +7157,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -9807,7 +9822,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -10920,7 +10935,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10975,7 +10990,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -11005,7 +11020,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -13290,9 +13305,9 @@
       }
     },
     "node_modules/markdown-flow-ui": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.23.tgz",
-      "integrity": "sha512-7EGn5hqwjxVDXQoCzpXl2C8BN30g0KHPoq+sLw4Ei4Rzk3S547wDr63oj+23pqY9Flgnz89DqH2qYN+abm/KQg==",
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/markdown-flow-ui/-/markdown-flow-ui-0.2.24.tgz",
+      "integrity": "sha512-Hxllh4jI+c1s9rhcPionlaODrOFuG3PnOxA0+VRKoW5/q9O9lH8gzN5bFxq/LM8n9n0WViiaOpiGRsXnT9BBNg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.7",
@@ -14730,7 +14745,7 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -15012,6 +15027,7 @@
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -15403,7 +15419,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -17563,7 +17579,7 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -67,7 +67,7 @@
     "immer": "^10.1.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.469.0",
-    "markdown-flow-ui": "0.2.23",
+    "markdown-flow-ui": "0.2.24",
     "next": "15.5.19",
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",

--- a/src/web/src/__tests__/ask-block-typewriter.test.tsx
+++ b/src/web/src/__tests__/ask-block-typewriter.test.tsx
@@ -35,6 +35,10 @@ jest.mock('@/hooks/useToast', () => ({
   toast: jest.fn(),
 }));
 
+jest.mock('@/c-common/hooks/useTracking', () => ({
+  useTracking: () => ({ trackEvent: jest.fn() }),
+}));
+
 jest.mock('@/c-store/useCourseStore', () => ({
   useCourseStore: jest.fn(() => ''),
 }));

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.test.tsx
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.test.tsx
@@ -55,12 +55,17 @@ jest.mock('markdown-flow-ui/renderer', () => ({
     value,
     onChange,
     onSend,
+    sendShortcut,
   }: {
     value: string;
     onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
     onSend: () => void;
+    sendShortcut?: 'enter' | 'none';
   }) => (
-    <div>
+    <div
+      data-testid='ask-input-wrapper'
+      data-send-shortcut={sendShortcut}
+    >
       <textarea
         aria-label='ask-input'
         value={value}
@@ -220,6 +225,39 @@ describe('AskBlock', () => {
       },
     );
   });
+
+  it.each([
+    ['desktop', false, 'enter'],
+    ['mobile', true, 'none'],
+  ] as const)(
+    'uses the %s input shortcut policy',
+    (_surface, mobileStyle, expectedShortcut) => {
+      render(
+        <AppContext.Provider
+          value={{
+            isLoggedIn: false,
+            mobileStyle,
+            userInfo: null,
+            theme: 'light',
+            frameLayout: 0,
+          }}
+        >
+          <AskBlock
+            isExpanded={true}
+            shifu_bid='shifu-1'
+            outline_bid='lesson-1'
+            element_bid='block-1'
+            askList={[]}
+          />
+        </AppContext.Provider>,
+      );
+
+      expect(screen.getByTestId('ask-input-wrapper')).toHaveAttribute(
+        'data-send-shortcut',
+        expectedShortcut,
+      );
+    },
+  );
 
   it.each(['read', 'listen'] as const)(
     'sends follow-up requests without TTS in %s mode',

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.test.tsx
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.test.tsx
@@ -12,6 +12,8 @@ import { SSE_OUTPUT_TYPE } from '@/c-api/studyV2';
 import { toast, toastOnce } from '@/hooks/useToast';
 import { useAskStateStore } from './useAskStateStore';
 
+const mockTrackEvent = jest.fn();
+
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
@@ -70,6 +72,16 @@ jest.mock('markdown-flow-ui/renderer', () => ({
         aria-label='ask-input'
         value={value}
         onChange={onChange}
+        onKeyDown={event => {
+          if (
+            sendShortcut === 'enter' &&
+            event.key === 'Enter' &&
+            !event.shiftKey &&
+            !event.nativeEvent.isComposing
+          ) {
+            onSend();
+          }
+        }}
       />
       <button onClick={onSend}>send</button>
     </div>
@@ -79,6 +91,10 @@ jest.mock('markdown-flow-ui/renderer', () => ({
 jest.mock('@/hooks/useToast', () => ({
   toast: jest.fn(),
   toastOnce: jest.fn(),
+}));
+
+jest.mock('@/c-common/hooks/useTracking', () => ({
+  useTracking: () => ({ trackEvent: mockTrackEvent }),
 }));
 
 jest.mock('next/image', () => {
@@ -224,6 +240,79 @@ describe('AskBlock', () => {
         return source;
       },
     );
+  });
+
+  it('tracks an accepted desktop Enter submission with a privacy-safe payload', async () => {
+    render(
+      <AppContext.Provider
+        value={{
+          isLoggedIn: false,
+          mobileStyle: false,
+          userInfo: null,
+          theme: 'light',
+          frameLayout: 0,
+        }}
+      >
+        <AskBlock
+          isExpanded={true}
+          shifu_bid='shifu-1'
+          outline_bid='lesson-1'
+          element_bid='block-1'
+          askList={[]}
+        />
+      </AppContext.Provider>,
+    );
+
+    fireEvent.change(screen.getByLabelText('ask-input'), {
+      target: { value: 'private question' },
+    });
+    fireEvent.keyDown(screen.getByLabelText('ask-input'), { key: 'Enter' });
+
+    await waitFor(() => expect(activeRun).toBeDefined());
+
+    expect(mockTrackEvent).toHaveBeenCalledWith('learner_follow_up_submit', {
+      surface: 'learner_desktop',
+      submission_method: 'keyboard',
+    });
+    expect(mockTrackEvent.mock.calls[0][1]).not.toHaveProperty('content');
+    expect(mockTrackEvent.mock.calls[0][1]).not.toHaveProperty('shifu_bid');
+  });
+
+  it('tracks an accepted mobile button submission and isolates tracking failures', async () => {
+    mockTrackEvent.mockImplementationOnce(() => {
+      throw new Error('tracking unavailable');
+    });
+
+    render(
+      <AppContext.Provider
+        value={{
+          isLoggedIn: false,
+          mobileStyle: true,
+          userInfo: null,
+          theme: 'light',
+          frameLayout: 0,
+        }}
+      >
+        <AskBlock
+          isExpanded={true}
+          shifu_bid='shifu-1'
+          outline_bid='lesson-1'
+          element_bid='block-1'
+          askList={[]}
+        />
+      </AppContext.Provider>,
+    );
+
+    fireEvent.change(screen.getByLabelText('ask-input'), {
+      target: { value: 'private question' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => expect(activeRun).toBeDefined());
+    expect(mockTrackEvent).toHaveBeenCalledWith('learner_follow_up_submit', {
+      surface: 'learner_mobile',
+      submission_method: 'button',
+    });
   });
 
   it.each([

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
@@ -43,7 +43,12 @@ import {
   resolveCourseCreditInsufficientAudience,
   showCreditInsufficientToast,
 } from '@/lib/creditInsufficientToast';
+import { useTracking } from '@/c-common/hooks/useTracking';
 export type { AskMessage } from './askState';
+
+type FollowUpSubmissionMethod = 'button' | 'keyboard';
+
+const FOLLOW_UP_SUBMIT_EVENT = 'learner_follow_up_submit';
 
 export interface AskBlockProps {
   askList?: AskMessage[];
@@ -79,6 +84,7 @@ export default function AskBlock({
     i18n.resolvedLanguage ?? i18n.language,
   );
   const { mobileStyle } = useContext(AppContext);
+  const { trackEvent } = useTracking();
   const courseAvatar = useCourseStore(state => state.courseAvatar);
   const isCurrentUserCourseOwner = useCourseStore(
     state => state.isCurrentUserCourseOwner,
@@ -115,6 +121,7 @@ export default function AskBlock({
   const currentContentRef = useRef<string>('');
   const currentAnswerElementBidRef = useRef<string>('');
   const isStreamingRef = useRef(false);
+  const pendingSubmissionMethodRef = useRef<FollowUpSubmissionMethod>('button');
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showMobileDialog, setShowMobileDialog] = useState(hasDisplayMessages);
   const mobileContentRef = useRef<HTMLDivElement | null>(null);
@@ -228,6 +235,8 @@ export default function AskBlock({
   );
 
   const handleSendCustomQuestion = useCallback(async () => {
+    const submissionMethod = pendingSubmissionMethodRef.current;
+    pendingSubmissionMethodRef.current = 'button';
     const question = inputValue.trim();
     if (creditInsufficientAudience === null) {
       return;
@@ -240,6 +249,13 @@ export default function AskBlock({
     if (!question) {
       return;
     }
+
+    try {
+      void trackEvent(FOLLOW_UP_SUBMIT_EVENT, {
+        surface: mobileStyle ? 'learner_mobile' : 'learner_desktop',
+        submission_method: submissionMethod,
+      });
+    } catch {}
 
     // Close any previous SSE connection
     sseRef.current?.close();
@@ -457,12 +473,31 @@ export default function AskBlock({
     setAskList,
     updateStreamingAnswerMessage,
     t,
+    mobileStyle,
+    trackEvent,
   ]);
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      pendingSubmissionMethodRef.current = 'button';
       setInputValue(e.target.value);
     },
     [],
+  );
+  const handleInputKeyDownCapture = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (
+        mobileStyle ||
+        event.key !== 'Enter' ||
+        event.shiftKey ||
+        event.nativeEvent.isComposing ||
+        event.keyCode === 229
+      ) {
+        return;
+      }
+
+      pendingSubmissionMethodRef.current = 'keyboard';
+    },
+    [mobileStyle],
   );
 
   // Decide which messages to display
@@ -767,6 +802,7 @@ export default function AskBlock({
       <div
         className={cn(extraClass)}
         ref={inputWrapperRef}
+        onKeyDownCapture={handleInputKeyDownCapture}
       >
         <MarkdownFlowInput
           locale={markdownFlowLocale}

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/AskBlock.tsx
@@ -774,6 +774,7 @@ export default function AskBlock({
           value={inputValue}
           onChange={handleInputChange}
           onSend={handleSendCustomQuestion}
+          sendShortcut={mobileStyle ? 'none' : 'enter'}
           className={cn(
             styles.inputGroup,
             isStreamingRef.current ? styles.isSending : '',

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlidePackageContract.test.ts
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlidePackageContract.test.ts
@@ -35,7 +35,7 @@ describe('markdown-flow-ui Slide package contract', () => {
     ) as { version?: string };
     const playerSource = readPublishedSource('Player');
 
-    expect(packageJson.version).toBe('0.2.23');
+    expect(packageJson.version).toBe('0.2.24');
     expect(playerSource).toContain('customActionList.length + 6');
     expect(playerSource).not.toContain('FilePenLine');
     expect(playerSource).not.toContain('notesLabel');


### PR DESCRIPTION
## Summary
- Upgrade markdown-flow-ui to the released 0.2.24 package.
- Send with Enter on desktop while preserving Shift+Enter for a new line.
- Keep mobile keyboard Enter as a new line and use the page send button to submit.
- Cover the desktop and mobile shortcut policies in the learner follow-up input test.

## Verification
- AskBlock focused Jest suite: 20 passed.
- Confirmed the published package provides the legacy CSS entry and the intl-messageformat dependency.
- Local pre-commit checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop learners can submit follow-up questions with Enter, while Shift+Enter adds a line break.
  * Mobile learners continue using the visible send button, with Enter reserved for line breaks.
  * IME composition is protected from accidental submissions.

* **Bug Fixes**
  * Disabled the Enter-key send shortcut on mobile.
  * Removed the Notes action and shortcut from slide content.

* **Tests**
  * Added coverage for desktop and mobile shortcut behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->