### PR TITLE
fix: keep toast messages visible for five seconds

### DIFF
--- a/src/web/src/hooks/useToast.tsx
+++ b/src/web/src/hooks/useToast.tsx
@@ -155,7 +155,7 @@ const isToastVisible = (toastId: string) =>
     toast => toast.id === toastId && toast.open !== false,
   );
 
-function toast({ duration = 2000, ...props }: Toast) {
+function toast({ duration = 5000, ...props }: Toast) {
   const id = genId();
   const radixDuration = duration === 0 ? Number.POSITIVE_INFINITY : duration;
 


### PR DESCRIPTION
## Changed

- Increase the default Toast duration from 2 seconds to 5 seconds.

## Verification

-  (7 tests passed)
- Pre-commit hooks passed
- Core lefthook toolchain:
  [OK  ] lefthook
  [OK  ] lefthook git hooks (lefthook install)
  [MISS] ruff 0.16.5
  [OK  ] cz (commitizen)
  [OK  ] check-yaml
  [OK  ] check-json
  [OK  ] check-merge-conflict
  [OK  ] check-symlinks
  [OK  ] end-of-file-fixer
  [OK  ] trailing-whitespace-fixer
  [OK  ] pretty-format-json
  [OK  ] requirements-txt-fixer

Cook Web (frontend) toolchain:
  [OK  ] node
  [OK  ] npm
  [OK  ] Cook Web prettier (node_modules)

Missing required tooling. Install with:
  pip install ruff==0.16.5 commitizen==4.16.2 pre-commit-hooks==6.0.0

Dev tooling check FAILED. See the commands above. reports missing ; Ruff hooks were skipped because no Python files were changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default-parameter change in the toast hook with no auth or data-handling impact.
> 
> **Overview**
> **Default toast duration** in `useToast` is raised from **2 seconds to 5 seconds** for the core `toast()` helper when callers do not pass a `duration`.
> 
> That gives users more time to read standard notifications. Call sites that set their own duration (for example `show` / `fail` at 20 seconds) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0d4804ffdf20dae7b39faac8d842143c164c3e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Toast notifications now remain visible for 5 seconds by default, providing more time to read them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->