### PR TITLE
feat: apply market course prices in authoring and learning

### DIFF
--- a/docs/exec-plans/active/course-price-market-rules-and-free-unlock.md
+++ b/docs/exec-plans/active/course-price-market-rules-and-free-unlock.md
@@ -48,8 +48,21 @@ provider.
 Implemented a server-owned market price contract and atomic, idempotent free
 course orders without a schema migration. Cook Web consumes the contract for
 authoring validation and waits for server-confirmed success before unlocking a
-free course. Focused backend tests, frontend tests, type-check, lint, Ruff, and
+free course. Prices are also constrained to the exact `DECIMAL(10, 2)` storage
+range. Focused backend tests, frontend tests, type-check, lint, Ruff, and
 repository harness checks pass.
+
+## Follow-up Opportunities
+
+- Retry runtime configuration after an initial fetch failure. The current
+  compatibility fallback remains 0.50 and requires a refresh to recover, so a
+  transient failure can temporarily hide China's 0.01 authoring option.
+- Freeze the analytics identity version across the existing asynchronous
+  course-settings save event. This attribution race predates the price-tier
+  field and should be corrected once for the shared tracking path.
+- Promote the real payment-hook and authoring-form boundary probes into stable
+  integration coverage. The current suite covers the price policy, order
+  transition, provider bypass, and settings analytics independently.
 
 ## Context and Orientation
 

--- a/docs/exec-plans/active/course-price-market-rules-and-free-unlock.md
+++ b/docs/exec-plans/active/course-price-market-rules-and-free-unlock.md
@@ -16,8 +16,8 @@ provider.
   order completion with regression coverage.
 - [x] 2026-09-09 17:45 CST: Implement frontend configuration-driven authoring
   validation and server-authoritative free unlock with regression coverage.
-- [ ] 2026-09-09 17:05 CST: Verify, self-review, publish two focused PRs, and
-  document their stacking/merge order.
+- [x] 2026-09-09 18:00 CST: Verified and self-reviewed two focused stacked
+  branches; publish them as backend-first PRs.
 
 ## Surprises & Discoveries
 
@@ -45,7 +45,11 @@ provider.
 
 ## Outcomes & Retrospective
 
-Pending implementation and verification.
+Implemented a server-owned market price contract and atomic, idempotent free
+course orders without a schema migration. Cook Web consumes the contract for
+authoring validation and waits for server-confirmed success before unlocking a
+free course. Focused backend tests, frontend tests, type-check, lint, Ruff, and
+repository harness checks pass.
 
 ## Context and Orientation
 

--- a/docs/exec-plans/active/course-price-market-rules-and-free-unlock.md
+++ b/docs/exec-plans/active/course-price-market-rules-and-free-unlock.md
@@ -14,7 +14,7 @@ provider.
   order initialization, provider dispatch, and learner payment state.
 - [x] 2026-09-09 17:25 CST: Implement backend pricing contract and atomic free
   order completion with regression coverage.
-- [ ] 2026-09-09 17:05 CST: Implement frontend configuration-driven authoring
+- [x] 2026-09-09 17:45 CST: Implement frontend configuration-driven authoring
   validation and server-authoritative free unlock with regression coverage.
 - [ ] 2026-09-09 17:05 CST: Verify, self-review, publish two focused PRs, and
   document their stacking/merge order.

--- a/docs/product-specs/web-umami-contract-remediation.md
+++ b/docs/product-specs/web-umami-contract-remediation.md
@@ -84,7 +84,8 @@ are not backfilled under another name.
 - Metric definition: raw successful saves/creates and accepted actions per day,
   grouped only by the documented enums or stable business IDs. The follow-up
   adoption view groups successful `creator_shifu_setting_save` rows by
-  `follow_up_mode`. These are usage counts, not exact user funnels.
+  `follow_up_mode` and `price_tier`. These are usage counts, not exact user
+  funnels.
 - Actor and surface: authenticated teachers in Cook Web authoring surfaces.
 - Population: normal and read-only-aware producer eligibility as implemented by
   each control; failed validation, rejected API calls, and disabled controls are
@@ -98,16 +99,17 @@ are not backfilled under another name.
   `creator_shifu_setting_save`; historical rows are not backfilled and a
   missing value must be treated as `legacy_unknown`, never inferred as `text`.
 
-| Event                          | Exact trigger                                                                | Complete payload                                                                                                 |
-| ------------------------------ | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `creator_shifu_setting_save`   | After the course-settings API succeeds                                       | `shifu_bid`, `save_type`, `tts_enabled`, `default_listen_mode_enabled`, `use_learner_language`, `follow_up_mode` |
-| `creator_outline_setting_save` | After lesson settings save succeeds                                          | `shifu_bid`, `outline_bid`, `save_type`, `variant`, `learning_permission`, `hide_chapter`                        |
-| `creator_outline_prompt_save`  | After chapter prompt/settings save succeeds                                  | `shifu_bid`, `outline_bid`, `save_type`                                                                          |
-| `creator_outline_create`       | After an outline unit is created                                             | `shifu_bid`, `outline_bid`, `parent_bid`                                                                         |
-| `creator_shifu_preview_click`  | Immediately after the enabled preview handler accepts the click, before save | `shifu_bid`                                                                                                      |
-| `creator_lesson_preview_click` | Immediately after the enabled lesson preview handler accepts the click       | `shifu_bid`, `outline_bid`                                                                                       |
+| Event                          | Exact trigger                                                                | Complete payload                                                                                                               |
+| ------------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `creator_shifu_setting_save`   | After the course-settings API succeeds                                       | `shifu_bid`, `save_type`, `tts_enabled`, `default_listen_mode_enabled`, `use_learner_language`, `follow_up_mode`, `price_tier` |
+| `creator_outline_setting_save` | After lesson settings save succeeds                                          | `shifu_bid`, `outline_bid`, `save_type`, `variant`, `learning_permission`, `hide_chapter`                                      |
+| `creator_outline_prompt_save`  | After chapter prompt/settings save succeeds                                  | `shifu_bid`, `outline_bid`, `save_type`                                                                                        |
+| `creator_outline_create`       | After an outline unit is created                                             | `shifu_bid`, `outline_bid`, `parent_bid`                                                                                       |
+| `creator_shifu_preview_click`  | Immediately after the enabled preview handler accepts the click, before save | `shifu_bid`                                                                                                                    |
+| `creator_lesson_preview_click` | Immediately after the enabled lesson preview handler accepts the click       | `shifu_bid`, `outline_bid`                                                                                                     |
 
 Allowed enums are `save_type=auto|manual`, `follow_up_mode=text|live_voice`,
+`price_tier=free|micro_paid|standard_paid`,
 `variant=chapter|lesson`, and `learning_permission=normal|trial|guest`, as
 defined by `LEARNING_PERMISSION` in `src/web/src/api/studyV2.ts`.
 Course/chapter/lesson names, descriptions, system prompts, model names, voice

--- a/src/web/src/app/c/[[...id]]/Components/Pay/hooks/usePaymentFlow.ts
+++ b/src/web/src/app/c/[[...id]]/Components/Pay/hooks/usePaymentFlow.ts
@@ -129,10 +129,7 @@ export const usePaymentFlow = ({
       setPriceItems(
         snapshot.price_item?.filter(item => item?.is_discount) || [],
       );
-      const valueToPayNumber = Number(snapshot.value_to_pay);
-      const isFreeOrder =
-        !Number.isNaN(valueToPayNumber) && valueToPayNumber <= 0;
-      if (snapshot.status === ORDER_STATUS.BUY_STATUS_SUCCESS || isFreeOrder) {
+      if (snapshot.status === ORDER_STATUS.BUY_STATUS_SUCCESS) {
         setIsCompleted(true);
         setPollingActive(false);
         onOrderPaid?.();
@@ -200,13 +197,7 @@ export const usePaymentFlow = ({
         }
         updateFromOrder(current);
         const currentSnapshot = current;
-        const valueToPayNumber = Number(currentSnapshot.value_to_pay);
-        const isFreeOrder =
-          !Number.isNaN(valueToPayNumber) && valueToPayNumber <= 0;
-        if (
-          currentSnapshot.status === ORDER_STATUS.BUY_STATUS_SUCCESS ||
-          isFreeOrder
-        ) {
+        if (currentSnapshot.status === ORDER_STATUS.BUY_STATUS_SUCCESS) {
           return current;
         }
         const payload = await getPayUrl({

--- a/src/web/src/components/shifu-setting/ShifuSetting.analytics.test.tsx
+++ b/src/web/src/components/shifu-setting/ShifuSetting.analytics.test.tsx
@@ -21,6 +21,7 @@ const mockBillingOverview = { debug_allowed: undefined as boolean | undefined };
 const mockEnvState = {
   defaultLlmModel: '',
   currencySymbol: '¥',
+  minimumPaidCoursePrice: 0.5,
   billingEnabled: 'false',
 };
 
@@ -225,6 +226,7 @@ describe('ShifuSettingDialog analytics producer', () => {
             default_listen_mode_enabled: false,
             use_learner_language: true,
             follow_up_mode: 'text',
+            price_tier: 'standard_paid',
           },
         );
       });
@@ -437,6 +439,7 @@ describe('ShifuSettingDialog analytics producer', () => {
           default_listen_mode_enabled: false,
           use_learner_language: false,
           follow_up_mode: 'text',
+          price_tier: 'standard_paid',
         },
       );
       expect(mockTrackEvent).toHaveBeenCalledTimes(1);
@@ -479,6 +482,7 @@ describe('ShifuSettingDialog analytics producer', () => {
           default_listen_mode_enabled: false,
           use_learner_language: true,
           follow_up_mode: 'text',
+          price_tier: 'standard_paid',
         },
       );
 

--- a/src/web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/web/src/components/shifu-setting/ShifuSetting.tsx
@@ -1293,6 +1293,7 @@ export default function ShifuSettingDialog({
                 defaultListenModeEnabled,
                 useLearnerLanguage,
                 followUpMode: isLiveVoiceFollowUp ? 'live_voice' : 'text',
+                price: Number(data.price),
               }),
             ),
           ).catch(() => {});

--- a/src/web/src/components/shifu-setting/ShifuSetting.tsx
+++ b/src/web/src/components/shifu-setting/ShifuSetting.tsx
@@ -36,6 +36,7 @@ import {
 import { BILLING_PACKAGES_HREF } from '@/lib/billingNavigation';
 import { getResolvedBaseURL } from '@/lib/envUtils';
 import { normalizeShifuDetail } from '@/lib/shifu-normalize';
+import { isAllowedCoursePrice } from '@/lib/coursePricePolicy';
 import {
   type AudioSegment,
   mergeAudioSegmentByUniqueKey,
@@ -171,7 +172,6 @@ interface Shifu {
   use_learner_language?: boolean;
 }
 
-const MIN_SHIFU_PRICE = 0.5;
 const TEMPERATURE_MIN = 0;
 const TEMPERATURE_MAX = 2;
 const ASK_MODE_ENABLE = 5103;
@@ -219,6 +219,9 @@ export default function ShifuSettingDialog({
   const { toast } = useToast();
   const defaultLlmModel = useEnvStore(state => state.defaultLlmModel);
   const currencySymbol = useEnvStore(state => state.currencySymbol);
+  const minimumPaidCoursePrice = useEnvStore(
+    state => state.minimumPaidCoursePrice,
+  );
   const billingEnabled = useEnvStore(state => state.billingEnabled === 'true');
   const { data: billingOverview } = useBillingOverview();
   const debugAllowed =
@@ -1099,7 +1102,7 @@ export default function ShifuSettingDialog({
       .max(20000, t('module.shifuSetting.shifuPromptMaxLength')),
     price: z
       .string()
-      .min(0.5, t('module.shifuSetting.shifuPriceEmpty'))
+      .min(1, t('module.shifuSetting.shifuPriceEmpty'))
       .regex(/^\d+(\.\d{1,2})?$/, t('module.shifuSetting.shifuPriceFormat')),
     temperature: z
       .string()
@@ -1709,11 +1712,11 @@ export default function ShifuSettingDialog({
         return false;
       }
       const priceValue = parseFloat(form.getValues('price') || '0');
-      if (!Number.isNaN(priceValue) && priceValue < MIN_SHIFU_PRICE) {
+      if (!isAllowedCoursePrice(priceValue, minimumPaidCoursePrice)) {
         form.setError('price', {
           type: 'manual',
           message: t('server.shifu.shifuPriceTooLow', {
-            min_shifu_price: MIN_SHIFU_PRICE,
+            min_shifu_price: minimumPaidCoursePrice,
           }),
         });
         if (needClose) {
@@ -1730,7 +1733,15 @@ export default function ShifuSettingDialog({
       await onSubmit(form.getValues(), needClose, saveType);
       return true;
     },
-    [currentShifu?.readonly, form, onSubmit, settingsLoading, t, updateOpen],
+    [
+      currentShifu?.readonly,
+      form,
+      minimumPaidCoursePrice,
+      onSubmit,
+      settingsLoading,
+      t,
+      updateOpen,
+    ],
   );
 
   useEffect(() => {

--- a/src/web/src/components/shifu-setting/shifuSettingAnalytics.test.ts
+++ b/src/web/src/components/shifu-setting/shifuSettingAnalytics.test.ts
@@ -9,6 +9,7 @@ describe('buildShifuSettingSaveAnalytics', () => {
       defaultListenModeEnabled: true,
       useLearnerLanguage: false,
       followUpMode: 'live_voice',
+      price: 0,
     });
 
     expect(payload).toEqual({
@@ -18,6 +19,7 @@ describe('buildShifuSettingSaveAnalytics', () => {
       default_listen_mode_enabled: true,
       use_learner_language: false,
       follow_up_mode: 'live_voice',
+      price_tier: 'free',
     });
     expect(payload).not.toHaveProperty('name');
     expect(payload).not.toHaveProperty('description');
@@ -33,6 +35,7 @@ describe('buildShifuSettingSaveAnalytics', () => {
       [
         'default_listen_mode_enabled',
         'follow_up_mode',
+        'price_tier',
         'save_type',
         'shifu_bid',
         'tts_enabled',
@@ -50,6 +53,7 @@ describe('buildShifuSettingSaveAnalytics', () => {
         defaultListenModeEnabled: true,
         useLearnerLanguage: true,
         followUpMode: 'text',
+        price: 0.01,
       }),
     ).toEqual({
       shifu_bid: 'course-1',
@@ -58,6 +62,21 @@ describe('buildShifuSettingSaveAnalytics', () => {
       default_listen_mode_enabled: false,
       use_learner_language: true,
       follow_up_mode: 'text',
+      price_tier: 'micro_paid',
     });
+  });
+
+  it('groups regular paid prices without recording the amount', () => {
+    expect(
+      buildShifuSettingSaveAnalytics({
+        shifuBid: 'course-1',
+        saveType: 'manual',
+        ttsEnabled: false,
+        defaultListenModeEnabled: false,
+        useLearnerLanguage: false,
+        followUpMode: 'text',
+        price: 0.5,
+      }).price_tier,
+    ).toBe('standard_paid');
   });
 });

--- a/src/web/src/components/shifu-setting/shifuSettingAnalytics.ts
+++ b/src/web/src/components/shifu-setting/shifuSettingAnalytics.ts
@@ -5,6 +5,7 @@ export type ShifuSettingSaveAnalyticsInput = {
   defaultListenModeEnabled: boolean;
   useLearnerLanguage: boolean;
   followUpMode: 'text' | 'live_voice';
+  price: number;
 };
 
 export const buildShifuSettingSaveAnalytics = ({
@@ -14,6 +15,7 @@ export const buildShifuSettingSaveAnalytics = ({
   defaultListenModeEnabled,
   useLearnerLanguage,
   followUpMode,
+  price,
 }: ShifuSettingSaveAnalyticsInput) => ({
   shifu_bid: shifuBid,
   save_type: saveType,
@@ -21,4 +23,6 @@ export const buildShifuSettingSaveAnalytics = ({
   default_listen_mode_enabled: ttsEnabled && defaultListenModeEnabled,
   use_learner_language: useLearnerLanguage,
   follow_up_mode: followUpMode,
+  price_tier:
+    price === 0 ? 'free' : price < 0.5 ? 'micro_paid' : 'standard_paid',
 });

--- a/src/web/src/lib/coursePricePolicy.test.ts
+++ b/src/web/src/lib/coursePricePolicy.test.ts
@@ -1,0 +1,14 @@
+import { isAllowedCoursePrice } from './coursePricePolicy';
+
+describe('course price policy', () => {
+  test.each([
+    [0, 0.01, true],
+    [0.01, 0.01, true],
+    [0, 0.5, true],
+    [0.49, 0.5, false],
+    [0.5, 0.5, true],
+    [-0.01, 0.01, false],
+  ])('validates %s against positive minimum %s', (price, minimum, expected) => {
+    expect(isAllowedCoursePrice(price, minimum)).toBe(expected);
+  });
+});

--- a/src/web/src/lib/coursePricePolicy.ts
+++ b/src/web/src/lib/coursePricePolicy.ts
@@ -1,0 +1,10 @@
+export function isAllowedCoursePrice(
+  price: number,
+  minimumPaidCoursePrice: number,
+): boolean {
+  return (
+    Number.isFinite(price) &&
+    price >= 0 &&
+    (price === 0 || price >= minimumPaidCoursePrice)
+  );
+}

--- a/src/web/src/lib/initializeEnvData.ts
+++ b/src/web/src/lib/initializeEnvData.ts
@@ -89,6 +89,8 @@ const loadRuntimeConfig = async () => {
     updateContactUsUrl,
     updateOfficialSiteUrl,
     updateCurrencySymbol,
+    updateDefaultCoursePrice,
+    updateMinimumPaidCoursePrice,
     updateBillingEnabled,
     updateStripePublishableKey,
     updateStripeEnabled,
@@ -177,6 +179,16 @@ const loadRuntimeConfig = async () => {
     resolveOfficialSiteUrl(runtimeConfig?.officialSiteUrl),
   );
   await updateCurrencySymbol(runtimeConfig?.currencySymbol || '¥');
+  await updateDefaultCoursePrice(
+    typeof runtimeConfig?.defaultCoursePrice === 'number'
+      ? runtimeConfig.defaultCoursePrice
+      : 0.5,
+  );
+  await updateMinimumPaidCoursePrice(
+    typeof runtimeConfig?.minimumPaidCoursePrice === 'number'
+      ? runtimeConfig.minimumPaidCoursePrice
+      : 0.5,
+  );
   await updateBillingEnabled(
     runtimeConfig?.billingEnabled !== undefined
       ? runtimeConfig.billingEnabled.toString()

--- a/src/web/src/store/envStore.ts
+++ b/src/web/src/store/envStore.ts
@@ -47,6 +47,12 @@ export const useEnvStore = create<EnvStoreState>(set => ({
   currencySymbol: environment.currencySymbol,
   updateCurrencySymbol: async (currencySymbol: string) =>
     set({ currencySymbol }),
+  defaultCoursePrice: 0.5,
+  updateDefaultCoursePrice: async (defaultCoursePrice: number) =>
+    set({ defaultCoursePrice }),
+  minimumPaidCoursePrice: 0.5,
+  updateMinimumPaidCoursePrice: async (minimumPaidCoursePrice: number) =>
+    set({ minimumPaidCoursePrice }),
   billingEnabled: environment.billingEnabled.toString(),
   updateBillingEnabled: async (billingEnabled: string) =>
     set({ billingEnabled }),

--- a/src/web/src/types/store.ts
+++ b/src/web/src/types/store.ts
@@ -28,6 +28,8 @@ export interface EnvStoreState {
   contactUsUrl: string;
   officialSiteUrl: string;
   currencySymbol: string;
+  defaultCoursePrice: number;
+  minimumPaidCoursePrice: number;
   billingEnabled: string;
   stripePublishableKey: string;
   stripeEnabled: string;
@@ -55,6 +57,8 @@ export interface EnvStoreState {
   updateContactUsUrl: (url: string) => Promise<void>;
   updateOfficialSiteUrl: (url: string) => Promise<void>;
   updateCurrencySymbol: (symbol: string) => Promise<void>;
+  updateDefaultCoursePrice: (price: number) => Promise<void>;
+  updateMinimumPaidCoursePrice: (price: number) => Promise<void>;
   updateBillingEnabled: (value: string) => Promise<void>;
   updateStripePublishableKey: (key: string) => Promise<void>;
   updateStripeEnabled: (value: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- load course price defaults and positive minimums from backend runtime configuration
- remove the hard-coded `0.5` authoring rule and allow zero as a free price
- require server-confirmed order success before the learner UI unlocks a zero-value course
- classify successful settings saves as free, small paid, or standard paid for privacy-safe adoption analytics
- add focused China/global price-boundary coverage

## Verification
- full frontend suite: 237 suites / 2593 tests passed
- TypeScript type-check passed
- frontend lint passed with pre-existing warnings only
- repository pre-commit and harness checks passed

## Dependency
Stacked on #2794. Merge #2794 first, then retarget this PR to `main`.