### PR TITLE
fix: show the correct channel for free orders

### DIFF
--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -628,6 +628,32 @@ def _resolve_order_display_payment_channel(order: Order) -> str:
     return resolve_market_payment_provider()
 
 
+def _apply_payment_channel_filter(query: Query, payment_channel: str) -> Query:
+    """Filter by the same effective channel exposed in order DTOs."""
+    normalized_channel = str(payment_channel or "").strip()
+    if not normalized_channel:
+        return query
+
+    market_provider = resolve_market_payment_provider()
+    if market_provider == "pingxx":
+        return query.filter(Order.payment_channel == normalized_channel)
+
+    legacy_free_order = db.and_(
+        Order.payment_channel == "pingxx",
+        Order.paid_price == Decimal(0),
+    )
+    if normalized_channel == market_provider:
+        return query.filter(
+            db.or_(Order.payment_channel == normalized_channel, legacy_free_order)
+        )
+    if normalized_channel == "pingxx":
+        return query.filter(
+            Order.payment_channel == "pingxx",
+            Order.paid_price != Decimal(0),
+        )
+    return query.filter(Order.payment_channel == normalized_channel)
+
+
 def _build_order_item(
     order: Order,
     shifu_map: dict[str, DraftShifu | PublishedShifu],
@@ -937,7 +963,7 @@ def list_orders(
 
         payment_channel = filters.get("payment_channel")
         if payment_channel:
-            query = query.filter(Order.payment_channel == payment_channel)
+            query = _apply_payment_channel_filter(query, str(payment_channel))
 
         start_time = _normalize_order_datetime_filter(filters.get("start_time"))
         if start_time:
@@ -1016,7 +1042,7 @@ def list_operator_orders(
 
         payment_channel = str(filters.get("payment_channel", "") or "").strip()
         if payment_channel:
-            query = query.filter(Order.payment_channel == payment_channel)
+            query = _apply_payment_channel_filter(query, payment_channel)
 
         order_source = str(filters.get("order_source", "") or "").strip()
         if order_source:

--- a/src/api/flaskr/service/order/admin.py
+++ b/src/api/flaskr/service/order/admin.py
@@ -40,6 +40,9 @@ from flaskr.service.order.models import (
     PingxxOrder,
     StripeOrder,
 )
+from flaskr.service.order.payment_channel_resolution import (
+    resolve_market_payment_provider,
+)
 from flaskr.service.order.raw_snapshots import (
     legacy_native_snapshot_query,
     legacy_pingxx_snapshot_query,
@@ -617,6 +620,14 @@ def _apply_order_source_filter(query: Query, order_source: str) -> Query:
     return query.filter(db.literal(False))  # noqa: FBT003 -- SQL literal value
 
 
+def _resolve_order_display_payment_channel(order: Order) -> str:
+    """Correct the legacy model default for free orders on non-Ping++ markets."""
+    payment_channel = str(order.payment_channel or "").strip()
+    if payment_channel != "pingxx" or Decimal(order.paid_price or 0) != Decimal(0):
+        return payment_channel
+    return resolve_market_payment_provider()
+
+
 def _build_order_item(
     order: Order,
     shifu_map: dict[str, DraftShifu | PublishedShifu],
@@ -626,7 +637,7 @@ def _build_order_item(
     """Build admin order summary DTO from order plus shifu/user lookups."""
     shifu = shifu_map.get(order.shifu_bid)
     user = user_map.get(order.user_bid, {})
-    payment_channel = order.payment_channel or ""
+    payment_channel = _resolve_order_display_payment_channel(order)
     status_key = ORDER_STATUS_KEY_MAP.get(order.status, "server.order.orderStatusInit")
     coupon_codes = []
     if coupon_map is not None:
@@ -1147,7 +1158,7 @@ def _load_order_coupons(order_bid: str) -> list[OrderAdminCouponDTO]:
 
 def _load_payment_detail(order: Order) -> OrderAdminPaymentDTO | None:
     """Build payment detail DTO from channel-specific order records."""
-    payment_channel = order.payment_channel or ""
+    payment_channel = _resolve_order_display_payment_channel(order)
     if payment_channel == "stripe":
         stripe_order = (
             legacy_stripe_snapshot_query()
@@ -1260,7 +1271,7 @@ def get_order_detail(app: Flask, user_id: str, order_bid: str) -> OrderAdminDeta
         summary = _build_order_item(order, shifu_map, user_map, coupon_map)
         payment_detail = _load_payment_detail(order)
         if not payment_detail:
-            payment_channel = order.payment_channel or ""
+            payment_channel = _resolve_order_display_payment_channel(order)
             payment_detail = OrderAdminPaymentDTO(
                 payment_channel=payment_channel,
                 payment_channel_key=PAYMENT_CHANNEL_KEY_MAP.get(
@@ -1296,7 +1307,7 @@ def get_operator_order_detail(app: Flask, order_bid: str) -> OrderAdminDetailDTO
         summary = _build_order_item(order, shifu_map, user_map, coupon_map)
         payment_detail = _load_payment_detail(order)
         if not payment_detail:
-            payment_channel = order.payment_channel or ""
+            payment_channel = _resolve_order_display_payment_channel(order)
             payment_detail = OrderAdminPaymentDTO(
                 payment_channel=payment_channel,
                 payment_channel_key=PAYMENT_CHANNEL_KEY_MAP.get(

--- a/src/api/flaskr/service/order/coupon_funcs.py
+++ b/src/api/flaskr/service/order/coupon_funcs.py
@@ -9,6 +9,7 @@ from flaskr.dao import db
 from flaskr.service.common import raise_error
 from flaskr.service.order.funs import (
     AICourseBuyRecordDTO,
+    assign_free_order_payment_channel,
     query_buy_record,
     success_buy_record,
 )
@@ -267,6 +268,8 @@ def use_coupon_code(
             )
         if decimal.Decimal(buy_record.paid_price) < 0:
             buy_record.paid_price = decimal.Decimal(0)
+        if buy_record.paid_price == 0:
+            assign_free_order_payment_channel(buy_record)
         buy_record.updated_at = now
         coupon_usage.updated_at = now
         if not user_usage_already_bound:

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -451,7 +451,7 @@ def init_buy_record(
                 active_id=None,
             )
             if decimal.Decimal(origin_record.paid_price) == decimal.Decimal(0):
-                _assign_free_order_payment_channel(origin_record)
+                assign_free_order_payment_channel(origin_record)
                 success_buy_record(app, origin_record.order_bid)
             return query_buy_record(app, origin_record.order_bid)
         order_id = str(get_uuid(app))
@@ -475,7 +475,7 @@ def init_buy_record(
             active_id=active_id,
         )
         if decimal.Decimal(buy_record.paid_price) == decimal.Decimal(0):
-            _assign_free_order_payment_channel(buy_record)
+            assign_free_order_payment_channel(buy_record)
             success_buy_record(app, buy_record.order_bid)
         price_items = []
         price_items.append(
@@ -727,8 +727,14 @@ def _resolve_payment_channel(
     )
 
 
-def _assign_free_order_payment_channel(order: Order) -> None:
+def assign_free_order_payment_channel(order: Order) -> None:
     """Attribute a free order to the market provider without creating a charge."""
+    recorded_channel = str(order.payment_channel or "").strip()
+    if recorded_channel in {"manual", "open_api"} or (
+        order.status != ORDER_STATUS_INIT
+        and recorded_channel in {"stripe", "alipay", "wechatpay"}
+    ):
+        return
     order.payment_channel = resolve_market_payment_provider()
 
 

--- a/src/api/flaskr/service/order/funs.py
+++ b/src/api/flaskr/service/order/funs.py
@@ -49,7 +49,10 @@ from flaskr.service.order.models import (
     PingxxOrder,
     StripeOrder,
 )
-from flaskr.service.order.payment_channel_resolution import resolve_payment_channel
+from flaskr.service.order.payment_channel_resolution import (
+    resolve_market_payment_provider,
+    resolve_payment_channel,
+)
 from flaskr.service.order.payment_providers import PaymentRequest, get_payment_provider
 from flaskr.service.order.payment_providers.base import (
     PaymentNotificationResult,
@@ -448,6 +451,7 @@ def init_buy_record(
                 active_id=None,
             )
             if decimal.Decimal(origin_record.paid_price) == decimal.Decimal(0):
+                _assign_free_order_payment_channel(origin_record)
                 success_buy_record(app, origin_record.order_bid)
             return query_buy_record(app, origin_record.order_bid)
         order_id = str(get_uuid(app))
@@ -471,6 +475,7 @@ def init_buy_record(
             active_id=active_id,
         )
         if decimal.Decimal(buy_record.paid_price) == decimal.Decimal(0):
+            _assign_free_order_payment_channel(buy_record)
             success_buy_record(app, buy_record.order_bid)
         price_items = []
         price_items.append(
@@ -720,6 +725,11 @@ def _resolve_payment_channel(
         stored_channel=stored_channel,
         additional_enabled_providers=additional_enabled_providers,
     )
+
+
+def _assign_free_order_payment_channel(order: Order) -> None:
+    """Attribute a free order to the market provider without creating a charge."""
+    order.payment_channel = resolve_market_payment_provider()
 
 
 def _resolve_custom_payment_provider_hints(creator_bid: str) -> set[str]:

--- a/src/api/flaskr/service/order/payment_channel_resolution.py
+++ b/src/api/flaskr/service/order/payment_channel_resolution.py
@@ -146,6 +146,20 @@ def resolve_payment_channel(
     return "pingxx", provider_channel
 
 
+def resolve_market_payment_provider(
+    *, additional_enabled_providers: Iterable[str] | None = None
+) -> str:
+    """Return the market provider used to attribute orders that need no charge."""
+    provider, _ = resolve_payment_channel(
+        payment_channel_hint=None,
+        channel_hint=None,
+        stored_channel=None,
+        default_pingxx_channel="alipay_qr",
+        additional_enabled_providers=additional_enabled_providers,
+    )
+    return provider
+
+
 def _provider_for_channel(channel: str, enabled_providers: set[str]) -> str:
     if channel == "alipay_qr":
         return "alipay" if "alipay" in enabled_providers else "pingxx"

--- a/src/api/tests/service/order/test_admin_orders.py
+++ b/src/api/tests/service/order/test_admin_orders.py
@@ -17,6 +17,7 @@ from flaskr.service.order.admin import (
     ORDER_SOURCE_OPEN_API,
     ORDER_SOURCE_USER_PURCHASE,
     _apply_order_source_filter,
+    _apply_payment_channel_filter,
     _load_matching_user_bids_for_keyword,
     _resolve_order_display_payment_channel,
     _resolve_order_source,
@@ -80,6 +81,38 @@ def test_paid_order_keeps_recorded_payment_channel() -> None:
     ) as resolver:
         assert _resolve_order_display_payment_channel(order) == "pingxx"
         resolver.assert_not_called()
+
+
+def test_stripe_filter_includes_legacy_free_pingxx_orders() -> None:
+    query = MagicMock()
+    query.filter.return_value = query
+
+    with patch(
+        "flaskr.service.order.admin.resolve_market_payment_provider",
+        return_value="stripe",
+    ):
+        _apply_payment_channel_filter(query, "stripe")
+
+    predicate = str(query.filter.call_args.args[0])
+    assert "payment_channel" in predicate
+    assert "paid_price" in predicate
+    assert " OR " in predicate
+
+
+def test_pingxx_filter_excludes_legacy_free_orders_on_stripe_market() -> None:
+    query = MagicMock()
+    query.filter.return_value = query
+
+    with patch(
+        "flaskr.service.order.admin.resolve_market_payment_provider",
+        return_value="stripe",
+    ):
+        _apply_payment_channel_filter(query, "pingxx")
+
+    predicates = query.filter.call_args.args
+    assert len(predicates) == 2
+    assert "payment_channel" in str(predicates[0])
+    assert "paid_price" in str(predicates[1])
 
 
 def _mock_operator(

--- a/src/api/tests/service/order/test_admin_orders.py
+++ b/src/api/tests/service/order/test_admin_orders.py
@@ -18,6 +18,7 @@ from flaskr.service.order.admin import (
     ORDER_SOURCE_USER_PURCHASE,
     _apply_order_source_filter,
     _load_matching_user_bids_for_keyword,
+    _resolve_order_display_payment_channel,
     _resolve_order_source,
     get_operator_order_detail,
     get_operator_order_overview,
@@ -56,6 +57,29 @@ class DummyShifu:
     def __init__(self) -> None:
         """Expose the fixed course title used by admin order tests."""
         self.title = "Demo Course"
+
+
+def test_free_order_legacy_default_uses_market_payment_channel() -> None:
+    order = DummyOrder()
+    order.paid_price = "0.00"
+    order.payment_channel = "pingxx"
+
+    with patch(
+        "flaskr.service.order.admin.resolve_market_payment_provider",
+        return_value="stripe",
+    ):
+        assert _resolve_order_display_payment_channel(order) == "stripe"
+
+
+def test_paid_order_keeps_recorded_payment_channel() -> None:
+    order = DummyOrder()
+    order.payment_channel = "pingxx"
+
+    with patch(
+        "flaskr.service.order.admin.resolve_market_payment_provider"
+    ) as resolver:
+        assert _resolve_order_display_payment_channel(order) == "pingxx"
+        resolver.assert_not_called()
 
 
 def _mock_operator(

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -144,9 +144,15 @@ def test_legacy_order_purchase_flow_stays_on_order_tables(
         assert BillingOrder.query.count() == 0
 
 
-def test_zero_price_order_completes_during_initialization_without_provider(
+@pytest.mark.parametrize(
+    ("enabled_payment_channels", "expected_payment_channel"),
+    [("pingxx", "pingxx"), ("stripe", "stripe")],
+)
+def test_zero_price_order_completes_with_market_channel_without_provider(
     legacy_order_app: Flask,
     monkeypatch: pytest.MonkeyPatch,
+    enabled_payment_channels: str,
+    expected_payment_channel: str,
 ) -> None:
     from flaskr.service.order import funs as order_funs
 
@@ -161,6 +167,12 @@ def test_zero_price_order_completes_during_initialization_without_provider(
     )
     monkeypatch.setattr(order_funs, "apply_promo_campaigns", lambda *_a, **_k: [])
     monkeypatch.setattr(order_funs, "set_user_state", lambda *_args: None)
+    monkeypatch.setattr(
+        "flaskr.service.order.payment_channel_resolution.get_config",
+        lambda key, default=None: (
+            enabled_payment_channels if key == "PAYMENT_CHANNELS_ENABLED" else default
+        ),
+    )
     notification_calls: list[str] = []
     monkeypatch.setattr(
         order_funs,
@@ -189,6 +201,7 @@ def test_zero_price_order_completes_during_initialization_without_provider(
     with legacy_order_app.app_context():
         order = Order.query.filter_by(order_bid=result.order_id).one()
         assert order.status == ORDER_STATUS_SUCCESS
+        assert order.payment_channel == expected_payment_channel
         assert Order.query.filter_by(user_bid="free-user").count() == 1
 
 

--- a/src/api/tests/service/order/test_legacy_purchase_flow.py
+++ b/src/api/tests/service/order/test_legacy_purchase_flow.py
@@ -14,9 +14,14 @@ from flask import Flask
 from flaskr import dao
 from flaskr.service.billing.entitlements import grant_creator_manual_entitlement
 from flaskr.service.billing.models import BillingOrder
-from flaskr.service.order.consts import ORDER_STATUS_SUCCESS, ORDER_STATUS_TO_BE_PAID
+from flaskr.service.order.consts import (
+    ORDER_STATUS_INIT,
+    ORDER_STATUS_SUCCESS,
+    ORDER_STATUS_TO_BE_PAID,
+)
 from flaskr.service.order.funs import (
     BuyRecordDTO,
+    assign_free_order_payment_channel,
     generate_charge,
     init_buy_record,
     query_buy_record,
@@ -203,6 +208,27 @@ def test_zero_price_order_completes_with_market_channel_without_provider(
         assert order.status == ORDER_STATUS_SUCCESS
         assert order.payment_channel == expected_payment_channel
         assert Order.query.filter_by(user_bid="free-user").count() == 1
+
+
+@pytest.mark.parametrize("payment_channel", ["manual", "open_api"])
+def test_free_order_keeps_explicit_non_provider_channel(
+    monkeypatch: pytest.MonkeyPatch, payment_channel: str
+) -> None:
+    order = SimpleNamespace(
+        payment_channel=payment_channel,
+        status=ORDER_STATUS_INIT,
+    )
+
+    def fail_if_called() -> None:
+        pytest.fail("market provider should not be resolved")
+
+    monkeypatch.setattr(
+        "flaskr.service.order.funs.resolve_market_payment_provider", fail_if_called
+    )
+
+    assign_free_order_payment_channel(order)
+
+    assert order.payment_channel == payment_channel
 
 
 def test_successful_order_retry_does_not_reprice_purchase_history(

--- a/src/api/tests/test_fix_discount.py
+++ b/src/api/tests/test_fix_discount.py
@@ -78,6 +78,69 @@ def test_use_coupon_code_applies_discount(app: object, monkeypatch: object) -> N
     assert sent["code"] == coupon_code
 
 
+def test_full_discount_coupon_attributes_free_order_to_stripe(
+    app: object, monkeypatch: object
+) -> None:
+    order_bid = "order-full-discount-stripe"
+    course_bid = "course-full-discount-stripe"
+    user_bid = "user-full-discount-stripe"
+    coupon_bid = "coupon-full-discount-stripe"
+    coupon_code = "FREE-STRIPE"
+
+    with app.app_context():
+        db.session.add(
+            Order(
+                order_bid=order_bid,
+                shifu_bid=course_bid,
+                user_bid=user_bid,
+                payable_price=Decimal("10.00"),
+                paid_price=Decimal("10.00"),
+            )
+        )
+        now = now_utc()
+        db.session.add(
+            Coupon(
+                coupon_bid=coupon_bid,
+                code=coupon_code,
+                discount_type=COUPON_TYPE_FIXED,
+                value=Decimal("10.00"),
+                start=now - timedelta(days=1),
+                end=now + timedelta(days=1),
+                channel="test",
+                filter="",
+                total_count=1,
+                used_count=0,
+                status=1,
+            )
+        )
+        db.session.commit()
+
+    monkeypatch.setattr(
+        "flaskr.service.order.payment_channel_resolution.get_config",
+        lambda key, default=None: (
+            "stripe" if key == "PAYMENT_CHANNELS_ENABLED" else default
+        ),
+    )
+    monkeypatch.setattr(
+        "flaskr.service.order.funs.get_shifu_creator_bid", lambda *_args: "owner"
+    )
+    monkeypatch.setattr(
+        "flaskr.service.order.funs.set_shifu_context", lambda *_args: None
+    )
+    monkeypatch.setattr("flaskr.service.order.funs.set_user_state", lambda *_args: None)
+    monkeypatch.setattr(
+        "flaskr.service.order.funs.send_order_feishu", lambda *_args: None
+    )
+
+    result = use_coupon_code(app, user_bid, coupon_code, order_bid)
+
+    assert result is not None
+    assert result.payment_channel == "stripe"
+    with app.app_context():
+        refreshed = Order.query.filter_by(order_bid=order_bid).one()
+        assert refreshed.payment_channel == "stripe"
+
+
 def test_use_specific_all_courses_coupon_keeps_unbound_usage_course(
     app: object, monkeypatch: object
 ) -> None:


### PR DESCRIPTION
## Summary
- attribute zero-price learning orders, including full-discount coupon orders, to the payment provider enabled for the current market without invoking that provider
- correct legacy zero-price orders that retained the Ping++ model default when they are read on Stripe-only deployments
- align creator and operator payment-channel filters with the effective channel shown in order rows
- preserve recorded channels for paid, manual, and API-created orders

## Verification
- `cd src/api && pytest tests/service/order/test_legacy_purchase_flow.py tests/service/order/test_admin_orders.py tests/service/order/test_payment_channel_resolution.py tests/test_fix_discount.py -q` (51 passed)
- focused Ruff checks passed
- pre-commit and commit-message hooks passed

## Deployment
- no database migration or environment change required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Free orders are now assigned an enabled market payment channel when completed, including orders initialized with no charge.
  - Existing free orders using the legacy payment channel now display the resolved market provider.
  - Paid orders continue to display their recorded payment channel without changes.
  - Payment-channel filters now correctly include or exclude legacy free orders according to the selected provider.
  - Orders made free through a full-discount coupon now receive the appropriate market payment channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->