### PR TITLE
fix: restore Gemini Live voice connections on dev

### DIFF
--- a/INSTALL_MANUAL.md
+++ b/INSTALL_MANUAL.md
@@ -113,7 +113,8 @@ WebSocket Upgrade route. Production still needs HTTPS for microphone access,
 and the browser must be able to reach `generativelanguage.googleapis.com`.
 The server must also reach the token-creation API. If `GEMINI_API_URL` is set,
 token creation reuses that HTTPS base URL, including any proxy path prefix,
-and appends `/v1beta/auth_tokens`; otherwise it uses Google's official API.
+and appends `/v1beta/auth_tokens`; an existing terminal `/v1beta` is reused
+instead of duplicated. If unset, token creation uses Google's official API.
 Only configure a trusted proxy because it receives the API key and private
 course context. This setting never changes the browser's Gemini WebSocket
 destination. Token requests do not follow redirects or fall back to another

--- a/INSTALL_MANUAL.md
+++ b/INSTALL_MANUAL.md
@@ -111,6 +111,13 @@ selected model, voice, and server-built prompt. The browser then opens the
 Gemini Live WebSocket directly, so the AI-Shifu ingress does not need a
 WebSocket Upgrade route. Production still needs HTTPS for microphone access,
 and the browser must be able to reach `generativelanguage.googleapis.com`.
+The server must also reach the token-creation API. If `GEMINI_API_URL` is set,
+token creation reuses that HTTPS base URL, including any proxy path prefix,
+and appends `/v1beta/auth_tokens`; otherwise it uses Google's official API.
+Only configure a trusted proxy because it receives the API key and private
+course context. This setting never changes the browser's Gemini WebSocket
+destination. Token requests do not follow redirects or fall back to another
+host when the configured endpoint fails.
 Disable the flag to roll back Live without changing courses that use text
 follow-up models.
 

--- a/docs/exec-plans/active/gemini-live-voice-follow-up.md
+++ b/docs/exec-plans/active/gemini-live-voice-follow-up.md
@@ -264,6 +264,17 @@ auditing, or another correctness-sensitive decision.
       all 91 accumulator/controller/writer tests and TypeScript checking pass.
       The complete frontend suite passes 2,136 tests across 226 suites, and the
       full pre-commit gate passes with no new architecture-boundary violations.
+- [x] 2026-09-04: Deployed the reviewed browser-direct tree through PR #2758
+      as dev commit `396b3aceb` (Drone #4726). Both API/web images, public HTTP
+      health, the public direct-transport bundle, and Redis PING were verified.
+      The existing Live flag remained enabled; no ingress/env changes were made.
+- [x] 2026-09-04: Reuse the server's existing `GEMINI_API_URL` for token
+      provisioning, preserving proxy prefixes and the fixed browser endpoint.
+      Reject unsafe URLs and disable redirects/fallback hosts. Seventeen
+      targeted cases reproduced the missing configuration before the fix;
+      all 97 focused token/route/deployment tests pass afterward.
+- [ ] 2026-09-04: Correct the provider-reported token FieldMask mismatch,
+      verify real constrained token creation, and deploy the connection fixes.
 - [ ] Exercise a real ephemeral token and direct Gemini WebSocket on the dev
       deployment with a valid credential and microphone.
 - [x] 2026-09-03: Repository harness and the full
@@ -275,6 +286,15 @@ auditing, or another correctness-sensitive decision.
 
 ## Surprises & Discoveries
 
+- The dev API container cannot reach Google's HTTPS endpoint directly. Its
+  existing Gemini reverse proxy is reachable, but the original token issuer
+  ignored `GEMINI_API_URL`. A healthy deployment and direct browser media path
+  therefore did not prove token provisioning worked.
+- A real request through the configured proxy reached Gemini but returned
+  HTTP 400: setup contains fields absent from its FieldMask. The token setup
+  still supplied empty `sessionResumption` despite intentionally leaving that
+  field unlocked. Client-settable fields must also be absent from the token's
+  constrained setup, not merely absent from the mask.
 - The dev ingress returned HTTP 200 rather than WebSocket 101 for the original
   internal Live path because its outer proxy did not forward Upgrade headers.
   This was the concrete reason the voice dialog failed after session creation.
@@ -313,6 +333,13 @@ auditing, or another correctness-sensitive decision.
 
 ## Decision Log
 
+- Decision: reuse `GEMINI_API_URL` only for backend token provisioning, with
+  the same base-plus-`/v1beta` path contract as Gemini model discovery.
+  - Why: existing environments already configure their trusted Gemini proxy.
+    Preserve proxy prefixes, require HTTPS without URL credentials/query/
+    fragment, and disable redirects to avoid forwarding the API-key header.
+    Do not add another environment variable or change the browser's fixed
+    official constrained WebSocket endpoint.
 - Decision: implement from current `origin/main` and do not inspect, repair,
   merge, or depend on pull request #2732.
   - Why: the user explicitly replaced the earlier delivery-order instruction.

--- a/docs/exec-plans/active/gemini-live-voice-follow-up.md
+++ b/docs/exec-plans/active/gemini-live-voice-follow-up.md
@@ -273,8 +273,14 @@ auditing, or another correctness-sensitive decision.
       Reject unsafe URLs and disable redirects/fallback hosts. Seventeen
       targeted cases reproduced the missing configuration before the fix;
       all 97 focused token/route/deployment tests pass afterward.
-- [ ] 2026-09-04: Correct the provider-reported token FieldMask mismatch,
-      verify real constrained token creation, and deploy the connection fixes.
+- [x] 2026-09-04: Remove client-owned `sessionResumption` from token setup
+      constraints as well as their FieldMask. Three regressions reproduced
+      the mismatch before the fix; all 97 focused tests pass afterward.
+      Candidate code using the dev container's existing proxy/key now mints
+      a real token (HTTP 200). A client-side direct Google WebSocket using that
+      token completes `setupComplete`; neither probe records audio or secrets.
+- [ ] Deploy the two connection fixes through a focused dev release PR and
+      recheck the running image, HTTP health, token minting, and direct setup.
 - [ ] Exercise a real ephemeral token and direct Gemini WebSocket on the dev
       deployment with a valid credential and microphone.
 - [x] 2026-09-03: Repository harness and the full
@@ -478,8 +484,11 @@ Automated evidence after the pivot currently covers token constraints,
 Redis fail-closed behavior, admission and Origin binding, direct-session
 lifecycle, report bounds, deterministic/non-billable persistence, protocol
 parsing, transcript reconciliation, audio backpressure, interruption,
-resumption, retry-only failures, analytics, and TypeScript. Real provider and
-browser acceptance remains outstanding and is not inferred from unit tests.
+resumption, retry-only failures, analytics, and TypeScript. Candidate code has
+also passed real ephemeral-token issuance through the dev server's existing
+Gemini proxy and direct client-side Google WebSocket `setupComplete`. This
+synthetic, no-audio check does not establish browser microphone, multi-turn,
+or resumption acceptance; those checks remain outstanding.
 
 ## Context and Orientation
 

--- a/docs/exec-plans/active/gemini-live-voice-follow-up.md
+++ b/docs/exec-plans/active/gemini-live-voice-follow-up.md
@@ -279,6 +279,11 @@ auditing, or another correctness-sensitive decision.
       Candidate code using the dev container's existing proxy/key now mints
       a real token (HTTP 200). A client-side direct Google WebSocket using that
       token completes `setupComplete`; neither probe records audio or secrets.
+- [x] 2026-09-04: Address the release review's versioned-base compatibility
+      case. Reuse an existing terminal `/v1beta` without changing proxy
+      prefixes or matching the hostname. Three cases reproduced duplicate
+      version segments before the fix; the wider Live selection passes
+      160 tests with one environment-dependent MySQL skip afterward.
 - [ ] Deploy the two connection fixes through a focused dev release PR and
       recheck the running image, HTTP health, token minting, and direct setup.
 - [ ] Exercise a real ephemeral token and direct Gemini WebSocket on the dev
@@ -340,7 +345,8 @@ auditing, or another correctness-sensitive decision.
 ## Decision Log
 
 - Decision: reuse `GEMINI_API_URL` only for backend token provisioning, with
-  the same base-plus-`/v1beta` path contract as Gemini model discovery.
+  the base-plus-`/v1beta` path contract used by Gemini model discovery, also
+  accepting an already-versioned `/v1beta` base without duplicating it.
   - Why: existing environments already configure their trusted Gemini proxy.
     Preserve proxy prefixes, require HTTPS without URL credentials/query/
     fragment, and disable redirects to avoid forwarding the API-key header.

--- a/src/api/flaskr/service/learn/gemini_live_token.py
+++ b/src/api/flaskr/service/learn/gemini_live_token.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 import requests
 from flaskr.util.datetime import now_utc, to_utc_iso
@@ -67,6 +68,29 @@ class GeminiLiveEphemeralToken:
 def _qualified_model(model: str) -> str:
     normalized = str(model or "").strip()
     return normalized if normalized.startswith("models/") else f"models/{normalized}"
+
+
+def _token_endpoint(api_base_url: str | None) -> str:
+    """Use the server's Gemini base URL, preserving any reverse-proxy prefix."""
+    base_url = str(api_base_url or "").strip()
+    if not base_url:
+        return GEMINI_LIVE_AUTH_TOKEN_ENDPOINT
+    base_url = base_url.rstrip("/")
+    try:
+        parsed = urlsplit(base_url)
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.port == 0
+            or parsed.username is not None
+            or parsed.password is not None
+            or "?" in base_url
+            or "#" in base_url
+        ):
+            raise GeminiLiveTokenError(_ERROR_INVALID_CONFIGURATION)
+    except ValueError:
+        raise GeminiLiveTokenError(_ERROR_INVALID_CONFIGURATION) from None
+    return f"{base_url}/v1beta/auth_tokens"
 
 
 def _bidi_setup(
@@ -189,6 +213,7 @@ def build_gemini_live_history_message(
 def mint_gemini_live_ephemeral_token(
     *,
     api_key: str,
+    api_base_url: str | None = None,
     model: str = GEMINI_LIVE_MODEL_ID,
     voice_name: str,
     system_instruction: str,
@@ -203,6 +228,7 @@ def mint_gemini_live_ephemeral_token(
     normalized_instruction = str(system_instruction or "").strip()
     if not all((normalized_key, normalized_model, normalized_voice)):
         raise GeminiLiveTokenError(_ERROR_INVALID_CONFIGURATION)
+    endpoint = _token_endpoint(api_base_url)
 
     issued_at = current_time or now_utc()
     expires_at = issued_at + timedelta(seconds=GEMINI_LIVE_TOKEN_LIFETIME_SECONDS)
@@ -226,13 +252,15 @@ def mint_gemini_live_ephemeral_token(
     }
     try:
         response = request_post(
-            GEMINI_LIVE_AUTH_TOKEN_ENDPOINT,
+            endpoint,
             headers={
                 "Content-Type": "application/json",
                 "x-goog-api-key": normalized_key,
             },
             json=payload,
             timeout=GEMINI_LIVE_TOKEN_REQUEST_TIMEOUT_SECONDS,
+            # A redirect must not forward the custom API-key header elsewhere.
+            allow_redirects=False,
         )
         response.raise_for_status()
         body = response.json()

--- a/src/api/flaskr/service/learn/gemini_live_token.py
+++ b/src/api/flaskr/service/learn/gemini_live_token.py
@@ -90,6 +90,8 @@ def _token_endpoint(api_base_url: str | None) -> str:
             raise GeminiLiveTokenError(_ERROR_INVALID_CONFIGURATION)
     except ValueError:
         raise GeminiLiveTokenError(_ERROR_INVALID_CONFIGURATION) from None
+    if parsed.path.endswith("/v1beta"):
+        return f"{base_url}/auth_tokens"
     return f"{base_url}/v1beta/auth_tokens"
 
 

--- a/src/api/flaskr/service/learn/gemini_live_token.py
+++ b/src/api/flaskr/service/learn/gemini_live_token.py
@@ -136,7 +136,6 @@ def _bidi_setup(
             "triggerTokens": "25000",
             "slidingWindow": {"targetTokens": "8000"},
         },
-        "sessionResumption": {},
         "historyConfig": {
             "initialHistoryInClientContent": include_initial_history,
         },
@@ -240,8 +239,9 @@ def mint_gemini_live_ephemeral_token(
         "expireTime": to_utc_iso(expires_at),
         "newSessionExpireTime": to_utc_iso(new_session_expires_at),
         # Keep every security-sensitive top-level setup field server-owned.
-        # Session resumption is intentionally excluded so the browser can add
-        # the latest server-issued handle after a GoAway.
+        # Exclude session resumption from both the constraints and their mask:
+        # Gemini rejects setup fields outside the mask, and the browser must
+        # remain free to add the latest server-issued handle after a GoAway.
         "fieldMask": ",".join(_LOCKED_BIDI_SETUP_FIELDS),
         "bidiGenerateContentSetup": _bidi_setup(
             model=normalized_model,

--- a/src/api/flaskr/service/learn/live_follow_up_routes.py
+++ b/src/api/flaskr/service/learn/live_follow_up_routes.py
@@ -529,6 +529,7 @@ def register_live_follow_up_routes(
             lease = acquire_live_follow_up_capacity(app, user_bid=user_bid)
             token = mint_gemini_live_ephemeral_token(
                 api_key=api_key,
+                api_base_url=str(get_config("GEMINI_API_URL", "") or "").strip(),
                 model=provisional_binding.model,
                 voice_name=voice,
                 system_instruction=system_instruction,

--- a/src/api/tests/service/learn/test_gemini_live_token.py
+++ b/src/api/tests/service/learn/test_gemini_live_token.py
@@ -101,6 +101,10 @@ def test_token_is_one_use_short_lived_and_locks_server_configuration() -> None:
         ("", GEMINI_LIVE_AUTH_TOKEN_ENDPOINT),
         ("  \n ", GEMINI_LIVE_AUTH_TOKEN_ENDPOINT),
         ("https://generativelanguage.googleapis.com/", GEMINI_LIVE_AUTH_TOKEN_ENDPOINT),
+        (
+            "https://generativelanguage.googleapis.com/v1beta/",
+            GEMINI_LIVE_AUTH_TOKEN_ENDPOINT,
+        ),
         ("https://proxy.example.com", "https://proxy.example.com/v1beta/auth_tokens"),
         (
             " https://proxy.example.com/google/ ",
@@ -109,6 +113,22 @@ def test_token_is_one_use_short_lived_and_locks_server_configuration() -> None:
         (
             "https://proxy.example.com:8443/api/google",
             "https://proxy.example.com:8443/api/google/v1beta/auth_tokens",
+        ),
+        (
+            "https://proxy.example.com/google/v1beta",
+            "https://proxy.example.com/google/v1beta/auth_tokens",
+        ),
+        (
+            " https://proxy.example.com:8443/google/v1beta/ ",
+            "https://proxy.example.com:8443/google/v1beta/auth_tokens",
+        ),
+        (
+            "https://proxy.example.com/v1beta/google",
+            "https://proxy.example.com/v1beta/google/v1beta/auth_tokens",
+        ),
+        (
+            "https://v1beta",
+            "https://v1beta/v1beta/auth_tokens",
         ),
     ],
 )

--- a/src/api/tests/service/learn/test_gemini_live_token.py
+++ b/src/api/tests/service/learn/test_gemini_live_token.py
@@ -76,6 +76,8 @@ def test_token_is_one_use_short_lived_and_locks_server_configuration() -> None:
     assert "sessionResumption" not in locked_fields
     assert not any("_" in field for field in locked_fields)
     setup = payload["bidiGenerateContentSetup"]
+    assert set(setup).issubset(locked_fields)
+    assert "sessionResumption" not in setup
     assert setup["model"] == "models/gemini-3.1-flash-live-preview"
     generation_config = setup["generationConfig"]
     assert generation_config["responseModalities"] == ["AUDIO"]
@@ -194,6 +196,9 @@ def test_token_allows_blank_prompt_without_unlocking_browser_instruction(
     payload = calls[0]["json"]
     assert "systemInstruction" in payload["fieldMask"].split(",")
     assert "systemInstruction" not in payload["bidiGenerateContentSetup"]
+    assert set(payload["bidiGenerateContentSetup"]).issubset(
+        payload["fieldMask"].split(",")
+    )
 
 
 @pytest.mark.parametrize("missing", ["api_key", "model", "voice_name"])
@@ -227,6 +232,7 @@ def test_browser_setup_omits_private_prompt_and_uses_constrained_endpoint() -> N
     )
     assert setup["setup"]["model"] == "models/gemini-3.1-flash-live-preview"
     assert "systemInstruction" not in setup["setup"]
+    assert setup["setup"]["sessionResumption"] == {}
     assert setup["setup"]["historyConfig"] == {"initialHistoryInClientContent": True}
 
     resumed = build_gemini_live_client_setup(

--- a/src/api/tests/service/learn/test_gemini_live_token.py
+++ b/src/api/tests/service/learn/test_gemini_live_token.py
@@ -56,6 +56,7 @@ def test_token_is_one_use_short_lived_and_locks_server_configuration() -> None:
         "Content-Type": "application/json",
         "x-goog-api-key": "server-api-key",
     }
+    assert calls[0]["allow_redirects"] is False
     payload = calls[0]["json"]
     assert payload["uses"] == 1
     assert payload["expireTime"] == "2026-09-03T04:20:06Z"
@@ -89,6 +90,86 @@ def test_token_is_one_use_short_lived_and_locks_server_configuration() -> None:
     assert setup["tools"] == []
     assert "proactivity" not in setup
     assert "safetySettings" not in setup
+
+
+@pytest.mark.parametrize(
+    ("api_base_url", "endpoint"),
+    [
+        (None, GEMINI_LIVE_AUTH_TOKEN_ENDPOINT),
+        ("", GEMINI_LIVE_AUTH_TOKEN_ENDPOINT),
+        ("  \n ", GEMINI_LIVE_AUTH_TOKEN_ENDPOINT),
+        ("https://generativelanguage.googleapis.com/", GEMINI_LIVE_AUTH_TOKEN_ENDPOINT),
+        ("https://proxy.example.com", "https://proxy.example.com/v1beta/auth_tokens"),
+        (
+            " https://proxy.example.com/google/ ",
+            "https://proxy.example.com/google/v1beta/auth_tokens",
+        ),
+        (
+            "https://proxy.example.com:8443/api/google",
+            "https://proxy.example.com:8443/api/google/v1beta/auth_tokens",
+        ),
+    ],
+)
+def test_token_uses_server_configured_api_base_without_changing_browser_endpoint(
+    api_base_url: str | None, endpoint: str
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def request_post(url: str, **kwargs: object) -> _Response:
+        calls.append({"url": url, **kwargs})
+        return _Response({"name": "auth_tokens/browser-only"})
+
+    token = mint_gemini_live_ephemeral_token(
+        api_key="server-api-key",
+        api_base_url=api_base_url,
+        voice_name="Kore",
+        system_instruction="Private prompt",
+        include_initial_history=False,
+        request_post=request_post,
+    )
+
+    assert token.token == "auth_tokens/browser-only"
+    assert len(calls) == 1
+    assert calls[0]["url"] == endpoint
+    assert calls[0]["headers"]["x-goog-api-key"] == "server-api-key"
+    assert calls[0]["allow_redirects"] is False
+    assert GEMINI_LIVE_CONSTRAINED_ENDPOINT == (
+        "wss://generativelanguage.googleapis.com/ws/"
+        "google.ai.generativelanguage.v1beta.GenerativeService."
+        "BidiGenerateContentConstrained"
+    )
+
+
+@pytest.mark.parametrize(
+    "api_base_url",
+    [
+        "/",
+        "http://proxy.example.com/google",
+        "wss://proxy.example.com/google",
+        "https:///google",
+        "https://user:password@proxy.example.com/google",
+        "https://proxy.example.com/google?key=secret",
+        "https://proxy.example.com/google?",
+        "https://proxy.example.com/google#fragment",
+        "https://proxy.example.com/google#",
+        "https://[invalid",
+        "https://proxy.example.com:invalid/google",
+    ],
+)
+def test_token_rejects_unsafe_configured_url_before_sending_credentials(
+    api_base_url: str,
+) -> None:
+    with pytest.raises(GeminiLiveTokenError, match=r"^invalid_configuration$"):
+        mint_gemini_live_ephemeral_token(
+            api_key="server-api-key",
+            api_base_url=api_base_url,
+            voice_name="Kore",
+            system_instruction="Private prompt",
+            include_initial_history=False,
+            request_post=lambda *_args, **_kwargs: pytest.fail(
+                "Unsafe configuration was sent"
+            ),
+        )
 
 
 @pytest.mark.parametrize("instruction", ["", "  \n "])
@@ -190,12 +271,27 @@ def test_token_rejects_malformed_provider_responses(body: object) -> None:
         )
 
 
-def test_token_failure_does_not_expose_provider_details() -> None:
+@pytest.mark.parametrize("api_base_url", [None, "https://proxy.example.com/google"])
+def test_token_failure_does_not_expose_provider_details_or_try_another_host(
+    api_base_url: str | None,
+) -> None:
+    calls: list[str] = []
+
+    def request_post(url: str, **_kwargs: object) -> _Response:
+        calls.append(url)
+        return _Response({}, raises=True)
+
     with pytest.raises(GeminiLiveTokenError, match="token_provision_failed"):
         mint_gemini_live_ephemeral_token(
             api_key="server-api-key",
+            api_base_url=api_base_url,
             voice_name="Kore",
             system_instruction="Prompt",
             include_initial_history=False,
-            request_post=lambda *_args, **_kwargs: _Response({}, raises=True),
+            request_post=request_post,
         )
+    assert calls == [
+        f"{api_base_url}/v1beta/auth_tokens"
+        if api_base_url
+        else GEMINI_LIVE_AUTH_TOKEN_ENDPOINT
+    ]

--- a/src/api/tests/service/learn/test_live_follow_up_routes.py
+++ b/src/api/tests/service/learn/test_live_follow_up_routes.py
@@ -273,11 +273,21 @@ def test_session_rejects_invalid_shape_mode_surface_and_origin(
         _post_session(app, payload, origin=origin)
 
 
+@pytest.mark.parametrize("api_base_url", ["", "https://proxy.example.com/google/"])
 def test_session_mints_constrained_token_and_returns_no_internal_ws_or_cookie(
     monkeypatch: pytest.MonkeyPatch,
+    api_base_url: str,
 ) -> None:
     app = _route_app(monkeypatch)
     _stub_session_validation(monkeypatch)
+    monkeypatch.setattr(
+        routes,
+        "get_config",
+        lambda name, default=None: {
+            "GEMINI_API_KEY": "test-gemini-key",
+            "GEMINI_API_URL": api_base_url,
+        }.get(name, default),
+    )
     minted: list[dict[str, object]] = []
     stored: list[StoredLiveFollowUpSession] = []
     lease = _stored_session().lease
@@ -297,7 +307,10 @@ def test_session_mints_constrained_token_and_returns_no_internal_ws_or_cookie(
         lambda _app, *, session: stored.append(session),
     )
 
-    response = _post_session(app, _valid_payload())
+    response = _post_session(
+        app,
+        _valid_payload(api_base_url="https://untrusted.example.com"),
+    )
     body = json.loads(response.get_data(as_text=True))["data"]
 
     assert body["session_bid"] == "session-1"
@@ -310,12 +323,16 @@ def test_session_mints_constrained_token_and_returns_no_internal_ws_or_cookie(
     assert response.mimetype == "application/json"
     assert response.headers["X-Content-Type-Options"] == "nosniff"
     assert "systemInstruction" not in body["setup"]["setup"]
+    assert "proxy.example.com" not in response.get_data(as_text=True)
+    assert "untrusted.example.com" not in response.get_data(as_text=True)
+    assert "test-gemini-key" not in response.get_data(as_text=True)
     assert body["history"]["clientContent"]["turns"][0]["parts"][0]["text"] == (
         "Earlier question"
     )
     assert minted == [
         {
             "api_key": "test-gemini-key",
+            "api_base_url": api_base_url,
             "model": routes.GEMINI_LIVE_MODEL_ID,
             "voice_name": "Kore",
             "system_instruction": "private system instruction",


### PR DESCRIPTION
## Summary

Repair the two concrete errors preventing browser-direct Gemini Live follow-ups on the existing dev deployment:

- Reuse the server-owned `GEMINI_API_URL` for ephemeral-token issuance, including its proxy prefix and reusing an existing terminal `/v1beta` instead of duplicating it. Require a safe HTTPS base, disable redirects, and never silently fall back to another host. The long-lived key stays server-side; the browser WebSocket remains fixed to Google.
- Remove client-settable `sessionResumption` from token setup constraints as well as the FieldMask. Gemini was rejecting the mismatched setup with HTTP 400. Browser setup/resumption remains enabled and all course/security-sensitive fields stay locked.
- Add endpoint-routing, untrusted-payload exclusion, configuration rejection, and FieldMask-consistency regressions. Document the existing proxy contract and verified connection path.

## Scope

Cherry-picks only the connection fixes from [#2744](https://github.com/ai-shifu/ai-shifu/pull/2744): `ee31aa7e1`, `b8596ca5a`, and review fix `d51206612`. Base is dev `396b3aceb`; only six files change. The release tree exactly matches feature head `d51206612`. No frontend behavior, ingress, environment variables, database migrations, production, dev01/dev02, or devus changes.

## Verification

- Focused token/route/deployment selection: **102 passed**.
- Wider Live backend selection: **160 passed, 1 MySQL-dependent skip**.
- Routing regressions reproduced the missing proxy configuration; three FieldMask regressions were red before the provider-contract fix.
- Full `lefthook run pre-commit --all-files` passed, including five-locale checks, Ruff/formatting, architecture boundaries, and repository harness.
- Real candidate code, executed without replacing running container files, used the existing dev proxy/key to mint a credential: **HTTP 200**.
- That credential completed a direct client-to-Google constrained WebSocket handshake: **`setupComplete`**. No microphone audio was sent and no token, API key, or course content was persisted. Browser microphone/multi-turn acceptance is not inferred from this smoke check.

- The versioned-base review was fixed and resolved in `89cd6632f`; official and proxy bases ending in `/v1beta` now pass without changing nested proxy prefixes. Current release head: `89cd6632f`.
- CodeRabbit skips automatic review for the non-default dev base; Bugbot is unavailable due to quota. Their skipped/neutral states are not counted as completed code reviews.

## Deployment

Merged after current-head CI completed, including the runtime harness and security checks, with the versioned-token-endpoint review fixed and resolved. Dev commit: `3bea8f2f6af1091c13d5657b45f0eb2c49047d85`; its tree exactly matches feature head `d51206612`. [Drone #4729](https://ci.pillowai.cn/ai-shifu/ai-shifu/4729) completed every build/deploy step successfully.

Verified both running containers use `20260904-3bea8f2` with zero restarts. Deployed token/routes/session-store file hashes match the candidate. Public web and API health returned HTTP 200; Redis PING passed; the existing Live flag and proxy configuration were preserved. A fresh token minted by the deployed module completed a direct client-to-Google `setupComplete` handshake. No microphone audio was sent, so real microphone/multi-turn acceptance remains a separate check.

No ingress, environment variables, database migrations, or non-dev deployments were changed. A later review about the existing global model-discovery behavior for versioned custom proxies remains open on [#2744](https://github.com/ai-shifu/ai-shifu/pull/2744#discussion_r3932264095); current dev does not use that terminal-version configuration.

Previous dev release: `396b3aceb`, images `20260904-396b3ac`, Drone #4726.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication-adjacent token minting (API key routing, URL validation, provider payload). Scope is narrow and well-tested, but misconfigured GEMINI_API_URL would block Live until fixed.
> 
> **Overview**
> Fixes **browser-direct Gemini Live** failing on dev where the API cannot reach Google directly but already has a trusted **`GEMINI_API_URL`** proxy.
> 
> **Token provisioning** now posts to that configured HTTPS base (keeping path prefixes, appending `/v1beta/auth_tokens`, and avoiding duplicate `/v1beta`). Unsafe bases are rejected before the API key is sent; **redirects are disabled** and there is **no fallback** to another host. Session creation passes server config into minting; the client still gets the fixed Google constrained WebSocket URL.
> 
> **Provider contract:** removes **`sessionResumption`** from the constrained token setup payload (not only the field mask), fixing Gemini **HTTP 400** when setup fields were outside the mask. The browser can still supply resumption on its own setup frame.
> 
> Docs describe the proxy contract; tests cover routing, rejection of bad URLs, mask/setup alignment, and that responses do not leak proxy URLs or keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89cd6632f986d7c61f66d65a48074825fe956c7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->