### PR TITLE
fix: keep newly issued sessions valid

### DIFF
--- a/docs/generated/uow-commit-baseline.json
+++ b/docs/generated/uow-commit-baseline.json
@@ -1,7 +1,7 @@
 {
   "command/import_user.py": 1,
   "command/update_shifu_demo.py": 2,
-  "route/user.py": 7,
+  "route/user.py": 5,
   "service/billing/campaigns.py": 3,
   "service/billing/checkout.py": 7,
   "service/billing/cli.py": 5,

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -1217,12 +1217,8 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
             raw_request_args=request.args.to_dict(flat=True),
             current_user_id=current_user_id,
         )
-        try:
+        with unit_of_work():
             auth_result = provider.handle_oauth_callback(app, callback_request)
-            db.session.commit()
-        except Exception:
-            db.session.rollback()
-            raise
         run_post_auth_extensions(
             app,
             PostAuthContext(
@@ -1264,26 +1260,28 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         vr = VerificationRequest(identifier=identifier, code=password)
         # TODO(geyunfei): Add rate-limiting and failed login attempt tracking
         # (record identifier, request.remote_addr, timestamp on failure)
-        auth_result = provider.verify(app, vr)
-        current_user = _best_effort_password_login_user(app)
-        current_user_id = (
-            getattr(current_user, "user_id", None) if current_user is not None else None
-        )
-        if current_user_id and current_user_id != auth_result.user.user_id:
-            merge_learner_profile_for_sign_in(
-                source_user_id=current_user_id,
-                target_user_id=auth_result.user.user_id,
+        with unit_of_work():
+            auth_result = provider.verify(app, vr)
+            current_user = _best_effort_password_login_user(app)
+            current_user_id = (
+                getattr(current_user, "user_id", None)
+                if current_user is not None
+                else None
             )
-            refreshed = load_user_aggregate(auth_result.user.user_id)
-            if not refreshed:
-                raise_error("USER.USER_NOT_FOUND")
-            refreshed_user = build_user_info_from_aggregate(refreshed)
-            auth_result.user = refreshed_user
-            auth_result.token = UserToken(
-                user_info=refreshed_user,
-                token=auth_result.token.token,
-            )
-        db.session.commit()
+            if current_user_id and current_user_id != auth_result.user.user_id:
+                merge_learner_profile_for_sign_in(
+                    source_user_id=current_user_id,
+                    target_user_id=auth_result.user.user_id,
+                )
+                refreshed = load_user_aggregate(auth_result.user.user_id)
+                if not refreshed:
+                    raise_error("USER.USER_NOT_FOUND")
+                refreshed_user = build_user_info_from_aggregate(refreshed)
+                auth_result.user = refreshed_user
+                auth_result.token = UserToken(
+                    user_info=refreshed_user,
+                    token=auth_result.token.token,
+                )
         run_post_auth_extensions(
             app,
             PostAuthContext(

--- a/src/api/flaskr/service/user/token_store.py
+++ b/src/api/flaskr/service/user/token_store.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from flaskr.common.cache_provider import cache
-from flaskr.dao import db
+from flaskr.dao import db, uow
 from flaskr.service.user.models import UserToken as UserTokenModel
 from flaskr.util.datetime import now_utc
 
@@ -71,45 +71,41 @@ class TokenStoreProvider:
         now = now_utc()
         expires_at = now + datetime.timedelta(seconds=ttl_seconds)
 
-        values: dict[str, object] = {
-            "user_id": user_id,
-            "token_expired_at": expires_at,
-        }
-        if metadata is not None:
-            # Recorded once, at creation: these describe where the session
-            # started, not where it was last used.
-            values.update(
-                session_bid=metadata.session_bid,
-                source=metadata.source,
-                device_name=metadata.device_name,
-                device_os=metadata.device_os,
-                created_ip=metadata.created_ip,
+        record = (
+            UserTokenModel.query.filter(UserTokenModel.token == token)
+            .order_by(UserTokenModel.id.desc())
+            .first()
+        )
+        if record is None:
+            record = UserTokenModel(
+                user_id=user_id,
+                token=token,
+                token_type=0,
+                token_expired_at=expires_at,
             )
+            if metadata is not None:
+                # Creation metadata describes where the session began and
+                # must not be replaced by a later save of the same token.
+                record.session_bid = metadata.session_bid
+                record.source = metadata.source
+                record.device_name = metadata.device_name
+                record.device_os = metadata.device_os
+                record.created_ip = metadata.created_ip
+            db.session.add(record)
+        else:
+            record.user_id = user_id
+            record.token_expired_at = expires_at
 
-        # A token is returned to the client immediately, and many sign-in flows
-        # do not commit the request-scoped ORM session afterwards. Persist it in
-        # an independent transaction so request teardown cannot roll it back.
-        # This also avoids committing unrelated caller-owned business changes.
-        with db.engine.begin() as connection:
-            result = connection.execute(
-                UserTokenModel.__table__.update()
-                .where(UserTokenModel.token == token)
-                .values(**values)
-            )
-            if result.rowcount < 1:
-                connection.execute(
-                    UserTokenModel.__table__.insert().values(
-                        token=token,
-                        token_type=0,
-                        **values,
-                    )
-                )
+        def populate_cache() -> None:
+            try:
+                self._cache.set(self._cache_key(app, token), user_id, ex=ttl_seconds)
+            except Exception:
+                # Cache failures should not block login flows.
+                return
 
-        try:
-            self._cache.set(self._cache_key(app, token), user_id, ex=ttl_seconds)
-        except Exception:
-            # Cache failures should not block login flows.
-            return
+        # Authentication flows own their transaction. Do not expose a token in
+        # cache when that transaction later rolls back.
+        uow.on_commit(populate_cache)
 
     def _refresh_marker_key(self, app: Flask, token: str) -> str:
         return f"{self._cache_key(app, token)}:row"

--- a/src/api/flaskr/service/user/token_store.py
+++ b/src/api/flaskr/service/user/token_store.py
@@ -71,32 +71,39 @@ class TokenStoreProvider:
         now = now_utc()
         expires_at = now + datetime.timedelta(seconds=ttl_seconds)
 
-        with db.session.begin_nested():
-            record = (
-                UserTokenModel.query.filter(UserTokenModel.token == token)
-                .order_by(UserTokenModel.id.desc())
-                .first()
+        values: dict[str, object] = {
+            "user_id": user_id,
+            "token_expired_at": expires_at,
+        }
+        if metadata is not None:
+            # Recorded once, at creation: these describe where the session
+            # started, not where it was last used.
+            values.update(
+                session_bid=metadata.session_bid,
+                source=metadata.source,
+                device_name=metadata.device_name,
+                device_os=metadata.device_os,
+                created_ip=metadata.created_ip,
             )
-            if record is None:
-                record = UserTokenModel(
-                    user_id=user_id,
-                    token=token,
-                    token_type=0,
-                    token_expired_at=expires_at,
-                )
-                db.session.add(record)
-            else:
-                record.user_id = user_id
-                record.token_expired_at = expires_at
 
-            if metadata is not None:
-                # Recorded once, at creation: these describe where the session
-                # started, not where it was last used.
-                record.session_bid = metadata.session_bid
-                record.source = metadata.source
-                record.device_name = metadata.device_name
-                record.device_os = metadata.device_os
-                record.created_ip = metadata.created_ip
+        # A token is returned to the client immediately, and many sign-in flows
+        # do not commit the request-scoped ORM session afterwards. Persist it in
+        # an independent transaction so request teardown cannot roll it back.
+        # This also avoids committing unrelated caller-owned business changes.
+        with db.engine.begin() as connection:
+            result = connection.execute(
+                UserTokenModel.__table__.update()
+                .where(UserTokenModel.token == token)
+                .values(**values)
+            )
+            if result.rowcount < 1:
+                connection.execute(
+                    UserTokenModel.__table__.insert().values(
+                        token=token,
+                        token_type=0,
+                        **values,
+                    )
+                )
 
         try:
             self._cache.set(self._cache_key(app, token), user_id, ex=ttl_seconds)

--- a/src/api/flaskr/service/user/user.py
+++ b/src/api/flaskr/service/user/user.py
@@ -12,6 +12,7 @@ from flask import Flask
 from flaskr.api.wechat import get_wechat_access_token
 from flaskr.common.shifu_context import get_shifu_creator_bid as get_context_creator_bid
 from flaskr.dao import db
+from flaskr.dao.uow import unit_of_work
 from flaskr.service.billing.api import resolve_creator_wechat_oauth_app_id
 from flaskr.service.common.dtos import USER_STATE_UNREGISTERED, UserToken
 from flaskr.service.common.models import raise_error
@@ -78,6 +79,12 @@ def generate_temp_user(
     language: object = "en-US",
 ) -> UserToken:
     """Generate temp user."""
+
+    def generate_committed_token(user_id: str) -> str:
+        """Persist a guest token after its account changes are durable."""
+        with unit_of_work():
+            return generate_token(app, user_id=user_id)
+
     with app.app_context():
         convert_user = UserConversion.query.filter(
             UserConversion.conversion_id == temp_id,
@@ -103,7 +110,7 @@ def generate_temp_user(
                     if aggregate:
                         return UserToken(
                             build_user_info_from_aggregate(aggregate),
-                            token=generate_token(app, user_id=aggregate.user_bid),
+                            token=generate_committed_token(aggregate.user_bid),
                         )
             user_id = uuid.uuid4().hex
             new_convert_user = UserConversion(
@@ -135,7 +142,7 @@ def generate_temp_user(
             aggregate = load_user_aggregate(user_id)
             if not aggregate:
                 raise_error("USER.USER_NOT_FOUND")
-            token = generate_token(app, user_id=user_id)
+            token = generate_committed_token(user_id)
             return UserToken(build_user_info_from_aggregate(aggregate), token=token)
         if wx_openid != "":
             credential = find_credential(
@@ -146,7 +153,7 @@ def generate_temp_user(
                 if aggregate:
                     return UserToken(
                         build_user_info_from_aggregate(aggregate),
-                        token=generate_token(app, user_id=aggregate.user_bid),
+                        token=generate_committed_token(aggregate.user_bid),
                     )
 
         aggregate, _ = ensure_user_aggregate(app, user_bid=convert_user.user_id)
@@ -164,7 +171,7 @@ def generate_temp_user(
         refreshed = load_user_aggregate(convert_user.user_id)
         if not refreshed:
             raise_error("USER.USER_NOT_FOUND")
-        token = generate_token(app, user_id=refreshed.user_bid)
+        token = generate_committed_token(refreshed.user_bid)
         return UserToken(build_user_info_from_aggregate(refreshed), token=token)
 
 

--- a/src/api/tests/service/user/test_google_auth.py
+++ b/src/api/tests/service/user/test_google_auth.py
@@ -2,6 +2,7 @@
 
 import uuid
 from collections.abc import Iterator
+from types import SimpleNamespace
 
 import flaskr.common.config as common_config
 import pytest
@@ -22,6 +23,7 @@ from flaskr.service.user.models import (
 from flaskr.service.user.models import (
     UserToken as UserTokenModel,
 )
+from flaskr.service.user.token_store import token_store
 from sqlalchemy import Text
 
 
@@ -96,6 +98,49 @@ def _run_google_callback(
 
     with app.test_request_context("/login/google-callback"):
         return provider.handle_oauth_callback(app, callback)
+
+
+def test_google_callback_commit_failure_does_not_populate_token_cache(
+    app: object, test_client: object, monkeypatch: object
+) -> None:
+    import flaskr.route.user as user_route
+
+    token = f"google-failed-{uuid.uuid4().hex}"
+    user_id = uuid.uuid4().hex
+
+    class FailingCommitProvider:
+        def handle_oauth_callback(self, route_app: object, _request: object) -> object:
+            token_store.save(
+                route_app,
+                user_id=user_id,
+                token=token,
+                ttl_seconds=60,
+            )
+            return SimpleNamespace(
+                user=SimpleNamespace(user_id=user_id, language="en-US"),
+                token=SimpleNamespace(token=token),
+                is_new_user=False,
+                metadata={},
+            )
+
+    def fail_commit() -> None:
+        message = "simulated Google login commit failure"
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(
+        user_route, "get_provider", lambda _name: FailingCommitProvider()
+    )
+    monkeypatch.setattr(db.session, "commit", fail_commit)
+
+    response = test_client.get(
+        "/api/user/oauth/google/callback",
+        query_string={"state": "state", "code": "code"},
+    )
+    assert response.get_json(force=True)["code"] == -1
+
+    with app.app_context():
+        assert UserTokenModel.query.filter_by(token=token).count() == 0
+        assert token_store._cache.get(token_store._cache_key(app, token)) is None
 
 
 def test_google_unverified_email_does_not_consume_first_account_bootstrap(

--- a/src/api/tests/service/user/test_onboarding_routes.py
+++ b/src/api/tests/service/user/test_onboarding_routes.py
@@ -9,9 +9,16 @@ from flaskr.dao import db
 from flaskr.service.user.models import UserInfo as UserEntity
 from flaskr.service.user.models import UserOnboardingState
 from flaskr.service.user.onboarding import _serialize_datetime
-from flaskr.service.user.utils import generate_token
+from flaskr.service.user.utils import generate_token as generate_uncommitted_token
 from flaskr.util.datetime import now_utc
 from sqlalchemy.exc import IntegrityError
+
+
+def generate_token(app: object, user_bid: str) -> str:
+    """Issue the durable session expected by the following HTTP request."""
+    token = generate_uncommitted_token(app, user_bid)
+    db.session.commit()
+    return token
 
 
 def _create_user(

--- a/src/api/tests/service/user/test_password_routes.py
+++ b/src/api/tests/service/user/test_password_routes.py
@@ -2,7 +2,9 @@
 
 import json
 import time
+import uuid
 from datetime import UTC, datetime
+from types import SimpleNamespace
 
 import jwt
 
@@ -17,6 +19,53 @@ def _post_json(
         headers=headers or {},
     )
     return resp, json.loads(resp.data)
+
+
+def test_password_login_commit_failure_does_not_populate_token_cache(
+    app: object, test_client: object, monkeypatch: object
+) -> None:
+    import flaskr.route.user as user_route
+    from flaskr.dao import db
+    from flaskr.service.user.models import UserToken
+    from flaskr.service.user.token_store import token_store
+
+    token = f"password-failed-{uuid.uuid4().hex}"
+    user_id = uuid.uuid4().hex
+
+    class FailingCommitProvider:
+        def verify(self, route_app: object, _request: object) -> object:
+            token_store.save(
+                route_app,
+                user_id=user_id,
+                token=token,
+                ttl_seconds=60,
+            )
+            return SimpleNamespace(
+                user=SimpleNamespace(user_id=user_id, language="en-US"),
+                token=SimpleNamespace(token=token),
+                is_new_user=False,
+                metadata={},
+            )
+
+    def fail_commit() -> None:
+        message = "simulated password login commit failure"
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(
+        user_route, "get_provider", lambda _name: FailingCommitProvider()
+    )
+    monkeypatch.setattr(db.session, "commit", fail_commit)
+
+    _response, body = _post_json(
+        test_client,
+        "/api/user/login_password",
+        {"identifier": "user@example.com", "password": "password"},
+    )
+    assert body["code"] == -1
+
+    with app.app_context():
+        assert UserToken.query.filter_by(token=token).count() == 0
+        assert token_store._cache.get(token_store._cache_key(app, token)) is None
 
 
 def test_reset_password_does_not_create_new_user(

--- a/src/api/tests/service/user/test_require_tmp_route.py
+++ b/src/api/tests/service/user/test_require_tmp_route.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 import json
+import uuid
+
+from flaskr.dao import db
+from flaskr.service.user.models import UserToken
+from flaskr.service.user.token_store import token_store
 
 
 def test_require_tmp_passes_payload_source_to_temp_user(
@@ -52,3 +57,35 @@ def test_require_tmp_passes_payload_source_to_temp_user(
             "language": "zh-CN",
         }
     ]
+
+
+def test_require_tmp_token_remains_valid_in_the_next_request(
+    app: object, test_client: object
+) -> None:
+    """A guest token must be durable before the issuing request ends."""
+    response = test_client.post(
+        "/api/user/require_tmp",
+        json={
+            "temp_id": f"guest-{uuid.uuid4().hex}",
+            "source": "web",
+            "language": "zh-CN",
+        },
+    )
+    payload = json.loads(response.get_data(as_text=True))
+    token = payload["data"]["token"]
+    user_id = payload["data"]["userInfo"]["user_id"]
+
+    # Prove authentication can fall back to the durable row instead of being
+    # accidentally rescued by the cache populated during token creation.
+    token_store._cache.delete(token_store._cache_key(app, token))
+    db.session.remove()
+
+    user_response = test_client.get(
+        "/api/user/info",
+        headers={"Token": token},
+    )
+    user_payload = json.loads(user_response.get_data(as_text=True))
+
+    assert user_payload["code"] == 0
+    assert user_payload["data"]["user_id"] == user_id
+    assert UserToken.query.filter_by(token=token, user_id=user_id).count() == 1

--- a/src/api/tests/service/user/test_sessions.py
+++ b/src/api/tests/service/user/test_sessions.py
@@ -4,6 +4,7 @@ import uuid
 
 import pytest
 from flaskr.dao import db
+from flaskr.dao.uow import unit_of_work
 from flaskr.service.common.models import ERROR_CODE, AppError
 from flaskr.service.user.models import UserToken
 from flaskr.service.user.sessions import (
@@ -11,7 +12,7 @@ from flaskr.service.user.sessions import (
     revoke_other_user_sessions,
     revoke_user_session,
 )
-from flaskr.service.user.token_store import token_store
+from flaskr.service.user.token_store import SessionMetadata, token_store
 from flaskr.service.user.utils import describe_user_agent, generate_token
 
 
@@ -30,6 +31,75 @@ def _sign_in(app: object, user_id: str, **kwargs: object) -> str:
     token = generate_token(app, user_id, **kwargs)
     db.session.commit()
     return token
+
+
+def test_a_failed_login_transaction_does_not_expose_its_token(
+    app: object, user_id: str
+) -> None:
+    token = f"rolled-back-{uuid.uuid4().hex}"
+
+    def fail_login_transaction() -> None:
+        with unit_of_work():
+            token_store.save(
+                app,
+                user_id=user_id,
+                token=token,
+                ttl_seconds=60,
+            )
+            message = "simulate a later login failure"
+            raise RuntimeError(message)
+
+    with app.test_request_context():
+        with pytest.raises(RuntimeError):
+            fail_login_transaction()
+
+        assert UserToken.query.filter_by(token=token).count() == 0
+        assert token_store._cache.get(token_store._cache_key(app, token)) is None
+
+
+def test_resaving_a_token_preserves_where_the_session_started(
+    app: object, user_id: str
+) -> None:
+    token = f"resaved-{uuid.uuid4().hex}"
+    original = SessionMetadata(
+        session_bid=uuid.uuid4().hex,
+        source="web",
+        device_name="Original device",
+        device_os="Original OS",
+        created_ip="203.0.113.8",
+    )
+    replacement = SessionMetadata(
+        session_bid=uuid.uuid4().hex,
+        source="cli",
+        device_name="Replacement device",
+        device_os="Replacement OS",
+        created_ip="203.0.113.9",
+    )
+
+    with app.test_request_context():
+        token_store.save(
+            app,
+            user_id=user_id,
+            token=token,
+            ttl_seconds=60,
+            metadata=original,
+        )
+        db.session.commit()
+        token_store.save(
+            app,
+            user_id=user_id,
+            token=token,
+            ttl_seconds=120,
+            metadata=replacement,
+        )
+        db.session.commit()
+
+        record = UserToken.query.filter_by(token=token).one()
+        assert record.session_bid == original.session_bid
+        assert record.source == original.source
+        assert record.device_name == original.device_name
+        assert record.device_os == original.device_os
+        assert record.created_ip == original.created_ip
 
 
 def test_a_session_is_recorded_for_every_sign_in(app: object, user_id: str) -> None:


### PR DESCRIPTION
## Summary

- persist newly issued tokens in the authentication transaction so failed sign-ins cannot leave live sessions
- populate the token cache only after a successful unit-of-work commit
- wrap password and Google OAuth sign-in routes in explicit unit-of-work boundaries
- give temporary guest sessions an explicit durable token transaction after account persistence
- preserve original session metadata when an existing token is refreshed

## Verification

- Python 3.11 focused authentication regression suite: 129 passed
- password and Google OAuth route probes confirm commit failures leave neither durable token rows nor cache entries
- Ruff check and format checks passed
- repository-wide pre-commit hooks passed, including architecture and unit-of-work ratchets
- guest token request-boundary test passed with the cache cleared before validation