### PR TITLE
feat: support market-aware course prices and free unlocks

### DIFF
--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -1046,12 +1046,14 @@ REDIS_USER=""
 
 # Default price assigned to a new shifu
 # (Optional - default: 0.5)
-# Type: float
+# Type: Decimal
+# (Has validation)
 DEFAULT_SHIFU_PRICE="0.5"
 
 # Minimum positive price of shifu; zero is free
 # (Optional - default: 0.5)
-# Type: float
+# Type: Decimal
+# (Has validation)
 MIN_SHIFU_PRICE="0.5"
 
 

--- a/docker/.env.example.full
+++ b/docker/.env.example.full
@@ -1044,7 +1044,12 @@ REDIS_USER=""
 # Shifu
 #============================================================
 
-# Minimum price of shifu
+# Default price assigned to a new shifu
+# (Optional - default: 0.5)
+# Type: float
+DEFAULT_SHIFU_PRICE="0.5"
+
+# Minimum positive price of shifu; zero is free
 # (Optional - default: 0.5)
 # Type: float
 MIN_SHIFU_PRICE="0.5"

--- a/docs/exec-plans/active/course-price-market-rules-and-free-unlock.md
+++ b/docs/exec-plans/active/course-price-market-rules-and-free-unlock.md
@@ -1,0 +1,106 @@
+# Market-aware course prices and free-course unlock
+
+## Purpose / Big Picture
+
+Course prices must reflect the payment capabilities of each deployment. China
+supports free courses and paid prices from CNY 0.01; global supports free
+courses and Stripe-paid prices from USD 0.50. A zero-price paywall creates a
+successful zero-value order and unlocks learning without invoking a payment
+provider.
+
+## Progress
+
+- [x] 2026-09-09 17:05 CST: Confirmed product rules and inspected authoring,
+  order initialization, provider dispatch, and learner payment state.
+- [x] 2026-09-09 17:25 CST: Implement backend pricing contract and atomic free
+  order completion with regression coverage.
+- [ ] 2026-09-09 17:05 CST: Implement frontend configuration-driven authoring
+  validation and server-authoritative free unlock with regression coverage.
+- [ ] 2026-09-09 17:05 CST: Verify, self-review, publish two focused PRs, and
+  document their stacking/merge order.
+
+## Surprises & Discoveries
+
+- `DraftShifu.price` and `PublishedShifu.price` already use `DECIMAL(10, 2)`,
+  so CNY 0.01 needs no schema migration.
+- `generate_charge()` already short-circuits zero amounts before provider
+  invocation, but the learner hook currently treats `value_to_pay <= 0` as
+  success without making the server transition the order from INIT to SUCCESS.
+- Draft creation uses Python truthiness (`price or minimum`), which replaces an
+  explicit zero with the configured minimum.
+
+## Decision Log
+
+- Decision: Both markets allow exactly zero. China additionally allows any
+  two-decimal price from 0.01; global permits a positive price only from 0.50.
+  Reason: zero bypasses payment providers, while positive prices must respect
+  the active provider's minimum.
+- Decision: Preserve a successful zero-value order rather than inventing a
+  separate free entitlement. Reason: existing access checks, audit history,
+  and analytics already use successful orders.
+- Decision: The server owns price policy and returns it to Cook Web; the web
+  app must not infer market rules from hostnames.
+- Decision: Initializing a zero-value order completes it atomically. Reason:
+  the client must never declare payment success from amount alone.
+
+## Outcomes & Retrospective
+
+Pending implementation and verification.
+
+## Context and Orientation
+
+Course authoring price validation is in
+`src/api/flaskr/service/shifu/shifu_draft_funcs.py` and
+`src/web/src/components/shifu-setting/ShifuSetting.tsx`. Runtime environment
+data flows through the backend runtime-config DTO into `src/web/src/store/envStore.ts`.
+Legacy course orders are initialized and charged in
+`src/api/flaskr/service/order/funs.py`; learner payment orchestration lives in
+`src/web/src/app/c/[[...id]]/Components/Pay/hooks/usePaymentFlow.ts`.
+
+## Plan of Work
+
+First expose one backend course-price policy derived from deployment config,
+use Decimal-safe validation for draft create/update, preserve explicit zero,
+and complete zero-value orders during initialization. Then consume the policy
+in Cook Web, remove the hard-coded 0.5, and require a server SUCCESS state for
+free unlock. Keep the backend and frontend commits in separate stacked PRs.
+
+## Concrete Steps
+
+1. Add configuration for default course price and positive minimum, with a
+   policy serializer in the existing runtime configuration path.
+2. Centralize backend course-price normalization and apply it to draft create
+   and update.
+3. Mark zero-value course orders successful in `init_buy_record()` within its
+   unit of work and return the committed state.
+4. Extend backend tests for zero, China 0.01, global 0.01 rejection/global 0.50,
+   and proof that no provider is invoked for zero.
+5. Extend Cook Web environment state and replace authoring constants with the
+   server policy.
+6. Make learner payment completion depend on order SUCCESS, with focused tests
+   for zero-value initialization.
+
+## Validation and Acceptance
+
+- China: a new course defaults to 0; 0, 0.01, and larger two-decimal values save.
+- Global: a new course defaults to 0.50; 0 and values at least 0.50 save; a
+  positive value below 0.50 is rejected by both API and UI.
+- Reaching a paywall on a zero-price course creates one successful zero-value
+  order, invokes no provider, and resumes learning on desktop and mobile.
+- A positive China order of 0.01 remains payable; a positive global order of
+  0.50 reaches Stripe normally.
+- Existing positive course prices remain unchanged.
+
+## Idempotence and Recovery
+
+Order initialization already serializes one active order per user/course and
+is retryable. Repeating free initialization must return the same successful
+order. Configuration defaults remain backward compatible until deployment
+values are explicitly split. No migration or destructive data operation is
+required.
+
+## Interfaces and Dependencies
+
+The backend runtime configuration gains course-price policy fields consumed by
+Cook Web. The frontend PR therefore depends on the backend PR. Payment provider
+interfaces do not change; zero-value orders stop before provider dispatch.

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -13,6 +13,7 @@ Active and completed ExecPlans live here. The structure and required sections ar
 - [Backend Overhaul Master Plan: Inventory and Optimization](./active/backend-overhaul-master.md)
 - [ExecPlan: Billing Credit Notifications](./active/billing-credit-notifications.md)
 - [Speed Up Backend Pull Request Feedback](./active/ci-backend-speed-stack.md)
+- [Market-aware course prices and free-course unlock](./active/course-price-market-rules-and-free-unlock.md)
 - [Course Sharing](./active/course-sharing.md)
 - [Creator Brand Domain And Payments](./active/creator-brand-domain-payments.md)
 - [Creator Dashboard Course Ownership Optimization](./active/creator-dashboard-course-ownership-optimization.md)

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -31,6 +31,7 @@
 | `docs/exec-plans/active/backend-overhaul-master.md` | Backend Overhaul Master Plan: Inventory and Optimization | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/billing-credit-notifications.md` | ExecPlan: Billing Credit Notifications | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/ci-backend-speed-stack.md` | Speed Up Backend Pull Request Feedback | `exec-plan-active` | `active` | `repo` | `-` | `true` |
+| `docs/exec-plans/active/course-price-market-rules-and-free-unlock.md` | Market-aware course prices and free-course unlock | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/course-sharing.md` | Course Sharing | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/creator-brand-domain-payments.md` | Creator Brand Domain And Payments | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/creator-dashboard-course-ownership-optimization.md` | Creator Dashboard Course Ownership Optimization | `exec-plan-active` | `active` | `repo` | `-` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -9,7 +9,7 @@ This generated report summarizes the repository harness control plane.
 - Design docs: `14`
 - Product specs: `11`
 - References: `6`
-- Active ExecPlans: `31`
+- Active ExecPlans: `32`
 - Completed ExecPlans: `37`
 
 ## Boundary Baseline

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -1632,7 +1632,14 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         name="MIN_SHIFU_PRICE",
         default=0.5,
         type=float,
-        description="Minimum price of shifu",
+        description="Minimum positive price of shifu; zero is free",
+        group="shifu",
+    ),
+    "DEFAULT_SHIFU_PRICE": EnvVar(
+        name="DEFAULT_SHIFU_PRICE",
+        default=0.5,
+        type=float,
+        description="Default price assigned to a new shifu",
         group="shifu",
     ),
     # TTS Configuration

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any
 
 from flask import Config as FlaskConfig
@@ -18,6 +19,28 @@ if TYPE_CHECKING:
 
 class EnvironmentConfigError(Exception):
     """Exception raised for environment configuration errors."""
+
+
+def parse_nonnegative_cent_amount(value: object) -> Decimal:
+    """Parse a finite, nonnegative monetary amount with exact cent precision."""
+    try:
+        amount = Decimal(str(value))
+        cent_amount = amount.quantize(Decimal("0.01"))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        message = "must be a finite nonnegative amount with at most two decimals"
+        raise ValueError(message) from exc
+    if not amount.is_finite() or amount < 0 or amount != cent_amount:
+        message = "must be a finite nonnegative amount with at most two decimals"
+        raise ValueError(message)
+    return cent_amount
+
+
+def _is_valid_nonnegative_cent_amount(value: object) -> bool:
+    try:
+        parse_nonnegative_cent_amount(value)
+    except ValueError:
+        return False
+    return True
 
 
 @dataclass
@@ -1632,6 +1655,7 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         name="MIN_SHIFU_PRICE",
         default=0.5,
         type=float,
+        validator=_is_valid_nonnegative_cent_amount,
         description="Minimum positive price of shifu; zero is free",
         group="shifu",
     ),
@@ -1639,6 +1663,7 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
         name="DEFAULT_SHIFU_PRICE",
         default=0.5,
         type=float,
+        validator=_is_valid_nonnegative_cent_amount,
         description="Default price assigned to a new shifu",
         group="shifu",
     ),

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -104,8 +104,14 @@ class EnvVar:
         elif self.type is float:
             try:
                 return float(value)
-            except ValueError as exc:
+            except (TypeError, ValueError) as exc:
                 message = f"Invalid float value for {self.name}: {value}"
+                raise EnvironmentConfigError(message) from exc
+        elif self.type is Decimal:
+            try:
+                return Decimal(str(value))
+            except (InvalidOperation, TypeError, ValueError) as exc:
+                message = f"Invalid decimal value for {self.name}: {value}"
                 raise EnvironmentConfigError(message) from exc
         elif self.type is list:
             if isinstance(value, str):
@@ -1661,16 +1667,16 @@ Generate secure key: python -c "import secrets; print(secrets.token_urlsafe(32))
     # Minimum Shifu Price
     "MIN_SHIFU_PRICE": EnvVar(
         name="MIN_SHIFU_PRICE",
-        default=0.5,
-        type=float,
+        default=Decimal("0.5"),
+        type=Decimal,
         validator=_is_valid_nonnegative_cent_amount,
         description="Minimum positive price of shifu; zero is free",
         group="shifu",
     ),
     "DEFAULT_SHIFU_PRICE": EnvVar(
         name="DEFAULT_SHIFU_PRICE",
-        default=0.5,
-        type=float,
+        default=Decimal("0.5"),
+        type=Decimal,
         validator=_is_valid_nonnegative_cent_amount,
         description="Default price assigned to a new shifu",
         group="shifu",

--- a/src/api/flaskr/common/config.py
+++ b/src/api/flaskr/common/config.py
@@ -21,15 +21,23 @@ class EnvironmentConfigError(Exception):
     """Exception raised for environment configuration errors."""
 
 
+MAX_COURSE_PRICE = Decimal("99999999.99")
+
+
 def parse_nonnegative_cent_amount(value: object) -> Decimal:
-    """Parse a finite, nonnegative monetary amount with exact cent precision."""
+    """Parse an amount that fits the course-price DECIMAL(10, 2) columns."""
     try:
         amount = Decimal(str(value))
         cent_amount = amount.quantize(Decimal("0.01"))
     except (InvalidOperation, TypeError, ValueError) as exc:
         message = "must be a finite nonnegative amount with at most two decimals"
         raise ValueError(message) from exc
-    if not amount.is_finite() or amount < 0 or amount != cent_amount:
+    if (
+        not amount.is_finite()
+        or amount < 0
+        or amount > MAX_COURSE_PRICE
+        or amount != cent_amount
+    ):
         message = "must be a finite nonnegative amount with at most two decimals"
         raise ValueError(message)
     return cent_amount

--- a/src/api/flaskr/route/config.py
+++ b/src/api/flaskr/route/config.py
@@ -269,6 +269,8 @@ def register_config_handler(app: Flask, path_prefix: str) -> Flask:
             contact_us_url=contact_us_url,
             official_site_url=official_site_url,
             currency_symbol=get_config("CURRENCY_SYMBOL", "¥"),
+            default_course_price=float(get_config("DEFAULT_SHIFU_PRICE", 0.5)),
+            minimum_paid_course_price=float(get_config("MIN_SHIFU_PRICE", 0.5)),
             legal_urls=legal_urls,
             entitlements=runtime_billing.entitlements,
             branding=runtime_billing.branding,

--- a/src/api/flaskr/service/billing/dtos.py
+++ b/src/api/flaskr/service/billing/dtos.py
@@ -928,6 +928,10 @@ class RuntimeConfigDTO(BillingBaseDTO):
     contact_us_url: str = Field(alias="contactUsUrl")
     official_site_url: str = Field(alias="officialSiteUrl")
     currency_symbol: str = Field(alias="currencySymbol")
+    default_course_price: float = Field(default=0.5, alias="defaultCoursePrice")
+    minimum_paid_course_price: float = Field(
+        default=0.5, alias="minimumPaidCoursePrice"
+    )
     legal_urls: RuntimeLegalUrlsDTO = Field(alias="legalUrls")
     entitlements: RuntimeBillingEntitlementsDTO
     branding: RuntimeBillingBrandingDTO

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -406,7 +406,9 @@ def init_buy_record(
             Order.query.filter(
                 Order.user_bid == user_id,
                 Order.shifu_bid == course_id,
-                Order.status.in_([ORDER_STATUS_INIT, ORDER_STATUS_TO_BE_PAID]),
+                Order.status.in_(
+                    [ORDER_STATUS_INIT, ORDER_STATUS_TO_BE_PAID, ORDER_STATUS_SUCCESS]
+                ),
             )
             .order_by(Order.id.desc())
             .first()
@@ -441,6 +443,8 @@ def init_buy_record(
                 course_id=course_id,
                 active_id=None,
             )
+            if decimal.Decimal(origin_record.paid_price) == decimal.Decimal(0):
+                success_buy_record(app, origin_record.order_bid)
             return query_buy_record(app, origin_record.order_bid)
         order_id = str(get_uuid(app))
         if order_timeout_make_new_order:

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -462,6 +462,8 @@ def init_buy_record(
             course_id=course_id,
             active_id=active_id,
         )
+        if decimal.Decimal(buy_record.paid_price) == decimal.Decimal(0):
+            success_buy_record(app, buy_record.order_bid)
         price_items = []
         price_items.append(
             PayItemDto(

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -435,6 +435,10 @@ def init_buy_record(
                 )
         else:
             order_timeout_make_new_order = True
+        if origin_record and origin_record.status == ORDER_STATUS_SUCCESS:
+            # A successful order is immutable purchase history. Reusing it must
+            # not apply newer campaigns or repeat completion side effects.
+            return query_buy_record(app, origin_record.order_bid)
         if (not order_timeout_make_new_order) and origin_record and active_id is None:
             _sync_order_campaign_pricing(
                 app,

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -9,11 +9,12 @@ Date: 2025-08-07
 import json
 import math
 from datetime import datetime
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from time import perf_counter
 from typing import Any
 
 from flask import Flask
+from flaskr.common.config import parse_nonnegative_cent_amount
 from flaskr.dao import db
 from flaskr.i18n import _
 from flaskr.service.check_risk.funcs import check_text_with_risk_control
@@ -80,7 +81,12 @@ SUPPORTED_ASK_ENABLED_STATUSES = {
 
 def _resolve_shifu_price(shifu_price: float | Decimal | None) -> Decimal:
     """Resolve and validate a course price for the current deployment."""
-    minimum_paid_price = Decimal(str(get_config("MIN_SHIFU_PRICE")))
+    try:
+        minimum_paid_price = parse_nonnegative_cent_amount(
+            get_config("MIN_SHIFU_PRICE")
+        )
+    except ValueError:
+        raise_param_error("shifu_price")
     configured_default = get_config("DEFAULT_SHIFU_PRICE")
     raw_price = (
         configured_default
@@ -90,18 +96,15 @@ def _resolve_shifu_price(shifu_price: float | Decimal | None) -> Decimal:
         else shifu_price
     )
     try:
-        price = Decimal(str(raw_price))
-    except (InvalidOperation, ValueError):
+        price = parse_nonnegative_cent_amount(raw_price)
+    except ValueError:
         raise_param_error("shifu_price")
-    cent_price = price.quantize(Decimal("0.01")) if price.is_finite() else price
-    if not price.is_finite() or price != cent_price:
-        raise_param_error("shifu_price")
-    if price < 0 or (price > 0 and price < minimum_paid_price):
+    if price > 0 and price < minimum_paid_price:
         raise_error_with_args(
             "server.shifu.shifuPriceTooLow",
             min_shifu_price=minimum_paid_price,
         )
-    return cent_price
+    return price
 
 
 def normalize_ask_provider_config(raw_config: object) -> dict[str, object]:

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -77,6 +77,26 @@ SUPPORTED_ASK_ENABLED_STATUSES = {
 }
 
 
+def _resolve_shifu_price(shifu_price: float | None) -> float:
+    """Resolve and validate a course price for the current deployment."""
+    minimum_paid_price = float(get_config("MIN_SHIFU_PRICE"))
+    configured_default = get_config("DEFAULT_SHIFU_PRICE")
+    if shifu_price is None:
+        price = (
+            float(configured_default)
+            if configured_default is not None
+            else minimum_paid_price
+        )
+    else:
+        price = float(shifu_price)
+    if price < 0 or (price > 0 and price < minimum_paid_price):
+        raise_error_with_args(
+            "server.shifu.shifuPriceTooLow",
+            min_shifu_price=minimum_paid_price,
+        )
+    return price
+
+
 def normalize_ask_provider_config(raw_config: object) -> dict[str, object]:
     """Normalize ask_provider_config into a stable object shape."""
     parsed: dict[str, Any] = {}
@@ -294,7 +314,7 @@ def create_shifu_draft(
             keywords=",".join(shifu_keywords) if shifu_keywords else "",
             llm=shifu_model or "",
             llm_temperature=shifu_temperature or 0.3,
-            price=shifu_price or get_config("MIN_SHIFU_PRICE"),
+            price=_resolve_shifu_price(shifu_price),
             deleted=0,  # not deleted
             created_user_bid=user_id,
             created_at=now_time,
@@ -615,15 +635,9 @@ def save_shifu_draft_info(
                 normalized_ask_provider_config
             )
 
-        min_shifu_price = get_config("MIN_SHIFU_PRICE")
         if shifu_price is None and shifu_draft:
             shifu_price = float(shifu_draft.price)
-        elif shifu_price is None:
-            shifu_price = min_shifu_price
-        if shifu_price < min_shifu_price:
-            raise_error_with_args(
-                "server.shifu.shifuPriceTooLow", min_shifu_price=min_shifu_price
-            )
+        shifu_price = _resolve_shifu_price(shifu_price)
         if not shifu_draft:
             # First-time draft: there is no current value to preserve, so fill
             # sensible defaults for any field the caller omitted (None).

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -9,6 +9,7 @@ Date: 2025-08-07
 import json
 import math
 from datetime import datetime
+from decimal import Decimal, InvalidOperation
 from time import perf_counter
 from typing import Any
 
@@ -77,24 +78,30 @@ SUPPORTED_ASK_ENABLED_STATUSES = {
 }
 
 
-def _resolve_shifu_price(shifu_price: float | None) -> float:
+def _resolve_shifu_price(shifu_price: float | Decimal | None) -> Decimal:
     """Resolve and validate a course price for the current deployment."""
-    minimum_paid_price = float(get_config("MIN_SHIFU_PRICE"))
+    minimum_paid_price = Decimal(str(get_config("MIN_SHIFU_PRICE")))
     configured_default = get_config("DEFAULT_SHIFU_PRICE")
-    if shifu_price is None:
-        price = (
-            float(configured_default)
-            if configured_default is not None
-            else minimum_paid_price
-        )
-    else:
-        price = float(shifu_price)
+    raw_price = (
+        configured_default
+        if shifu_price is None and configured_default is not None
+        else minimum_paid_price
+        if shifu_price is None
+        else shifu_price
+    )
+    try:
+        price = Decimal(str(raw_price))
+    except (InvalidOperation, ValueError):
+        raise_param_error("shifu_price")
+    cent_price = price.quantize(Decimal("0.01")) if price.is_finite() else price
+    if not price.is_finite() or price != cent_price:
+        raise_param_error("shifu_price")
     if price < 0 or (price > 0 and price < minimum_paid_price):
         raise_error_with_args(
             "server.shifu.shifuPriceTooLow",
             min_shifu_price=minimum_paid_price,
         )
-    return price
+    return cent_price
 
 
 def normalize_ask_provider_config(raw_config: object) -> dict[str, object]:

--- a/src/api/tests/common/test_config_enhanced.py
+++ b/src/api/tests/common/test_config_enhanced.py
@@ -3,7 +3,12 @@
 from unittest.mock import patch
 
 import pytest
-from flaskr.common.config import EnhancedConfig, EnvironmentConfigError, EnvVar
+from flaskr.common.config import (
+    ENV_VARS,
+    EnhancedConfig,
+    EnvironmentConfigError,
+    EnvVar,
+)
 
 from tests.common.fixtures.config_data import (
     DOCKER_ENV_CONFIG,
@@ -48,6 +53,20 @@ class TestEnhancedConfigValidation:
         config.validate_environment()
 
         assert config._validated is True
+
+    @pytest.mark.parametrize(
+        "variable_name", ["MIN_SHIFU_PRICE", "DEFAULT_SHIFU_PRICE"]
+    )
+    def test_course_price_validation_preserves_environment_precision(
+        self, monkeypatch: object, variable_name: str
+    ) -> None:
+        """Reject extra decimals that binary float conversion would discard."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.setenv(variable_name, "0.50000000000000001")
+        config = EnhancedConfig({variable_name: ENV_VARS[variable_name]})
+
+        with pytest.raises(EnvironmentConfigError, match=variable_name):
+            config.validate_environment()
 
     def test_validate_missing_required(self, monkeypatch: object) -> None:
         """Test validation fails when required variables are missing."""

--- a/src/api/tests/common/test_config_envvar.py
+++ b/src/api/tests/common/test_config_envvar.py
@@ -19,13 +19,17 @@ from tests.common.fixtures.mock_validators import (
 )
 
 
-@pytest.mark.parametrize("value", ["nan", "inf", "-0.01", "0.501", "1e100"])
+@pytest.mark.parametrize(
+    "value", ["nan", "inf", "-0.01", "0.501", "100000000.00", "1e100"]
+)
 def test_parse_nonnegative_cent_amount_rejects_invalid_money(value: str) -> None:
     with pytest.raises(ValueError, match="finite nonnegative amount"):
         parse_nonnegative_cent_amount(value)
 
 
-@pytest.mark.parametrize("value", ["0", "0.01", 0.5, Decimal("12.30")])
+@pytest.mark.parametrize(
+    "value", ["0", "0.01", 0.5, Decimal("12.30"), Decimal("99999999.99")]
+)
 def test_parse_nonnegative_cent_amount_accepts_exact_money(value: object) -> None:
     assert parse_nonnegative_cent_amount(value) == Decimal(str(value)).quantize(
         Decimal("0.01")

--- a/src/api/tests/common/test_config_envvar.py
+++ b/src/api/tests/common/test_config_envvar.py
@@ -1,10 +1,13 @@
 """Unit tests for EnvVar dataclass."""
 
+from decimal import Decimal
+
 import pytest
 from flaskr.common.config import (
     ENV_VARS,
     EnvVar,
     parse_llm_model_max_output_tokens,
+    parse_nonnegative_cent_amount,
 )
 
 from tests.common.fixtures.mock_validators import (
@@ -14,6 +17,19 @@ from tests.common.fixtures.mock_validators import (
     mock_port_validator,
     range_validator,
 )
+
+
+@pytest.mark.parametrize("value", ["nan", "inf", "-0.01", "0.501", "1e100"])
+def test_parse_nonnegative_cent_amount_rejects_invalid_money(value: str) -> None:
+    with pytest.raises(ValueError, match="finite nonnegative amount"):
+        parse_nonnegative_cent_amount(value)
+
+
+@pytest.mark.parametrize("value", ["0", "0.01", 0.5, Decimal("12.30")])
+def test_parse_nonnegative_cent_amount_accepts_exact_money(value: object) -> None:
+    assert parse_nonnegative_cent_amount(value) == Decimal(str(value)).quantize(
+        Decimal("0.01")
+    )
 
 
 class TestEnvVarInitialization:

--- a/src/api/tests/common/test_config_envvar.py
+++ b/src/api/tests/common/test_config_envvar.py
@@ -141,6 +141,15 @@ class TestEnvVarTypeConversion:
         assert env_var.convert_type("10") == 10.0
         assert env_var.convert_type("") == 1.5  # Empty returns default
 
+    def test_convert_to_decimal_preserves_source_precision(self) -> None:
+        """Test decimal conversion does not round through binary floating point."""
+        env_var = EnvVar(name="DECIMAL_VAR", type=Decimal, default=Decimal("0.5"))
+
+        assert env_var.convert_type("0.50000000000000001") == Decimal(
+            "0.50000000000000001"
+        )
+        assert env_var.convert_type("") == Decimal("0.5")
+
     def test_convert_to_bool(self) -> None:
         """Test string to bool conversion."""
         env_var = EnvVar(name="BOOL_VAR", type=bool, default=False)

--- a/src/api/tests/service/billing/test_billing_dtos.py
+++ b/src/api/tests/service/billing/test_billing_dtos.py
@@ -211,6 +211,8 @@ def test_runtime_config_dto_json_uses_public_aliases() -> None:
         contact_us_url="https://ai-shifu.cn/contact.html",
         official_site_url="https://official.example.com",
         currency_symbol="¥",
+        default_course_price=0,
+        minimum_paid_course_price=0.01,
         legal_urls=RuntimeLegalUrlsDTO(
             agreement=RuntimeLocalizedUrlDTO(
                 **{
@@ -302,6 +304,8 @@ def test_runtime_config_dto_json_uses_public_aliases() -> None:
         "contactUsUrl",
         "officialSiteUrl",
         "currencySymbol",
+        "defaultCoursePrice",
+        "minimumPaidCoursePrice",
         "legalUrls",
         "entitlements",
         "branding",

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -174,13 +174,16 @@ def test_zero_price_order_completes_during_initialization_without_provider(
     )
 
     result = init_buy_record(legacy_order_app, "free-user", "free-course")
+    repeated = init_buy_record(legacy_order_app, "free-user", "free-course")
 
     assert result.status == ORDER_STATUS_SUCCESS
+    assert repeated.order_id == result.order_id
     assert Decimal(result.value_to_pay) == Decimal("0.00")
     assert provider_calls == []
     with legacy_order_app.app_context():
         order = Order.query.filter_by(order_bid=result.order_id).one()
         assert order.status == ORDER_STATUS_SUCCESS
+        assert Order.query.filter_by(user_bid="free-user").count() == 1
 
 
 class _FakeSaasConfigFuncs:

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -161,7 +161,12 @@ def test_zero_price_order_completes_during_initialization_without_provider(
     )
     monkeypatch.setattr(order_funs, "apply_promo_campaigns", lambda *_a, **_k: [])
     monkeypatch.setattr(order_funs, "set_user_state", lambda *_args: None)
-    monkeypatch.setattr(order_funs, "send_order_feishu", lambda *_args: None)
+    notification_calls: list[str] = []
+    monkeypatch.setattr(
+        order_funs,
+        "send_order_feishu",
+        lambda _app, order_bid: notification_calls.append(order_bid),
+    )
     provider_calls: list[str] = []
 
     def record_provider_call(name: str) -> None:
@@ -180,10 +185,49 @@ def test_zero_price_order_completes_during_initialization_without_provider(
     assert repeated.order_id == result.order_id
     assert Decimal(result.value_to_pay) == Decimal("0.00")
     assert provider_calls == []
+    assert notification_calls == [result.order_id]
     with legacy_order_app.app_context():
         order = Order.query.filter_by(order_bid=result.order_id).one()
         assert order.status == ORDER_STATUS_SUCCESS
         assert Order.query.filter_by(user_bid="free-user").count() == 1
+
+
+def test_successful_order_retry_does_not_reprice_purchase_history(
+    legacy_order_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from flaskr.service.order import funs as order_funs
+
+    monkeypatch.setattr(order_funs, "get_shifu_creator_bid", lambda *_args: "u1")
+    monkeypatch.setattr(order_funs, "set_shifu_context", lambda *_args: None)
+    monkeypatch.setattr(
+        order_funs,
+        "get_shifu_info",
+        lambda *_args, **_kwargs: SimpleNamespace(price=Decimal("20.00")),
+    )
+    with legacy_order_app.app_context():
+        order = Order(
+            order_bid="paid-order",
+            user_bid="paid-user",
+            shifu_bid="paid-course",
+            creator_bid="u1",
+            payable_price=Decimal("20.00"),
+            paid_price=Decimal("20.00"),
+            status=ORDER_STATUS_SUCCESS,
+        )
+        dao.db.session.add(order)
+        dao.db.session.commit()
+
+    monkeypatch.setattr(
+        order_funs,
+        "_sync_order_campaign_pricing",
+        lambda *_args, **_kwargs: pytest.fail("successful orders must not be repriced"),
+    )
+
+    result = init_buy_record(legacy_order_app, "paid-user", "paid-course")
+
+    assert result.order_id == "paid-order"
+    assert Decimal(result.value_to_pay) == Decimal("20.00")
 
 
 class _FakeSaasConfigFuncs:

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -14,7 +14,7 @@ from flask import Flask
 from flaskr import dao
 from flaskr.service.billing.entitlements import grant_creator_manual_entitlement
 from flaskr.service.billing.models import BillingOrder
-from flaskr.service.order.consts import ORDER_STATUS_TO_BE_PAID
+from flaskr.service.order.consts import ORDER_STATUS_SUCCESS, ORDER_STATUS_TO_BE_PAID
 from flaskr.service.order.funs import (
     BuyRecordDTO,
     generate_charge,
@@ -142,6 +142,45 @@ def test_legacy_order_purchase_flow_stays_on_order_tables(
         assert order.status == ORDER_STATUS_TO_BE_PAID
         assert order.payment_channel == "pingxx"
         assert BillingOrder.query.count() == 0
+
+
+def test_zero_price_order_completes_during_initialization_without_provider(
+    legacy_order_app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from flaskr.service.order import funs as order_funs
+
+    monkeypatch.setattr(order_funs, "get_shifu_creator_bid", lambda *_args: "u1")
+    monkeypatch.setattr(order_funs, "set_shifu_context", lambda *_args: None)
+    monkeypatch.setattr(
+        order_funs,
+        "get_shifu_info",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            price=Decimal("0.00"), title="Free course", description="Free"
+        ),
+    )
+    monkeypatch.setattr(order_funs, "apply_promo_campaigns", lambda *_a, **_k: [])
+    monkeypatch.setattr(order_funs, "set_user_state", lambda *_args: None)
+    monkeypatch.setattr(order_funs, "send_order_feishu", lambda *_args: None)
+    provider_calls: list[str] = []
+
+    def record_provider_call(name: str) -> None:
+        provider_calls.append(name)
+
+    monkeypatch.setattr(
+        order_funs,
+        "get_payment_provider",
+        record_provider_call,
+    )
+
+    result = init_buy_record(legacy_order_app, "free-user", "free-course")
+
+    assert result.status == ORDER_STATUS_SUCCESS
+    assert Decimal(result.value_to_pay) == Decimal("0.00")
+    assert provider_calls == []
+    with legacy_order_app.app_context():
+        order = Order.query.filter_by(order_bid=result.order_id).one()
+        assert order.status == ORDER_STATUS_SUCCESS
 
 
 class _FakeSaasConfigFuncs:

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -132,7 +132,9 @@ def test_global_course_price_policy_rejects_positive_amount_below_stripe_minimum
         shifu_draft_funcs._resolve_shifu_price(0.01)
 
 
-@pytest.mark.parametrize("price", [0.011, 0.501, float("nan"), float("inf")])
+@pytest.mark.parametrize(
+    "price", [0.011, 0.501, float("nan"), float("inf"), Decimal("1e100")]
+)
 def test_course_price_policy_rejects_values_that_cannot_be_stored_exactly(
     monkeypatch: pytest.MonkeyPatch, price: float
 ) -> None:

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -94,6 +94,44 @@ def _mock_route_permission(
     )
 
 
+@pytest.mark.parametrize(
+    ("minimum", "default", "price", "expected"),
+    [
+        (0.01, 0.0, None, 0.0),
+        (0.01, 0.0, 0.0, 0.0),
+        (0.01, 0.0, 0.01, 0.01),
+        (0.5, 0.5, 0.0, 0.0),
+        (0.5, 0.5, 0.5, 0.5),
+    ],
+)
+def test_course_price_policy_accepts_market_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    minimum: float,
+    default: float,
+    price: float | None,
+    expected: float,
+) -> None:
+    from flaskr.service.shifu import shifu_draft_funcs
+
+    values = {"MIN_SHIFU_PRICE": minimum, "DEFAULT_SHIFU_PRICE": default}
+    monkeypatch.setattr(shifu_draft_funcs, "get_config", values.__getitem__)
+
+    assert shifu_draft_funcs._resolve_shifu_price(price) == expected
+
+
+def test_global_course_price_policy_rejects_positive_amount_below_stripe_minimum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from flaskr.service.common.models import AppError
+    from flaskr.service.shifu import shifu_draft_funcs
+
+    values = {"MIN_SHIFU_PRICE": 0.5, "DEFAULT_SHIFU_PRICE": 0.5}
+    monkeypatch.setattr(shifu_draft_funcs, "get_config", values.__getitem__)
+
+    with pytest.raises(AppError):
+        shifu_draft_funcs._resolve_shifu_price(0.01)
+
+
 def test_save_shifu_draft_info_keeps_existing_price_when_input_is_none(
     app: object, monkeypatch: object
 ) -> None:

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -116,7 +116,7 @@ def test_course_price_policy_accepts_market_boundaries(
     values = {"MIN_SHIFU_PRICE": minimum, "DEFAULT_SHIFU_PRICE": default}
     monkeypatch.setattr(shifu_draft_funcs, "get_config", values.__getitem__)
 
-    assert shifu_draft_funcs._resolve_shifu_price(price) == expected
+    assert shifu_draft_funcs._resolve_shifu_price(price) == Decimal(str(expected))
 
 
 def test_global_course_price_policy_rejects_positive_amount_below_stripe_minimum(
@@ -130,6 +130,20 @@ def test_global_course_price_policy_rejects_positive_amount_below_stripe_minimum
 
     with pytest.raises(AppError):
         shifu_draft_funcs._resolve_shifu_price(0.01)
+
+
+@pytest.mark.parametrize("price", [0.011, 0.501, float("nan"), float("inf")])
+def test_course_price_policy_rejects_values_that_cannot_be_stored_exactly(
+    monkeypatch: pytest.MonkeyPatch, price: float
+) -> None:
+    from flaskr.service.common.models import AppError
+    from flaskr.service.shifu import shifu_draft_funcs
+
+    values = {"MIN_SHIFU_PRICE": 0.01, "DEFAULT_SHIFU_PRICE": 0.0}
+    monkeypatch.setattr(shifu_draft_funcs, "get_config", values.__getitem__)
+
+    with pytest.raises(AppError):
+        shifu_draft_funcs._resolve_shifu_price(price)
 
 
 def test_save_shifu_draft_info_keeps_existing_price_when_input_is_none(

--- a/src/api/tests/service/shifu/test_shifu_draft_info.py
+++ b/src/api/tests/service/shifu/test_shifu_draft_info.py
@@ -133,7 +133,15 @@ def test_global_course_price_policy_rejects_positive_amount_below_stripe_minimum
 
 
 @pytest.mark.parametrize(
-    "price", [0.011, 0.501, float("nan"), float("inf"), Decimal("1e100")]
+    "price",
+    [
+        0.011,
+        0.501,
+        float("nan"),
+        float("inf"),
+        Decimal("100000000.00"),
+        Decimal("1e100"),
+    ],
 )
 def test_course_price_policy_rejects_values_that_cannot_be_stored_exactly(
     monkeypatch: pytest.MonkeyPatch, price: float


### PR DESCRIPTION
## Summary
- expose deployment-controlled default and minimum positive course prices
- allow exactly zero in every market while preserving the configured positive minimum
- complete zero-value orders atomically without invoking a payment provider
- keep successful orders immutable and make free-unlock retries idempotent
- reject non-finite, negative, oversized, and sub-cent course prices
- refresh the generated deployment environment example

## Market contract
- China config: default `0`, minimum paid `0.01`
- Global config: default `0.50`, minimum paid `0.50`
- Both markets: exactly `0` creates a successful free order and bypasses payment providers

## Verification
- focused order and course-price suites: 41 passed
- configuration and course-price suites: 82 passed
- Ruff passed
- repository pre-commit and harness checks passed
- no database migration

## Follow-up
The stacked frontend PR consumes this runtime contract and must merge after this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable default and minimum course prices to runtime settings.
  - Added support for free courses, completing zero-value orders without payment processing.
  - Added precise course-price validation for cent values, nonnegative amounts, and maximum limits.
  - Preserved successful purchase history and prevented duplicate completion notifications.

- **Documentation**
  - Added an execution plan covering course-pricing rules and free-course access.
  - Documented the default price setting and clarified that a zero minimum price indicates free courses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->