### PR TITLE
refactor: remove unused course editing helpers

### DIFF
--- a/docs/exec-plans/active/frontend-unused-function-stack.md
+++ b/docs/exec-plans/active/frontend-unused-function-stack.md
@@ -18,7 +18,9 @@ each PR's diff relative to the preceding stack branch.
 - [x] 2026-09-05 06:53 CST: Removed five unused upload/password-strength
   helpers; 11 related suites / 115 tests and type checking pass, with all
   retained declarations structurally unchanged.
-- [ ] Remove and validate unused authoring helpers.
+- [x] 2026-09-05 06:56 CST: Removed three unused authoring helpers and the
+  obsolete commented loader call; 102 related suites / 1173 tests and type
+  checking pass, with retained declarations structurally unchanged.
 - [ ] Remove and validate the unused learner URL helper.
 - [ ] Verify the entire stack, production routes, and complete rollback patch.
 
@@ -27,6 +29,8 @@ each PR's diff relative to the preceding stack branch.
 - File reachability alone missed unused declarations in maintained files.
 - Knip's 231 export candidates include functions used inside their own module;
   an unused export does not establish an unused implementation.
+- ESLint removed an unnecessary file-level no-unused-vars directive from
+  tree utilities during the required checks; this changes no runtime code.
 - The current TypeScript project has other noUnused diagnostics. They remain
   audit data, not a reason to change public arguments, Hook state, or unrelated
   behavior in this stack.
@@ -34,7 +38,8 @@ each PR's diff relative to the preceding stack branch.
 ## Decision Log
 
 - Scope is exactly the 13 verified functions, their exclusive imports/constants,
-  and the obsolete commented call to the deleted authoring loader.
+  the obsolete commented call to the deleted authoring loader, and the
+  unnecessary tree-utilities lint directive removed by the required hook.
 - Keep active implementations, API wrappers, public types, state shape, shared
   translations, dependencies, and compatibility module boundaries intact.
 - Use four PRs with one cleanup commit per layer. No merge or deployment is
@@ -49,8 +54,10 @@ Layer 1 removes four unused declarations and their exclusive imports/cache
 key, totaling 43 source lines. Its 13 related suites / 227 tests and type
 checking pass. Layer 2 removes five unused upload/password-strength helpers
 and their adjacent documentation, totaling 164 source lines; its 11 related
-suites / 115 tests and type checking pass. Further layers and cumulative
-verification are pending.
+suites / 115 tests and type checking pass. Layer 3 removes three unused
+authoring helpers and an obsolete commented call, totaling 22 source lines;
+its 102 related suites / 1173 tests and type checking pass. Layer 4 and
+cumulative verification are pending.
 
 ## Context and Orientation
 

--- a/src/web/src/components/dnd-kit-sortable-tree/utilities.ts
+++ b/src/web/src/components/dnd-kit-sortable-tree/utilities.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { arrayMove } from '@dnd-kit/sortable';
 
 import type { FlattenedItem, TreeItem, TreeItems } from './types';
@@ -8,10 +7,6 @@ export const iOS =
   typeof window !== 'undefined'
     ? /iPad|iPhone|iPod/.test(navigator.platform)
     : false;
-
-function getDragDepth(offset: number, indentationWidth: number) {
-  return Math.round(offset / indentationWidth);
-}
 
 let _revertLastChanges = () => {};
 export function getProjection<T>(
@@ -79,14 +74,6 @@ export function getProjection<T>(
     isLast,
   };
 
-  function findParentWithDepth(depth: number, previousItem: FlattenedItem<T>) {
-    if (!previousItem) return null;
-    while (depth < previousItem.depth) {
-      if (previousItem.parent === null) return null;
-      previousItem = previousItem.parent;
-    }
-    return previousItem;
-  }
   function findParentWhichCanHaveChildren(
     parent: FlattenedItem<T> | null,
     dragItem: FlattenedItem<T>,

--- a/src/web/src/store/useShifu.tsx
+++ b/src/web/src/store/useShifu.tsx
@@ -485,14 +485,6 @@ export const ShifuProvider = ({
     }
   };
 
-  const loadProfileItemDefinations = async (shifuId: string) => {
-    const list = await api.getProfileItemDefinitions({
-      parent_id: shifuId,
-      type: 'all',
-    });
-    setProfileItemDefinations(list);
-  };
-
   const remapOutlineTree = (
     items: any,
     parentBid = '',
@@ -739,7 +731,6 @@ export const ShifuProvider = ({
       setChapters(list);
       buildOutlineTree(list);
       await refreshVariableUsage(shifuId);
-      // loadProfileItemDefinations(shifuId);
     } catch (error) {
       console.error(error);
       setError('Failed to load chapters');


### PR DESCRIPTION
## Summary

Remove the unused profile-definition loader and its obsolete commented call from `useShifu`, plus two unused drag-depth and parent-lookup functions in tree utilities: 22 source lines.

The required ESLint hook also removes an unnecessary file-level lint directive.

TypeScript symbol references and repository searches found no active consumers. Retained declarations are structurally identical, including the active variable refresh and tree projection implementation and parameters.

## Stack

#2762 → #2763 → #2764 → #2765 → #2767 (bottom to top).

This PR is layer 3 of 4 and targets #2764. Review its incremental branch diff and merge bottom to top. After the parent merges, retarget to main and transplant only this layer's commit if needed after a squash merge; update descendants bottom to top with `--force-with-lease` after checking their remote heads.

## Validation

- Related Jest coverage: 102 suites / 1173 tests pass, including existing store tests.
- Type checking and retained-AST comparison pass.
- Development-tool checks and `lefthook run pre-commit --all-files` pass.

- Cumulative validation at #2767: 214 suites / 1966 tests, frontend lint, type checking, and production build pass. Route manifests match; bundle differences are fully accounted for in the completed plan.
- Per-layer and combined reverse-patch checks pass.

## Rollback

One incremental commit. Revert this layer's commit (or its squash commit after merge) through a rollback PR. No migration, configuration, or dependency change is involved.

[Completed stack validation and recovery plan](https://github.com/ai-shifu/ai-shifu/blob/710dadc836c8df65b0f7474f4a65c7a947e4bcf3/docs/exec-plans/completed/frontend-unused-function-stack.md).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletes unreachable helpers with no remaining references; active profile refresh and `getProjection` tree logic are untouched.
> 
> **Overview**
> **Layer 3** of the unused-function cleanup stack deletes dead code only; behavior for course editing and drag-and-drop trees is unchanged.
> 
> Removes the unused `loadProfileItemDefinations` helper from `useShifu` and the obsolete commented call in `loadChapters`. Profile definitions continue to load through `refreshProfileDefinitions` / `refreshVariableUsage` on chapter load.
> 
> In sortable-tree `utilities.ts`, drops unused `getDragDepth` and `findParentWithDepth` and the file-level ESLint `no-unused-vars` disable that pre-commit no longer needs.
> 
> The active exec plan is updated to mark layer 3 complete (~22 lines removed; related tests and type checks reported passing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 636ea751f9182489710ddc7f2b6d104a9a8bd083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->