### PR TITLE
fix: stop forcing Live replies into the interface language

### DIFF
--- a/docs/exec-plans/active/gemini-live-voice-follow-up.md
+++ b/docs/exec-plans/active/gemini-live-voice-follow-up.md
@@ -1,5 +1,16 @@
 # Gemini Live Voice Follow-Up
 
+## 2026-09-07: Do not force Live output into the interface language
+
+Live no longer reads the course's learner-language output switch or appends
+the shared builder's mandatory response-language instruction. Request language
+remains session metadata, but is not injected into learner profile variables
+by this path. Teacher-authored follow-up prompts and saved history are preserved;
+no new language-selection prompt is added. Ordinary text follow-ups and lesson
+output retain their existing learner-language behavior. Regression tests cover
+Chinese, English and French request locales across read/listen and preview/live
+surfaces, alongside the shared text-context language contract.
+
 ## 2026-09-07: Accepted eviction-policy compatibility tradeoff
 
 At the user's explicit request, admission no longer requires Redis

--- a/src/api/flaskr/service/learn/live_follow_up_routes.py
+++ b/src/api/flaskr/service/learn/live_follow_up_routes.py
@@ -107,7 +107,6 @@ from flaskr.service.learn.preview_permissions import require_shifu_preview_permi
 from flaskr.service.learn.utils_v2 import get_follow_up_info_v2
 from flaskr.service.shifu.api import get_effective_ask_provider_config
 from flaskr.service.shifu.consts import ASK_MODE_DISABLE
-from flaskr.service.shifu.models import DraftShifu, PublishedShifu
 from flaskr.service.user.api import is_allowed_oauth_origin, load_user_aggregate
 from flaskr.util.datetime import to_utc_iso
 from flaskr.util.prompt_loader import load_prompt_template
@@ -303,16 +302,6 @@ def _resolve_live_config(
     return follow_up_info, voice
 
 
-def _load_use_learner_language(*, shifu_bid: str, preview_mode: bool) -> bool:
-    model = DraftShifu if preview_mode else PublishedShifu
-    row = (
-        model.query.filter(model.shifu_bid == shifu_bid, model.deleted == 0)
-        .order_by(model.id.desc())
-        .first()
-    )
-    return bool(getattr(row, "use_learner_language", 0))
-
-
 def _build_conversation(
     app: Flask,
     *,
@@ -333,10 +322,8 @@ def _build_conversation(
         # Live must not inherit the course's text-output and formatting rules.
         course_system_prompt=None,
         fallback_system_prompt=load_prompt_template("live_follow_up"),
-        use_learner_language=_load_use_learner_language(
-            shifu_bid=binding.shifu_bid,
-            preview_mode=binding.preview_mode,
-        ),
+        # Live conversations must not be forced into the interface language.
+        use_learner_language=False,
         runtime_language=binding.language,
         anchor_element_bid=binding.anchor_element_bid,
         max_history_messages=20,

--- a/src/api/tests/service/learn/test_live_follow_up_context.py
+++ b/src/api/tests/service/learn/test_live_follow_up_context.py
@@ -15,6 +15,7 @@ from flaskr.util.prompt_loader import load_prompt_template
 
 @pytest.mark.parametrize("preview_mode", [False, True])
 @pytest.mark.parametrize("learning_mode", ["read", "listen"])
+@pytest.mark.parametrize("language", ["zh-CN", "en-US", "fr-FR"])
 @pytest.mark.parametrize(
     "ask_prompt",
     ["", " \n ", "FOLLOW-UP\n{shifu_system_message}", "Follow-up instructions only."],
@@ -23,6 +24,7 @@ def test_live_context_omits_course_prompt_and_preserves_follow_up_context(
     monkeypatch: pytest.MonkeyPatch,
     preview_mode: bool,
     learning_mode: str,
+    language: str,
     ask_prompt: str,
 ) -> None:
     """Both learner and preview sessions omit course-prompt lookup and fallback."""
@@ -38,7 +40,7 @@ def test_live_context_omits_course_prompt_and_preserves_follow_up_context(
         origin="https://learn.example.com",
         model=routes.GEMINI_LIVE_MODEL_ID,
         voice_name="Kore",
-        language="zh-CN",
+        language=language,
         learning_mode=learning_mode,
         expires_at_epoch=900,
     )
@@ -51,10 +53,6 @@ def test_live_context_omits_course_prompt_and_preserves_follow_up_context(
 
     def reject_course_prompt(*_args: object, **_kwargs: object) -> None:
         pytest.fail("Live must not load or inherit the course system prompt")
-
-    def load_language(**kwargs: object) -> bool:
-        captured["language_scope"] = kwargs
-        return True
 
     def load_history(**kwargs: object) -> list[dict[str, str]]:
         captured["history_scope"] = kwargs
@@ -81,7 +79,6 @@ def test_live_context_omits_course_prompt_and_preserves_follow_up_context(
         "load_user_aggregate",
         lambda _bid: SimpleNamespace(user_id="user-1", user_bid="user-1", identify=""),
     )
-    monkeypatch.setattr(routes, "_load_use_learner_language", load_language)
     monkeypatch.setattr(
         context,
         "get_user_profiles",
@@ -112,12 +109,9 @@ def test_live_context_omits_course_prompt_and_preserves_follow_up_context(
         assert '"Synthetic learner background"' in instruction
         if ask_prompt.strip():
             assert instruction.startswith("FOLLOW-UP\n")
-    assert instruction.endswith("IMPORTANT: You MUST respond in 简体中文.")
-    assert captured["profiles"]["sys_user_language"] == "zh-CN"
-    assert captured["language_scope"] == {
-        "shifu_bid": "course-1",
-        "preview_mode": preview_mode,
-    }
+    assert "IMPORTANT: You MUST respond in" not in instruction
+    assert "sys_user_language" not in captured["profiles"]
+    assert "language" not in captured["profiles"]
     assert captured["history_scope"]["anchor_element_bid"] == "anchor-1"
     assert captured["history_scope"]["progress_record_bid"] == "progress-1"
     assert captured["history_scope"]["max_history_messages"] == 20


### PR DESCRIPTION
## Summary

Gemini Live currently inherits the course learner-language switch and appends a mandatory response-language instruction based on the interface locale. This can force Chinese replies in an English course preview.

- Disable that mandatory language instruction only in the Live context builder call.
- Remove the now-unused Live course-language lookup.
- Preserve ordinary text follow-up and lesson language behavior, teacher-authored follow-up prompts, learner profiles and history.
- Keep request language as session metadata. Do not add a replacement language-selection prompt or modify course settings.
- Update the existing ExecPlan and tests for Chinese, English and French request locales across reading/listening and learner/preview surfaces.

## Verification

- 170 focused context, persistence and route tests passed using Flask 3.1.3 and Werkzeug 3.1.6 matching repository requirements via an isolated local dependency overlay.
- The old local Flask version initially failed route tests before route execution; no project dependency change was needed.
- Full lefthook pre-commit --all-files and commit hooks passed.
- Ruff, repository harness and architecture boundary checks passed.
- No deployment or database migration. Real Gemini multilingual acceptance has not been performed.

## Review focus

Please verify that Live no longer adds an interface-locale language restriction while the shared text-context language contract remains unchanged. Teacher-authored instructions and existing history can still influence the model response language.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Live conversation context assembly in `live_follow_up_routes.py`; text follow-up language handling is untouched. Main risk is product behavior change for multilingual UI vs course language in voice sessions.
> 
> **Overview**
> **Gemini Live** no longer inherits the course **learner-language** switch or appends the shared follow-up builder’s **“You MUST respond in …”** instruction. Live session context is built with **`use_learner_language=False`**, and the **`_load_use_learner_language`** Shifu lookup is removed.
> 
> Request **language** stays on the session binding for metadata; it is **not** injected into learner profile variables on this path. **Teacher follow-up prompts**, **history**, **profiles**, and the **live_follow_up** voice default are unchanged. **Text** follow-ups and lesson output keep their existing learner-language behavior.
> 
> The exec plan documents the decision. **Context tests** now cover **zh-CN**, **en-US**, and **fr-FR** across read/listen and learner/preview, asserting the mandatory language line and `sys_user_language` are absent from Live instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e3721fe7c39060ac22c9dc89a944751febe536c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gemini Live follow-up conversations no longer force responses to match the learner’s selected language.
  * Request language remains session context without being added to learner profile data.
  * Existing teacher follow-ups, saved history, text follow-ups, and lesson output behavior remain unchanged.
  * Improved coverage across Chinese, English, and French for read/listen and preview/live experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->