### PR TITLE
fix: keep course prompts out of dev voice follow-ups

### DIFF
--- a/docs/exec-plans/active/gemini-live-voice-follow-up.md
+++ b/docs/exec-plans/active/gemini-live-voice-follow-up.md
@@ -12,13 +12,20 @@ is never stored and no text fallback is offered.
 
 The long-lived Gemini API key remains on the backend. The backend mints a
 one-use, short-lived [Gemini ephemeral token](https://ai.google.dev/gemini-api/docs/live-api/ephemeral-tokens)
-whose Live constraints lock the model, course system instruction, selected
+whose Live constraints lock the model, follow-up system instruction, selected
 voice, and session behavior. The browser uses that token to connect directly
 to Gemini's constrained Live WebSocket. AI-Shifu continues to own admission,
 capacity, session lifetime, transcript history, and non-billable usage through
 ordinary authenticated HTTPS endpoints. Consequently, the feature does not
 require a WebSocket Upgrade route or a different Gunicorn worker at the
 AI-Shifu ingress.
+
+Live does not load or concatenate the teacher-authored Course Prompt. A short
+voice instruction supplies the default base context, including the existing
+learner-profile formatting. Configured follow-up prompts are retained; their
+`{shifu_system_message}` placeholder resolves to that voice context. Learner
+language, current learning content, and recent follow-up history remain
+available. Ordinary text follow-ups continue to inherit the Course Prompt.
 
 The first release supports reading mode, listen mode, and teacher preview;
 classroom remains excluded. It is available to every teacher only when
@@ -135,7 +142,8 @@ auditing, or another correctness-sensitive decision.
       publications: both transports fall back to the effective course prompt.
       If no prompt exists, token provisioning omits empty content while keeping
       `systemInstruction` locked in the field mask. Credentials/model/voice
-      remain required.
+      remain required. The later Live-only Course Prompt exclusion below
+      supersedes this fallback for voice sessions, not text sessions.
 - [x] 2026-09-04: Bound HTTP session provisioning at 20 seconds, stop audio on
       timeout, and apply a 30-second retry backoff. Late credentials are retired
       without opening a socket and still update the known admission deadline.
@@ -298,6 +306,19 @@ auditing, or another correctness-sensitive decision.
       226 suites; the full pre-commit gate, five-locale checks, architecture
       boundaries, and repository harness pass. Deploy the fix to dev before
       microphone acceptance.
+- [x] 2026-09-04: Exclude Course Prompt lookup and inheritance from Live at the
+      user's request. Preserve configured follow-up prompts, learner language,
+      profile formatting, current anchor, and the latest ten turns through the
+      shared context builder. Blank prompts and the system-message placeholder
+      use a versioned voice default instead. All 22 focused context regressions
+      pass across reading/listening and learner/preview sessions; text retains
+      its original Course Prompt precedence. Saved course data is unchanged.
+- [x] 2026-09-04: The wider Live/text/profile/backend selection passes 201 tests
+      with one isolated-MySQL skip, using the repository-pinned Flask/Werkzeug
+      from an isolated dependency overlay. Ruff, architecture boundaries,
+      repository harness, all five locales, and the full pre-commit gate pass.
+      No shared virtualenv or environment configuration was changed.
+- [ ] Deploy the Live-only prompt change and validate audible responses on dev.
 - [ ] Exercise a real ephemeral token and direct Gemini WebSocket on the dev
       deployment with a valid credential and microphone.
 - [x] 2026-09-03: Repository harness and the full
@@ -309,6 +330,12 @@ auditing, or another correctness-sensitive decision.
 
 ## Surprises & Discoveries
 
+- The provider can complete with output transcription but no PCM audio even
+  when server and browser setup both request only `AUDIO`. Authorized temporary
+  probes with the affected Course Prompt reproduced this; adding one voice
+  sentence produced audio in two of three trials, not a reliable guarantee.
+  Prompt variants do not establish a single offending phrase or model-internal
+  cause. No private course prompt or audio from those probes is stored here.
 - Gemini returns JSON in binary WebSocket frames (observed opcode 2), not
   only text frames. Browser WebSockets default to Blob delivery, while the
   controller previously ignored non-string messages. A successful Python
@@ -362,6 +389,16 @@ auditing, or another correctness-sensitive decision.
 
 ## Decision Log
 
+- Decision: omit the Course Prompt from Live only, rather than heuristically
+  editing its formatting or teaching rules. Use `prompts/live_follow_up.md`
+  as the shared builder's explicit fallback while passing no course prompt.
+  - Why: the user explicitly chose not to concatenate the Course Prompt after
+    the transcript-only response diagnosis. Preserve the teacher's separate
+    follow-up prompt, including its existing standalone override behavior;
+    placeholder/blank prompts receive the voice/profile default. Ordinary text
+    prompt composition, saved course settings, audio configuration, and native
+    safety remain unchanged. This changes no analytics invocation, outcome,
+    eligibility, deduplication, payload, or downstream consumer contract.
 - Decision: set every Gemini socket's `binaryType` to `arraybuffer` and decode
   binary JSON synchronously in the existing protocol parser, retaining text
   message compatibility.
@@ -505,7 +542,7 @@ auditing, or another correctness-sensitive decision.
 
 The implementation is now aligned with the deployment the user actually has:
 the AI-Shifu ingress handles only ordinary HTTPS for Live, while the browser
-opens Gemini's own WebSocket. The long-lived provider secret and private course
+opens Gemini's own WebSocket. The long-lived provider secret and private follow-up
 instruction are not returned to the browser; the returned credential is
 short-lived, one-use, and constrained. The old Flask-Sock dependencies,
 server-side Gemini WebSocket wrapper, cookie ticket, backend turn accumulator,
@@ -525,6 +562,12 @@ sufficient: the browser also has to consume that setup response. The protocol
 and controller regressions now cover its real binary representation, including
 ordered interruption and resumption, but do not replace microphone acceptance.
 
+Live now intentionally differs from text in its base instruction: it never
+resolves the Course Prompt and uses a concise voice default instead. Shared
+profile, language, anchor, and history handling remain in place. Context
+regressions prove the exclusion and unchanged text behavior; they do not prove
+that every provider response contains audio or replace post-deployment testing.
+
 ## Context and Orientation
 
 The Flask routes are registered through
@@ -540,6 +583,10 @@ implemented by:
 - `live_follow_up_persistence.py`: saves deterministic history and
   client-reported, non-billable usage;
 - `live_follow_up_capacity.py`: owns per-worker/global/user Redis leases.
+
+`src/api/prompts/live_follow_up.md` owns the default Live voice instruction;
+`follow_up_context.py` composes it with the same profile and history handling
+used by text, without resolving the Course Prompt on the Live path.
 
 The frontend direct transport is implemented by:
 
@@ -576,8 +623,9 @@ into the lesson tree so learner UI never guesses.
 
 On authenticated session POST, validate learner or preview access, effective
 model/provider/voice, outline, anchor, learning mode, and Origin. Reserve Redis
-capacity through the credential lifetime. Build the shared follow-up system
-instruction and latest ten turns. Mint a Gemini token with `uses=1`, a
+capacity through the credential lifetime. Build the follow-up instruction and
+latest ten turns through the shared context builder, with the Live voice
+default instead of the Course Prompt. Mint a Gemini token with `uses=1`, a
 30-second new-session window, 15-minute expiry, and a locked effective Bidi
 setup. Store a separate 45-second Redis session binding and return only the
 ephemeral token, allowlisted constrained WSS endpoint, prompt-free setup,
@@ -700,6 +748,11 @@ IDs, WSS/HTTP URLs, token, resumption handle, and raw error are prohibited.
 - Token tests assert one use, 30-second connection window, 15-minute expiry,
   exact constrained model/config, private system instruction placement, prompt-
   free browser setup, and bounded provider failure handling.
+- Context tests forbid Live Course Prompt lookup in reading/listening and
+  learner/preview sessions. Cover blank, whitespace-only, placeholder, and
+  standalone follow-up prompts, preserving profile formatting, language,
+  anchor, and ten-turn history. Text regressions retain Course Prompt
+  composition and precedence over an optional fallback.
 - Session tests cover permission and Origin binding, Redis fail-closed,
   capacity acquisition/pre-disclosure rollback/token-lifetime expiry, hashed
   Redis keys, the independent heartbeat TTL, consume-once end without early

--- a/src/api/flaskr/service/learn/follow_up_context.py
+++ b/src/api/flaskr/service/learn/follow_up_context.py
@@ -263,6 +263,7 @@ def build_follow_up_conversation_context(
     generated_block_model: object | None = None,
     format_prompt: Callable[..., str] | None = None,
     output_language: str | None = None,
+    fallback_system_prompt: str | None = None,
 ) -> FollowUpConversationContext:
     """Compose the effective prompt and history for either follow-up transport."""
     if not str(outline_item_bid or "").strip():
@@ -281,9 +282,10 @@ def build_follow_up_conversation_context(
             }
         )
 
-    if course_system_prompt:
+    context_prompt = course_system_prompt or fallback_system_prompt
+    if context_prompt:
         variable_course_prompt = build_course_prompt(
-            course_system_prompt,
+            context_prompt,
             variables=profiles,
             nickname_identifiers=(
                 getattr(user_info, "user_bid", ""),
@@ -311,8 +313,8 @@ def build_follow_up_conversation_context(
         base_system_prompt = None
 
     ask_prompt = str(follow_up_info.ask_prompt or "")
-    # Drafts and freshly published courses may not have a generated follow-up
-    # prompt yet. Keep their inherited course context available to both paths.
+    # Blank follow-up prompts use the transport's base instruction: inherited
+    # course instructions for text, or an explicit voice fallback for Live.
     system_instruction = (
         ask_prompt if ask_prompt.strip() else "{shifu_system_message}"
     ).replace(

--- a/src/api/flaskr/service/learn/live_follow_up_routes.py
+++ b/src/api/flaskr/service/learn/live_follow_up_routes.py
@@ -23,7 +23,6 @@ from flaskr.service.common.models import raise_param_error
 from flaskr.service.config import get_config
 from flaskr.service.learn.follow_up_context import (
     build_follow_up_conversation_context,
-    resolve_course_system_prompt,
 )
 from flaskr.service.learn.gemini_live_token import (
     GEMINI_LIVE_CONSTRAINED_ENDPOINT,
@@ -84,6 +83,7 @@ from flaskr.service.shifu.consts import ASK_MODE_DISABLE
 from flaskr.service.shifu.models import DraftShifu, PublishedShifu
 from flaskr.service.user.api import is_allowed_oauth_origin, load_user_aggregate
 from flaskr.util.datetime import to_utc_iso
+from flaskr.util.prompt_loader import load_prompt_template
 from flaskr.util.uuid import generate_id
 from sqlalchemy import or_
 
@@ -288,12 +288,9 @@ def _build_conversation(
         outline_item_bid=binding.outline_bid,
         progress_record_bid=binding.progress_record_bid,
         follow_up_info=follow_up_info,
-        course_system_prompt=resolve_course_system_prompt(
-            app,
-            shifu_bid=binding.shifu_bid,
-            outline_item_bid=binding.outline_bid,
-            preview_mode=binding.preview_mode,
-        ),
+        # Live must not inherit the course's text-output and formatting rules.
+        course_system_prompt=None,
+        fallback_system_prompt=load_prompt_template("live_follow_up"),
         use_learner_language=_load_use_learner_language(
             shifu_bid=binding.shifu_bid,
             preview_mode=binding.preview_mode,

--- a/src/api/prompts/live_follow_up.md
+++ b/src/api/prompts/live_follow_up.md
@@ -1,0 +1,3 @@
+You are a tutor in a real-time, two-way voice conversation.
+Respond with audible speech in natural spoken language.
+Answer the learner's questions using the supplied learning context and conversation history.

--- a/src/api/tests/service/learn/test_live_follow_up_context.py
+++ b/src/api/tests/service/learn/test_live_follow_up_context.py
@@ -1,0 +1,127 @@
+"""Keep course instructions out of Live while retaining follow-up context."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from flaskr.service.learn import follow_up_context as context
+from flaskr.service.learn import live_follow_up_routes as routes
+from flaskr.service.learn.gemini_live_token import GeminiLiveHistoryTurn
+from flaskr.service.learn.live_follow_up_session_store import LiveFollowUpSessionBinding
+from flaskr.util.prompt_loader import load_prompt_template
+
+
+@pytest.mark.parametrize("preview_mode", [False, True])
+@pytest.mark.parametrize("learning_mode", ["read", "listen"])
+@pytest.mark.parametrize(
+    "ask_prompt",
+    ["", " \n ", "FOLLOW-UP\n{shifu_system_message}", "Follow-up instructions only."],
+)
+def test_live_context_omits_course_prompt_and_preserves_follow_up_context(
+    monkeypatch: pytest.MonkeyPatch,
+    preview_mode: bool,
+    learning_mode: str,
+    ask_prompt: str,
+) -> None:
+    """Both learner and preview sessions omit course-prompt lookup and fallback."""
+    app = Flask("live-context-test")
+    binding = LiveFollowUpSessionBinding(
+        session_bid="session-1",
+        user_bid="user-1",
+        shifu_bid="course-1",
+        outline_bid="lesson-1",
+        anchor_element_bid="anchor-1",
+        progress_record_bid="progress-1",
+        preview_mode=preview_mode,
+        origin="https://learn.example.com",
+        model=routes.GEMINI_LIVE_MODEL_ID,
+        voice_name="Kore",
+        language="zh-CN",
+        learning_mode=learning_mode,
+        expires_at_epoch=900,
+    )
+    captured: dict[str, object] = {}
+    history = [
+        {"role": "assistant", "content": "Current learning content"},
+        {"role": "user", "content": "Earlier question"},
+        {"role": "assistant", "content": "Earlier answer"},
+    ]
+
+    def reject_course_prompt(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("Live must not load or inherit the course system prompt")
+
+    def load_language(**kwargs: object) -> bool:
+        captured["language_scope"] = kwargs
+        return True
+
+    def load_history(**kwargs: object) -> list[dict[str, str]]:
+        captured["history_scope"] = kwargs
+        return history
+
+    def format_prompt(
+        _app: Flask,
+        _user_bid: str,
+        _shifu_bid: str,
+        prompt: str,
+        *,
+        resolved_profiles: dict[str, object],
+    ) -> str:
+        captured["profiles"] = resolved_profiles
+        captured["base_prompt"] = prompt
+        return prompt
+
+    monkeypatch.setattr(
+        routes, "resolve_course_system_prompt", reject_course_prompt, raising=False
+    )
+    monkeypatch.setattr(context, "resolve_course_system_prompt", reject_course_prompt)
+    monkeypatch.setattr(
+        routes,
+        "load_user_aggregate",
+        lambda _bid: SimpleNamespace(user_id="user-1", user_bid="user-1", identify=""),
+    )
+    monkeypatch.setattr(routes, "_load_use_learner_language", load_language)
+    monkeypatch.setattr(
+        context,
+        "get_user_profiles",
+        lambda *_args: {
+            "sys_user_nickname": "Alex",
+            "sys_user_background": "Synthetic learner background",
+        },
+    )
+    monkeypatch.setattr(context, "get_fmt_prompt", format_prompt)
+    monkeypatch.setattr(context, "load_follow_up_history", load_history)
+
+    instruction, turns = routes._build_conversation(
+        app,
+        binding=binding,
+        follow_up_info=SimpleNamespace(ask_prompt=ask_prompt),
+    )
+
+    voice_prompt = load_prompt_template("live_follow_up").strip()
+    base_prompt = captured["base_prompt"]
+    assert voice_prompt in base_prompt
+    assert '"Alex"' in base_prompt
+    assert '"Synthetic learner background"' in base_prompt
+    assert "{shifu_system_message}" not in instruction
+    if ask_prompt.strip() and "{shifu_system_message}" not in ask_prompt:
+        assert instruction.startswith(ask_prompt)
+    else:
+        assert instruction.count(voice_prompt) == 1
+        assert '"Synthetic learner background"' in instruction
+        if ask_prompt.strip():
+            assert instruction.startswith("FOLLOW-UP\n")
+    assert instruction.endswith("IMPORTANT: You MUST respond in 简体中文.")
+    assert captured["profiles"]["sys_user_language"] == "zh-CN"
+    assert captured["language_scope"] == {
+        "shifu_bid": "course-1",
+        "preview_mode": preview_mode,
+    }
+    assert captured["history_scope"]["anchor_element_bid"] == "anchor-1"
+    assert captured["history_scope"]["progress_record_bid"] == "progress-1"
+    assert captured["history_scope"]["max_history_messages"] == 20
+    assert turns == tuple(
+        GeminiLiveHistoryTurn(role=item["role"], text=item["content"])
+        for item in history
+    )

--- a/src/api/tests/service/learn/test_live_follow_up_persistence.py
+++ b/src/api/tests/service/learn/test_live_follow_up_persistence.py
@@ -456,12 +456,14 @@ def test_shared_element_history_prefers_sidecars_and_bounds_zero() -> None:
     ("ask_prompt", "expected_prefix"),
     [("FOLLOW-UP\n{shifu_system_message}", "FOLLOW-UP\n"), ("", ""), (" \n ", "")],
 )
+@pytest.mark.parametrize("fallback_system_prompt", [None, "UNUSED FALLBACK"])
 def test_shared_context_composes_profiles_language_prompt_and_history(
     monkeypatch: object,
     ask_prompt: str,
     expected_prefix: str,
+    fallback_system_prompt: str | None,
 ) -> None:
-    """Text and Live transports receive the same composed instruction and history."""
+    """Text retains course instructions even when an optional fallback is supplied."""
     app = Flask("shared-live-follow-up-context")
     user_info = types.SimpleNamespace(
         user_id="user-id",
@@ -541,6 +543,7 @@ def test_shared_context_composes_profiles_language_prompt_and_history(
         runtime_profiles=None,
         anchor_element_bid="anchor",
         max_history_messages=20,
+        fallback_system_prompt=fallback_system_prompt,
     )
 
     assert captured["prompt"] == "COURSE TEMPLATE"


### PR DESCRIPTION
## Summary

- Deploy the Gemini Live Course Prompt exclusion from #2744 (`85af60a49e545aaef78d69f1dc6cac821f69d27c`) to dev only.
- Live no longer resolves or concatenates the teacher-authored Course Prompt. Blank follow-up prompts and the system-message placeholder use a short versioned voice default with existing learner-profile formatting. Separate follow-up prompts, learner language, the current learning anchor, and recent history are retained.
- Ordinary text follow-ups, saved course data, native Gemini safety, audio-only setup, capacity, and billing remain unchanged. No environment, ingress, production, dev01/dev02, or devus changes are included.

## Scope and verification

- Based on current dev `39043a92e486a3dc08f37fdb8490767edb7e386d`, with only the six-file prompt fix cherry-picked; existing dev history is preserved.
- Release candidate `9e5a51d7d65b0a0ea97d3d3748d6319797b25bac` has the exact same source tree as the tested feature head `85af60a49e545aaef78d69f1dc6cac821f69d27c`.
- 201 focused backend tests passed; one isolated-MySQL test was skipped. Coverage includes Live/read/listen/preview context, custom/blank/placeholder prompts, text-provider behavior, token constraints, routes, persistence, capacity, and learner profiles.
- Ruff/formatting, architecture boundaries, repository harness, five-locale checks, and the full pre-commit gate passed on this identical tree. The shared virtualenv was not modified.
- Source and release CI passed before merge. The normal dev pipeline and post-deployment image, fingerprint, API/web readiness, Redis, and enabled-flag checks passed; see the deployment evidence below.

## Rollout limits

This release does not claim that automated context tests guarantee audio from every Gemini response. Actual browser microphone and multi-turn acceptance must still be performed after deployment. Existing credential cooldown may apply to a new learner attempt.

The previously acknowledged versioned custom-proxy discovery follow-up in #2744 is outside this focused deployment; its current dev configuration was verified not to use a terminal API-version base during the earlier connection repair.

### Live Course Prompt exclusion deployed on 2026-09-04

[#2761](https://github.com/ai-shifu/ai-shifu/pull/2761) is merged into dev as `36e8f9409da4a9f04d3d6f5d6a2a2ca9f76aac67`, with the exact same source tree as tested feature head `85af60a49e545aaef78d69f1dc6cac821f69d27c`. [Drone #4733](https://ci.pillowai.cn/ai-shifu/ai-shifu/4733) completed successfully.

At 2026-09-04T11:43:28Z, both running API/web images use `20260904-36e8f94`, started at 11:42:13Z, with zero restarts. The deployed context builder, Live routes, and new voice prompt SHA-256 fingerprints match the reviewed candidate. The running route's AST also confirms `course_system_prompt=None` and no Course Prompt lookup.

Public web and runtime-config requests return HTTP 200 (API business code 0); the API's internal health endpoint returns HTTP 200 / code 0. Redis PING passes and the existing `GEMINI_LIVE_ENABLED=true` remains enabled. No environment variables, ingress settings, saved course configuration, production, dev01/dev02, or devus were changed.

Both source and release heads completed their applicable CI checks, including backend tests and the Docker/Playwright runtime smoke harness. The release has no unresolved review threads. CodeRabbit skipped its review and Bugbot was neutral/unavailable; these are not counted as completed code reviews. The previously acknowledged versioned-proxy discovery follow-up in #2744 remains outside this deployment.

The new instruction policy applies to freshly issued Live sessions. An existing token retains its locked instruction, so the learner must end the old session and explicitly start a new one; credential cooldown still applies where relevant. Actual browser microphone/multi-turn/audio acceptance remains outstanding. Deployment and context verification are not a guarantee that every provider response contains PCM audio.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Live tutoring behavior and Gemini system instructions change for all voice sessions without altering text or persisted course data; incorrect prompt wiring could affect answer quality or provider audio output until post-deploy validation.
> 
> **Overview**
> **Gemini Live** voice sessions no longer resolve or concatenate the teacher-authored **Course Prompt**. Session provisioning builds the locked system instruction from a short **`live_follow_up.md`** voice default (with existing learner-profile formatting) via a new optional **`fallback_system_prompt`** on the shared context builder, while **text follow-ups** still inherit the course prompt and ignore that fallback when a course prompt is present.
> 
> Configured follow-up prompts are unchanged: blank or `{shifu_system_message}` placeholders resolve to the voice base context on Live; standalone follow-up text still applies. Learner language, anchor content, and recent history composition are preserved. Regression tests cover Live read/listen and learner/preview paths plus unchanged text precedence; the exec plan documents the decision and remaining dev audio validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e5a51d7d65b0a0ea97d3d3748d6319797b25bac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
