### PR TITLE
fix: restore Gemini voice follow-up connections

### DIFF
--- a/docs/exec-plans/active/gemini-live-voice-follow-up.md
+++ b/docs/exec-plans/active/gemini-live-voice-follow-up.md
@@ -284,8 +284,20 @@ auditing, or another correctness-sensitive decision.
       prefixes or matching the hostname. Three cases reproduced duplicate
       version segments before the fix; the wider Live selection passes
       160 tests with one environment-dependent MySQL skip afterward.
-- [ ] Deploy the two connection fixes through a focused dev release PR and
-      recheck the running image, HTTP health, token minting, and direct setup.
+- [x] 2026-09-04: Deployed the connection fixes through PR #2759 as dev
+      commit `3bea8f2f6` (Drone #4729). Verified API/web images, HTTP health,
+      token minting, and a synthetic direct Google `setupComplete` handshake.
+- [x] 2026-09-04: Fix browser handling of Gemini binary WebSocket messages.
+      A new no-audio probe received `setupComplete` in opcode 2, while the
+      browser controller discarded every non-string message and timed out.
+      Initial and resumed sockets now deliver ArrayBuffer messages for strict,
+      synchronous UTF-8 parsing. All 132 tests across nine Live frontend suites
+      and TypeScript checking pass, covering binary setup, UTF-8 transcripts/
+      audio, malformed input, interruption order, resumption, and exactly-once
+      success analytics. The full frontend suite passes 2,139 tests across
+      226 suites; the full pre-commit gate, five-locale checks, architecture
+      boundaries, and repository harness pass. Deploy the fix to dev before
+      microphone acceptance.
 - [ ] Exercise a real ephemeral token and direct Gemini WebSocket on the dev
       deployment with a valid credential and microphone.
 - [x] 2026-09-03: Repository harness and the full
@@ -297,6 +309,12 @@ auditing, or another correctness-sensitive decision.
 
 ## Surprises & Discoveries
 
+- Gemini returns JSON in binary WebSocket frames (observed opcode 2), not
+  only text frames. Browser WebSockets default to Blob delivery, while the
+  controller previously ignored non-string messages. A successful Python
+  handshake therefore did not verify that the browser consumed setup. Later
+  retries returned AI-Shifu code 4018 because the issued credential's capacity
+  reservation outlived the failed attempt; that is separate from its cause.
 - The dev API container cannot reach Google's HTTPS endpoint directly. Its
   existing Gemini reverse proxy is reachable, but the original token issuer
   ignored `GEMINI_API_URL`. A healthy deployment and direct browser media path
@@ -344,6 +362,13 @@ auditing, or another correctness-sensitive decision.
 
 ## Decision Log
 
+- Decision: set every Gemini socket's `binaryType` to `arraybuffer` and decode
+  binary JSON synchronously in the existing protocol parser, retaining text
+  message compatibility.
+  - Why: the real provider sends binary JSON. Unlike asynchronous Blob reads,
+    synchronous decoding preserves the arrival order of setup, audio, and
+    interruption without introducing stale callbacks across resumed sockets.
+    Invalid UTF-8 or JSON remains a discarded protocol message, never logged.
 - Decision: reuse `GEMINI_API_URL` only for backend token provisioning, with
   the base-plus-`/v1beta` path contract used by Gemini model discovery, also
   accepting an already-versioned `/v1beta` base without duplicating it.
@@ -494,7 +519,11 @@ resumption, retry-only failures, analytics, and TypeScript. Candidate code has
 also passed real ephemeral-token issuance through the dev server's existing
 Gemini proxy and direct client-side Google WebSocket `setupComplete`. This
 synthetic, no-audio check does not establish browser microphone, multi-turn,
-or resumption acceptance; those checks remain outstanding.
+or resumption acceptance; those checks remain outstanding. The later binary
+frame diagnosis demonstrates why successful network setup alone was not
+sufficient: the browser also has to consume that setup response. The protocol
+and controller regressions now cover its real binary representation, including
+ordered interruption and resumption, but do not replace microphone acceptance.
 
 ## Context and Orientation
 

--- a/src/web/src/components/live-follow-up/useLiveVoiceFollowUp.test.tsx
+++ b/src/web/src/components/live-follow-up/useLiveVoiceFollowUp.test.tsx
@@ -77,6 +77,7 @@ class MockWebSocket {
   static readonly CLOSED = 3;
 
   readonly url: string;
+  binaryType: BinaryType = 'blob';
   bufferedAmount = 0;
   readyState = MockWebSocket.CONNECTING;
   onopen: (() => void) | null = null;
@@ -102,6 +103,13 @@ class MockWebSocket {
   message(message: GeminiLiveServerEvent) {
     mockParseServerMessage.mockReturnValueOnce(message);
     this.onmessage?.(new MessageEvent('message', { data: '{}' }));
+  }
+
+  binaryMessage(message: GeminiLiveServerEvent) {
+    mockParseServerMessage.mockReturnValueOnce(message);
+    const data = new Uint8Array([123, 125]).buffer;
+    this.onmessage?.(new MessageEvent('message', { data }));
+    return data;
   }
 
   fail() {
@@ -284,6 +292,7 @@ describe('useLiveVoiceFollowUp browser-direct transport', () => {
     jest.useRealTimers();
     jest.clearAllMocks();
     mockTrackEvent.mockReset();
+    mockParseServerMessage.mockReset();
     mockSockets.length = 0;
     mockActivateAudio.mockResolvedValue(mockAudio);
     mockCreateSession.mockResolvedValue(sessionResponse());
@@ -329,6 +338,55 @@ describe('useLiveVoiceFollowUp browser-direct transport', () => {
       'auth_tokens/browser-only',
     );
     expect(mockSockets[0].url).toContain('generativelanguage.googleapis.com');
+    expect(mockSockets[0].binaryType).toBe('arraybuffer');
+  });
+
+  it('accepts binary setup and interruption in order without timing out or duplicating success', async () => {
+    jest.useFakeTimers();
+    render(<Harness />);
+    await startAndOpen();
+
+    let setupFrame!: ArrayBuffer;
+    act(() => {
+      setupFrame = mockSockets[0].binaryMessage(
+        serverEvent({ setupComplete: true }),
+      );
+    });
+    expect(mockParseServerMessage).toHaveBeenCalledWith(setupFrame);
+    expect(screen.getByTestId('state')).toHaveTextContent('listening');
+
+    const pcm = new Uint8Array([1, 2, 3, 4]).buffer;
+    act(() => {
+      mockSockets[0].binaryMessage(
+        serverEvent({ audioChunks: [pcm], outputTranscripts: ['Answer'] }),
+      );
+      mockSockets[0].binaryMessage(serverEvent({ interrupted: true }));
+    });
+    expect(mockAudio.enqueueOutput).toHaveBeenCalledWith(pcm, 1);
+    expect(mockAudio.clearPlayback).toHaveBeenCalledTimes(1);
+    expect(mockAudio.enqueueOutput.mock.invocationCallOrder[0]).toBeLessThan(
+      mockAudio.clearPlayback.mock.invocationCallOrder[0],
+    );
+    act(() => jest.advanceTimersByTime(20_000));
+    expect(screen.getByTestId('state')).toHaveTextContent('listening');
+    expect(mockSockets[0].close).not.toHaveBeenCalled();
+    expect(
+      mockTrackEvent.mock.calls.filter(
+        ([name]) => name === 'learner_voice_follow_up_result',
+      ),
+    ).toEqual([
+      [
+        'learner_voice_follow_up_result',
+        {
+          shifu_bid: 'course-1',
+          outline_bid: 'lesson-1',
+          learning_mode: 'read',
+          surface: 'read_content',
+          outcome: 'success',
+          error_code: 'none',
+        },
+      ],
+    ]);
   });
 
   it('sends setup first, then history, and reports success only when audio is ready', async () => {
@@ -1032,6 +1090,7 @@ describe('useLiveVoiceFollowUp browser-direct transport', () => {
     act(() => mockSockets[0].message(serverEvent({ goAway: true })));
 
     expect(mockSockets).toHaveLength(2);
+    expect(mockSockets[1].binaryType).toBe('arraybuffer');
     expect(mockResolveWebSocketUrl).toHaveBeenLastCalledWith(
       sessionResponse().websocket_url,
       'auth_tokens/browser-only',
@@ -1042,7 +1101,9 @@ describe('useLiveVoiceFollowUp browser-direct transport', () => {
       handle: 'resume-handle',
     });
     expect(resumedSetup.setup).not.toHaveProperty('historyConfig');
-    act(() => mockSockets[1].message(serverEvent({ setupComplete: true })));
+    act(() =>
+      mockSockets[1].binaryMessage(serverEvent({ setupComplete: true })),
+    );
     expect(mockSockets[1].send).toHaveBeenCalledTimes(1);
     act(() => jest.advanceTimersByTime(20_000));
     expect(screen.getByTestId('state')).toHaveTextContent('listening');

--- a/src/web/src/components/live-follow-up/useLiveVoiceFollowUp.ts
+++ b/src/web/src/components/live-follow-up/useLiveVoiceFollowUp.ts
@@ -904,6 +904,8 @@ export const useLiveVoiceFollowUp = ({
             session.ephemeral_token,
           ),
         );
+        // Gemini sends binary JSON; decode it synchronously to preserve event order.
+        websocket.binaryType = 'arraybuffer';
         websocketRef.current = websocket;
 
         websocket.onopen = () => {
@@ -926,7 +928,8 @@ export const useLiveVoiceFollowUp = ({
         websocket.onmessage = event => {
           if (
             attemptRef.current?.generation !== generation ||
-            typeof event.data !== 'string'
+            (typeof event.data !== 'string' &&
+              !(event.data instanceof ArrayBuffer))
           ) {
             return;
           }

--- a/src/web/src/lib/liveVoiceFollowUp.test.ts
+++ b/src/web/src/lib/liveVoiceFollowUp.test.ts
@@ -1,3 +1,5 @@
+import { TextDecoder, TextEncoder } from 'node:util';
+
 import request from '@/lib/request';
 
 import {
@@ -23,6 +25,13 @@ jest.mock('@/lib/request', () => ({
 
 describe('live voice follow-up direct protocol helpers', () => {
   const mockedPost = jest.mocked(request.post);
+
+  beforeAll(() => {
+    Object.defineProperty(global, 'TextDecoder', {
+      configurable: true,
+      value: TextDecoder,
+    });
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -112,6 +121,52 @@ describe('live voice follow-up direct protocol helpers', () => {
         audio: { mimeType: 'audio/pcm;rate=16000', data: 'AQID' },
       },
     });
+  });
+
+  it('decodes binary UTF-8 setup, audio and transcript messages', () => {
+    const payload = {
+      setupComplete: {},
+      serverContent: {
+        inputTranscription: { text: '为什么？' },
+        outputTranscription: { text: '你好，世界 🌏' },
+        modelTurn: {
+          parts: [
+            { inlineData: { mimeType: 'audio/pcm;rate=24000', data: 'AQID' } },
+            { inlineData: { mimeType: 'audio/pcm;rate=24000', data: 'BAUG' } },
+          ],
+        },
+        turnComplete: true,
+      },
+    };
+    const json = JSON.stringify(payload);
+    const binary = Uint8Array.from(new TextEncoder().encode(json)).buffer;
+
+    expect(parseGeminiLiveServerMessage(binary)).toEqual(
+      parseGeminiLiveServerMessage(json),
+    );
+    expect(parseGeminiLiveServerMessage(binary)).toEqual(
+      expect.objectContaining({
+        setupComplete: true,
+        inputTranscripts: ['为什么？'],
+        outputTranscripts: ['你好，世界 🌏'],
+        audioChunks: [
+          new Uint8Array([1, 2, 3]).buffer,
+          new Uint8Array([4, 5, 6]).buffer,
+        ],
+        turnComplete: true,
+      }),
+    );
+  });
+
+  it('rejects malformed binary messages without exposing their contents', () => {
+    expect(parseGeminiLiveServerMessage(new ArrayBuffer(0))).toBeNull();
+    expect(
+      parseGeminiLiveServerMessage(new Uint8Array([0xff, 0xfe]).buffer),
+    ).toBeNull();
+    const invalidJson = Uint8Array.from(
+      new TextEncoder().encode('not json'),
+    ).buffer;
+    expect(parseGeminiLiveServerMessage(invalidJson)).toBeNull();
   });
 
   it('parses all relevant Gemini parts without exposing raw errors', () => {

--- a/src/web/src/lib/liveVoiceFollowUp.ts
+++ b/src/web/src/lib/liveVoiceFollowUp.ts
@@ -262,11 +262,15 @@ export const encodeGeminiLiveAudioMessage = (frame: ArrayBuffer): string => {
 };
 
 export const parseGeminiLiveServerMessage = (
-  payload: string,
+  payload: string | ArrayBuffer,
 ): GeminiLiveServerEvent | null => {
   let parsed: Record<string, unknown>;
   try {
-    const value = JSON.parse(payload);
+    const text =
+      typeof payload === 'string'
+        ? payload
+        : new TextDecoder('utf-8', { fatal: true }).decode(payload);
+    const value = JSON.parse(text);
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
       return null;
     }


### PR DESCRIPTION
## Problem

Dev successfully provisions a Gemini credential, but the voice dialog still times out. A synthetic no-audio check against the deployed token service observed Gemini's `setupComplete` as a binary WebSocket frame (opcode 2). The browser default delivers binary messages as Blob, while our controller only accepted strings, silently dropping setup and subsequent output.

## Changes

- Set `binaryType = 'arraybuffer'` for both initial and resumed Gemini sockets.
- Decode UTF-8 binary JSON synchronously in the existing parser; retain string compatibility and reject invalid UTF-8/JSON without logging payloads.
- Preserve setup/audio/interruption order, cancel the false setup timeout, and emit the existing success event exactly once.
- Add protocol and controller regressions and update the execution plan.

Only this fix is cherry-picked from source PR #2744 (commit `5613a31da`) onto current `origin/dev`. No environment, network, capacity, billing, course settings, or production changes.

## Verification

- Focused protocol/controller: **71 passed**.
- All nine Live frontend suites: **132 passed**.
- Complete frontend suite: **226 suites / 2,139 tests passed**.
- TypeScript, full pre-commit, five-locale checks, architecture boundaries, and repository harness passed.
- The release tree is identical to the tested source feature tree.
- Real Google setup returned binary opcode 2 through the existing local proxy. This is a synthetic no-audio protocol check, not microphone or multi-turn acceptance.

## Deployment evidence

[#2760](https://github.com/ai-shifu/ai-shifu/pull/2760) is merged into dev as `39043a92e486a3dc08f37fdb8490767edb7e386d`, with the same source tree as feature head `5613a31da`. [Drone #4730](https://ci.pillowai.cn/ai-shifu/ai-shifu/4730) succeeded. Both running API/web images use `20260904-39043a9`, with zero restarts at verification.

Public web/API health return HTTP 200; the existing Live flag and Redis PING are verified. The public controller chunk `1672.5663ea43e47443e1.js` contains ArrayBuffer socket delivery and the binary message guard. The public protocol chunk `7519.3dd25eda6cddcafb.js` contains strict UTF-8 decoding and the constrained Gemini endpoint. Their SHA-256 hashes match the running container's files. No ingress/environment settings, course configuration, production, dev01/dev02, or devus were changed.

Both source and release heads completed all applicable CI checks. Release code/security review completed without open threads; Bugbot was unavailable due to quota, and CodeRabbit skipped the non-default base, so those are not counted as completed reviews. The existing versioned-proxy discovery follow-up in #2744 remains open and outside this focused dev fix.

The learner must reload the page to load the corrected chunks and start voice explicitly. A prior credential cooldown remains enforced when applicable. Actual microphone/multi-turn acceptance is still outstanding; the no-audio Google handshake and binary parser tests are not presented as a real voice session.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live Gemini WebSocket message handling on the learner voice path; scope is frontend-only with strong regression tests, but incorrect parsing or ordering could still break connection, playback, or analytics until dev microphone acceptance.
> 
> **Overview**
> Fixes voice follow-up **connection timeouts** when Gemini returns `setupComplete` and other events as **binary WebSocket frames** (opcode 2). The controller previously ignored any non-string `message` data, so setup never completed even though server-side probes succeeded.
> 
> **WebSocket handling:** Initial and resumed Gemini sockets now set `binaryType` to `arraybuffer`. `onmessage` accepts both strings and `ArrayBuffer` and feeds them through the existing parser.
> 
> **Protocol parsing:** `parseGeminiLiveServerMessage` decodes UTF-8 binary JSON synchronously (fatal decode, no payload logging on failure) while keeping text-frame behavior. Malformed binary input returns `null` like bad JSON.
> 
> **Tests & docs:** Controller tests cover binary setup, ordered audio/interruption, resumption, and single success analytics; protocol tests cover UTF-8 transcripts/audio and malformed binary. The active exec plan records the root cause, deployment note, and decision to prefer synchronous `ArrayBuffer` decoding over Blob reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71d9102c4cb27b983d5ae6ff49cafc51d82cc7ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->