### PR TITLE
fix: allow Live conversations with Redis eviction policies

### DIFF
--- a/INSTALL_MANUAL.md
+++ b/INSTALL_MANUAL.md
@@ -110,7 +110,11 @@ Live readiness is separate from ordinary HTTP health. On startup, every
 enabled API worker schedules a single background task to resolve the effective
 (environment or DB-backed) flag and
 initializes the shared Redis recovery guard without minting
-a credential. Redis must use `noeviction`. A missing accounting marker or a
+a credential. Redis eviction policies are not an admission prerequisite.
+`noeviction` is recommended for retaining credential-risk records: with an
+evicting policy, records may disappear before Google credentials expire,
+undercounting outstanding credentials or interrupting ownership. Capacity
+guarantees depend on record retention. A missing accounting marker or a
 changed Redis run ID starts the full shared 15-minute safety window; repeated
 worker starts and probes do not reset or shorten it. Do not delete accounting
 records to bypass this window.

--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -727,7 +727,7 @@ GEMINI_API_KEY=""
 # (Optional - default: )
 GEMINI_API_URL=""
 
-# Expose the allowlisted Gemini Live model for voice follow-up sessions. Keep disabled until the WebSocket infrastructure is ready.
+# Expose the allowlisted Gemini Live model for voice follow-up sessions. Keep disabled until compatible workers and the Redis recovery gate are ready. Redis eviction can invalidate credential capacity accounting even when credential rotation is disabled.
 # (Optional - default: False)
 # Type: bool
 GEMINI_LIVE_ENABLED="False"

--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -732,7 +732,7 @@ GEMINI_API_URL=""
 # Type: bool
 GEMINI_LIVE_ENABLED="False"
 
-# Allow bounded Gemini Live credential rotation. Requires compatible workers, non-evicting Redis and the credential-drain recovery gate.
+# Allow bounded Gemini Live credential rotation. Requires compatible workers, Redis and the credential-drain recovery gate. Eviction can invalidate credential capacity accounting.
 # (Optional - default: False)
 # Type: bool
 GEMINI_LIVE_ROTATION_ENABLED="False"

--- a/docs/exec-plans/active/gemini-live-voice-follow-up.md
+++ b/docs/exec-plans/active/gemini-live-voice-follow-up.md
@@ -227,7 +227,8 @@ ten seconds from the start of the last successful check, not its response.
 
 - [x] 2026-09-06: Initialize the shared recovery guard at API startup, expose
   non-minting readiness for deployment/UI, and gate new Live input until ready.
-  Preserve Redis generation/noeviction checks and the full recovery window.
+  Preserve Redis generation checks and the full recovery window. The original
+  noeviction check was removed by the 2026-09-07 compatibility decision above.
   Remove idle input instructions and the repeated inline privacy notice;
   keep privacy policies, active status and actionable errors. Validate startup,
   multi-worker idempotence, recovery, input/analytics gating and five locales.
@@ -1543,12 +1544,13 @@ already-issued Google credentials do not depend on this new admission gate.
 A surviving marker is not sufficient after restoring an older snapshot. Verify
 the shared Redis instance/recovery generation on admission; restart, failover,
 or restore invalidates it and triggers the same conservative window even when
-the marker survives. Risk/owner/operation keys must not be individually evicted:
-verify non-evicting storage on admission. The new binary always applies this
-generation/noeviction gate, even while rotation is off; otherwise accounting
-loss could hide still-valid V2 credentials during rollback. First bootstrap or
+the marker survives. Retaining risk/owner/operation keys is necessary for
+accurate accounting, but eviction policy is no longer checked on admission.
+The binary always applies the generation gate, even while rotation is off.
+Eviction of individual records can hide still-valid V2 credentials and is an
+accepted limitation of using an evicting Redis policy. First bootstrap or
 a missing/changed Redis run ID starts a shared 15-minute quarantine. Redis
-generation and eviction policy are checked inside the admission Lua operation.
+generation is checked inside the admission Lua operation.
 A same-process privileged DEBUG RELOAD/RESTORE or selective administrative key
 deletion cannot be detected reliably from run ID; prohibit those operations
 while admission is enabled. Operators must disable admission and establish a
@@ -1556,9 +1558,11 @@ fresh recovery epoch/quarantine before such restoration. This implementation
 does not claim arbitrary privileged partial-restore detection. If these
 properties cannot be established, keep Live admission disabled and report the
 operational gate; do not silently change Redis deployment settings here.
-Non-eviction must hold continuously while credentials are valid, not just at
-the instant of a check; a temporary privileged policy change also requires
-disabled admission and a complete drain/recovery window before reopening.
+Non-evicting storage remains recommended, not a prerequisite. When record
+retention cannot be assured, the configured credential limits are not a hard
+bound on outstanding Google credentials. Known accounting loss requires
+disabled admission and a complete drain/recovery window before reopening;
+do not delete risk records or shorten credential lifetimes to regain capacity.
 
 Implementation uses `live_follow_up_admission.py` alongside the existing
 `live_follow_up_capacity.py`,

--- a/docs/exec-plans/active/gemini-live-voice-follow-up.md
+++ b/docs/exec-plans/active/gemini-live-voice-follow-up.md
@@ -1,5 +1,24 @@
 # Gemini Live Voice Follow-Up
 
+## 2026-09-07: Accepted eviction-policy compatibility tradeoff
+
+At the user's explicit request, admission no longer requires Redis
+`maxmemory-policy=noeviction`. Readiness and credential issuance accept
+`volatile-lru` and other policies. This supersedes the non-eviction deployment
+gate described in the historical implementation notes below. Redis generation
+validation, the 15-minute recovery quarantine, ownership checks, capacity
+limits, issuance limits and Redis-error fail-closed behavior remain unchanged.
+
+This does not make an evicting Redis a durable credential ledger. Eviction can
+remove ownership or risk records before Google credentials expire, causing
+disconnects or undercounted outstanding credentials. Capacity guarantees now
+depend on record retention; this is an explicitly accepted operational risk,
+not a claim of equivalent safety. No production Redis settings, existing
+records, token lifetimes or billing behavior are changed by this patch.
+
+Regression coverage exercises readiness and issuance with noeviction,
+volatile-lru and allkeys-lru, while retaining restart recovery coverage.
+
 ## Purpose / Big Picture
 
 Courses whose effective follow-up model is

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -617,7 +617,8 @@ Default: "phone".""",
         type=bool,
         description=(
             "Allow bounded Gemini Live credential rotation. Requires compatible "
-            "workers, non-evicting Redis and the credential-drain recovery gate."
+            "workers, Redis and the credential-drain recovery gate. Eviction "
+            "can invalidate credential capacity accounting."
         ),
         group="llm",
         required=False,

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -606,7 +606,9 @@ Default: "phone".""",
         type=bool,
         description=(
             "Expose the allowlisted Gemini Live model for voice follow-up sessions. "
-            "Keep disabled until the WebSocket infrastructure is ready."
+            "Keep disabled until compatible workers and the Redis recovery gate "
+            "are ready. Redis eviction can invalidate credential capacity "
+            "accounting even when credential rotation is disabled."
         ),
         group="llm",
         required=False,

--- a/src/api/flaskr/service/learn/live_follow_up_admission.py
+++ b/src/api/flaskr/service/learn/live_follow_up_admission.py
@@ -2,8 +2,9 @@
 
 Redis is the admission authority, not a media proxy. Logical ownership may move,
 but every disclosed or uncertain credential continues consuming risk capacity.
-The guarded Redis instance must use noeviction. Privileged same-process RESTORE
-is an operationally prohibited action unless admission is disabled and drained.
+Eviction policies are accepted, but eviction can erase risk/ownership records
+before credentials expire; capacity guarantees require retained records.
+Privileged same-process RESTORE remains prohibited unless admission is drained.
 """
 
 from __future__ import annotations
@@ -43,10 +44,8 @@ _ERROR_UNAVAILABLE = "admission_unavailable"
 # preflight outside Lua would leave a restart/restore race before admission.
 _RECOVERY_GUARD = r"""
 local server = redis.call('INFO', 'server')
-local memory = redis.call('INFO', 'memory')
 local generation = string.match(server, 'run_id:([^\r\n]+)')
-local policy = string.match(memory, 'maxmemory_policy:([^\r\n]+)')
-if not generation or policy ~= 'noeviction' then return rejected('admission_unavailable') end
+if not generation then return rejected('admission_unavailable') end
 local marker = read(accounting_key)
 if not marker or marker.generation ~= generation then
     marker = {generation=generation, safe_after_ms=now + 900000}

--- a/src/api/tests/service/learn/test_live_follow_up_admission.py
+++ b/src/api/tests/service/learn/test_live_follow_up_admission.py
@@ -1333,7 +1333,8 @@ def test_evicting_redis_policy_still_records_credential_capacity(
     request = _request(client)
     result = _begin(ready_app, request)
     assert result.lease is not None
-    assert client.exists(*_keys(ready_app, request)[:7]) > 0
+    expected_keys = _keys(ready_app, request)[:7]
+    assert client.exists(*expected_keys) == len(expected_keys)
     duplicate = _begin(ready_app, request)
     assert duplicate.lease is None
     assert duplicate.data["session_bid"] == result.data["session_bid"]

--- a/src/api/tests/service/learn/test_live_follow_up_admission.py
+++ b/src/api/tests/service/learn/test_live_follow_up_admission.py
@@ -173,21 +173,22 @@ def test_startup_readiness_initializes_once_without_reserving_credentials(
     assert _begin(admission_app, _request(client)).lease is not None
 
 
-def test_readiness_fails_closed_on_unsafe_policy_or_restart(
+@pytest.mark.parametrize("policy", ["noeviction", "volatile-lru", "allkeys-lru"])
+def test_readiness_accepts_eviction_policy_but_preserves_restart_guard(
     admission_app: Flask,
     real_redis: RedisHarness,
+    policy: str,
 ) -> None:
     admission_app.config["GEMINI_LIVE_ENABLED"] = True
     client = real_redis.client
-    client.config_set("maxmemory-policy", "allkeys-lru")
-    assert admission.live_follow_up_readiness(admission_app)["status"] == "unavailable"
-    assert client.dbsize() == 0
-    client.config_set("maxmemory-policy", "noeviction")
+    client.config_set("maxmemory-policy", policy)
     assert admission.live_follow_up_readiness(admission_app)["status"] == "warming"
     key = client.keys("*")[0]
     marker = json.loads(client.get(key))
     marker["safe_after_ms"] = 0
     client.set(key, json.dumps(marker))
+    assert admission.live_follow_up_readiness(admission_app)["status"] == "ready"
+    assert _begin(admission_app, _request(client)).lease is not None
     real_redis.stop()
     real_redis.start()
     client.set(key, json.dumps(marker))
@@ -1321,17 +1322,21 @@ def test_surviving_old_marker_after_redis_restart_triggers_generation_quarantine
     assert restored["safe_after_ms"] > _now_ms(client) + 899_000
 
 
-def test_evicting_redis_policy_is_rejected_without_mutating_capacity(
+@pytest.mark.parametrize("policy", ["volatile-lru", "allkeys-lru"])
+def test_evicting_redis_policy_still_records_credential_capacity(
     ready_app: Flask,
     real_redis: RedisHarness,
+    policy: str,
 ) -> None:
     client = real_redis.client
-    client.config_set("maxmemory-policy", "allkeys-lru")
+    client.config_set("maxmemory-policy", policy)
     request = _request(client)
     result = _begin(ready_app, request)
-    assert result.lease is None
-    assert result.data["error_code"] == "admission_unavailable"
-    assert client.exists(*_keys(ready_app, request)[:7]) == 0
+    assert result.lease is not None
+    assert client.exists(*_keys(ready_app, request)[:7]) > 0
+    duplicate = _begin(ready_app, request)
+    assert duplicate.lease is None
+    assert duplicate.data["session_bid"] == result.data["session_bid"]
 
 
 def test_redis_unavailability_fails_closed_before_issuance(


### PR DESCRIPTION
## Summary

Remove only the Redis maxmemory-policy=noeviction admission requirement so Gemini Live can start on existing Redis deployments such as US volatile-lru.

- Preserve Redis generation validation, 15-minute recovery quarantine, Redis-error fail-closed behavior, ownership checks, issuance limits and credential-capacity accounting.
- Update real-Redis readiness/issuance tests, configuration descriptions, installation manual and the existing ExecPlan.
- No UI, database migration, Redis configuration change, deployment or unrelated cleanup.

## Accepted risk

This deliberately relaxes the former storage-safety prerequisite at the explicit request of the product owner. It does not make eviction safe: an evicted risk record can undercount still-valid Google credentials, and an evicted ownership record can interrupt a conversation. Capacity guarantees depend on record retention. No replacement durability mechanism is introduced.

## Verification

- Focused admission and capacity suite: 90 passed, including isolated real Redis 7.4.7 tests.
- Policies covered: noeviction, volatile-lru and allkeys-lru; restart recovery and issuance idempotency retained.
- Full lefthook pre-commit --all-files passed, including Ruff, architecture, repo harness and i18n checks.
- Commit hooks passed.
- Not deployed; real Gemini end-to-end verification is not included in this patch.

## Review focus

Please review the narrow gate removal, retained recovery/capacity checks and explicit operational tradeoff. This PR does not claim equivalent credential accounting safety under eviction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes a safety gate on credential-capacity accounting in Redis; evicting policies can break capacity limits or live sessions without changing auth or billing code paths.
> 
> **Overview**
> **Removes the Redis `maxmemory-policy=noeviction` prerequisite** for Gemini Live readiness and credential issuance so deployments on evicting policies (e.g. `volatile-lru`, `allkeys-lru`) can admit Live without changing Redis config.
> 
> The admission Lua `_RECOVERY_GUARD` no longer reads `INFO memory` or rejects non-`noeviction` policies; **Redis `run_id` generation checks, the 15-minute recovery quarantine, capacity accounting, and fail-closed Redis errors are unchanged.** Module docstrings, `GEMINI_LIVE_*` env descriptions, `INSTALL_MANUAL.md`, and the exec plan now document that eviction is an accepted operational tradeoff: evicted risk/ownership keys can undercount outstanding Google credentials or interrupt sessions, so **`noeviction` is recommended but not required.**
> 
> Tests are updated from rejecting evicting policies to parametrized coverage (`noeviction`, `volatile-lru`, `allkeys-lru`) for readiness, restart guard behavior, and successful issuance with capacity keys recorded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e83127b6a29d6dd79c422ee9f0c4bac5d24de548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Gemini Live credential rotation now supports Redis configurations with eviction policies, including `volatile-lru` and `allkeys-lru`.
  * Readiness checks and credential issuance continue to enforce restart recovery, capacity limits, and fail-closed behavior for Redis errors.
  * Redis eviction may remove credential ownership records before credentials expire, affecting capacity accounting and ownership tracking.

* **Documentation**
  * Updated configuration and operational guidance to describe supported Redis policies and their limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->