### PR TITLE
fix: keep valid users signed in during token refresh errors

### DIFF
--- a/src/api/flaskr/service/user/token_store.py
+++ b/src/api/flaskr/service/user/token_store.py
@@ -109,7 +109,7 @@ class TokenStoreProvider:
 
     def _refresh_row_periodically(
         self, app: Flask, *, token: str, user_id: str, ttl_seconds: int
-    ) -> bool:
+    ) -> bool | None:
         """Keep the stored expiry from falling behind a cache-served session.
 
         A cache hit renews only the cache entry, so a session in constant use
@@ -143,7 +143,7 @@ class TokenStoreProvider:
                     return False
         except Exception:
             app.logger.warning("could not refresh token row expiry")
-            return False
+            return None
 
         with contextlib.suppress(Exception):
             self._cache.set(marker, "1", ex=max(1, ttl_seconds // 2))
@@ -191,12 +191,17 @@ class TokenStoreProvider:
                             self._cache.delete(cache_key)
                             self._cache.delete(self._refresh_marker_key(app, token))
                         return None
-                    if not self._refresh_row_periodically(
+                    refresh_result = self._refresh_row_periodically(
                         app,
                         token=token,
                         user_id=expected_user_id,
                         ttl_seconds=ttl_seconds,
-                    ):
+                    )
+                    # A missing row means the session was revoked between the
+                    # validation query and the refresh write. Database errors are
+                    # different: expiry renewal is best-effort and must not turn a
+                    # valid request into a logout.
+                    if refresh_result is False:
                         return None
                     return TokenLookupResult(user_id=expected_user_id)
                 # Defensive: token should never map to a different user id.

--- a/src/api/tests/service/user/test_sessions.py
+++ b/src/api/tests/service/user/test_sessions.py
@@ -234,6 +234,67 @@ def test_a_session_served_from_cache_keeps_its_row_alive(
         assert len(list_user_sessions(user_id=user_id)) == 1
 
 
+def test_a_valid_cached_session_survives_a_transient_row_refresh_failure(
+    app: object, user_id: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed sliding-expiry write must not sign out a valid session."""
+    with app.test_request_context():
+        token = _sign_in(app, user_id)
+
+    def fail_to_refresh(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(token_store, "_refresh_row_periodically", fail_to_refresh)
+
+    with app.test_request_context():
+        ttl = int(app.config.get("TOKEN_EXPIRE_TIME", 604800))
+        result = token_store.get_and_refresh(
+            app, token=token, expected_user_id=user_id, ttl_seconds=ttl
+        )
+
+    assert result is not None
+    assert result.user_id == user_id
+
+
+def test_a_session_revoked_during_its_cached_refresh_is_rejected(
+    app: object, user_id: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Do not revive a row deleted between validation and expiry renewal."""
+    with app.test_request_context():
+        token = _sign_in(app, user_id)
+
+    def report_missing_row(*_args: object, **_kwargs: object) -> bool:
+        return False
+
+    monkeypatch.setattr(token_store, "_refresh_row_periodically", report_missing_row)
+
+    with app.test_request_context():
+        ttl = int(app.config.get("TOKEN_EXPIRE_TIME", 604800))
+        result = token_store.get_and_refresh(
+            app, token=token, expected_user_id=user_id, ttl_seconds=ttl
+        )
+
+    assert result is None
+
+
+def test_a_cached_session_without_its_durable_row_is_rejected(
+    app: object, user_id: str
+) -> None:
+    """Deleting the durable row must still revoke a cache-resident session."""
+    with app.test_request_context():
+        token = _sign_in(app, user_id)
+        UserToken.query.filter(UserToken.token == token).delete()
+        db.session.commit()
+
+    with app.test_request_context():
+        ttl = int(app.config.get("TOKEN_EXPIRE_TIME", 604800))
+        result = token_store.get_and_refresh(
+            app, token=token, expected_user_id=user_id, ttl_seconds=ttl
+        )
+
+    assert result is None
+
+
 @pytest.mark.parametrize(
     ("user_agent", "expected"),
     [


### PR DESCRIPTION
## Summary
- distinguish transient database refresh failures from confirmed token-row removal
- keep an already validated cached session active when sliding-expiry persistence temporarily fails
- continue rejecting sessions whose durable row is missing, including the validation/refresh race

## Why
The account-cancellation rollout made durable token rows authoritative on cache hits. A temporary database failure while extending an otherwise valid row could therefore be surfaced as an unauthenticated response, causing Cook Web to clear the browser login state even though the token had not been revoked.

## Verification
- `cd src/api && pytest -q tests/service/user/test_sessions.py` (19 passed)
- `cd src/api && python -m ruff check flaskr/service/user/token_store.py tests/service/user/test_sessions.py`
- `git diff --check`
- pre-commit architecture, translation, Ruff, formatting, and repository checks passed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved valid user sessions when a temporary database error prevents session expiry renewal.
  * Continued rejecting sessions when their stored token is missing or revoked.
* **Tests**
  * Added coverage for temporary refresh failures, missing token records, and revoked sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->