### PR TITLE
chore: clarify PR description format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,8 @@ rules, but must not duplicate or redefine them.
 - The local `commit-msg` hook is only a baseline Conventional Commits syntax
   check. It does not enforce the `Changed:` / `Benefit:` body or the
   classification rules below.
+- The `Changed:` / `Benefit:` body requirement applies only to commit messages;
+  PR descriptions are not subject to this constraint.
 - Subject: use English Conventional Commits without scope parentheses, such as
   `type: summary`; do not use `type(scope): summary`. Write the summary in
   plain language that product users can understand. When a change affects


### PR DESCRIPTION
## Summary
- clarify that the Changed and Benefit sections apply only to commit messages
- confirm that PR descriptions are not restricted by this commit-body convention

## Verification
- python3 scripts/check_repo_harness.py
- PATH with the repository virtualenv first: python3 scripts/check_dev_tools.py
- full pre-commit checks: all non-frontend checks passed; Cook Web eslint and prettier could not run because src/web/node_modules is absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the `Changed:` / `Benefit:` body requirement applies to commit messages only, not pull request descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->