### PR TITLE
fix: resume listening after switching modes

### DIFF
--- a/docs/exec-plans/active/learner-listen-playback-stability.md
+++ b/docs/exec-plans/active/learner-listen-playback-stability.md
@@ -51,6 +51,11 @@ refer to the stream that was actually playing, never the first stream.
     narration is reattached. The element identity remains valid during that
     interval, and allowing normal startup would both erase the checkpoint and
     play the first sentence.
+- Decision: Ignore a near-zero checkpoint for the same logical audio key when
+  a valid later position is already stored.
+  - Why: Player teardown resets its media time before the unmount checkpoint is
+    delivered. A same-key zero is lifecycle noise, while a different-key zero
+    still means regenerated playback replaced the previously stored audio.
 
 ## Context and Orientation
 

--- a/docs/exec-plans/active/learner-listen-playback-stability.md
+++ b/docs/exec-plans/active/learner-listen-playback-stability.md
@@ -25,6 +25,9 @@ refer to the stream that was actually playing, never the first stream.
 - [x] Reproduced and fixed a production mode-round-trip race where historical
   text returned before its audio backfill and the application discarded the
   still-valid checkpoint.
+- [x] Limited restore waiting to audio items whose backfill remains eligible;
+  terminal failures and ineligible items now release the player and clear the
+  unusable checkpoint.
 - [ ] Run verification and publish the production race fix.
 
 ## Decision Log
@@ -56,6 +59,10 @@ refer to the stream that was actually playing, never the first stream.
   - Why: Player teardown resets its media time before the unmount checkpoint is
     delivered. A same-key zero is lifecycle noise, while a different-key zero
     still means regenerated playback replaced the previously stored audio.
+- Decision: Derive restore waiting from the application backfill lifecycle,
+  including its terminal failure set, instead of from element presence alone.
+  - Why: Persisted text can legitimately wait for narration, but failed or
+    ineligible narration must not leave the player permanently disabled.
 
 ## Context and Orientation
 

--- a/docs/exec-plans/active/learner-listen-playback-stability.md
+++ b/docs/exec-plans/active/learner-listen-playback-stability.md
@@ -20,9 +20,12 @@ refer to the stream that was actually playing, never the first stream.
   first audio item while a restore request is pending.
 - [x] Locally verified the supplied multi-stream lesson, including refresh and
   mode round trips, with the learner test environment.
-- [ ] Run repository verification, commit, push, and open the replacement PRs.
-- [ ] Publish an approved release of `markdown-flow-ui`, then update the
-  application dependency pin before either branch merges into `main`.
+- [x] Published `markdown-flow-ui` 0.2.25, updated the application release pin,
+  and merged the library and application changes.
+- [x] Reproduced and fixed a production mode-round-trip race where historical
+  text returned before its audio backfill and the application discarded the
+  still-valid checkpoint.
+- [ ] Run verification and publish the production race fix.
 
 ## Decision Log
 
@@ -42,6 +45,12 @@ refer to the stream that was actually playing, never the first stream.
   - Why: Timeline UI, arbitrary seek, subtitle positioning, interaction-card
     positioning, and playback-source ordering were unrelated experimental
     changes and remain excluded.
+- Decision: Treat a restored element without playable audio as pending audio
+  backfill, not as a stale checkpoint.
+  - Why: Returning from reading mode can restore persisted text before its
+    narration is reattached. The element identity remains valid during that
+    interval, and allowing normal startup would both erase the checkpoint and
+    play the first sentence.
 
 ## Context and Orientation
 

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -392,6 +392,86 @@ describe('ListenModeSlideRenderer', () => {
     ).toBeNull();
   });
 
+  it('keeps a checkpoint while its restored history audio is being backfilled', async () => {
+    writeListenPlaybackCheckpoint(
+      { courseId: 'course-1', lessonId: 'lesson-1' },
+      { audioKey: 'later-stream', timeMs: 12_000 },
+    );
+
+    const { rerender } = render(
+      <ListenModeSlideRenderer
+        items={[
+          {
+            type: 'content',
+            content: 'Later stream',
+            element_bid: 'later-stream',
+            is_speakable: true,
+          },
+        ]}
+        mobileStyle={false}
+        chatRef={createChatRef()}
+        isLoading={false}
+        shifuBid='course-1'
+        lessonId='lesson-1'
+        variant='listen'
+      />,
+    );
+
+    await waitFor(() => {
+      const slideProps = getMockSlide().mock.calls.at(-1)?.[0] as
+        | {
+            playbackRestoreRequest?: { audioKey: string } | null;
+            playerEnabled?: boolean;
+          }
+        | undefined;
+      expect(slideProps?.playbackRestoreRequest?.audioKey).toBe('later-stream');
+      expect(slideProps?.playerEnabled).toBe(false);
+    });
+    expect(
+      readListenPlaybackCheckpoint({
+        courseId: 'course-1',
+        lessonId: 'lesson-1',
+      }),
+    ).toEqual({ audioKey: 'later-stream', timeMs: 12_000 });
+
+    rerender(
+      <ListenModeSlideRenderer
+        items={[
+          {
+            type: 'content',
+            content: 'Later stream',
+            element_bid: 'later-stream',
+            is_speakable: true,
+            audioTracks: [
+              {
+                position: 0,
+                audioUrl: '/audio/later-stream.mp3',
+                isAudioStreaming: false,
+              },
+            ],
+          },
+        ]}
+        mobileStyle={false}
+        chatRef={createChatRef()}
+        isLoading={false}
+        shifuBid='course-1'
+        lessonId='lesson-1'
+        variant='listen'
+      />,
+    );
+
+    await waitFor(() => {
+      const slideProps = getMockSlide().mock.calls.at(-1)?.[0] as
+        | {
+            playbackRestoreRequest?: { audioKey: string } | null;
+            playerEnabled?: boolean;
+          }
+        | undefined;
+      expect(slideProps?.playbackRestoreRequest?.audioKey).toBe('later-stream');
+      expect(slideProps?.playerEnabled).toBe(true);
+    });
+  });
+
   it('clears the saved checkpoint when its logical audio item completes', () => {
     writeListenPlaybackCheckpoint(
       { courseId: 'course-1', lessonId: 'lesson-1' },

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx
@@ -414,6 +414,7 @@ describe('ListenModeSlideRenderer', () => {
         shifuBid='course-1'
         lessonId='lesson-1'
         variant='listen'
+        pendingAudioBackfillElementBids={new Set(['later-stream'])}
       />,
     );
 
@@ -457,6 +458,7 @@ describe('ListenModeSlideRenderer', () => {
         shifuBid='course-1'
         lessonId='lesson-1'
         variant='listen'
+        pendingAudioBackfillElementBids={new Set(['later-stream'])}
       />,
     );
 
@@ -470,6 +472,50 @@ describe('ListenModeSlideRenderer', () => {
       expect(slideProps?.playbackRestoreRequest?.audioKey).toBe('later-stream');
       expect(slideProps?.playerEnabled).toBe(true);
     });
+  });
+
+  it('clears a checkpoint when its matching element cannot be backfilled', async () => {
+    writeListenPlaybackCheckpoint(
+      { courseId: 'course-1', lessonId: 'lesson-1' },
+      { audioKey: 'failed-stream', timeMs: 12_000 },
+    );
+
+    render(
+      <ListenModeSlideRenderer
+        items={[
+          {
+            type: 'content',
+            content: 'Failed stream',
+            element_bid: 'failed-stream',
+            is_speakable: true,
+          },
+        ]}
+        mobileStyle={false}
+        chatRef={createChatRef()}
+        isLoading={false}
+        shifuBid='course-1'
+        lessonId='lesson-1'
+        variant='listen'
+        pendingAudioBackfillElementBids={new Set()}
+      />,
+    );
+
+    await waitFor(() => {
+      const slideProps = getMockSlide().mock.calls.at(-1)?.[0] as
+        | {
+            playbackRestoreRequest?: { audioKey: string } | null;
+            playerEnabled?: boolean;
+          }
+        | undefined;
+      expect(slideProps?.playbackRestoreRequest).toBeNull();
+      expect(slideProps?.playerEnabled).toBe(true);
+    });
+    expect(
+      readListenPlaybackCheckpoint({
+        courseId: 'course-1',
+        lessonId: 'lesson-1',
+      }),
+    ).toBeNull();
   });
 
   it('clears the saved checkpoint when its logical audio item completes', () => {

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -37,6 +37,7 @@ import {
 } from 'markdown-flow-ui/slide';
 import { ChatContentItemType, type ChatContentItem } from './useChatLogicHook';
 import {
+  hasPlayableListenAudioForItem,
   resolveListenSlideAudioSource,
   resolveListenSlideElementType,
   resolveListenSlideSubtitleCues,
@@ -172,6 +173,8 @@ const shouldIgnoreClassroomPageShortcutEvent = (event: KeyboardEvent) => {
 };
 
 type ListenSlidePresentationVariant = 'listen' | 'classroom';
+const EMPTY_PENDING_AUDIO_BACKFILL_ELEMENT_BIDS: ReadonlySet<string> =
+  new Set();
 
 interface ListenModeSlideRendererProps {
   items: ChatContentItem[];
@@ -196,6 +199,7 @@ interface ListenModeSlideRendererProps {
   onMobileViewModeChange?: (viewMode: MobileViewMode) => void;
   pausePlaybackWhen?: boolean;
   disableInteractionEdits?: boolean;
+  pendingAudioBackfillElementBids?: ReadonlySet<string>;
 }
 
 interface ListenSlidePresentationProfile {
@@ -746,6 +750,7 @@ const ListenModeSlideRenderer = ({
   onMobileViewModeChange,
   pausePlaybackWhen = false,
   disableInteractionEdits = false,
+  pendingAudioBackfillElementBids = EMPTY_PENDING_AUDIO_BACKFILL_ELEMENT_BIDS,
 }: ListenModeSlideRendererProps) => {
   const { t, i18n } = useTranslation();
   const { trackEvent } = useTracking();
@@ -1055,22 +1060,21 @@ const ListenModeSlideRenderer = ({
   const playbackRestoreScopeKey = `${shifuBid}:${lessonId}`;
   const playbackRestoreTargetState = useMemo(() => {
     if (!playbackRestoreRequest) {
-      return { exists: false, isPlayable: false };
+      return { exists: false, isPlayable: false, isPendingBackfill: false };
     }
 
-    const matchingElements = elementList.filter(
-      element => element.blockBid === playbackRestoreRequest.audioKey,
+    const matchingItems = items.filter(
+      item => item.element_bid === playbackRestoreRequest.audioKey,
     );
 
     return {
-      exists: matchingElements.length > 0,
-      isPlayable: matchingElements.some(
-        element =>
-          element.is_speakable &&
-          Boolean(element.audio_url || element.audio_segments?.length),
+      exists: matchingItems.length > 0,
+      isPlayable: matchingItems.some(hasPlayableListenAudioForItem),
+      isPendingBackfill: pendingAudioBackfillElementBids.has(
+        playbackRestoreRequest.audioKey,
       ),
     };
-  }, [elementList, playbackRestoreRequest]);
+  }, [items, pendingAudioBackfillElementBids, playbackRestoreRequest]);
   const isPlaybackRestoreReady =
     variant !== 'listen' ||
     (Boolean(shifuBid && lessonId) &&
@@ -1091,7 +1095,14 @@ const ListenModeSlideRenderer = ({
     // Returning from reading mode can restore the historical element before
     // its audio backfill completes. The checkpoint is still valid in that
     // state, so keep both the request and the startup gate until audio arrives.
-    if (playbackRestoreTargetState.exists) {
+    if (playbackRestoreTargetState.isPlayable) {
+      return;
+    }
+
+    if (
+      playbackRestoreTargetState.exists &&
+      playbackRestoreTargetState.isPendingBackfill
+    ) {
       return;
     }
 
@@ -1104,6 +1115,8 @@ const ListenModeSlideRenderer = ({
     lessonId,
     playbackRestoreRequest,
     playbackRestoreTargetState.exists,
+    playbackRestoreTargetState.isPlayable,
+    playbackRestoreTargetState.isPendingBackfill,
     shifuBid,
     variant,
   ]);

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.tsx
@@ -1053,10 +1053,29 @@ const ListenModeSlideRenderer = ({
   }, [lessonId, previewMode, shifuBid, trackEvent, variant]);
 
   const playbackRestoreScopeKey = `${shifuBid}:${lessonId}`;
+  const playbackRestoreTargetState = useMemo(() => {
+    if (!playbackRestoreRequest) {
+      return { exists: false, isPlayable: false };
+    }
+
+    const matchingElements = elementList.filter(
+      element => element.blockBid === playbackRestoreRequest.audioKey,
+    );
+
+    return {
+      exists: matchingElements.length > 0,
+      isPlayable: matchingElements.some(
+        element =>
+          element.is_speakable &&
+          Boolean(element.audio_url || element.audio_segments?.length),
+      ),
+    };
+  }, [elementList, playbackRestoreRequest]);
   const isPlaybackRestoreReady =
     variant !== 'listen' ||
     (Boolean(shifuBid && lessonId) &&
-      resolvedPlaybackRestoreScope === playbackRestoreScopeKey);
+      resolvedPlaybackRestoreScope === playbackRestoreScopeKey &&
+      (!playbackRestoreRequest || playbackRestoreTargetState.isPlayable));
 
   useEffect(() => {
     if (
@@ -1069,13 +1088,10 @@ const ListenModeSlideRenderer = ({
       return;
     }
 
-    const hasMatchingAudio = elementList.some(
-      element =>
-        element.blockBid === playbackRestoreRequest.audioKey &&
-        element.is_speakable &&
-        Boolean(element.audio_url || element.audio_segments?.length),
-    );
-    if (hasMatchingAudio) {
+    // Returning from reading mode can restore the historical element before
+    // its audio backfill completes. The checkpoint is still valid in that
+    // state, so keep both the request and the startup gate until audio arrives.
+    if (playbackRestoreTargetState.exists) {
       return;
     }
 
@@ -1084,10 +1100,10 @@ const ListenModeSlideRenderer = ({
       currentRequest?.id === playbackRestoreRequest.id ? null : currentRequest,
     );
   }, [
-    elementList,
     isLoading,
     lessonId,
     playbackRestoreRequest,
+    playbackRestoreTargetState.exists,
     shifuBid,
     variant,
   ]);

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/NewChatComp.tsx
@@ -64,6 +64,7 @@ import type { ListenMobileViewModeChangeHandler } from './listenModeTypes';
 import { isListenModeActive as getIsListenModeActive } from '../learningModeOptions';
 import {
   getMissingListenModeAudioBlockBids,
+  getPendingListenModeAudioBackfillElementBids,
   hasPlayableListenAudioForItem,
   isListenModeAudioBackfillReady,
   isListenModeAudioBackfillCandidate,
@@ -238,6 +239,10 @@ export const NewChatComponents = ({
     {},
   );
   const listenAudioBackfillFailedBlockBidsRef = useRef<Set<string>>(new Set());
+  const [
+    listenAudioBackfillFailedBlockBids,
+    setListenAudioBackfillFailedBlockBids,
+  ] = useState<ReadonlySet<string>>(new Set());
   const listenAudioBackfillLessonIdRef = useRef('');
 
   const isScrollableElementForFeedback = useCallback(
@@ -326,11 +331,13 @@ export const NewChatComponents = ({
     listenAudioBackfillLessonIdRef.current = resolvedLessonId;
     listenAudioBackfillInFlightRef.current = {};
     listenAudioBackfillFailedBlockBidsRef.current = new Set();
+    setListenAudioBackfillFailedBlockBids(new Set());
   }, [resolvedLessonId]);
 
   useEffect(() => {
     if (!previousListenModeActiveRef.current && isListenModeActive) {
       listenAudioBackfillFailedBlockBidsRef.current = new Set();
+      setListenAudioBackfillFailedBlockBids(new Set());
     }
     previousListenModeActiveRef.current = isListenModeActive;
     isListenModeActiveRef.current = isListenModeActive;
@@ -481,7 +488,11 @@ export const NewChatComponents = ({
         onStreamSettled: clearTrackedRequest,
       }).then(result => {
         if (result) {
-          listenAudioBackfillFailedBlockBidsRef.current.delete(blockBid);
+          if (listenAudioBackfillFailedBlockBidsRef.current.delete(blockBid)) {
+            setListenAudioBackfillFailedBlockBids(
+              new Set(listenAudioBackfillFailedBlockBidsRef.current),
+            );
+          }
           const askEntry = Object.entries(
             useAskStateStore.getState().askListByAnchorElementBid,
           ).find(([, askList]) =>
@@ -903,6 +914,11 @@ export const NewChatComponents = ({
       failedBlockBids.forEach(blockBid => {
         listenAudioBackfillFailedBlockBidsRef.current.add(blockBid);
       });
+      if (failedBlockBids.length > 0) {
+        setListenAudioBackfillFailedBlockBids(
+          new Set(listenAudioBackfillFailedBlockBidsRef.current),
+        );
+      }
       const hasBackfillFailure = failedBlockBids.length > 0;
       const hasBackfillInFlight =
         Object.keys(listenAudioBackfillInFlightRef.current).length > 0;
@@ -950,6 +966,17 @@ export const NewChatComponents = ({
     t,
     updateLearningMode,
   ]);
+
+  const isEnteringListenMode =
+    isListenModeActive && !previousListenModeActiveRef.current;
+  const pendingListenAudioBackfillElementBids = useMemo(
+    () =>
+      getPendingListenModeAudioBackfillElementBids(
+        slideModeItems,
+        isEnteringListenMode ? new Set() : listenAudioBackfillFailedBlockBids,
+      ),
+    [isEnteringListenMode, listenAudioBackfillFailedBlockBids, slideModeItems],
+  );
 
   useEffect(() => {
     setIsListenFeedbackReady(false);
@@ -1346,6 +1373,9 @@ export const NewChatComponents = ({
               onLessonFeedbackPromptStateChange={setIsListenFeedbackReady}
               pausePlaybackWhen={reGenerateConfirm.open}
               disableInteractionEdits={isOutputInProgress}
+              pendingAudioBackfillElementBids={
+                pendingListenAudioBackfillElementBids
+              }
             />
           </>
         ) : (

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts
@@ -2,6 +2,7 @@ import {
   buildSlidePageMapping,
   canRequestListenModeTtsForItem,
   getMissingListenModeAudioBlockBids,
+  getPendingListenModeAudioBackfillElementBids,
   hasPlayableListenAudioForItem,
   isListenModeAudioBackfillCandidate,
   isListenModeAudioBackfillReady,
@@ -131,6 +132,44 @@ describe('listenModeUtils', () => {
     ]);
 
     expect(missingBids).toEqual(['generated-block-1', 'generated-block-2']);
+  });
+
+  it('tracks pending backfill by element bid until its request fails', () => {
+    const items = [
+      createContentItem({
+        element_bid: 'text-position-0',
+        generated_block_bid: 'generated-block-1',
+        is_speakable: true,
+      }),
+    ];
+
+    expect(getPendingListenModeAudioBackfillElementBids(items)).toEqual(
+      new Set(['text-position-0']),
+    );
+    expect(
+      getPendingListenModeAudioBackfillElementBids(
+        items,
+        new Set(['generated-block-1']),
+      ),
+    ).toEqual(new Set());
+  });
+
+  it('does not keep ineligible or playable elements pending backfill', () => {
+    const items = [
+      createContentItem({
+        element_bid: 'visual-only',
+        is_speakable: false,
+      }),
+      createContentItem({
+        element_bid: 'already-playable',
+        is_speakable: true,
+        audioUrl: 'https://example.com/audio.mp3',
+      }),
+    ];
+
+    expect(getPendingListenModeAudioBackfillElementBids(items)).toEqual(
+      new Set(),
+    );
   });
 
   it('does not re-request a generated block when a sibling already has audio', () => {

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.ts
@@ -402,6 +402,31 @@ export const getMissingListenModeAudioBlockBids = (
   return missingBids;
 };
 
+export const getPendingListenModeAudioBackfillElementBids = (
+  items: ChatContentItem[],
+  failedRequestBids: ReadonlySet<string> = new Set(),
+) => {
+  const pendingRequestBids = new Set(
+    getMissingListenModeAudioBlockBids(items).filter(
+      requestBid => !failedRequestBids.has(requestBid),
+    ),
+  );
+
+  return new Set(
+    items.flatMap(item => {
+      if (!isListenModeAudioBackfillCandidate(item)) {
+        return [];
+      }
+
+      const requestBid = resolveListenModeAudioBackfillRequestBid(item);
+      const elementBid = item.element_bid?.trim();
+      return requestBid && elementBid && pendingRequestBids.has(requestBid)
+        ? [elementBid]
+        : [];
+    }),
+  );
+};
+
 export const resolveListenModeTtsReadyElementBids = (
   items: ChatContentItem[],
 ) => {

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/listenPlaybackCheckpoint.test.ts
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/listenPlaybackCheckpoint.test.ts
@@ -23,7 +23,7 @@ describe('listen playback checkpoints', () => {
     });
   });
 
-  it('does not retain completed or near-zero checkpoints', () => {
+  it('discards an older audio checkpoint when a replacement starts near zero', () => {
     writeListenPlaybackCheckpoint(scope, {
       audioKey: 'previous-stream-element',
       timeMs: 4_000,
@@ -34,11 +34,30 @@ describe('listen playback checkpoints', () => {
     });
 
     expect(readListenPlaybackCheckpoint(scope)).toBeNull();
+  });
 
+  it('keeps the saved position when teardown reports the same audio near zero', () => {
     writeListenPlaybackCheckpoint(scope, {
       audioKey: 'first-stream-element',
       timeMs: 4_000,
     });
+    writeListenPlaybackCheckpoint(scope, {
+      audioKey: 'first-stream-element',
+      timeMs: 0,
+    });
+
+    expect(readListenPlaybackCheckpoint(scope)).toEqual({
+      audioKey: 'first-stream-element',
+      timeMs: 4_000,
+    });
+  });
+
+  it('clears a checkpoint explicitly after its logical audio completes', () => {
+    writeListenPlaybackCheckpoint(scope, {
+      audioKey: 'first-stream-element',
+      timeMs: 4_000,
+    });
+
     clearListenPlaybackCheckpoint(scope);
 
     expect(readListenPlaybackCheckpoint(scope)).toBeNull();

--- a/src/web/src/app/c/[[...id]]/Components/ChatUi/listenPlaybackCheckpoint.ts
+++ b/src/web/src/app/c/[[...id]]/Components/ChatUi/listenPlaybackCheckpoint.ts
@@ -57,6 +57,11 @@ export const writeListenPlaybackCheckpoint = (
   }
 
   if (checkpoint.timeMs < MINIMUM_POSITION_MS) {
+    const existingCheckpoint = readListenPlaybackCheckpoint(scope);
+    if (existingCheckpoint?.audioKey === checkpoint.audioKey) {
+      return;
+    }
+
     clearListenPlaybackCheckpoint(scope);
     return;
   }


### PR DESCRIPTION
## Summary
- preserve valid listen checkpoints while historical narration is being backfilled
- keep player startup gated until the restore target becomes playable
- release the gate and clear unusable checkpoints when narration backfill fails or the item is ineligible
- ignore same-audio near-zero teardown checkpoints without weakening replacement-audio cleanup
- document the production mode-switch races and terminal-backfill behavior in the playback stability ExecPlan

## Verification
- `npm test -- --runInBand --runTestsByPath ./src/app/c/[[...id]]/Components/ChatUi/listenModeUtils.test.ts ./src/app/c/[[...id]]/Components/ChatUi/ListenModeSlideRenderer.test.tsx ./src/app/c/[[...id]]/Components/ChatUi/listenPlaybackCheckpoint.test.ts` (80/80 passed)
- local browser regression on the reported course: saved at 4.1s, checkpoint retained in reading mode, resumed at the saved position after returning to listen mode
- `npm run type-check`
- targeted ESLint checks with no warnings or errors
- `python scripts/check_repo_harness.py`
- `python scripts/check_architecture_boundaries.py`
- strict pre-PR self-review and commit-time architecture, translation, formatting, and repository checks