### PR TITLE
feat: preserve Lobster registration and course attribution

### DIFF
--- a/docs/exec-plans/active/course-creation-attribution.md
+++ b/docs/exec-plans/active/course-creation-attribution.md
@@ -1,0 +1,147 @@
+# Persist AI-assisted course creation attribution
+
+## Purpose / Big Picture
+
+AI Shifu must be able to distinguish users registered through the Lobster
+authorization handoff and courses created through the Lobster course-creator
+Skill. The attribution must be recorded in the correctness-oriented database
+rather than inferred later from best-effort browser or CLI analytics. This
+enables reliable registration, creation, publication, order, and learning
+conversion analysis.
+
+## Progress
+
+- [x] 2026-09-11 16:10 CST: Confirmed that the current Skill create/import
+  requests send no attribution fields and that AI Shifu has no receiving
+  persistence path.
+- [x] 2026-09-11 17:35 CST: Added the immutable backend attribution contract,
+  model, migration, and focused regression tests.
+- [x] 2026-09-11 17:35 CST: Added the matching Skill request producer and tests
+  in the separate Skills repository.
+- [x] 2026-09-11 17:35 CST: Ran focused and repository-required verification.
+- [x] 2026-09-11 17:45 CST: Prepared one focused commit and pull request per
+  repository.
+  commit, push, and open one focused PR per repository.
+
+## Surprises & Discoveries
+
+- The Skill already emits fail-open Umami events such as `cli_import`, but the
+  event deliberately contains neither course identifiers nor command results.
+  It is useful for adoption measurement but cannot be the course-attribution
+  source of truth.
+- GitHub and Gitee Skills `main` currently resolve to the same commit,
+  `cf9cf1d0de76f626a3b24c2e5cfa1ab6f51fdc20`.
+- The existing MySQL `users.created_at` column has second precision, while the
+  device authorization timestamp is generated with subsecond precision. The
+  comparison must normalize both to seconds or registrations completed in the
+  authorization's starting second can be missed.
+
+## Decision Log
+
+- Decision: Store course attribution in a one-row-per-course table rather than on
+  versioned draft rows. Rationale: draft edits create revisions, while course
+  origin is immutable course-level metadata that must survive publication and
+  ownership transfer without copying across every revision.
+- Decision: Use one structured optional create payload named
+  `creation_attribution`, containing `creation_source`, `source_product`, and
+  `handoff_id`. Rationale: existing clients remain compatible and the three
+  values are accepted or rejected atomically.
+- Decision: Initially allow only `ai_assistant` plus `lobster`, with a UUID
+  handoff identifier. Rationale: a narrow allowlist prevents uncontrolled
+  analytics dimensions and leaves deliberate extension points.
+- Decision: Treat the record as immutable. Rationale: origin is a creation-time
+  fact and must not be rewritten by subsequent course edits.
+- Decision: Carry the authorization handoff UUID into the first new course
+  created after authorization. Rationale: this joins a newly registered user
+  to their first Skill-created course without collecting contact details.
+- Decision: Attribute registration only when the persisted user was created
+  after the device authorization began. Rationale: an existing teacher who
+  merely authorizes the CLI must not be reclassified as Lobster-acquired.
+
+## Outcomes & Retrospective
+
+The backend now stores immutable Lobster registration and course-creation
+facts, and the Skill supplies one cross-system handoff UUID without changing
+existing-user or existing-course attribution. Focused backend tests passed
+(430 tests), Skills validation passed (3 skills and 229 tests), Ruff passed,
+and the repository harness, architecture-boundary checks, and full pre-commit
+gate passed. The implementation is ready for review in one focused pull
+request per repository.
+
+## Context and Orientation
+
+The authenticated create endpoint is `PUT /api/shifu/shifus` in
+`src/api/flaskr/service/shifu/route.py`. Course creation and its transaction
+are owned by `create_shifu_draft` in
+`src/api/flaskr/service/shifu/shifu_draft_funcs.py`. Course models live in
+`src/api/flaskr/service/shifu/models.py`; schema revisions live under
+`src/api/migrations/versions/`.
+
+The producer is `skills/ai-shifu-course-creator/scripts/shifu-cli.py` in the
+Skills repository. Both `create` and `import --new` call the same AI Shifu
+course creation endpoint.
+
+## Plan of Work
+
+Define and validate the structured attribution at the service boundary. Add an
+immutable database row in the same transaction as course creation. Add the
+schema migration and tests for absent attribution, valid Lobster attribution,
+invalid enums/identifiers, and rollback behavior. Then update both Skill paths
+that create courses to generate a UUID handoff and submit the agreed payload,
+with request-contract tests proving existing-course imports do not rewrite
+origin.
+
+## Concrete Steps
+
+1. Add the backend registration/course models and migration.
+2. Add a narrow parser/value object and wire it through the create route and
+   creation transaction.
+3. Add focused backend tests and run the Shifu test subset.
+4. Update the Skills CLI producer and its unit tests/documented deployment
+   contract.
+5. Run each repository's required checks, commit with compliant messages,
+   push both branches, and open both PRs with their dependency documented.
+
+## Validation and Acceptance
+
+- Existing create requests without `creation_attribution` behave unchanged and
+  create no attribution row.
+- A valid Lobster request creates exactly one attribution row with the course
+  BID, teacher BID, stable enum values, UUID handoff, and UTC creation time.
+- Malformed or unsupported attribution is rejected before course creation.
+- A failed course transaction leaves no attribution row.
+- Skill `create` and `import --new` send valid attribution; importing into an
+  existing course does not send or mutate it.
+- A browser authorization started by the Skill attributes a user only when
+  that authorization began before the user account was created; the same
+  handoff UUID is reused for the first subsequent new course and then consumed.
+
+## Idempotence and Recovery
+
+The migration is a normal Alembic upgrade/downgrade. Attribution insertion is
+part of the course creation transaction, so rollback removes both records.
+The table has uniqueness constraints on course BID and handoff ID to prevent
+ambiguous duplicate attribution. Re-running tests is safe.
+
+## Interfaces and Dependencies
+
+The cross-repository course request contract is:
+
+```json
+{
+  "creation_attribution": {
+    "creation_source": "ai_assistant",
+    "source_product": "lobster",
+    "handoff_id": "<canonical UUID>"
+  }
+}
+```
+
+The device authorization endpoint accepts the same object under
+`registration_attribution`. The Skill stores the generated handoff UUID in its
+owner-only credentials file only until the first new course succeeds.
+
+The Skills PR depends on the AI Shifu backend accepting this optional field,
+but older backends currently ignore unknown JSON members, so rollout remains
+backward compatible. Umami remains best-effort and is not used as the source
+of truth.

--- a/docs/exec-plans/active/course-creation-attribution.md
+++ b/docs/exec-plans/active/course-creation-attribution.md
@@ -21,7 +21,9 @@ conversion analysis.
 - [x] 2026-09-11 17:35 CST: Ran focused and repository-required verification.
 - [x] 2026-09-11 17:45 CST: Prepared one focused commit and pull request per
   repository.
-  commit, push, and open one focused PR per repository.
+- [x] 2026-09-11 20:40 CST: Reworked registration attribution around the exact
+  browser handoff and explicit new-user result; made course handoffs safe for
+  retries and concurrent Skill commands.
 
 ## Surprises & Discoveries
 
@@ -31,10 +33,9 @@ conversion analysis.
   source of truth.
 - GitHub and Gitee Skills `main` currently resolve to the same commit,
   `cf9cf1d0de76f626a3b24c2e5cfa1ab6f51fdc20`.
-- The existing MySQL `users.created_at` column has second precision, while the
-  device authorization timestamp is generated with subsecond precision. The
-  comparison must normalize both to seconds or registrations completed in the
-  authorization's starting second can be missed.
+- Temporary guest accounts retain their original `created_at` when promoted,
+  so account timestamps cannot reliably determine whether the browser handoff
+  caused registration.
 
 ## Decision Log
 
@@ -54,9 +55,14 @@ conversion analysis.
 - Decision: Carry the authorization handoff UUID into the first new course
   created after authorization. Rationale: this joins a newly registered user
   to their first Skill-created course without collecting contact details.
-- Decision: Attribute registration only when the persisted user was created
-  after the device authorization began. Rationale: an existing teacher who
-  merely authorizes the CLI must not be reclassified as Lobster-acquired.
+- Decision: Pass the device `user_code` through the browser login request and
+  persist registration attribution only when the auth provider explicitly
+  reports a new registration. Rationale: this identifies the exact handoff,
+  handles guest promotion, and does not depend on the CLI polling afterward.
+- Decision: Reserve a saved course handoff atomically and only when its saved
+  token matches the token used for the request. Rationale: explicit-token and
+  concurrent CLI invocations must not consume or duplicate another account's
+  registration handoff.
 
 ## Outcomes & Retrospective
 
@@ -112,16 +118,18 @@ origin.
 - A failed course transaction leaves no attribution row.
 - Skill `create` and `import --new` send valid attribution; importing into an
   existing course does not send or mutate it.
-- A browser authorization started by the Skill attributes a user only when
-  that authorization began before the user account was created; the same
-  handoff UUID is reused for the first subsequent new course and then consumed.
+- A browser authorization started by the Skill attributes a user only when the
+  linked login operation explicitly creates or promotes that user; the same
+  handoff UUID is reserved for the first subsequent new course and restored if
+  that request fails.
 
 ## Idempotence and Recovery
 
-The migration is a normal Alembic upgrade/downgrade. Attribution insertion is
-part of the course creation transaction, so rollback removes both records.
-The table has uniqueness constraints on course BID and handoff ID to prevent
-ambiguous duplicate attribution. Re-running tests is safe.
+The migration is a normal Alembic upgrade/downgrade and must run before the
+backend code is deployed. Attribution insertion is part of the course creation
+transaction, so rollback removes both records. The table has uniqueness
+constraints on course BID and handoff ID; retrying an identical course handoff
+returns its original course, while conflicting ownership is rejected.
 
 ## Interfaces and Dependencies
 

--- a/docs/exec-plans/active/course-creation-attribution.md
+++ b/docs/exec-plans/active/course-creation-attribution.md
@@ -63,6 +63,10 @@ conversion analysis.
   token matches the token used for the request. Rationale: explicit-token and
   concurrent CLI invocations must not consume or duplicate another account's
   registration handoff.
+- Decision: After a create request begins, retain its handoff in an
+  operation-specific retry journal instead of returning it to the account-level
+  credential slot. Rationale: a lost response cannot reveal whether the server
+  committed, so only the exact same command payload may reuse that handoff.
 
 ## Outcomes & Retrospective
 
@@ -120,8 +124,9 @@ origin.
   existing course does not send or mutate it.
 - A browser authorization started by the Skill attributes a user only when the
   linked login operation explicitly creates or promotes that user; the same
-  handoff UUID is reserved for the first subsequent new course and restored if
-  that request fails.
+  handoff UUID is reserved for the first subsequent new-course operation; an
+  uncertain result remains bound to that exact operation for an idempotent
+  retry.
 
 ## Idempotence and Recovery
 

--- a/docs/exec-plans/index.md
+++ b/docs/exec-plans/index.md
@@ -13,6 +13,7 @@ Active and completed ExecPlans live here. The structure and required sections ar
 - [Backend Overhaul Master Plan: Inventory and Optimization](./active/backend-overhaul-master.md)
 - [ExecPlan: Billing Credit Notifications](./active/billing-credit-notifications.md)
 - [Speed Up Backend Pull Request Feedback](./active/ci-backend-speed-stack.md)
+- [Persist AI-assisted course creation attribution](./active/course-creation-attribution.md)
 - [Market-aware course prices and free-course unlock](./active/course-price-market-rules-and-free-unlock.md)
 - [Course Sharing](./active/course-sharing.md)
 - [Creator Brand Domain And Payments](./active/creator-brand-domain-payments.md)

--- a/docs/generated/doc-inventory.md
+++ b/docs/generated/doc-inventory.md
@@ -31,6 +31,7 @@
 | `docs/exec-plans/active/backend-overhaul-master.md` | Backend Overhaul Master Plan: Inventory and Optimization | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/billing-credit-notifications.md` | ExecPlan: Billing Credit Notifications | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/ci-backend-speed-stack.md` | Speed Up Backend Pull Request Feedback | `exec-plan-active` | `active` | `repo` | `-` | `true` |
+| `docs/exec-plans/active/course-creation-attribution.md` | Persist AI-assisted course creation attribution | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/course-price-market-rules-and-free-unlock.md` | Market-aware course prices and free-course unlock | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/course-sharing.md` | Course Sharing | `exec-plan-active` | `active` | `repo` | `-` | `true` |
 | `docs/exec-plans/active/creator-brand-domain-payments.md` | Creator Brand Domain And Payments | `exec-plan-active` | `active` | `repo` | `-` | `true` |

--- a/docs/generated/harness-health.md
+++ b/docs/generated/harness-health.md
@@ -9,7 +9,7 @@ This generated report summarizes the repository harness control plane.
 - Design docs: `14`
 - Product specs: `11`
 - References: `6`
-- Active ExecPlans: `33`
+- Active ExecPlans: `34`
 - Completed ExecPlans: `37`
 
 ## Boundary Baseline

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -8,6 +8,7 @@ from typing import ParamSpec, TypeVar
 
 from flask import Flask, Response, current_app, make_response, request
 
+from flaskr.common.http import sensitive_body
 from flaskr.common.public_urls import resolve_request_origin
 from flaskr.common.shifu_context import with_shifu_context
 from flaskr.dao import db
@@ -751,6 +752,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/login_sms", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation
+    @sensitive_body(max_bytes=16 * 1024)
     def login_sms_api() -> Response:
         """Login through SMS verification code for web clients.
 
@@ -763,6 +765,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
     @app.route(path_prefix + "/login_email", methods=["POST"])
     @bypass_token_validation
     @optional_token_validation
+    @sensitive_body(max_bytes=16 * 1024)
     def login_email_api() -> Response:
         """Login through email verification code for web clients.
 

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -44,6 +44,7 @@ from flaskr.service.user.device_auth import (
     deny_device_authorization,
     get_device_authorization,
     poll_device_authorization,
+    record_device_registration_attribution,
 )
 from flaskr.service.user.models import AuthCredential, UserInfo
 from flaskr.service.user.onboarding import (
@@ -725,6 +726,12 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
                         },
                     ),
                 )
+                if auth_result.is_new_user:
+                    record_device_registration_attribution(
+                        app,
+                        user_code=payload.get("device_user_code"),
+                        user_id=auth_result.user.user_id,
+                    )
             run_post_auth_extensions(
                 app,
                 PostAuthContext(
@@ -1166,6 +1173,9 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         login_context = request.args.get("login_context")
         if login_context:
             metadata["login_context"] = login_context
+        device_user_code = request.args.get("device_user_code")
+        if device_user_code:
+            metadata["device_user_code"] = device_user_code
         ui_language = request.args.get("language")
         if ui_language:
             metadata["language"] = ui_language
@@ -1220,6 +1230,12 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
         )
         with unit_of_work():
             auth_result = provider.handle_oauth_callback(app, callback_request)
+            if auth_result.is_new_user:
+                record_device_registration_attribution(
+                    app,
+                    user_code=auth_result.metadata.get("device_user_code"),
+                    user_id=auth_result.user.user_id,
+                )
         run_post_auth_extensions(
             app,
             PostAuthContext(

--- a/src/api/flaskr/route/user.py
+++ b/src/api/flaskr/route/user.py
@@ -784,6 +784,7 @@ def register_user_handler(app: Flask, path_prefix: str) -> Flask:
                 device_os=payload.get("device_os"),
                 client_version=payload.get("client_version"),
                 client_ip=_request_client_ip(),
+                registration_attribution=payload.get("registration_attribution"),
             )
         )
 

--- a/src/api/flaskr/service/common/source_attribution.py
+++ b/src/api/flaskr/service/common/source_attribution.py
@@ -1,0 +1,57 @@
+"""Shared validation contract for AI-assisted source attribution."""
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from flaskr.service.common.models import raise_param_error
+
+CREATION_SOURCE_AI_ASSISTANT = "ai_assistant"
+SOURCE_PRODUCT_LOBSTER = "lobster"
+
+
+@dataclass(frozen=True)
+class SourceAttributionInput:
+    """Validated, low-cardinality attribution supplied by an AI workflow."""
+
+    creation_source: str
+    source_product: str
+    handoff_id: str
+
+
+def parse_source_attribution(
+    value: object,
+    *,
+    field_name: str,
+) -> SourceAttributionInput | None:
+    """Validate one optional structured attribution payload."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise_param_error(field_name)
+
+    allowed_keys = {"creation_source", "source_product", "handoff_id"}
+    if set(value) != allowed_keys:
+        raise_param_error(field_name)
+
+    creation_source = value.get("creation_source")
+    source_product = value.get("source_product")
+    handoff_id = value.get("handoff_id")
+    if creation_source != CREATION_SOURCE_AI_ASSISTANT:
+        raise_param_error(f"{field_name}.creation_source")
+    if source_product != SOURCE_PRODUCT_LOBSTER:
+        raise_param_error(f"{field_name}.source_product")
+    if not isinstance(handoff_id, str):
+        raise_param_error(f"{field_name}.handoff_id")
+    try:
+        parsed_handoff_id = UUID(handoff_id)
+    except (ValueError, AttributeError, TypeError):
+        raise_param_error(f"{field_name}.handoff_id")
+    canonical_handoff_id = str(parsed_handoff_id)
+    if handoff_id != canonical_handoff_id:
+        raise_param_error(f"{field_name}.handoff_id")
+
+    return SourceAttributionInput(
+        creation_source=creation_source,
+        source_product=source_product,
+        handoff_id=canonical_handoff_id,
+    )

--- a/src/api/flaskr/service/shifu/models.py
+++ b/src/api/flaskr/service/shifu/models.py
@@ -160,6 +160,56 @@ class ShifuUserArchive(db.Model):
     )
 
 
+class CourseCreationAttribution(db.Model):
+    """Immutable creation-source attribution for one course."""
+
+    __tablename__ = "shifu_course_creation_attributions"
+    __table_args__ = (
+        UniqueConstraint(
+            "shifu_bid",
+            name="uk_shifu_course_creation_attribution_shifu_bid",
+        ),
+        UniqueConstraint(
+            "handoff_id",
+            name="uk_shifu_course_creation_attribution_handoff_id",
+        ),
+    )
+
+    id = Column(BIGINT, primary_key=True, autoincrement=True)
+    shifu_bid = Column(
+        String(32),
+        nullable=False,
+        comment="Shifu business identifier",
+    )
+    created_user_bid = Column(
+        String(32),
+        nullable=False,
+        index=True,
+        comment="Teacher business identifier at creation time",
+    )
+    creation_source = Column(
+        String(32),
+        nullable=False,
+        comment="Stable course creation source",
+    )
+    source_product = Column(
+        String(32),
+        nullable=False,
+        comment="Stable source product identifier",
+    )
+    handoff_id = Column(
+        String(36),
+        nullable=False,
+        comment="Cross-system handoff UUID",
+    )
+    created_at = Column(
+        DateTime,
+        nullable=False,
+        default=now_utc,
+        comment="Attribution creation timestamp",
+    )
+
+
 # draft shifu's model
 class DraftShifu(db.Model):
     """Shifu draft shifu."""

--- a/src/api/flaskr/service/shifu/route.py
+++ b/src/api/flaskr/service/shifu/route.py
@@ -67,6 +67,7 @@ from flaskr.service.billing.api import (
     assert_creator_debug_allowed,
 )
 from flaskr.service.common.models import ERROR_CODE, raise_error, raise_param_error
+from flaskr.service.common.source_attribution import parse_source_attribution
 from flaskr.service.learn.ask_provider_langfuse import stream_provider_with_langfuse
 from flaskr.service.learn.langfuse_naming import (
     build_langfuse_generation_name,
@@ -788,14 +789,25 @@ def register_shifu_routes(app: Flask, path_prefix: str = "/api/shifu") -> Flask:
                                     $ref: "#/components/schemas/ShifuDto"
         """
         user_id = request.user.user_id
-        shifu_name = request.get_json().get("name")
+        payload = request.get_json() or {}
+        shifu_name = payload.get("name")
         if not shifu_name:
             raise_param_error("name is required")
-        shifu_description = request.get_json().get("description")
-        shifu_avatar = request.get_json().get("avatar", "")
+        shifu_description = payload.get("description")
+        shifu_avatar = payload.get("avatar", "")
+        creation_attribution = parse_source_attribution(
+            payload.get("creation_attribution"),
+            field_name="creation_attribution",
+        )
         return make_common_response(
             create_shifu_draft(
-                app, user_id, shifu_name, shifu_description, shifu_avatar, []
+                app,
+                user_id,
+                shifu_name,
+                shifu_description,
+                shifu_avatar,
+                [],
+                creation_attribution=creation_attribution,
             )
         )
 

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -24,6 +24,7 @@ from flaskr.service.common.models import (
     raise_error_with_args,
     raise_param_error,
 )
+from flaskr.service.common.source_attribution import SourceAttributionInput
 from flaskr.service.config import get_config
 from flaskr.service.learn.api import (
     is_live_follow_up_model,
@@ -62,7 +63,13 @@ from .course_activity import load_course_activity_map
 from .demo_courses import is_builtin_demo_course
 from .dtos import ShifuDetailDto, ShifuDto
 from .funcs import shifu_permission_verification
-from .models import DraftShifu, FavoriteScenario, PublishedShifu, ShifuUserArchive
+from .models import (
+    CourseCreationAttribution,
+    DraftShifu,
+    FavoriteScenario,
+    PublishedShifu,
+    ShifuUserArchive,
+)
 from .permissions import get_user_shifu_permissions
 from .shifu_history_manager import save_shifu_history
 from .shifu_outline_funcs import create_default_outlines_for_new_shifu
@@ -280,6 +287,7 @@ def create_shifu_draft(
     shifu_model: str | None = None,
     shifu_temperature: float | None = None,
     shifu_price: float | None = None,
+    creation_attribution: SourceAttributionInput | None = None,
 ) -> ShifuDto:
     """Create a shifu draft.
 
@@ -293,6 +301,7 @@ def create_shifu_draft(
         shifu_model: Shifu model
         shifu_temperature: Shifu temperature
         shifu_price: Shifu price
+        creation_attribution: Optional immutable creation-source attribution
     Returns:
         ShifuDto: Shifu dto.
 
@@ -349,6 +358,18 @@ def create_shifu_draft(
         stage_started_at = perf_counter()
         db.session.add(shifu_draft)
         db.session.flush()
+
+        if creation_attribution is not None:
+            db.session.add(
+                CourseCreationAttribution(
+                    shifu_bid=shifu_id,
+                    created_user_bid=user_id,
+                    creation_source=creation_attribution.creation_source,
+                    source_product=creation_attribution.source_product,
+                    handoff_id=creation_attribution.handoff_id,
+                    created_at=now_time,
+                )
+            )
 
         save_shifu_history(app, user_id, shifu_id, shifu_draft.id)
 

--- a/src/api/flaskr/service/shifu/shifu_draft_funcs.py
+++ b/src/api/flaskr/service/shifu/shifu_draft_funcs.py
@@ -50,6 +50,7 @@ from flaskr.service.learn.ask_provider_adapters.consts import (  # noqa: F401
 from flaskr.service.tts.validation import validate_tts_settings_strict
 from flaskr.util import generate_id
 from flaskr.util.datetime import NAIVE_DATETIME_MIN, now_utc
+from sqlalchemy.exc import IntegrityError
 
 from .consts import (
     ASK_MODE_DEFAULT,
@@ -84,6 +85,36 @@ SUPPORTED_ASK_ENABLED_STATUSES = {
     ASK_MODE_DISABLE,
     ASK_MODE_ENABLE,
 }
+
+
+def _attributed_course_result(
+    attribution: CourseCreationAttribution,
+    *,
+    user_id: str,
+    creation_attribution: SourceAttributionInput,
+) -> ShifuDto:
+    """Return an idempotent course result or reject a reused handoff."""
+    if (
+        attribution.created_user_bid != user_id
+        or attribution.creation_source != creation_attribution.creation_source
+        or attribution.source_product != creation_attribution.source_product
+    ):
+        raise_param_error("creation_attribution.handoff_id")
+    draft = get_latest_shifu_draft(attribution.shifu_bid)
+    if draft is None:
+        raise_param_error("creation_attribution.handoff_id")
+    return ShifuDto(
+        shifu_id=draft.shifu_bid,
+        shifu_name=draft.title,
+        shifu_description=draft.description,
+        shifu_avatar=draft.avatar_res_bid,
+        shifu_state=STATUS_DRAFT,
+        is_favorite=False,
+        archived=False,
+        can_manage_archive=True,
+        can_manage_permissions=True,
+        created_user_bid=draft.created_user_bid,
+    )
 
 
 def _resolve_shifu_price(shifu_price: float | Decimal | None) -> Decimal:
@@ -311,6 +342,17 @@ def create_shifu_draft(
         stage_started_at = total_started_at
         now_time = now_utc()
 
+        if creation_attribution is not None:
+            existing_attribution = CourseCreationAttribution.query.filter_by(
+                handoff_id=creation_attribution.handoff_id
+            ).one_or_none()
+            if existing_attribution is not None:
+                return _attributed_course_result(
+                    existing_attribution,
+                    user_id=user_id,
+                    creation_attribution=creation_attribution,
+                )
+
         shifu_id = generate_id(app)
 
         if not shifu_name:
@@ -360,16 +402,30 @@ def create_shifu_draft(
         db.session.flush()
 
         if creation_attribution is not None:
-            db.session.add(
-                CourseCreationAttribution(
-                    shifu_bid=shifu_id,
-                    created_user_bid=user_id,
-                    creation_source=creation_attribution.creation_source,
-                    source_product=creation_attribution.source_product,
-                    handoff_id=creation_attribution.handoff_id,
-                    created_at=now_time,
+            try:
+                db.session.add(
+                    CourseCreationAttribution(
+                        shifu_bid=shifu_id,
+                        created_user_bid=user_id,
+                        creation_source=creation_attribution.creation_source,
+                        source_product=creation_attribution.source_product,
+                        handoff_id=creation_attribution.handoff_id,
+                        created_at=now_time,
+                    )
                 )
-            )
+                db.session.flush()
+            except IntegrityError:
+                db.session.rollback()
+                existing_attribution = CourseCreationAttribution.query.filter_by(
+                    handoff_id=creation_attribution.handoff_id
+                ).one_or_none()
+                if existing_attribution is None:
+                    raise
+                return _attributed_course_result(
+                    existing_attribution,
+                    user_id=user_id,
+                    creation_attribution=creation_attribution,
+                )
 
         save_shifu_history(app, user_id, shifu_id, shifu_draft.id)
 

--- a/src/api/flaskr/service/user/auth/providers/google.py
+++ b/src/api/flaskr/service/user/auth/providers/google.py
@@ -200,6 +200,9 @@ class GoogleAuthProvider(AuthProvider):
             "redirect_uri": redirect_uri,
             "login_context": login_context,
         }
+        device_user_code = str(metadata.get("device_user_code") or "").strip()
+        if device_user_code:
+            state_payload["device_user_code"] = device_user_code
         # All domains share one Google callback, so remember where the browser
         # came from to hand it back afterwards. The origin is derived from
         # headers an attacker can set, so it is only honored together with the
@@ -247,10 +250,12 @@ class GoogleAuthProvider(AuthProvider):
         redirect_uri = None
         login_context = None
         language: str | None = None
+        device_user_code = None
         try:
             redirect_uri = state_payload.get("redirect_uri")
             login_context = state_payload.get("login_context")
             language = state_payload.get("language")
+            device_user_code = state_payload.get("device_user_code")
         except Exception:  # defensive fallback
             current_app.logger.warning("Failed to parse Google OAuth state payload")
 
@@ -318,11 +323,13 @@ class GoogleAuthProvider(AuthProvider):
                 )
                 if entity:
                     updates: dict[str, Any] = {"identify": email}
-                    if email_verified and aggregate.state in (
+                    promoted_user = email_verified and aggregate.state in (
                         USER_STATE_UNREGISTERED,
                         0,
-                    ):
+                    )
+                    if promoted_user:
                         updates["state"] = USER_STATE_REGISTERED
+                        created_user = True
                     display_name = profile.get("name")
                     if display_name:
                         updates["nickname"] = display_name
@@ -411,6 +418,7 @@ class GoogleAuthProvider(AuthProvider):
                 "profile": profile,
                 "creator_granted_now": creator_granted_now,
                 "snapshot": snapshot.to_dict(),
+                "device_user_code": device_user_code,
             },
         )
 

--- a/src/api/flaskr/service/user/auth/providers/google.py
+++ b/src/api/flaskr/service/user/auth/providers/google.py
@@ -227,7 +227,6 @@ class GoogleAuthProvider(AuthProvider):
             state=state,
             **create_url_kwargs,
         )
-        current_app.logger.info("Google OAuth begin state=%s", state)
         return {"authorization_url": authorization_url, "state": state}
 
     def handle_oauth_callback(
@@ -242,7 +241,6 @@ class GoogleAuthProvider(AuthProvider):
             )
             raise_error("server.user.googleOAuthStateInvalid")
 
-        current_app.logger.info("Google OAuth callback state=%s", request.state)
         state_payload = _decode_state(app, request.state)
         if not state_payload:
             raise_error("server.user.googleOAuthStateInvalid")

--- a/src/api/flaskr/service/user/device_auth.py
+++ b/src/api/flaskr/service/user/device_auth.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import json
 import secrets
 import time
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from flaskr.common.cache_provider import cache as redis
@@ -32,11 +31,10 @@ from flaskr.common.config import get_redis_derived_prefix
 from flaskr.common.public_urls import build_public_url
 from flaskr.dao import db
 from flaskr.dao.uow import unit_of_work
-from flaskr.service.common.models import raise_error
+from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.common.source_attribution import parse_source_attribution
-from flaskr.service.user.models import UserInfo, UserRegistrationAttribution
+from flaskr.service.user.models import UserRegistrationAttribution
 from flaskr.service.user.utils import generate_token
-from sqlalchemy.exc import SQLAlchemyError
 
 if TYPE_CHECKING:
     from flask import Flask
@@ -409,7 +407,6 @@ def poll_device_authorization(app: Flask, *, device_code: str) -> dict[str, Any]
                 _drop_session(app, normalized, user_code)
                 raise_error("server.user.deviceCodeInvalid")
             with unit_of_work():
-                _record_registration_attribution_if_new(app, user_id, payload)
                 # Name the session after the machine the user approved, not
                 # after the polling client's user agent.
                 token = generate_token(
@@ -429,51 +426,59 @@ def poll_device_authorization(app: Flask, *, device_code: str) -> dict[str, Any]
         lock.release()
 
 
-def _record_registration_attribution_if_new(
+def record_device_registration_attribution(
     app: Flask,
+    *,
+    user_code: object,
     user_id: str,
-    device_payload: dict[str, Any],
-) -> None:
-    """Persist source only when registration occurred after this handoff began."""
+) -> bool:
+    """Persist a new registration's source from its exact device handoff.
+
+    The caller supplies the explicit ``is_new_user`` decision from the
+    registration transaction. This function deliberately does not infer that
+    fact from entity timestamps because guest-to-user promotion keeps the
+    guest row's original creation time.
+    """
+    normalized_user_code = normalize_user_code(user_code)
+    if not normalized_user_code:
+        return False
+    device_code = _decode(redis.get(_user_code_key(app, normalized_user_code)))
+    if not device_code:
+        return False
+    device_payload = _load_session(app, device_code)
+    if device_payload is None or device_payload.get("status") != STATUS_PENDING:
+        return False
     attribution = parse_source_attribution(
         device_payload.get("registration_attribution"),
         field_name="registration_attribution",
     )
     if attribution is None:
-        return
+        return False
 
-    user = (
-        UserInfo.query.filter(
-            UserInfo.user_bid == user_id,
-            UserInfo.deleted == 0,
+    existing_user = UserRegistrationAttribution.query.filter_by(
+        user_bid=user_id
+    ).one_or_none()
+    if existing_user is not None:
+        if (
+            existing_user.registration_source == attribution.creation_source
+            and existing_user.source_product == attribution.source_product
+            and existing_user.handoff_id == attribution.handoff_id
+        ):
+            return True
+        raise_param_error("registration_attribution")
+    existing_handoff = UserRegistrationAttribution.query.filter_by(
+        handoff_id=attribution.handoff_id
+    ).one_or_none()
+    if existing_handoff is not None:
+        raise_param_error("registration_attribution.handoff_id")
+
+    db.session.add(
+        UserRegistrationAttribution(
+            user_bid=user_id,
+            registration_source=attribution.creation_source,
+            source_product=attribution.source_product,
+            handoff_id=attribution.handoff_id,
         )
-        .order_by(UserInfo.id.desc())
-        .first()
     )
-    if user is None or user.created_at is None:
-        return
-    # MySQL's existing ``users.created_at`` column is second-precision. Floor
-    # the Redis timestamp to the same precision so a user created later in the
-    # authorization's starting second is not incorrectly treated as existing.
-    request_started_at = datetime.fromtimestamp(
-        int(float(device_payload.get("created_at") or 0)), UTC
-    ).replace(tzinfo=None)
-    if user.created_at < request_started_at:
-        return
-
-    try:
-        with db.session.begin_nested():
-            db.session.add(
-                UserRegistrationAttribution(
-                    user_bid=user_id,
-                    registration_source=attribution.creation_source,
-                    source_product=attribution.source_product,
-                    handoff_id=attribution.handoff_id,
-                )
-            )
-            db.session.flush()
-    except SQLAlchemyError:
-        app.logger.exception(
-            "registration attribution persistence failed | user_id=%s",
-            user_id,
-        )
+    db.session.flush()
+    return True

--- a/src/api/flaskr/service/user/device_auth.py
+++ b/src/api/flaskr/service/user/device_auth.py
@@ -24,14 +24,19 @@ from __future__ import annotations
 import json
 import secrets
 import time
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from flaskr.common.cache_provider import cache as redis
 from flaskr.common.config import get_redis_derived_prefix
 from flaskr.common.public_urls import build_public_url
+from flaskr.dao import db
 from flaskr.dao.uow import unit_of_work
 from flaskr.service.common.models import raise_error
+from flaskr.service.common.source_attribution import parse_source_attribution
+from flaskr.service.user.models import UserInfo, UserRegistrationAttribution
 from flaskr.service.user.utils import generate_token
+from sqlalchemy.exc import SQLAlchemyError
 
 if TYPE_CHECKING:
     from flask import Flask
@@ -218,8 +223,13 @@ def create_device_authorization(
     device_os: str | None = None,
     client_version: str | None = None,
     client_ip: str | None = None,
+    registration_attribution: object = None,
 ) -> dict[str, Any]:
     """Start a pending authorization and hand the CLI its polling secret."""
+    attribution = parse_source_attribution(
+        registration_attribution,
+        field_name="registration_attribution",
+    )
     _guard_issue_rate(app, client_ip)
     ttl_seconds = _expire_seconds(app)
     device_code = secrets.token_urlsafe(32)
@@ -233,8 +243,14 @@ def create_device_authorization(
         "device_os": _clean_text(device_os),
         "client_version": _clean_text(client_version),
         "client_ip": _clean_text(client_ip),
-        "created_at": int(time.time()),
+        "created_at": time.time(),
     }
+    if attribution is not None:
+        payload["registration_attribution"] = {
+            "creation_source": attribution.creation_source,
+            "source_product": attribution.source_product,
+            "handoff_id": attribution.handoff_id,
+        }
     _store_session(app, device_code, payload, ttl_seconds)
     redis.set(_user_code_key(app, user_code), device_code, ex=ttl_seconds)
 
@@ -393,6 +409,7 @@ def poll_device_authorization(app: Flask, *, device_code: str) -> dict[str, Any]
                 _drop_session(app, normalized, user_code)
                 raise_error("server.user.deviceCodeInvalid")
             with unit_of_work():
+                _record_registration_attribution_if_new(app, user_id, payload)
                 # Name the session after the machine the user approved, not
                 # after the polling client's user agent.
                 token = generate_token(
@@ -410,3 +427,53 @@ def poll_device_authorization(app: Flask, *, device_code: str) -> dict[str, Any]
         return {"status": STATUS_PENDING, "token": "", "interval": _poll_interval(app)}
     finally:
         lock.release()
+
+
+def _record_registration_attribution_if_new(
+    app: Flask,
+    user_id: str,
+    device_payload: dict[str, Any],
+) -> None:
+    """Persist source only when registration occurred after this handoff began."""
+    attribution = parse_source_attribution(
+        device_payload.get("registration_attribution"),
+        field_name="registration_attribution",
+    )
+    if attribution is None:
+        return
+
+    user = (
+        UserInfo.query.filter(
+            UserInfo.user_bid == user_id,
+            UserInfo.deleted == 0,
+        )
+        .order_by(UserInfo.id.desc())
+        .first()
+    )
+    if user is None or user.created_at is None:
+        return
+    # MySQL's existing ``users.created_at`` column is second-precision. Floor
+    # the Redis timestamp to the same precision so a user created later in the
+    # authorization's starting second is not incorrectly treated as existing.
+    request_started_at = datetime.fromtimestamp(
+        int(float(device_payload.get("created_at") or 0)), UTC
+    ).replace(tzinfo=None)
+    if user.created_at < request_started_at:
+        return
+
+    try:
+        with db.session.begin_nested():
+            db.session.add(
+                UserRegistrationAttribution(
+                    user_bid=user_id,
+                    registration_source=attribution.creation_source,
+                    source_product=attribution.source_product,
+                    handoff_id=attribution.handoff_id,
+                )
+            )
+            db.session.flush()
+    except SQLAlchemyError:
+        app.logger.exception(
+            "registration attribution persistence failed | user_id=%s",
+            user_id,
+        )

--- a/src/api/flaskr/service/user/device_auth.py
+++ b/src/api/flaskr/service/user/device_auth.py
@@ -485,12 +485,18 @@ def record_device_registration_attribution(
             )
             db.session.flush()
     except IntegrityError:
-        existing_user = UserRegistrationAttribution.query.filter_by(
-            user_bid=user_id
-        ).one_or_none()
-        existing_handoff = UserRegistrationAttribution.query.filter_by(
-            handoff_id=attribution.handoff_id
-        ).one_or_none()
+        existing_user = (
+            UserRegistrationAttribution.query.filter_by(user_bid=user_id)
+            .with_for_update()
+            .one_or_none()
+        )
+        existing_handoff = (
+            UserRegistrationAttribution.query.filter_by(
+                handoff_id=attribution.handoff_id
+            )
+            .with_for_update()
+            .one_or_none()
+        )
         if (
             existing_user is not None
             and existing_user.id == getattr(existing_handoff, "id", None)

--- a/src/api/flaskr/service/user/device_auth.py
+++ b/src/api/flaskr/service/user/device_auth.py
@@ -35,6 +35,7 @@ from flaskr.service.common.models import raise_error, raise_param_error
 from flaskr.service.common.source_attribution import parse_source_attribution
 from flaskr.service.user.models import UserRegistrationAttribution
 from flaskr.service.user.utils import generate_token
+from sqlalchemy.exc import IntegrityError
 
 if TYPE_CHECKING:
     from flask import Flask
@@ -472,13 +473,31 @@ def record_device_registration_attribution(
     if existing_handoff is not None:
         raise_param_error("registration_attribution.handoff_id")
 
-    db.session.add(
-        UserRegistrationAttribution(
-            user_bid=user_id,
-            registration_source=attribution.creation_source,
-            source_product=attribution.source_product,
-            handoff_id=attribution.handoff_id,
-        )
-    )
-    db.session.flush()
+    try:
+        with db.session.begin_nested():
+            db.session.add(
+                UserRegistrationAttribution(
+                    user_bid=user_id,
+                    registration_source=attribution.creation_source,
+                    source_product=attribution.source_product,
+                    handoff_id=attribution.handoff_id,
+                )
+            )
+            db.session.flush()
+    except IntegrityError:
+        existing_user = UserRegistrationAttribution.query.filter_by(
+            user_bid=user_id
+        ).one_or_none()
+        existing_handoff = UserRegistrationAttribution.query.filter_by(
+            handoff_id=attribution.handoff_id
+        ).one_or_none()
+        if (
+            existing_user is not None
+            and existing_user.id == getattr(existing_handoff, "id", None)
+            and existing_user.registration_source == attribution.creation_source
+            and existing_user.source_product == attribution.source_product
+            and existing_user.handoff_id == attribution.handoff_id
+        ):
+            return True
+        raise
     return True

--- a/src/api/flaskr/service/user/models.py
+++ b/src/api/flaskr/service/user/models.py
@@ -251,6 +251,50 @@ class UserInfo(db.Model):
     )
 
 
+class UserRegistrationAttribution(db.Model):
+    """Immutable AI-workflow attribution for a newly registered user."""
+
+    __tablename__ = "user_registration_attributions"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_bid",
+            name="uk_user_registration_attribution_user_bid",
+        ),
+        UniqueConstraint(
+            "handoff_id",
+            name="uk_user_registration_attribution_handoff_id",
+        ),
+    )
+
+    id = Column(BIGINT, primary_key=True, autoincrement=True)
+    user_bid = Column(
+        String(32),
+        nullable=False,
+        comment="Registered user business identifier",
+    )
+    registration_source = Column(
+        String(32),
+        nullable=False,
+        comment="Stable registration source",
+    )
+    source_product = Column(
+        String(32),
+        nullable=False,
+        comment="Stable source product identifier",
+    )
+    handoff_id = Column(
+        String(36),
+        nullable=False,
+        comment="Cross-system handoff UUID",
+    )
+    created_at = Column(
+        DateTime,
+        nullable=False,
+        default=now_utc,
+        comment="Attribution creation timestamp",
+    )
+
+
 class UserAccountCancellation(db.Model):
     """Persist the authoritative audit record for a cancelled account."""
 

--- a/src/api/migrations/versions/b3e5f7a9c1d2_add_course_creation_attribution.py
+++ b/src/api/migrations/versions/b3e5f7a9c1d2_add_course_creation_attribution.py
@@ -1,0 +1,131 @@
+"""add course creation attribution
+
+Revision ID: b3e5f7a9c1d2
+Revises: b2d4f6a8c0e1
+Create Date: 2026-09-11 16:20:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision: str = "b3e5f7a9c1d2"
+down_revision: str | None = "b2d4f6a8c0e1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create immutable registration and course attribution storage."""
+    op.create_table(
+        "user_registration_attributions",
+        sa.Column("id", mysql.BIGINT(), autoincrement=True, nullable=False),
+        sa.Column(
+            "user_bid",
+            sa.String(length=32),
+            nullable=False,
+            comment="Registered user business identifier",
+        ),
+        sa.Column(
+            "registration_source",
+            sa.String(length=32),
+            nullable=False,
+            comment="Stable registration source",
+        ),
+        sa.Column(
+            "source_product",
+            sa.String(length=32),
+            nullable=False,
+            comment="Stable source product identifier",
+        ),
+        sa.Column(
+            "handoff_id",
+            sa.String(length=36),
+            nullable=False,
+            comment="Cross-system handoff UUID",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            comment="Attribution creation timestamp",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "handoff_id",
+            name="uk_user_registration_attribution_handoff_id",
+        ),
+        sa.UniqueConstraint(
+            "user_bid",
+            name="uk_user_registration_attribution_user_bid",
+        ),
+    )
+    op.create_table(
+        "shifu_course_creation_attributions",
+        sa.Column("id", mysql.BIGINT(), autoincrement=True, nullable=False),
+        sa.Column(
+            "shifu_bid",
+            sa.String(length=32),
+            nullable=False,
+            comment="Shifu business identifier",
+        ),
+        sa.Column(
+            "created_user_bid",
+            sa.String(length=32),
+            nullable=False,
+            comment="Teacher business identifier at creation time",
+        ),
+        sa.Column(
+            "creation_source",
+            sa.String(length=32),
+            nullable=False,
+            comment="Stable course creation source",
+        ),
+        sa.Column(
+            "source_product",
+            sa.String(length=32),
+            nullable=False,
+            comment="Stable source product identifier",
+        ),
+        sa.Column(
+            "handoff_id",
+            sa.String(length=36),
+            nullable=False,
+            comment="Cross-system handoff UUID",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            comment="Attribution creation timestamp",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "handoff_id",
+            name="uk_shifu_course_creation_attribution_handoff_id",
+        ),
+        sa.UniqueConstraint(
+            "shifu_bid",
+            name="uk_shifu_course_creation_attribution_shifu_bid",
+        ),
+    )
+    op.create_index(
+        op.f("ix_shifu_course_creation_attributions_created_user_bid"),
+        "shifu_course_creation_attributions",
+        ["created_user_bid"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop immutable registration and course attribution storage."""
+    op.drop_index(
+        op.f("ix_shifu_course_creation_attributions_created_user_bid"),
+        table_name="shifu_course_creation_attributions",
+    )
+    op.drop_table("shifu_course_creation_attributions")
+    op.drop_table("user_registration_attributions")

--- a/src/api/tests/service/shifu/test_course_creation_attribution.py
+++ b/src/api/tests/service/shifu/test_course_creation_attribution.py
@@ -1,0 +1,121 @@
+"""Verify immutable course creation attribution behavior."""
+
+from uuid import uuid4
+
+import pytest
+
+
+def _valid_payload(handoff_id: str | None = None) -> dict[str, str]:
+    return {
+        "creation_source": "ai_assistant",
+        "source_product": "lobster",
+        "handoff_id": handoff_id or str(uuid4()),
+    }
+
+
+def test_attribution_payload_is_optional() -> None:
+    from flaskr.service.common.source_attribution import parse_source_attribution
+
+    assert parse_source_attribution(None, field_name="creation_attribution") is None
+
+
+def test_lobster_attribution_payload_is_normalized() -> None:
+    from flaskr.service.common.source_attribution import parse_source_attribution
+
+    handoff_id = str(uuid4())
+
+    result = parse_source_attribution(
+        _valid_payload(handoff_id), field_name="creation_attribution"
+    )
+
+    assert result is not None
+    assert result.creation_source == "ai_assistant"
+    assert result.source_product == "lobster"
+    assert result.handoff_id == handoff_id
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "lobster",
+        {},
+        {
+            "creation_source": "manual",
+            "source_product": "lobster",
+            "handoff_id": "52cefd54-930a-4c06-b62d-00de456cd56f",
+        },
+        {
+            "creation_source": "ai_assistant",
+            "source_product": "unknown",
+            "handoff_id": "52cefd54-930a-4c06-b62d-00de456cd56f",
+        },
+        {
+            "creation_source": "ai_assistant",
+            "source_product": "lobster",
+            "handoff_id": "not-a-uuid",
+        },
+        {
+            **_valid_payload("52cefd54-930a-4c06-b62d-00de456cd56f"),
+            "course_title": "sensitive free-form value",
+        },
+    ],
+)
+def test_invalid_attribution_payload_is_rejected(payload: object) -> None:
+    from flaskr.service.common.models import AppError
+    from flaskr.service.common.source_attribution import parse_source_attribution
+
+    with pytest.raises(AppError):
+        parse_source_attribution(payload, field_name="creation_attribution")
+
+
+def test_create_persists_attribution_in_course_transaction(app: object) -> None:
+    from flaskr import dao
+    from flaskr.service.common.source_attribution import parse_source_attribution
+    from flaskr.service.shifu.models import CourseCreationAttribution
+    from flaskr.service.shifu.shifu_draft_funcs import create_shifu_draft
+
+    teacher_bid = "teacher-lobster-attribution"
+    handoff_id = str(uuid4())
+    attribution = parse_source_attribution(
+        _valid_payload(handoff_id), field_name="creation_attribution"
+    )
+
+    created = create_shifu_draft(
+        app=app,
+        user_id=teacher_bid,
+        shifu_name="Attributed course",
+        shifu_description="Created through Lobster",
+        shifu_image="",
+        creation_attribution=attribution,
+    )
+
+    with app.app_context():
+        row = CourseCreationAttribution.query.filter_by(shifu_bid=created.bid).one()
+        assert row.created_user_bid == teacher_bid
+        assert row.creation_source == "ai_assistant"
+        assert row.source_product == "lobster"
+        assert row.handoff_id == handoff_id
+        assert row.created_at is not None
+        dao.db.session.delete(row)
+        dao.db.session.commit()
+
+
+def test_create_without_attribution_does_not_infer_origin(app: object) -> None:
+    from flaskr.service.shifu.models import CourseCreationAttribution
+    from flaskr.service.shifu.shifu_draft_funcs import create_shifu_draft
+
+    created = create_shifu_draft(
+        app=app,
+        user_id="teacher-manual-course",
+        shifu_name="Manual course",
+        shifu_description="Created without attribution",
+        shifu_image="",
+    )
+
+    with app.app_context():
+        assert (
+            CourseCreationAttribution.query.filter_by(
+                shifu_bid=created.bid
+            ).one_or_none()
+            is None
+        )

--- a/src/api/tests/service/shifu/test_course_creation_attribution.py
+++ b/src/api/tests/service/shifu/test_course_creation_attribution.py
@@ -119,3 +119,68 @@ def test_create_without_attribution_does_not_infer_origin(app: object) -> None:
             ).one_or_none()
             is None
         )
+
+
+def test_retried_handoff_returns_the_original_course(app: object) -> None:
+    from flaskr.service.common.source_attribution import parse_source_attribution
+    from flaskr.service.shifu.models import CourseCreationAttribution
+    from flaskr.service.shifu.shifu_draft_funcs import create_shifu_draft
+
+    teacher_bid = "teacher-retried-handoff"
+    attribution = parse_source_attribution(
+        _valid_payload(), field_name="creation_attribution"
+    )
+    first = create_shifu_draft(
+        app=app,
+        user_id=teacher_bid,
+        shifu_name="Original course",
+        shifu_description="Original request",
+        shifu_image="",
+        creation_attribution=attribution,
+    )
+    retried = create_shifu_draft(
+        app=app,
+        user_id=teacher_bid,
+        shifu_name="Duplicate request",
+        shifu_description="Must not create another course",
+        shifu_image="",
+        creation_attribution=attribution,
+    )
+
+    assert retried.bid == first.bid
+    assert retried.name == "Original course"
+    with app.app_context():
+        assert (
+            CourseCreationAttribution.query.filter_by(
+                handoff_id=attribution.handoff_id
+            ).count()
+            == 1
+        )
+
+
+def test_handoff_cannot_be_reused_by_another_teacher(app: object) -> None:
+    from flaskr.service.common.models import AppError
+    from flaskr.service.common.source_attribution import parse_source_attribution
+    from flaskr.service.shifu.shifu_draft_funcs import create_shifu_draft
+
+    attribution = parse_source_attribution(
+        _valid_payload(), field_name="creation_attribution"
+    )
+    create_shifu_draft(
+        app=app,
+        user_id="teacher-original-handoff",
+        shifu_name="Original course",
+        shifu_description="",
+        shifu_image="",
+        creation_attribution=attribution,
+    )
+
+    with pytest.raises(AppError):
+        create_shifu_draft(
+            app=app,
+            user_id="teacher-other-handoff",
+            shifu_name="Other course",
+            shifu_description="",
+            shifu_image="",
+            creation_attribution=attribution,
+        )

--- a/src/api/tests/service/user/test_device_auth.py
+++ b/src/api/tests/service/user/test_device_auth.py
@@ -1,6 +1,8 @@
 """Verify the device authorization flow used by command-line clients."""
 
 import json
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
 
 import pytest
 from flaskr.service.common.models import ERROR_CODE, AppError
@@ -16,6 +18,7 @@ from flaskr.service.user.device_auth import (
     normalize_user_code,
     poll_device_authorization,
 )
+from flaskr.util.datetime import now_utc
 
 USER_ID = "test-user-bid-0001"
 
@@ -28,6 +31,133 @@ def _start(app: object) -> dict:
         client_version="1.2.6",
         client_ip="203.0.113.7",
     )
+
+
+def _lobster_attribution(handoff_id: str | None = None) -> dict[str, str]:
+    return {
+        "creation_source": "ai_assistant",
+        "source_product": "lobster",
+        "handoff_id": handoff_id or str(uuid4()),
+    }
+
+
+def test_new_registration_after_lobster_authorization_is_attributed(
+    app: object,
+) -> None:
+    from flaskr import dao
+    from flaskr.service.user.models import UserInfo, UserRegistrationAttribution
+
+    user_id = "new-lobster-user"
+    handoff_id = str(uuid4())
+    with app.test_request_context():
+        started = create_device_authorization(
+            app,
+            registration_attribution=_lobster_attribution(handoff_id),
+        )
+        dao.db.session.add(
+            UserInfo(
+                user_bid=user_id,
+                user_identify="new-lobster@example.test",
+                nickname="",
+                avatar="",
+                language="en-US",
+            )
+        )
+        dao.db.session.commit()
+
+        approve_device_authorization(
+            app, user_code=started["user_code"], user_id=user_id
+        )
+        assert (
+            poll_device_authorization(app, device_code=started["device_code"])["status"]
+            == STATUS_APPROVED
+        )
+
+        row = UserRegistrationAttribution.query.filter_by(user_bid=user_id).one()
+        assert row.registration_source == "ai_assistant"
+        assert row.source_product == "lobster"
+        assert row.handoff_id == handoff_id
+
+
+def test_existing_user_authorizing_lobster_is_not_reclassified(app: object) -> None:
+    from flaskr import dao
+    from flaskr.service.user.models import UserInfo, UserRegistrationAttribution
+
+    user_id = "existing-lobster-user"
+    with app.test_request_context():
+        dao.db.session.add(
+            UserInfo(
+                user_bid=user_id,
+                user_identify="existing-lobster@example.test",
+                nickname="",
+                avatar="",
+                language="en-US",
+                created_at=now_utc() - timedelta(days=1),
+            )
+        )
+        dao.db.session.commit()
+        started = create_device_authorization(
+            app,
+            registration_attribution=_lobster_attribution(),
+        )
+
+        approve_device_authorization(
+            app, user_code=started["user_code"], user_id=user_id
+        )
+        poll_device_authorization(app, device_code=started["device_code"])
+
+        assert (
+            UserRegistrationAttribution.query.filter_by(user_bid=user_id).one_or_none()
+            is None
+        )
+
+
+def test_registration_in_authorization_starting_second_is_attributed(
+    app: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from flaskr import dao
+    from flaskr.service.user.models import UserInfo, UserRegistrationAttribution
+
+    user_id = "same-second-lobster-user"
+    handoff_id = str(uuid4())
+    monkeypatch.setattr("flaskr.service.user.device_auth.time.time", lambda: 1000.9)
+    with app.test_request_context():
+        started = create_device_authorization(
+            app,
+            registration_attribution=_lobster_attribution(handoff_id),
+        )
+        dao.db.session.add(
+            UserInfo(
+                user_bid=user_id,
+                user_identify="same-second-lobster@example.test",
+                nickname="",
+                avatar="",
+                language="en-US",
+                created_at=datetime.fromtimestamp(1000, UTC).replace(tzinfo=None),
+            )
+        )
+        dao.db.session.commit()
+
+        approve_device_authorization(
+            app, user_code=started["user_code"], user_id=user_id
+        )
+        poll_device_authorization(app, device_code=started["device_code"])
+
+        row = UserRegistrationAttribution.query.filter_by(user_bid=user_id).one()
+        assert row.handoff_id == handoff_id
+
+
+def test_device_authorization_rejects_invalid_source_attribution(app: object) -> None:
+    with app.test_request_context(), pytest.raises(AppError):
+        create_device_authorization(
+            app,
+            registration_attribution={
+                "creation_source": "ai_assistant",
+                "source_product": "lobster",
+                "handoff_id": "invalid",
+            },
+        )
 
 
 def test_full_flow_issues_token_after_approval(app: object) -> None:

--- a/src/api/tests/service/user/test_device_auth.py
+++ b/src/api/tests/service/user/test_device_auth.py
@@ -1,6 +1,10 @@
 """Verify the device authorization flow used by command-line clients."""
 
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -92,6 +96,51 @@ def test_registration_attribution_requires_the_exact_pending_handoff(
         assert not record_device_registration_attribution(
             app, user_code="MISSING", user_id="new-lobster-user"
         )
+
+
+def test_concurrent_exact_registration_attribution_is_idempotent(app: object) -> None:
+    from flaskr import dao
+    from flaskr.service.user.models import UserRegistrationAttribution
+    from sqlalchemy.exc import IntegrityError
+
+    user_id = "concurrent-lobster-user"
+    handoff_id = str(uuid4())
+    with app.test_request_context():
+        started = create_device_authorization(
+            app,
+            registration_attribution=_lobster_attribution(handoff_id),
+        )
+        existing = SimpleNamespace(
+            id=42,
+            registration_source="ai_assistant",
+            source_product="lobster",
+            handoff_id=handoff_id,
+        )
+        results = {
+            ("user_bid", user_id): iter((None, existing)),
+            ("handoff_id", handoff_id): iter((None, existing)),
+        }
+
+        class FakeQuery:
+            def filter_by(self, **kwargs: object) -> object:
+                key, value = next(iter(kwargs.items()))
+                result = next(results[(key, value)])
+                return SimpleNamespace(one_or_none=lambda: result)
+
+        @contextmanager
+        def savepoint() -> Iterator[None]:
+            yield
+
+        conflict = IntegrityError("insert", {}, RuntimeError("duplicate"))
+        with (
+            mock.patch.object(UserRegistrationAttribution, "query", FakeQuery()),
+            mock.patch.object(dao.db.session, "begin_nested", side_effect=savepoint),
+            mock.patch.object(dao.db.session, "add"),
+            mock.patch.object(dao.db.session, "flush", side_effect=conflict),
+        ):
+            assert record_device_registration_attribution(
+                app, user_code=started["user_code"], user_id=user_id
+            )
 
 
 def test_device_authorization_rejects_invalid_source_attribution(app: object) -> None:

--- a/src/api/tests/service/user/test_device_auth.py
+++ b/src/api/tests/service/user/test_device_auth.py
@@ -1,7 +1,6 @@
 """Verify the device authorization flow used by command-line clients."""
 
 import json
-from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
@@ -17,8 +16,8 @@ from flaskr.service.user.device_auth import (
     get_device_authorization,
     normalize_user_code,
     poll_device_authorization,
+    record_device_registration_attribution,
 )
-from flaskr.util.datetime import now_utc
 
 USER_ID = "test-user-bid-0001"
 
@@ -41,11 +40,11 @@ def _lobster_attribution(handoff_id: str | None = None) -> dict[str, str]:
     }
 
 
-def test_new_registration_after_lobster_authorization_is_attributed(
+def test_explicit_new_registration_from_lobster_is_attributed(
     app: object,
 ) -> None:
     from flaskr import dao
-    from flaskr.service.user.models import UserInfo, UserRegistrationAttribution
+    from flaskr.service.user.models import UserRegistrationAttribution
 
     user_id = "new-lobster-user"
     handoff_id = str(uuid4())
@@ -54,24 +53,10 @@ def test_new_registration_after_lobster_authorization_is_attributed(
             app,
             registration_attribution=_lobster_attribution(handoff_id),
         )
-        dao.db.session.add(
-            UserInfo(
-                user_bid=user_id,
-                user_identify="new-lobster@example.test",
-                nickname="",
-                avatar="",
-                language="en-US",
-            )
-        )
-        dao.db.session.commit()
-
-        approve_device_authorization(
+        assert record_device_registration_attribution(
             app, user_code=started["user_code"], user_id=user_id
         )
-        assert (
-            poll_device_authorization(app, device_code=started["device_code"])["status"]
-            == STATUS_APPROVED
-        )
+        dao.db.session.commit()
 
         row = UserRegistrationAttribution.query.filter_by(user_bid=user_id).one()
         assert row.registration_source == "ai_assistant"
@@ -79,23 +64,11 @@ def test_new_registration_after_lobster_authorization_is_attributed(
         assert row.handoff_id == handoff_id
 
 
-def test_existing_user_authorizing_lobster_is_not_reclassified(app: object) -> None:
-    from flaskr import dao
-    from flaskr.service.user.models import UserInfo, UserRegistrationAttribution
+def test_device_poll_does_not_infer_registration_from_user_age(app: object) -> None:
+    from flaskr.service.user.models import UserRegistrationAttribution
 
     user_id = "existing-lobster-user"
     with app.test_request_context():
-        dao.db.session.add(
-            UserInfo(
-                user_bid=user_id,
-                user_identify="existing-lobster@example.test",
-                nickname="",
-                avatar="",
-                language="en-US",
-                created_at=now_utc() - timedelta(days=1),
-            )
-        )
-        dao.db.session.commit()
         started = create_device_authorization(
             app,
             registration_attribution=_lobster_attribution(),
@@ -112,40 +85,13 @@ def test_existing_user_authorizing_lobster_is_not_reclassified(app: object) -> N
         )
 
 
-def test_registration_in_authorization_starting_second_is_attributed(
+def test_registration_attribution_requires_the_exact_pending_handoff(
     app: object,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from flaskr import dao
-    from flaskr.service.user.models import UserInfo, UserRegistrationAttribution
-
-    user_id = "same-second-lobster-user"
-    handoff_id = str(uuid4())
-    monkeypatch.setattr("flaskr.service.user.device_auth.time.time", lambda: 1000.9)
     with app.test_request_context():
-        started = create_device_authorization(
-            app,
-            registration_attribution=_lobster_attribution(handoff_id),
+        assert not record_device_registration_attribution(
+            app, user_code="MISSING", user_id="new-lobster-user"
         )
-        dao.db.session.add(
-            UserInfo(
-                user_bid=user_id,
-                user_identify="same-second-lobster@example.test",
-                nickname="",
-                avatar="",
-                language="en-US",
-                created_at=datetime.fromtimestamp(1000, UTC).replace(tzinfo=None),
-            )
-        )
-        dao.db.session.commit()
-
-        approve_device_authorization(
-            app, user_code=started["user_code"], user_id=user_id
-        )
-        poll_device_authorization(app, device_code=started["device_code"])
-
-        row = UserRegistrationAttribution.query.filter_by(user_bid=user_id).one()
-        assert row.handoff_id == handoff_id
 
 
 def test_device_authorization_rejects_invalid_source_attribution(app: object) -> None:

--- a/src/api/tests/service/user/test_device_auth.py
+++ b/src/api/tests/service/user/test_device_auth.py
@@ -120,12 +120,21 @@ def test_concurrent_exact_registration_attribution_is_idempotent(app: object) ->
             ("user_bid", user_id): iter((None, existing)),
             ("handoff_id", handoff_id): iter((None, existing)),
         }
+        current_reads: list[tuple[str, object]] = []
 
         class FakeQuery:
             def filter_by(self, **kwargs: object) -> object:
                 key, value = next(iter(kwargs.items()))
                 result = next(results[(key, value)])
-                return SimpleNamespace(one_or_none=lambda: result)
+
+                def with_for_update() -> object:
+                    current_reads.append((key, value))
+                    return SimpleNamespace(one_or_none=lambda: result)
+
+                return SimpleNamespace(
+                    with_for_update=with_for_update,
+                    one_or_none=lambda: result,
+                )
 
         @contextmanager
         def savepoint() -> Iterator[None]:
@@ -141,6 +150,10 @@ def test_concurrent_exact_registration_attribution_is_idempotent(app: object) ->
             assert record_device_registration_attribution(
                 app, user_code=started["user_code"], user_id=user_id
             )
+        assert current_reads == [
+            ("user_bid", user_id),
+            ("handoff_id", handoff_id),
+        ]
 
 
 def test_device_authorization_rejects_invalid_source_attribution(app: object) -> None:

--- a/src/api/tests/service/user/test_google_auth.py
+++ b/src/api/tests/service/user/test_google_auth.py
@@ -339,6 +339,7 @@ def test_google_existing_account_accepts_long_avatar_url(
                 },
             )
 
+            assert result.is_new_user is True
             stored = UserEntity.query.filter_by(user_bid=result.user.user_id).one()
             assert stored.avatar == avatar_url
         finally:

--- a/src/web/src/app/login/page.test.tsx
+++ b/src/web/src/app/login/page.test.tsx
@@ -9,7 +9,10 @@ const logoutMock = jest.fn(() => Promise.resolve());
 // effect that depends on them re-run on every render.
 const mockRouter = { replace: replaceMock };
 const mockSearchParams = {
-  get: jest.fn(() => null),
+  get: jest.fn((key: string): string | null => {
+    void key;
+    return null;
+  }),
 };
 const mockPasswordLogin = jest.fn(
   ({
@@ -30,14 +33,17 @@ const mockEmailLogin = jest.fn(
   ({
     loginContext,
     courseId,
+    deviceUserCode,
   }: {
     loginContext?: string;
     courseId?: string;
+    deviceUserCode?: string;
   }) => (
     <div
       data-testid='email-login'
       data-login-context={loginContext}
       data-course-id={courseId}
+      data-device-user-code={deviceUserCode}
     />
   ),
 );
@@ -112,8 +118,11 @@ jest.mock('@/components/auth/PhoneLogin', () => ({
 }));
 
 jest.mock('@/components/auth/EmailLogin', () => ({
-  EmailLogin: (props: { loginContext?: string; courseId?: string }) =>
-    mockEmailLogin(props),
+  EmailLogin: (props: {
+    loginContext?: string;
+    courseId?: string;
+    deviceUserCode?: string;
+  }) => mockEmailLogin(props),
 }));
 
 jest.mock('@/components/auth/FeedbackForm', () => ({
@@ -208,6 +217,7 @@ jest.mock('@/components/ui/Card', () => ({
 describe('AuthPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSearchParams.get.mockImplementation(() => null);
     mockPasswordLogin.mockClear();
     mockEmailLogin.mockClear();
     mockUserState.userInfo = null;
@@ -217,6 +227,21 @@ describe('AuthPage', () => {
     mockEnvState.loginMethodsEnabled = ['phone'];
     mockEnvState.defaultLoginMethod = 'phone';
     mockEnvState.runtimeConfigLoaded = true;
+  });
+
+  it('passes the nested device handoff code into registration login', async () => {
+    mockEnvState.loginMethodsEnabled = ['email'];
+    mockEnvState.defaultLoginMethod = 'email';
+    mockSearchParams.get.mockImplementation((key: string) =>
+      key === 'redirect' ? '/login/device?code=AC4-7HK' : null,
+    );
+
+    render(<AuthPage />);
+
+    expect(await screen.findByTestId('email-login')).toHaveAttribute(
+      'data-device-user-code',
+      'AC4-7HK',
+    );
   });
 
   it('switches an authenticated browser session to a guest session on the login page', async () => {

--- a/src/web/src/app/login/page.tsx
+++ b/src/web/src/app/login/page.tsx
@@ -185,6 +185,17 @@ export default function AuthPage() {
       return match[1];
     }
   }, [resolveRedirectPath]);
+  const deviceUserCode = useMemo(() => {
+    const redirectPath = resolveRedirectPath();
+    try {
+      const target = new URL(redirectPath, 'https://local.ai-shifu.invalid');
+      return target.pathname === '/login/device'
+        ? (target.searchParams.get('code') ?? '')
+        : '';
+    } catch {
+      return '';
+    }
+  }, [resolveRedirectPath]);
 
   const handleAuthSuccess = useCallback(() => {
     router.replace(resolveRedirectPath());
@@ -322,11 +333,12 @@ export default function AuthPage() {
       await startGoogleLogin({
         redirectPath: resolveRedirectPath(),
         language: language ?? undefined,
+        deviceUserCode: deviceUserCode || undefined,
       });
     } catch {
       setIsGoogleLoading(false);
     }
-  }, [language, resolveRedirectPath, startGoogleLogin]);
+  }, [deviceUserCode, language, resolveRedirectPath, startGoogleLogin]);
 
   const handleGoogleSignIn = useCallback(async () => {
     if (!isGoogleEnabled) {
@@ -364,6 +376,7 @@ export default function AuthPage() {
               onLoginSuccess={handleAuthSuccess}
               loginContext={loginContext}
               courseId={courseIdFromRedirect || undefined}
+              deviceUserCode={deviceUserCode || undefined}
               referralMetadata={referralMetadata}
             />
           );
@@ -373,6 +386,7 @@ export default function AuthPage() {
               onLoginSuccess={handleAuthSuccess}
               loginContext={loginContext}
               courseId={courseIdFromRedirect || undefined}
+              deviceUserCode={deviceUserCode || undefined}
               referralMetadata={referralMetadata}
             />
           );
@@ -410,6 +424,7 @@ export default function AuthPage() {
       isGoogleLoading,
       loginContext,
       courseIdFromRedirect,
+      deviceUserCode,
       referralMetadata,
       isEmailEnabled,
       isGoogleEnabled,

--- a/src/web/src/components/auth/EmailLogin.tsx
+++ b/src/web/src/components/auth/EmailLogin.tsx
@@ -8,6 +8,7 @@ interface EmailLoginProps {
   onLoginSuccess: (userInfo: UserInfo) => void;
   loginContext?: string;
   courseId?: string;
+  deviceUserCode?: string;
   referralMetadata?: ReferralLoginMetadata;
 }
 

--- a/src/web/src/components/auth/PhoneLogin.tsx
+++ b/src/web/src/components/auth/PhoneLogin.tsx
@@ -8,6 +8,7 @@ interface PhoneLoginProps {
   onLoginSuccess: (userInfo: UserInfo) => void;
   loginContext?: string;
   courseId?: string;
+  deviceUserCode?: string;
   referralMetadata?: ReferralLoginMetadata;
 }
 

--- a/src/web/src/components/auth/VerificationCodeLogin.tsx
+++ b/src/web/src/components/auth/VerificationCodeLogin.tsx
@@ -30,6 +30,7 @@ type VerificationCodeLoginProps = {
   onLoginSuccess: (userInfo: UserInfo) => void;
   loginContext?: string;
   courseId?: string;
+  deviceUserCode?: string;
   referralMetadata?: ReferralLoginMetadata;
 };
 
@@ -58,6 +59,7 @@ export function VerificationCodeLogin({
   onLoginSuccess,
   loginContext,
   courseId,
+  deviceUserCode,
   referralMetadata,
 }: VerificationCodeLoginProps) {
   const isPhone = mode === 'phone';
@@ -78,6 +80,7 @@ export function VerificationCodeLogin({
       onSuccess: onLoginSuccess,
       loginContext,
       courseId,
+      deviceUserCode,
     });
   const {
     captchaImage,

--- a/src/web/src/hooks/useAuth.analytics.test.tsx
+++ b/src/web/src/hooks/useAuth.analytics.test.tsx
@@ -121,6 +121,21 @@ describe('useAuth login analytics contract', () => {
     );
   });
 
+  it('forwards the device handoff code only to the login request', async () => {
+    mockSmsLogin.mockResolvedValue(successfulSmsResponse);
+    const { result } = renderHook(() => useAuth({ deviceUserCode: 'AC4-7HK' }));
+
+    await act(async () => {
+      await result.current.loginWithSmsCode('13800138000', '123456', 'zh-CN');
+    });
+
+    expect(mockSmsLogin).toHaveBeenCalledWith(
+      expect.objectContaining({ device_user_code: 'AC4-7HK' }),
+      { skipErrorToast: true },
+    );
+    expect(JSON.stringify(mockTrackEvent.mock.calls)).not.toContain('AC4-7HK');
+  });
+
   it('keeps SMS success terminal when the post-login callback throws', async () => {
     const callbackError = new Error('private post-login callback error');
     const onSuccess = jest.fn(() => {

--- a/src/web/src/hooks/useAuth.ts
+++ b/src/web/src/hooks/useAuth.ts
@@ -48,6 +48,7 @@ interface UseAuthOptions {
   onError?: (error: any) => void;
   loginContext?: string;
   courseId?: string;
+  deviceUserCode?: string;
 }
 
 export function useAuth(options: UseAuthOptions = {}) {
@@ -188,6 +189,7 @@ export function useAuth(options: UseAuthOptions = {}) {
                 language,
                 login_context: options.loginContext,
                 course_id: options.courseId,
+                device_user_code: options.deviceUserCode,
                 ...referralPayload,
               },
               { skipErrorToast: true },
@@ -199,6 +201,7 @@ export function useAuth(options: UseAuthOptions = {}) {
                 language,
                 login_context: options.loginContext,
                 course_id: options.courseId,
+                device_user_code: options.deviceUserCode,
                 ...referralPayload,
               },
               { skipErrorToast: true },

--- a/src/web/src/hooks/useGoogleAuth.analytics.test.tsx
+++ b/src/web/src/hooks/useGoogleAuth.analytics.test.tsx
@@ -113,6 +113,23 @@ describe('useGoogleAuth analytics contract', () => {
     );
   });
 
+  it('forwards the device handoff code without adding it to analytics', async () => {
+    mockGoogleOauthStart.mockResolvedValue({
+      code: 0,
+      data: { authorization_url: 'https://accounts.example.test' },
+    });
+    const { result } = renderHook(() => useGoogleAuth());
+
+    await act(async () => {
+      await result.current.startGoogleLogin({ deviceUserCode: 'AC4-7HK' });
+    });
+
+    expect(mockGoogleOauthStart).toHaveBeenCalledWith(
+      expect.objectContaining({ device_user_code: 'AC4-7HK' }),
+    );
+    expect(JSON.stringify(mockTrackEvent.mock.calls)).not.toContain('AC4-7HK');
+  });
+
   it('records a successful callback without OAuth state, code, token, or identity', async () => {
     mockGoogleOauthCallback.mockResolvedValue(successfulGoogleCallbackResponse);
     const onSuccess = jest.fn();

--- a/src/web/src/hooks/useGoogleAuth.ts
+++ b/src/web/src/hooks/useGoogleAuth.ts
@@ -47,6 +47,7 @@ interface StartGoogleLoginOptions {
   redirectPath?: string;
   redirectUriOverride?: string;
   language?: string;
+  deviceUserCode?: string;
 }
 
 interface FinalizeGoogleLoginOptions {
@@ -104,6 +105,7 @@ export function useGoogleAuth(options: UseGoogleAuthOptions = {}) {
       redirectPath,
       redirectUriOverride,
       language,
+      deviceUserCode,
     }: StartGoogleLoginOptions = {}) => {
       trackEvent('learner_login_attempt', buildLoginAttemptAnalytics('google'));
       try {
@@ -127,6 +129,7 @@ export function useGoogleAuth(options: UseGoogleAuthOptions = {}) {
             redirect_uri: redirectUri,
             login_context: loginContext,
             language,
+            device_user_code: deviceUserCode,
           }),
         );
         const payload = extractData<OAuthStartPayload>(response);


### PR DESCRIPTION
## Summary
- accept and persist validated Lobster attribution during device authorization, registration, and new-course creation
- make repeated course handoffs idempotently return the original course and reject conflicting ownership
- recover attribution uniqueness conflicts with savepoints and locking current reads under the repository Unit of Work boundary
- omit sensitive authorization request bodies from generic request logs
- add the Alembic migration, focused regression tests, and tracked ExecPlan

## Related PR
- producer: https://github.com/ai-shifu/skills/pull/152

## Database migration and rollout
- **This PR changes the database schema. Run the Alembic upgrade before deploying the backend code.**
- migration: `b3e5f7a9c1d2_add_course_creation_attribution.py`
- deploy this backend and migration before enabling the updated Skills producer
- older clients remain compatible because both attribution payloads are optional

## Verification
- focused attribution and Shifu UoW tests (45 passed)
- `python scripts/check_uow_commit_sites.py` (0 new commit sites)
- `cd src/web && npm run type-check`
- `python scripts/check_repo_harness.py`
- `python scripts/check_architecture_boundaries.py`
- lefthook pre-commit checks