### PR TITLE
chore: remove unused Cook Web API catalog entries

### DIFF
--- a/src/web/src/api/api.test.ts
+++ b/src/web/src/api/api.test.ts
@@ -1,5 +1,28 @@
 import api from './api';
 
+describe('unused catalog cleanup', () => {
+  test('drops unused catalog keys and keeps profile item definitions', () => {
+    const unusedCatalogKeys = [
+      'requireTmp',
+      'getProfile',
+      'getProfileList',
+      'addBlock',
+      'getSystemPrompt',
+      'debugPrompt',
+      'getVideoInfo',
+      'upfileByUrl',
+    ];
+
+    unusedCatalogKeys.forEach(key => {
+      expect(Object.prototype.hasOwnProperty.call(api, key)).toBe(false);
+    });
+
+    expect(api.getProfileItemDefinitions).toBe(
+      'GET /profiles/get-profile-item-definitions',
+    );
+  });
+});
+
 describe('auth api definitions', () => {
   test('exposes captcha, SMS, and email login endpoints', () => {
     expect(api.getCaptcha).toBe('GET /user/captcha');

--- a/src/web/src/api/api.ts
+++ b/src/web/src/api/api.ts
@@ -21,7 +21,6 @@ const api = {
   sendSmsCode: 'POST /user/send_sms_code',
   sendEmailCode: 'POST /user/send_email_code',
   emailLogin: 'POST /user/login_email',
-  requireTmp: 'POST /user/require_tmp',
   smsLogin: 'POST /user/login_sms',
   deviceAuthPending: 'GET /user/device/pending',
   deviceAuthApprove: 'POST /user/device/approve',
@@ -85,10 +84,8 @@ const api = {
   // blocks api
   getBlocks: 'GET /shifu/shifus/{shifu_bid}/outlines/{outline_bid}/blocks',
   saveBlocks: 'POST /shifu/shifus/{shifu_bid}/outlines/{outline_bid}/blocks',
-  addBlock: 'PUT /shifu/shifus/{shifu_bid}/outlines/{outline_bid}/blocks',
   // block api end
 
-  getProfile: 'GET /user/get_profile',
   getProfileItemDefinitions: 'GET /profiles/get-profile-item-definitions',
   addProfileItem: 'POST /profiles/add-profile-item-quick',
   getUserInfo: 'GET /user/info',
@@ -96,13 +93,6 @@ const api = {
   updateChapterOrder: 'POST /shifu/update-chapter-order',
 
   getModelList: 'GET /llm/model-list',
-  getSystemPrompt: 'GET /llm/get-system-prompt',
-  debugPrompt: 'GET /llm/debug-prompt',
-
-  // resource api start
-  getVideoInfo: 'POST /shifu/get-video-info',
-  upfileByUrl: 'POST /shifu/url-upfile',
-  // resource api end
 
   // TTS api
   askConfig: 'GET /shifu/ask/config',
@@ -274,7 +264,6 @@ const api = {
 
   saveProfile: 'POST /profiles/save-profile-item',
   deleteProfile: 'POST /profiles/delete-profile-item',
-  getProfileList: 'GET /profiles/get-profile-item-definitions',
   hideUnusedProfileItems: 'POST /profiles/hide-unused-profile-items',
   getProfileVariableUsage: 'GET /profiles/profile-variable-usage',
   updateProfileHiddenState: 'POST /profiles/update-profile-hidden-state',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

Removes unused Cook Web API catalog keys from `src/web/src/api/api.ts`. This is a dead-surface cleanup only: generated wrappers for those keys had no runtime callers.

The `require_tmp` and `get_profile` backend endpoints remain in use through the existing `src/web/src/api/user.ts` helpers (`registerTmp` and `getUserProfile`). Those helpers call `request` directly and do not use the catalog wrappers.

# Removed catalog keys

| Catalog key | Catalog path | Why removed |
| --- | --- | --- |
| `requireTmp` | `POST /user/require_tmp` | No `api.requireTmp` caller. Guest temp-token exchange still uses `registerTmp()` in `user.ts`. |
| `getProfile` | `GET /user/get_profile` | No `api.getProfile` caller. Learner profile fetch still exists as `getUserProfile()` in `user.ts`. |
| `getProfileList` | `GET /profiles/get-profile-item-definitions` | Duplicate of `getProfileItemDefinitions`. No callers. |
| `addBlock` | `PUT /shifu/shifus/{shifu_bid}/outlines/{outline_bid}/blocks` | No callers. `getBlocks` / `saveBlocks` remain. |
| `getSystemPrompt` | `GET /llm/get-system-prompt` | No callers. |
| `debugPrompt` | `GET /llm/debug-prompt` | No callers. |
| `getVideoInfo` | `POST /shifu/get-video-info` | No callers. |
| `upfileByUrl` | `POST /shifu/url-upfile` | No callers. |

# Kept

- `getProfileItemDefinitions` — still called from `useShifu.tsx`.

# Unused-ness verification

Before deleting, searched `src/web` (legacy `src/cook-web` is not present after the frontend rename) for:

- Direct catalog wrappers: `api.requireTmp`, `api.getProfile`, `api.getProfileList`, `api.addBlock`, `api.getSystemPrompt`, `api.debugPrompt`, `api.getVideoInfo`, `api.upfileByUrl`
- String-key / dynamic access: `'requireTmp'`, `'getProfile'`, `'getProfileList'`, `'addBlock'`, `'getSystemPrompt'`, `'debugPrompt'`, `'getVideoInfo'`, `'upfileByUrl'`
- Endpoint path strings used through the catalog (`get-system-prompt`, `debug-prompt`, `get-video-info`, `url-upfile`)
- Test assertions against those catalog keys

The only matches were the catalog definitions themselves. Unrelated `addBlockedCreators` names in credit-notification admin UI were ignored.

`src/web/src/api/index.ts` generates wrappers by iterating catalog keys, so removing the entries is sufficient. No standalone wrapper methods existed for these keys.

# Tests

- Added a focused Jest assertion that the unused keys are absent and `getProfileItemDefinitions` remains.
- `cd src/web && npm test -- src/api/api.test.ts --no-coverage` — 10 passed
- `cd src/web && npm run type-check` — passed
- `cd src/web && npm run lint -- --file src/api/api.ts --file src/api/api.test.ts` — no warnings or errors

# Notes

- No user-facing behavior change.
- Backend routes are unchanged.
- No analytics change (behavior-preserving cleanup).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b6462a4-d500-4b4e-aeeb-de5fbaa5eede?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b6462a4-d500-4b4e-aeeb-de5fbaa5eede&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed several obsolete API operations related to temporary resources, profiles, prompts, blocks, video information, and URL-based uploads.
  - Existing block listing and saving, profile management, and profile item definition operations remain available.

- **Tests**
  - Added coverage confirming removed operations are no longer exposed.
  - Verified that profile item definitions continue to use the correct API route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->