### PR TITLE
fix: use consistent colors for the share menu copy icon

### DIFF
--- a/src/web/src/components/course-share/CourseShareMenu.tsx
+++ b/src/web/src/components/course-share/CourseShareMenu.tsx
@@ -203,7 +203,7 @@ export function CourseShareMenu(props: CourseShareButtonProps) {
           onClick={() => void copyPrompt()}
         >
           <Copy
-            className='h-4 w-4 text-primary'
+            className='h-4 w-4'
             aria-hidden='true'
           />
           {t('common.core.posterCopy')}


### PR DESCRIPTION
The course share menu copy icon used a primary color independently of its button. Remove that override so the icon inherits the menu button color.

Validation: CourseShareMenu Jest suite, frontend lint, and all applicable commit hooks passed. The repository-wide hook run was attempted but could not complete because of local tooling and sandbox file permissions. No browser visual check was performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic class change on a share menu icon with no behavior, API, or data impact.
> 
> **Overview**
> Removes the **`text-primary`** class from the **Copy** icon in `CourseShareMenu` so it no longer forces the primary brand color on that icon alone.
> 
> The copy action stays on the same ghost menu row; the icon now inherits the button’s text color like the other share menu controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76754487571606c440d06a4309528b9b33449b67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the course sharing menu’s copy icon color styling.
  * Icon size and accessibility behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->