### PR TITLE
feat: measure Lobster course entry adoption

### DIFF
--- a/docs/exec-plans/active/lobster-course-entry-analytics.md
+++ b/docs/exec-plans/active/lobster-course-entry-analytics.md
@@ -1,0 +1,123 @@
+# Lobster Course Entry Analytics
+
+## Purpose / Big Picture
+
+Measure whether eligible teachers actually see and choose the Lobster-assisted
+course-creation entry on the admin course list. The immediate consumer is the
+product decision about promoting that entry from a weak text link to the
+recommended first-course CTA. This change must not claim that an external
+handoff created a course; confirmed generation/import attribution requires a
+later cross-system contract.
+
+## Progress
+
+- [x] 2026-09-11 13:20 CST: Audited the existing course-creation events and
+  production data limitations.
+- [x] 2026-09-11 13:35 CST: Added the entry impression/click contract and
+  producers.
+- [x] 2026-09-11 13:40 CST: Added focused eligibility, deduplication, payload,
+  privacy, and failure-isolation tests.
+- [x] 2026-09-11 13:45 CST: Ran 14 focused tests, TypeScript type-check,
+  focused lint, developer-tool verification, and the repository harness.
+
+## Surprises & Discoveries
+
+- Existing `creator_course_create_result` with `creation_path=ai_assistant`
+  means that the browser accepted the external handoff. It is not evidence of
+  course creation, generation, import, or publication.
+- Existing admin pageviews overstate exposure because they do not prove that
+  the configured entry rendered for the teacher.
+
+## Decision Log
+
+- 2026-09-11: Introduce a dedicated additive impression/click family and keep
+  dual-writing the existing course-creation attempt/result events for
+  historical dashboards.
+- 2026-09-11: Use fixed `surface` and `presentation` enums. Do not send URLs,
+  course content, contact information, or a duplicate user identifier.
+- 2026-09-11: Treat one mounted eligible course-list visit as one impression.
+  Route re-entry is a new exposure; React rerenders within the visit are not.
+
+## Outcomes & Retrospective
+
+The admin course list now reports a real eligible-view denominator and a
+deliberate Lobster-entry click with a stable baseline presentation. Existing
+course-creation events remain available for historical consumers. Confirmed
+external generation/import attribution remains a separate cross-system task.
+
+## Context and Orientation
+
+The entry is rendered by `src/web/src/app/admin/page.tsx` when runtime config
+provides `courseCreatorUrl`. Course-creation analytics builders live beside it
+in `courseCreationAnalytics.ts`, and the page tests mock the shared tracking
+hook. Business events must continue through `useTracking`; analytics failure
+must not affect rendering or native navigation.
+
+### Event family contract
+
+- Business question: among teachers shown the Lobster entry on the admin
+  course-list surface, what proportion deliberately choose it, and how does
+  adoption differ when the presentation changes?
+- Metric definition: distinct identified users emitting click divided by
+  distinct identified users emitting impression, over the same time window,
+  grouped by `surface` and `presentation`. Raw events are diagnostic only.
+- Event names: `creator_ai_course_entry_impression`,
+  `creator_ai_course_entry_click`.
+- Actor and surface: authenticated teachers on `admin_course_list`.
+- Trigger: impression after the configured entry is committed to the mounted
+  page; click after the native anchor accepts a deliberate click and before
+  navigation.
+- Population: authenticated teachers for whom `courseCreatorUrl` is present.
+  Missing-config pages and non-admin learner surfaces are excluded.
+- Count unit: one mounted eligible route visit for impressions; one accepted
+  user click for clicks.
+- Deduplication: impressions once per component mount using an in-memory ref;
+  clicks are not deduplicated because repeated deliberate handoffs are useful.
+- Correlation: shared identified-user/session context only; no feature-owned
+  stable identifier is necessary.
+- Consumers: the Lobster entry promotion decision and subsequent A/B reports.
+- Compatibility: additive events. Existing `creator_course_create_*` events
+  remain unchanged and are dual-written on click.
+- Verification: exact event names/payloads, missing-config exclusion,
+  once-per-mount behavior across rerenders, privacy assertions, and fail-open
+  behavior.
+
+| Field | Type | Allowed values | Cardinality | Privacy class | Why required |
+| --- | --- | --- | --- | --- | --- |
+| `surface` | string | `admin_course_list` | low | non-personal | Fix the eligible UI surface. |
+| `presentation` | string | `text_link` | low | non-personal | Baseline for a future promoted CTA comparison. |
+
+## Plan of Work
+
+Extend the feature-owned analytics helper with the new contract, emit one
+impression from a guarded effect when the configured link is eligible, and
+emit the click alongside existing compatibility events. Keep the implementation
+independent from course loading and avoid inventing downstream success.
+
+## Concrete Steps
+
+1. Add typed event names and a fixed allowlisted payload builder.
+2. Add an impression guard to the admin page lifecycle.
+3. Add click dual-write at the real anchor handler.
+4. Extend focused unit/component tests and run type/lint checks.
+
+## Validation and Acceptance
+
+- A configured entry emits exactly one impression during one mounted visit.
+- Rerenders do not duplicate the impression.
+- No configured entry means no impression.
+- Each deliberate click emits the new click plus the historical attempt/result
+  events, and native anchor behavior remains intact.
+- Payloads contain only `surface` and `presentation`.
+- Tracking errors do not hide the entry or prevent navigation.
+
+## Idempotence and Recovery
+
+The change is additive and can be reverted without data migration. Historical
+events remain interpretable. Re-running tests and code generation is safe.
+
+## Interfaces and Dependencies
+
+No backend, database, or external Lobster change is required for this first
+stage. Confirmed course-source attribution remains dependent on a future
+external callback and server-owned persistence contract.

--- a/docs/exec-plans/active/lobster-course-entry-analytics.md
+++ b/docs/exec-plans/active/lobster-course-entry-analytics.md
@@ -17,8 +17,10 @@ later cross-system contract.
   producers.
 - [x] 2026-09-11 13:40 CST: Added focused eligibility, deduplication, payload,
   privacy, and failure-isolation tests.
-- [x] 2026-09-11 13:45 CST: Ran 14 focused tests, TypeScript type-check,
+- [x] 2026-09-11 13:45 CST: Ran 16 focused tests, TypeScript type-check,
   focused lint, developer-tool verification, and the repository harness.
+- [x] 2026-09-11 14:05 CST: Gated entry rendering and impressions on resolved
+  administrator access after review identified an ineligible-view window.
 
 ## Surprises & Discoveries
 
@@ -27,6 +29,8 @@ later cross-system contract.
   course creation, generation, import, or publication.
 - Existing admin pageviews overstate exposure because they do not prove that
   the configured entry rendered for the teacher.
+- The configured URL resolves before administrator permission. Both rendering
+  and impression production therefore need the same resolved-access gate.
 
 ## Decision Log
 

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -26,6 +26,7 @@ Active and completed ExecPlans live here. The structure and required sections ar
 - [Gemini Live Voice Follow-Up](./active/gemini-live-voice-follow-up.md)
 - [Gemini TTS Provider](./active/gemini-tts.md)
 - [Learner listen playback stability](./active/learner-listen-playback-stability.md)
+- [Lobster Course Entry Analytics](./active/lobster-course-entry-analytics.md)
 - [Local MarkdownFlow slide comparison ExecPlan](./active/markdownflow-model-arena.md)
 - [Notification Channel Foundation](./active/notification-channel-foundation.md)
 - [Observability Artifacts, Consistency Probes, and Frontend Trace IDs](./active/observability-artifacts-consistency-frontend-trace.md)

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -44,6 +44,7 @@
 | `docs/exec-plans/active/gemini-live-voice-follow-up.md` | Gemini Live Voice Follow-Up | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/gemini-tts.md` | Gemini TTS Provider | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/learner-listen-playback-stability.md` | Learner listen playback stability | `exec-plan-active` | `active` | `repo` | `-` | `true` |
+| `docs/exec-plans/active/lobster-course-entry-analytics.md` | Lobster Course Entry Analytics | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/markdownflow-model-arena.md` | Local MarkdownFlow slide comparison ExecPlan | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/notification-channel-foundation.md` | Notification Channel Foundation | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/observability-artifacts-consistency-frontend-trace.md` | Observability Artifacts, Consistency Probes, and Frontend Trace IDs | `exec-plan-active` | `active` | `repo` | `-` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -9,7 +9,7 @@ This generated report summarizes the repository harness control plane.
 - Design docs: `14`
 - Product specs: `11`
 - References: `6`
-- Active ExecPlans: `32`
+- Active ExecPlans: `33`
 - Completed ExecPlans: `37`
 
 ## Boundary Baseline

--- a/src/web/src/app/admin/courseCreationAnalytics.test.ts
+++ b/src/web/src/app/admin/courseCreationAnalytics.test.ts
@@ -1,8 +1,19 @@
 import {
+  buildAiCourseEntryAnalytics,
   buildCourseCreationAttemptAnalytics,
   buildCourseCreationCancelAnalytics,
   buildCourseCreationResultAnalytics,
 } from './courseCreationAnalytics';
+
+describe('AI course entry analytics', () => {
+  test('uses a bounded payload that can compare entry presentations', () => {
+    expect(buildAiCourseEntryAnalytics()).toEqual({
+      surface: 'admin_course_list',
+      presentation: 'text_link',
+    });
+    expect(JSON.stringify(buildAiCourseEntryAnalytics())).not.toContain('url');
+  });
+});
 
 describe('courseCreationAnalytics', () => {
   test('builds bounded path payloads for attempts and cancellations', () => {

--- a/src/web/src/app/admin/courseCreationAnalytics.ts
+++ b/src/web/src/app/admin/courseCreationAnalytics.ts
@@ -1,8 +1,19 @@
 export const COURSE_CREATION_EVENTS = {
+  AI_ENTRY_IMPRESSION: 'creator_ai_course_entry_impression',
+  AI_ENTRY_CLICK: 'creator_ai_course_entry_click',
   ATTEMPT: 'creator_course_create_attempt',
   RESULT: 'creator_course_create_result',
   CANCEL: 'creator_course_create_cancel',
 } as const;
+
+export const AI_COURSE_ENTRY_ANALYTICS = {
+  surface: 'admin_course_list',
+  presentation: 'text_link',
+} as const;
+
+export const buildAiCourseEntryAnalytics = () => ({
+  ...AI_COURSE_ENTRY_ANALYTICS,
+});
 
 export type CourseCreationPath = 'manual' | 'ai_assistant';
 export type CourseCreationFailureCategory = 'request_failed';

--- a/src/web/src/app/admin/page.test.tsx
+++ b/src/web/src/app/admin/page.test.tsx
@@ -521,6 +521,40 @@ describe('AdminPage', () => {
     );
   });
 
+  test('does not expose or track the AI entry before admin access resolves', async () => {
+    mockCourseCreatorUrl = 'https://creator.example.test/new';
+    mockEnsureAdminCreator.mockReturnValue(new Promise(() => {}));
+    render(<AdminPage />);
+
+    await waitFor(() => expect(mockEnsureAdminCreator).toHaveBeenCalled());
+    expect(
+      screen.queryByRole('link', { name: 'common.core.aiCourseCreator' }),
+    ).not.toBeInTheDocument();
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      'creator_ai_course_entry_impression',
+      expect.anything(),
+    );
+  });
+
+  test('does not expose or track the AI entry when admin access fails', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    mockCourseCreatorUrl = 'https://creator.example.test/new';
+    mockEnsureAdminCreator.mockRejectedValue(new Error('permission denied'));
+    render(<AdminPage />);
+
+    await screen.findByText('permission denied');
+    expect(
+      screen.queryByRole('link', { name: 'common.core.aiCourseCreator' }),
+    ).not.toBeInTheDocument();
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      'creator_ai_course_entry_impression',
+      expect.anything(),
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
   test('keeps the AI entry usable when tracking is unavailable', async () => {
     mockCourseCreatorUrl = 'https://creator.example.test/new';
     mockTrackEvent.mockImplementation(() => {

--- a/src/web/src/app/admin/page.test.tsx
+++ b/src/web/src/app/admin/page.test.tsx
@@ -458,8 +458,24 @@ describe('AdminPage', () => {
     const link = await screen.findByRole('link', {
       name: 'common.core.aiCourseCreator',
     });
+    await waitFor(() =>
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        'creator_ai_course_entry_impression',
+        {
+          surface: 'admin_course_list',
+          presentation: 'text_link',
+        },
+      ),
+    );
     fireEvent.click(link);
 
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      'creator_ai_course_entry_click',
+      {
+        surface: 'admin_course_list',
+        presentation: 'text_link',
+      },
+    );
     expect(mockTrackEvent).toHaveBeenCalledWith(
       'creator_course_create_attempt',
       { creation_path: 'ai_assistant' },
@@ -468,6 +484,55 @@ describe('AdminPage', () => {
       'creator_course_create_result',
       { creation_path: 'ai_assistant', outcome: 'success' },
     );
+    const serializedCalls = JSON.stringify(mockTrackEvent.mock.calls);
+    expect(serializedCalls).not.toContain('creator.example.test');
+  });
+
+  test('tracks one AI entry impression per mounted visit across rerenders', async () => {
+    mockCourseCreatorUrl = 'https://creator.example.test/new';
+    const { rerender } = render(<AdminPage />);
+    await screen.findByRole('link', {
+      name: 'common.core.aiCourseCreator',
+    });
+    await waitFor(() =>
+      expect(
+        mockTrackEvent.mock.calls.filter(
+          ([eventName]) => eventName === 'creator_ai_course_entry_impression',
+        ),
+      ).toHaveLength(1),
+    );
+
+    rerender(<AdminPage />);
+
+    expect(
+      mockTrackEvent.mock.calls.filter(
+        ([eventName]) => eventName === 'creator_ai_course_entry_impression',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('does not track an AI entry impression when the entry is unavailable', async () => {
+    render(<AdminPage />);
+    await screen.findByText('Course 1');
+
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      'creator_ai_course_entry_impression',
+      expect.anything(),
+    );
+  });
+
+  test('keeps the AI entry usable when tracking is unavailable', async () => {
+    mockCourseCreatorUrl = 'https://creator.example.test/new';
+    mockTrackEvent.mockImplementation(() => {
+      throw new Error('tracking unavailable');
+    });
+    render(<AdminPage />);
+
+    const link = await screen.findByRole('link', {
+      name: 'common.core.aiCourseCreator',
+    });
+    expect(link).toHaveAttribute('href', 'https://creator.example.test/new');
+    expect(() => fireEvent.click(link)).not.toThrow();
   });
 
   test('keeps the manual create workflow usable when tracking throws', async () => {

--- a/src/web/src/app/admin/page.tsx
+++ b/src/web/src/app/admin/page.tsx
@@ -253,7 +253,12 @@ const ScriptManagementPage = () => {
   );
 
   useEffect(() => {
-    if (!courseCreatorUrl || aiCourseEntryImpressionSentRef.current) {
+    if (
+      !courseCreatorUrl ||
+      !hasResolvedAdminSession ||
+      !adminReady ||
+      aiCourseEntryImpressionSentRef.current
+    ) {
       return;
     }
     aiCourseEntryImpressionSentRef.current = true;
@@ -261,7 +266,7 @@ const ScriptManagementPage = () => {
       COURSE_CREATION_EVENTS.AI_ENTRY_IMPRESSION,
       buildAiCourseEntryAnalytics(),
     );
-  }, [courseCreatorUrl, sendAnalytics]);
+  }, [adminReady, courseCreatorUrl, hasResolvedAdminSession, sendAnalytics]);
 
   const onCreateShifu = async (values: any) => {
     sendAnalytics(
@@ -658,7 +663,7 @@ const ScriptManagementPage = () => {
                   ONBOARDING_TARGET_IDS.courseCreationEntry,
                 )}
               >
-                {courseCreatorUrl ? (
+                {courseCreatorUrl && hasResolvedAdminSession && adminReady ? (
                   <a
                     href={courseCreatorUrl}
                     target='_blank'

--- a/src/web/src/app/admin/page.tsx
+++ b/src/web/src/app/admin/page.tsx
@@ -42,6 +42,7 @@ import {
 import AdminTitle from './components/AdminTitle';
 import ShifuCard from './components/ShifuCard';
 import {
+  buildAiCourseEntryAnalytics,
   buildCourseCreationAttemptAnalytics,
   buildCourseCreationCancelAnalytics,
   buildCourseCreationResultAnalytics,
@@ -100,6 +101,7 @@ const ScriptManagementPage = () => {
   const loadingRef = useRef(false);
   const hasMoreRef = useRef(true);
   const listVersionRef = useRef(0);
+  const aiCourseEntryImpressionSentRef = useRef(false);
   const createRedirectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -250,6 +252,17 @@ const ScriptManagementPage = () => {
     [trackEvent],
   );
 
+  useEffect(() => {
+    if (!courseCreatorUrl || aiCourseEntryImpressionSentRef.current) {
+      return;
+    }
+    aiCourseEntryImpressionSentRef.current = true;
+    sendAnalytics(
+      COURSE_CREATION_EVENTS.AI_ENTRY_IMPRESSION,
+      buildAiCourseEntryAnalytics(),
+    );
+  }, [courseCreatorUrl, sendAnalytics]);
+
   const onCreateShifu = async (values: any) => {
     sendAnalytics(
       COURSE_CREATION_EVENTS.ATTEMPT,
@@ -311,6 +324,10 @@ const ScriptManagementPage = () => {
   };
 
   const handleAiCourseCreatorClick = () => {
+    sendAnalytics(
+      COURSE_CREATION_EVENTS.AI_ENTRY_CLICK,
+      buildAiCourseEntryAnalytics(),
+    );
     sendAnalytics(
       COURSE_CREATION_EVENTS.ATTEMPT,
       buildCourseCreationAttemptAnalytics('ai_assistant'),


### PR DESCRIPTION
## Summary

- add a true eligible-view impression for the Lobster course creation entry
- add a deliberate click event with fixed surface and presentation dimensions
- keep the existing course-creation attempt/result events as compatibility dual-writes
- document the metric contract and the cross-system attribution boundary

## Analytics contract

- denominator: distinct identified users emitting `creator_ai_course_entry_impression`
- numerator: distinct identified users emitting `creator_ai_course_entry_click`
- dimensions: `surface=admin_course_list`, `presentation=text_link`
- eligibility: authenticated teachers whose runtime config renders the entry
- impression deduplication: once per mounted course-list visit
- external handoff is not treated as confirmed course creation or import

## Verification

- 14 focused Jest tests passed
- TypeScript type-check passed
- focused frontend lint passed (pre-existing console warnings only)
- repository harness passed
- full pre-commit and commit-message hooks passed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-shifu/ai-shifu/pull/2799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for eligible users viewing and selecting the AI-assisted course-creation entry.
  * Impression events are recorded once per page visit, while click events capture selections without including sensitive URLs or content.
  * Entry rendering and impressions occur only after administrator access is resolved.
  * Existing course-creation tracking continues alongside the new click analytics.
* **Documentation**
  * Added an execution plan documenting event details, privacy safeguards, and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->