### PR TITLE
fix: support low reasoning for Gemini 3.8 Flash

### DIFF
--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -773,7 +773,10 @@ _LITELLM_198_COMPATIBILITY_PATCHES: dict[tuple[str, str | None], dict[str, objec
         "additional_drop_params": ["enable_thinking"],
     },
     ("gemini", "gemini-3.7-flash"): {"reasoning_effort": "low"},
-    ("gemini", "gemini-3.8-flash"): {"reasoning_effort": "low"},
+    ("gemini", "gemini-3.8-flash"): {
+        "reasoning_effort": "low",
+        "allowed_openai_params": ["reasoning_effort"],
+    },
     ("gemini", "gemini-2.5-pro"): {"reasoning_effort": "minimal"},
     ("openai", "gpt-5-pro"): {"reasoning_effort": "high"},
     ("openai", "gpt-5-pro-2025-10-06"): {"reasoning_effort": "high"},

--- a/src/api/flaskr/api/llm/__init__.py
+++ b/src/api/flaskr/api/llm/__init__.py
@@ -773,6 +773,7 @@ _LITELLM_198_COMPATIBILITY_PATCHES: dict[tuple[str, str | None], dict[str, objec
         "additional_drop_params": ["enable_thinking"],
     },
     ("gemini", "gemini-3.7-flash"): {"reasoning_effort": "low"},
+    ("gemini", "gemini-3.8-flash"): {"reasoning_effort": "low"},
     ("gemini", "gemini-2.5-pro"): {"reasoning_effort": "minimal"},
     ("openai", "gpt-5-pro"): {"reasoning_effort": "high"},
     ("openai", "gpt-5-pro-2025-10-06"): {"reasoning_effort": "high"},

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -1498,7 +1498,10 @@ def test_gemini_exact_minimum_patches(
 
     assert prepared["reasoning_effort"] == expected_effort
     assert ("temperature" in prepared) is expects_temperature
-    assert "allowed_openai_params" not in prepared
+    if str(model_id).lower() == "gemini-3.8-flash":
+        assert prepared["allowed_openai_params"] == ["reasoning_effort"]
+    else:
+        assert "allowed_openai_params" not in prepared
 
 
 @pytest.mark.parametrize(

--- a/src/api/tests/test_llm.py
+++ b/src/api/tests/test_llm.py
@@ -1472,6 +1472,8 @@ def test_gemini_uses_native_mapping_and_does_not_override_temperature(
     [
         ("gemini-3.7-flash", "low", False),
         ("GEMINI-3.7-FLASH", "low", False),
+        ("gemini-3.8-flash", "low", False),
+        ("GEMINI-3.8-FLASH", "low", False),
         ("gemini-2.5-pro", "minimal", True),
     ],
 )
@@ -1856,6 +1858,11 @@ def test_litellm_198_native_adapter_contracts() -> None:
                 custom_llm_provider="gemini",
                 reasoning_effort="none",
             ),
+            "gemini_38_flash": litellm.get_optional_params(
+                model="gemini-3.8-flash",
+                custom_llm_provider="gemini",
+                **prepared("gemini", "gemini", "gemini-3.8-flash"),
+            ),
             "gemini_25_pro": litellm.get_optional_params(
                 model="gemini-2.5-pro",
                 custom_llm_provider="gemini",
@@ -1984,6 +1991,10 @@ def test_litellm_198_native_adapter_contracts() -> None:
         "includeThoughts": False,
     }
     assert contracts["gemini_37_flash"]["thinkingConfig"] == {
+        "thinkingLevel": "low",
+        "includeThoughts": True,
+    }
+    assert contracts["gemini_38_flash"]["thinkingConfig"] == {
         "thinkingLevel": "low",
         "includeThoughts": True,
     }


### PR DESCRIPTION
Gemini 3.8 Flash now uses `reasoning_effort="low"`, matching Gemini 3.7 Flash. The override also explicitly allows `reasoning_effort` because the pinned LiteLLM 1.98.0 model metadata does not yet advertise support; without this, the adapter rejects the request.

Adds lowercase/uppercase model coverage and verifies the native LiteLLM mapping produces `thinkingLevel="low"` and `includeThoughts=true`.

Validation:
- All 108 LLM tests passed with LiteLLM 1.98.0 installed in an isolated temporary dependency directory, including the native adapter contract.
- All staged pre-commit checks passed, including Ruff and architecture boundaries.
- Repository-wide pre-commit was attempted but blocked by missing frontend dependencies and sandbox write restrictions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to one Gemini model’s request-prep overrides and matching tests; no auth, billing, or broad routing changes.
> 
> **Overview**
> Adds **Gemini 3.8 Flash** to the LiteLLM 1.98 compatibility patch map so requests use **`reasoning_effort="low"`**, aligned with Gemini 3.7 Flash. The patch also sets **`allowed_openai_params`** to include `reasoning_effort` so LiteLLM does not reject the parameter when model metadata does not yet advertise it.
> 
> Tests cover case-insensitive model IDs, assert **`allowed_openai_params`** only for 3.8 (not 3.7), and extend the native adapter contract check so prepared kwargs map to **`thinkingLevel: low`** and **`includeThoughts: true`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66891e44b1d48ac7ba1535180e4a04ffe007a76d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with the Gemini 3.8 Flash model.
  * Gemini 3.8 Flash now uses low reasoning effort and correctly supports the reasoning-effort setting.
  * Gemini responses now include configured thought details for more consistent model behavior.

* **Tests**
  * Added coverage for Gemini 3.8 Flash model variants and their reasoning configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->